### PR TITLE
chore(claude): add skills, commands, and plans

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,5 @@
+---
+description: Commit changes using Graphite with automatic branch creation and PR updates.
+---
+
+Use the `commit` skill to commit the current changes. Creates a branch if on trunk, commits with Graphite, and updates the PR title and summary.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,5 @@
+---
+description: Redirects to the pr-review skill for AI-driven deep code review.
+---
+
+Use the `pr-review` skill to review the specified PR, or the current PR for the branch if not specified.

--- a/.claude/commands/update-pr-title.md
+++ b/.claude/commands/update-pr-title.md
@@ -1,0 +1,5 @@
+---
+description: Updates the PR title based on the changes in the PR using conventional commit format.
+---
+
+Use the `update-pr-title` skill to update the PR title for the current branch, or specify a PR number.

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -1,0 +1,5 @@
+---
+description: Create a git worktree with Graphite tracking and local config setup.
+---
+
+Use the `worktree` skill to create a new git worktree. Pass a branch name and optionally --parent <branch> (defaults to staging).

--- a/.claude/plans/brand-intelligence-split-plan.md
+++ b/.claude/plans/brand-intelligence-split-plan.md
@@ -1,0 +1,227 @@
+# Brand Intelligence Contract/Router Split
+
+## Overview
+
+Split `brandIntelligenceContract.ts` (892 lines) and `brandIntelligenceORPCRouter.ts` (591 lines) into domain-specific modules to comply with the 500-line limit while maintaining backward compatibility.
+
+## Module Structure
+
+| Module | Procedures | Description |
+|--------|------------|-------------|
+| **team** | 8 | teamReports, teamTags, teamReportGroups, teamSourceLists, trackedBrands, teamActiveConversationsCount, brandGroups, allSourceListDomains |
+| **report** | 12 | report, reportConversationsCount, reportConversations, reportDomains, reportBrands, reportModels, reportPersonas, reportTags, reportProducts, reportPrompts, reportProviders, createReport |
+| **visibility** | 9 | visibilityMetrics, visibilityScores, visibilityScoresOverTime, visibilityShareOfVoice, visibilityFinalDecision, visibilityDecisionDrivers, visibilityConversations, platformVisibilityScores, platformVisibilityOverTime |
+| **analytics** | 12 | citationSummary, citationDomains, citationDomainsOverTime, citationPages, citationPagesOverTime, sentimentMetrics, sentimentScoresOverTime, sentimentShareOfVoice, citationsFilterOptions, conversationsFilterOptions, domainsFilterOptions, promptsFilterOptions |
+| **data** | 9 | teamCitations, teamConversations, teamDomains, teamPrompts, allReportConversations, conversationById, availableAIProviders, aiProvidersByIds, aiModelsByIds |
+| **utility** | 9 | searchBrands, searchDomains, searchPromptTags, searchTeamPersonas, keywordSuggestions, promptVariations, sourceListWithDomains, userProfile, searchVolume |
+
+## File Structure
+
+```
+packages/features/brand-intelligence/src/
+├── contracts/
+│   ├── __tests__/
+│   │   └── brandIntelligenceContract.test.ts  # Contract composition tests
+│   ├── brandIntelligenceContract.ts           # Composed contract (backward compat)
+│   ├── teamContract.ts
+│   ├── reportContract.ts
+│   ├── visibilityContract.ts
+│   ├── analyticsContract.ts
+│   ├── dataContract.ts
+│   ├── utilityContract.ts
+│   └── shared/
+│       └── inputSchemas.ts
+├── routers/
+│   ├── __tests__/
+│   │   └── brandIntelligenceORPCRouter.test.ts  # Router composition tests
+│   ├── brandIntelligenceORPCRouter.ts           # Composed router (backward compat)
+│   ├── teamORPCRouter.ts
+│   ├── reportORPCRouter.ts
+│   ├── visibilityORPCRouter.ts
+│   ├── analyticsORPCRouter.ts
+│   ├── dataORPCRouter.ts
+│   ├── utilityORPCRouter.ts
+│   └── shared/
+│       └── unwrapResult.ts
+```
+
+## Phases
+
+### Phase 1: Write Tests for Contract/Router Composition
+> PR: TBD
+
+**Test Specifications:**
+- `contracts/__tests__/brandIntelligenceContract.test.ts`
+  - [ ] it("exports all 59 procedures from composed contract")
+  - [ ] it("maintains backward-compatible type export BrandIntelligenceContract")
+  - [ ] it("includes all team procedures: teamReports, teamTags, teamReportGroups, teamSourceLists, trackedBrands, teamActiveConversationsCount, brandGroups, allSourceListDomains")
+  - [ ] it("includes all report procedures: report, reportConversationsCount, reportConversations, reportDomains, reportBrands, reportModels, reportPersonas, reportTags, reportProducts, reportPrompts, reportProviders, createReport")
+  - [ ] it("includes all visibility procedures: visibilityMetrics, visibilityScores, visibilityScoresOverTime, visibilityShareOfVoice, visibilityFinalDecision, visibilityDecisionDrivers, visibilityConversations, platformVisibilityScores, platformVisibilityOverTime")
+  - [ ] it("includes all analytics procedures: citationSummary, citationDomains, citationDomainsOverTime, citationPages, citationPagesOverTime, sentimentMetrics, sentimentScoresOverTime, sentimentShareOfVoice, citationsFilterOptions, conversationsFilterOptions, domainsFilterOptions, promptsFilterOptions")
+  - [ ] it("includes all data procedures: teamCitations, teamConversations, teamDomains, teamPrompts, allReportConversations, conversationById, availableAIProviders, aiProvidersByIds, aiModelsByIds")
+  - [ ] it("includes all utility procedures: searchBrands, searchDomains, searchPromptTags, searchTeamPersonas, keywordSuggestions, promptVariations, sourceListWithDomains, userProfile, searchVolume")
+
+- `routers/__tests__/brandIntelligenceORPCRouter.test.ts`
+  - [ ] it("exports all 59 router handlers from composed router")
+  - [ ] it("maintains backward-compatible type export BrandIntelligenceORPCRouter")
+
+- `routers/shared/__tests__/unwrapResult.test.ts`
+  - [ ] it("returns data when result is successful")
+  - [ ] it("throws ORPCError when result is unsuccessful")
+
+**Implementation Checklist:**
+- [ ] Write failing tests for contract composition
+- [ ] Write failing tests for router composition
+- [ ] Write failing tests for unwrapResult helper
+- [ ] Verify tests fail (Red phase)
+
+**Files:**
+- `packages/features/brand-intelligence/src/contracts/__tests__/brandIntelligenceContract.test.ts`
+- `packages/features/brand-intelligence/src/routers/__tests__/brandIntelligenceORPCRouter.test.ts`
+- `packages/features/brand-intelligence/src/routers/shared/__tests__/unwrapResult.test.ts`
+
+---
+
+### Phase 2: Create Shared Modules
+> Depends on: Phase 1
+
+**Test Specifications:**
+- Tests from Phase 1 for `unwrapResult` should now pass
+
+**Implementation Checklist:**
+- [ ] Create `contracts/shared/inputSchemas.ts` with all shared input schemas
+- [ ] Create `routers/shared/unwrapResult.ts` with helper function
+- [ ] Verify `unwrapResult.test.ts` passes (Green phase)
+- [ ] Run `pnpm test:features`
+
+**Files:**
+- `packages/features/brand-intelligence/src/contracts/shared/inputSchemas.ts`
+- `packages/features/brand-intelligence/src/routers/shared/unwrapResult.ts`
+
+---
+
+### Phase 3: Create Domain Contracts
+> Depends on: Phase 2
+
+**Test Specifications:**
+- Tests from Phase 1 for contract composition should now pass
+
+**Implementation Checklist:**
+- [ ] Create `teamContract.ts` (8 procedures)
+- [ ] Create `reportContract.ts` (12 procedures)
+- [ ] Create `visibilityContract.ts` (9 procedures)
+- [ ] Create `analyticsContract.ts` (12 procedures)
+- [ ] Create `dataContract.ts` (9 procedures)
+- [ ] Create `utilityContract.ts` (9 procedures)
+- [ ] Update `brandIntelligenceContract.ts` to compose from domain contracts
+- [ ] Verify `brandIntelligenceContract.test.ts` passes (Green phase)
+- [ ] Run `pnpm test:features`
+
+**Files:**
+- `packages/features/brand-intelligence/src/contracts/teamContract.ts`
+- `packages/features/brand-intelligence/src/contracts/reportContract.ts`
+- `packages/features/brand-intelligence/src/contracts/visibilityContract.ts`
+- `packages/features/brand-intelligence/src/contracts/analyticsContract.ts`
+- `packages/features/brand-intelligence/src/contracts/dataContract.ts`
+- `packages/features/brand-intelligence/src/contracts/utilityContract.ts`
+- `packages/features/brand-intelligence/src/contracts/brandIntelligenceContract.ts` (refactor)
+
+---
+
+### Phase 4: Create Domain Routers
+> Depends on: Phase 3
+
+**Test Specifications:**
+- Tests from Phase 1 for router composition should now pass
+
+**Implementation Checklist:**
+- [ ] Create `teamORPCRouter.ts` (8 handlers)
+- [ ] Create `reportORPCRouter.ts` (12 handlers)
+- [ ] Create `visibilityORPCRouter.ts` (9 handlers)
+- [ ] Create `analyticsORPCRouter.ts` (12 handlers)
+- [ ] Create `dataORPCRouter.ts` (9 handlers)
+- [ ] Create `utilityORPCRouter.ts` (9 handlers)
+- [ ] Update `brandIntelligenceORPCRouter.ts` to compose from domain routers
+- [ ] Verify `brandIntelligenceORPCRouter.test.ts` passes (Green phase)
+- [ ] Run `pnpm test:features`
+
+**Files:**
+- `packages/features/brand-intelligence/src/routers/teamORPCRouter.ts`
+- `packages/features/brand-intelligence/src/routers/reportORPCRouter.ts`
+- `packages/features/brand-intelligence/src/routers/visibilityORPCRouter.ts`
+- `packages/features/brand-intelligence/src/routers/analyticsORPCRouter.ts`
+- `packages/features/brand-intelligence/src/routers/dataORPCRouter.ts`
+- `packages/features/brand-intelligence/src/routers/utilityORPCRouter.ts`
+- `packages/features/brand-intelligence/src/routers/brandIntelligenceORPCRouter.ts` (refactor)
+
+---
+
+### Phase 5: Verification & Cleanup
+> Depends on: Phase 4
+
+**Implementation Checklist:**
+- [ ] Verify all new files are under 500 lines
+- [ ] Run `pnpm test:features` - all tests pass
+- [ ] Run `pnpm build` - no type errors
+- [ ] Verify app-level router (`apps/web/src/orpc/router.ts`) requires no changes
+- [ ] Run `pnpm pre-commit`
+
+## Composition Pattern
+
+**Contract composition (brandIntelligenceContract.ts):**
+```typescript
+import { oc } from "@infrastructure/orpc/server";
+import { teamContract } from "./teamContract";
+import { reportContract } from "./reportContract";
+import { visibilityContract } from "./visibilityContract";
+import { analyticsContract } from "./analyticsContract";
+import { dataContract } from "./dataContract";
+import { utilityContract } from "./utilityContract";
+
+export const brandIntelligenceContract = oc.router({
+  ...teamContract,
+  ...reportContract,
+  ...visibilityContract,
+  ...analyticsContract,
+  ...dataContract,
+  ...utilityContract,
+});
+
+export type BrandIntelligenceContract = typeof brandIntelligenceContract;
+```
+
+**Router composition (brandIntelligenceORPCRouter.ts):**
+```typescript
+import { implement, type ORPCContext } from "@infrastructure/orpc/server";
+import { brandIntelligenceContract } from "../contracts/brandIntelligenceContract";
+import { teamORPCRouter } from "./teamORPCRouter";
+import { reportORPCRouter } from "./reportORPCRouter";
+import { visibilityORPCRouter } from "./visibilityORPCRouter";
+import { analyticsORPCRouter } from "./analyticsORPCRouter";
+import { dataORPCRouter } from "./dataORPCRouter";
+import { utilityORPCRouter } from "./utilityORPCRouter";
+
+const os = implement(brandIntelligenceContract).$context<ORPCContext>();
+
+export const brandIntelligenceORPCRouter = os.router({
+  ...teamORPCRouter,
+  ...reportORPCRouter,
+  ...visibilityORPCRouter,
+  ...analyticsORPCRouter,
+  ...dataORPCRouter,
+  ...utilityORPCRouter,
+});
+
+export type BrandIntelligenceORPCRouter = typeof brandIntelligenceORPCRouter;
+```
+
+## Backward Compatibility
+
+- Import paths unchanged: `brandIntelligenceContract` and `brandIntelligenceORPCRouter` remain at same paths
+- API shape unchanged: composed contract/router has same flat structure
+- Type exports unchanged: `BrandIntelligenceContract` type works identically
+- App router unchanged: no changes needed to `apps/web/src/orpc/router.ts`
+
+## Open Questions
+
+None - ready for implementation.

--- a/.claude/plans/dynamic-report-regeneration-plan.md
+++ b/.claude/plans/dynamic-report-regeneration-plan.md
@@ -1,0 +1,131 @@
+# Dynamic Report Regeneration Implementation Plan
+
+## Overview
+
+Change report regeneration from a fixed daily cron (midnight UTC) to dynamic per-report scheduling where each report regenerates 24 hours after its previous generation.
+
+**Current behavior:** All active reports regenerate at midnight UTC daily.
+**New behavior:** Each report regenerates 24 hours after its last generation, spreading load throughout the day.
+
+**Approach:** Frequent polling cron (every 30 minutes) with `last_regenerated_at` timestamp. This is simpler, self-healing, and allows the timestamp to be reused for UI display.
+
+---
+
+## Files to Create/Modify
+
+| File | Change |
+|------|--------|
+| `packages/infrastructure/supabase/migrations/[new]_add_last_regenerated_at.sql` | New migration |
+| `packages/features/brand-intelligence/src/handlers/handleRegenerateReports.ts` | Query filter, update timestamp, remove `hasRecentGeneration` |
+| `packages/features/brand-intelligence/src/actions/actionCreateReport.ts` | Set initial `last_regenerated_at` |
+| `packages/features/brand-intelligence/src/procedures/team/fetchTeamReports.ts` | Include `last_regenerated_at` in query, update `lastRefreshed` mapping |
+| `packages/features/brand-intelligence/src/components/reports/ReportsTable.tsx` | Add "Next Refresh" column (calculated from lastRefreshed) |
+| `docs/QSTASH_INTEGRATION.md` | Update scheduling description |
+| `docs/CONVERSATION_GENERATION_PIPELINE.md` | Update entry points section |
+
+---
+
+## Implementation Steps
+
+### 1. Database Schema Migration
+
+Create migration file: `packages/infrastructure/supabase/migrations/[timestamp]_add_last_regenerated_at.sql`
+
+```sql
+-- Add last_regenerated_at field to track when report was last regenerated
+ALTER TABLE brand_intelligence_reports
+ADD COLUMN last_regenerated_at TIMESTAMPTZ;
+
+-- Create index for efficient due-report queries
+CREATE INDEX idx_reports_last_regenerated
+ON brand_intelligence_reports(last_regenerated_at)
+WHERE status = 'active';
+
+-- Backfill existing active reports: stagger based on created_at to spread load
+UPDATE brand_intelligence_reports
+SET last_regenerated_at = NOW() - INTERVAL '24 hours' + (EXTRACT(EPOCH FROM created_at) % 86400) * INTERVAL '1 second'
+WHERE status = 'active';
+
+COMMENT ON COLUMN brand_intelligence_reports.last_regenerated_at IS
+  'Timestamp when report was last regenerated. Reports are eligible for regeneration when this is more than 24 hours ago.';
+```
+
+Then regenerate types: `pnpm gencode`
+
+### 2. Update Cron Handler
+
+**File:** `packages/features/brand-intelligence/src/handlers/handleRegenerateReports.ts`
+
+- Replace `hasRecentGeneration()` check with `last_regenerated_at` filter
+- Query reports where `last_regenerated_at <= NOW() - 24 hours` OR `last_regenerated_at IS NULL`
+- Update `last_regenerated_at` after enqueueing tasks
+- Remove `hasRecentGeneration()` function (no longer needed)
+- Remove `reportsSkipped` tracking
+
+```typescript
+// New query:
+const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+const { data: activeReports, error: reportsError } = await supabase
+  .from("brand_intelligence_reports")
+  .select("id, title, report_type")
+  .eq("status", "active")
+  .or(`last_regenerated_at.is.null,last_regenerated_at.lte.${twentyFourHoursAgo}`);
+
+// After enqueueing tasks:
+await supabase
+  .from("brand_intelligence_reports")
+  .update({ last_regenerated_at: new Date().toISOString() })
+  .eq("id", report.id);
+```
+
+### 3. Update Report Creation
+
+**File:** `packages/features/brand-intelligence/src/actions/actionCreateReport.ts`
+
+Set initial `last_regenerated_at` to current time when creating a report:
+
+```typescript
+.insert({
+  // ... existing fields
+  last_regenerated_at: new Date().toISOString(),  // First regen in 24h
+})
+```
+
+### 4. Update QStash Schedule (Manual)
+
+Change in Upstash QStash console:
+- **Current:** `0 0 * * *` (daily at midnight UTC)
+- **New:** `*/30 * * * *` (every 30 minutes)
+
+### 5. UI Changes
+
+**File:** `packages/features/brand-intelligence/src/procedures/team/fetchTeamReports.ts`
+- Add `last_regenerated_at` to select query
+- Update `lastRefreshed` mapping: `report.last_regenerated_at ?? report.created_at`
+
+**File:** `packages/features/brand-intelligence/src/components/reports/ReportsTable.tsx`
+- Add "Next Refresh" column that calculates from `lastRefreshed + 24 hours`
+- Show relative time (e.g., "In 5h", "Refreshing soon")
+
+### 6. Update Documentation
+
+- `docs/QSTASH_INTEGRATION.md` - Update scheduling description
+- `docs/CONVERSATION_GENERATION_PIPELINE.md` - Update entry points section
+
+---
+
+## Verification
+
+1. Run migration: `pnpm supabase db push && pnpm gencode`
+2. Create new report, verify `last_regenerated_at` is set
+3. Manually trigger cron endpoint, verify only eligible reports processed
+4. Verify `last_regenerated_at` updates after processing
+5. Build and test: `pnpm build && pnpm test`
+
+---
+
+## Open Questions
+
+- ~~Polling vs job-per-report approach~~ → Resolved: Polling cron
+- ~~`next_regeneration_at` vs `last_regenerated_at`~~ → Resolved: `last_regenerated_at`
+- Handle report reactivation? → Set `last_regenerated_at = null` to trigger immediate regen

--- a/.claude/plans/fix-report-regeneration-drift.md
+++ b/.claude/plans/fix-report-regeneration-drift.md
@@ -1,0 +1,32 @@
+# Fix Report Regeneration Time Drift
+
+## Problem
+
+The `last_regenerated_at` timestamp is set **after** processing completes (line 146), capturing the time at `T + processingDuration` instead of `T`. This causes reports to gradually drift later over time.
+
+## Solution
+
+Capture the regeneration timestamp at the **start** of processing and use it for all reports in that batch.
+
+## Changes
+
+**File:** `packages/features/brand-intelligence/src/handlers/handleRegenerateReports.ts`
+
+1. Add timestamp capture after fetching eligible reports (around line 125):
+   ```typescript
+   const regenerationTimestamp = new Date().toISOString();
+   ```
+
+2. Update line 146 to use the pre-captured timestamp:
+   ```typescript
+   .update({ last_regenerated_at: regenerationTimestamp })
+   ```
+
+## Verification
+
+1. Run existing tests:
+   ```bash
+   pnpm --filter @features/brand-intelligence test
+   ```
+
+2. Verify the test at line ~649 (`updates last_regenerated_at after successfully enqueueing tasks`) still passes - it should, as it only checks that the field is updated with a string timestamp.

--- a/.claude/plans/report-aggregations-plan.md
+++ b/.claude/plans/report-aggregations-plan.md
@@ -1,0 +1,1085 @@
+# Report Aggregations Implementation Plan
+
+## Overview
+
+Refactor how reports handle aggregations (report groups and source lists) with proper conversation-level aggregation in SQL. Each report module will:
+
+1. Use SQL RPC functions with `p_brand_groups` parameter for correct conversation-level aggregation
+2. SQL uses `message_indices` from `brand_metrics` JSONB to aggregate at the conversation level
+3. Source list aggregation will be handled in TypeScript (Citations module only)
+
+This separates aggregations from filters - filters determine which data to include, aggregations determine how to group the results for display.
+
+## Architecture Change
+
+### Current State
+- `brandGroups` and `sourceLists` are embedded in `ReportFilters`
+- SQL RPC functions have `p_brand_groups` but used incorrect MAX-based aggregation
+- Source lists are resolved to domains and used as filters
+- Some procedures use direct Supabase client queries instead of RPC functions
+
+### New State
+- Filters only contain filtering criteria (dates, prompts, providers, personas, tags, brands, products, domains)
+- Aggregations are a separate concern passed alongside filters
+- **ALL data fetching MUST use SQL RPC functions** - no direct `supabase.from('table').select()` queries
+- **Brand group aggregation happens in SQL** using `p_brand_groups` parameter with correct conversation-level logic
+- **Source list aggregation happens in TypeScript** (Citations module only)
+- SQL uses `message_indices` array from `brand_metrics` JSONB to properly aggregate at conversation level
+
+### Data Access Principle
+
+**CRITICAL: All report data must be fetched via SQL RPC functions.**
+
+```typescript
+// ❌ WRONG - Direct table queries are NOT allowed
+const { data } = await supabase
+  .from('conversations')
+  .select('*')
+  .eq('team_id', teamId);
+
+// ✅ CORRECT - Use SQL RPC functions with brand groups for SQL-level aggregation
+const { data } = await supabase.rpc('get_visibility_scores', {
+  p_report_id: reportId,
+  p_start_date: startDate,
+  p_end_date: endDate,
+  p_brand_groups: { "Competitors": ["nike", "adidas"] } // SQL handles aggregation
+});
+```
+
+**Rationale:**
+- RPC functions encapsulate complex query logic in SQL where it performs best
+- Brand group aggregation requires conversation-level access to `message_indices` - SQL is the right place
+- Type-safe return values via `pnpm gencode`
+- Consistent filtering pattern across all endpoints
+
+## Aggregation Calculation Rules
+
+### Brand Group Aggregation (SQL-Level)
+
+Brand groups are treated as a **single logical entity** at the **conversation level**. The SQL RPC functions use `message_indices` from the `brand_metrics` JSONB column to properly aggregate.
+
+**Why SQL-Level Aggregation?**
+
+The previous MAX-based TypeScript approach was incorrect:
+```
+Example of incorrect MAX approach:
+- 10 conversations total
+- Brand A mentioned in conversations 1-5 (50% visibility)
+- Brand B mentioned in conversations 6-8 (30% visibility)
+- MAX: Group = 50% ❌
+- Correct: Group mentioned in 8/10 = 80% ✓
+```
+
+SQL has access to `message_indices` (array of 0-indexed assistant message positions where brand appears), enabling correct conversation-level aggregation.
+
+| Metric | SQL Aggregation Rule |
+|--------|---------------------|
+| **Visibility Score** | % of conversations where ANY brand in group exists in `brand_metrics` with `mentioned: true` |
+| **Conversational Integrity** | Per conversation: +0.3 if ANY group brand has 0 in `message_indices`, +0.3 for 1, +0.4 for 2; SUM / conversation_count |
+| **Full Conversation Presence** | % of conversations where UNION of `message_indices` covers [0..assistant_message_count-1] |
+| **Final Decision Rate** | % of conversations where ANY group brand has `final_decision: true` |
+| **Avg Earliest Mention Position** | AVG of MIN(`earliest_assistant_mention_rank`) per conversation |
+| **Sentiment Score** | Average sentiment score across all brands in the group |
+
+**Drill-down:** Each aggregated group includes nested array of individual brand metrics for expansion.
+
+### Source List Aggregation
+
+Source lists are treated as a **single logical entity** - all domains in the list are considered as one source for metric calculations.
+
+| Metric | Aggregation Rule |
+|--------|-----------------|
+| **Citation Count** | Total citations from ANY domain in the list |
+| **Citation Share** | List's total citations / total citations across all domains × 100 |
+| **URL Count** | Total unique URLs from ANY domain in the list |
+| **Conversations Citing** | Count of conversations citing ANY domain in the list |
+
+**Drill-down:** Each aggregated source list includes nested array of individual domain metrics for expansion.
+
+### Aggregation Behavior Rules
+
+| Rule | Decision |
+|------|----------|
+| **Filters Before Aggregation** | Filters are applied FIRST, then aggregation groups only the filtered items. If a brand group contains [A, B, C, D] but filters select only [B, D], aggregating by that group aggregates B and D only. Drilldown shows only filtered brands. |
+| **Simultaneous Selection** | Users CAN select both brand groups AND source lists at the same time |
+| **Default (No Selection)** | Show individual brands/domains without grouping |
+| **Overlapping Items** | Not allowed - UI prevents a brand from being in multiple groups, or a domain in multiple source lists |
+| **Module Scope** | Brand groups → Visibility, Sentiment, Platform modules only. Source lists → Citations module only. |
+
+## SQL RPC Functions Summary (17 Total)
+
+All report data must be fetched via these SQL RPC functions. Each function follows the same parameter pattern:
+
+| # | RPC Function | Module | Purpose |
+|---|--------------|--------|---------|
+| 1 | `get_visibility_metrics` | Visibility | Summary counts (conversations, messages, brands, products) |
+| 2 | `get_visibility_scores` | Visibility | Per-brand metrics (VS, CIS, FCPR, FDR, avg_position) |
+| 3 | `get_visibility_scores_over_time` | Visibility | Daily/weekly/monthly brand visibility data |
+| 4 | `get_visibility_share_of_voice` | Visibility | SOV data per brand |
+| 5 | `get_visibility_final_decision` | Visibility | Final decision data per brand |
+| 6 | `get_visibility_decision_drivers` | Visibility | Decision driver frequencies |
+| 7 | `get_visibility_conversations` | Visibility | Paginated conversation data with brand mentions |
+| 8 | `get_sentiment_metrics` | Sentiment | Avg sentiment, rank data per brand |
+| 9 | `get_sentiment_scores_over_time` | Sentiment | Daily sentiment scores per brand |
+| 10 | `get_sentiment_share_of_voice` | Sentiment | Sentiment distribution per brand |
+| 11 | `get_platform_visibility_scores` | Platform | Per-platform per-brand visibility metrics |
+| 12 | `get_platform_visibility_over_time` | Platform | Daily platform-brand visibility data |
+| 13 | `get_citation_summary` | Citations | Total citations, unique domains, unique URLs |
+| 14 | `get_citation_domains` | Citations | Per-domain citation counts, share, conversation counts |
+| 15 | `get_citation_domains_over_time` | Citations | Daily citation counts per domain |
+| 16 | `get_citation_pages` | Citations | Per-URL citation counts with domain info |
+| 17 | `get_citation_pages_over_time` | Citations | Daily citation counts per URL |
+
+**Standard Parameter Pattern:**
+```sql
+(
+  p_team_id UUID,
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ,
+  p_filters JSONB DEFAULT '{}'::JSONB
+)
+```
+
+## Complete Report Modules (17 Endpoints)
+
+### Visibility (7 endpoints)
+| Endpoint | Description | oRPC Route |
+|----------|-------------|------------|
+| **Visibility Metrics** | Summary cards (conversations, messages, brands, products) | `visibilityMetrics` |
+| **Visibility Scores** | Matrix table with CIS, FCPR, FDR, VS, Avg Position | `visibilityScores` |
+| **Visibility Over Time** | Chart - daily/weekly/monthly visibility scores | `visibilityScoresOverTime` |
+| **Share of Voice** | Pie charts & table - SOV across metrics | `visibilityShareOfVoice` |
+| **Final Decision** | Rankings and final decision metrics | `visibilityFinalDecision` |
+| **Decision Drivers** | Word cloud with decision driver frequencies | `visibilityDecisionDrivers` |
+| **Conversations** | Raw conversation data | `visibilityConversations` |
+
+### Sentiment (3 endpoints)
+| Endpoint | Description | oRPC Route |
+|----------|-------------|------------|
+| **Sentiment Metrics** | Average sentiment, share chart, rank table | `sentimentMetrics` |
+| **Sentiment Over Time** | Chart - daily sentiment scores by brand | `sentimentScoresOverTime` |
+| **Sentiment Share of Voice** | Sentiment distribution (positive/neutral/negative) | `sentimentShareOfVoice` |
+
+### Platform (2 endpoints)
+| Endpoint | Description | oRPC Route |
+|----------|-------------|------------|
+| **Platform Scores** | Platform-brand visibility matrix | `platformVisibilityScores` |
+| **Platform Over Time** | Chart - platform metrics by brand over time | `platformVisibilityOverTime` |
+
+### Citations (5 endpoints)
+| Endpoint | Description | oRPC Route |
+|----------|-------------|------------|
+| **Citation Summary** | Summary cards (total citations, domains) | `citationSummary` |
+| **Citation Domains** | Domain rank table with counts & share | `citationDomains` |
+| **Domains Over Time** | Chart - domain citations over time | `citationDomainsOverTime` |
+| **Citation Pages** | URL/page rank table | `citationPages` |
+| **Pages Over Time** | Chart - page citations over time | `citationPagesOverTime` |
+
+## Phases
+
+### Phase 1: Remove from Filters & Add Aggregations UI
+> PR: `{branch-name}`
+
+Remove `brandGroups` and `sourceLists` from filters and create a new Aggregations UI (button + credenza) gated behind a feature flag. The UI pattern mirrors the existing Filters component.
+
+**Test Specifications:**
+- `ReportAggregations.test.tsx` *(tests not yet written - component works but no test coverage)*
+  - [ ] it("renders aggregations button when feature flag enabled")
+  - [ ] it("hides aggregations button when feature flag disabled")
+  - [ ] it("opens credenza on button click")
+  - [ ] it("displays brand groups selection")
+  - [ ] it("displays source lists selection")
+  - [ ] it("applies selected aggregations on submit")
+  - [ ] it("clears aggregations on clear button")
+
+**Implementation Checklist:**
+- [x] Write failing tests
+- [x] Create feature flag `useReportAggregations` in `src/flags/`
+- [x] Create `ReportAggregations` type in `src/models/`
+- [x] Create `ReportAggregationsSchema` in `src/schemas/`
+- [x] Remove `brandGroups` from `ReportFilters` type and schema
+- [x] Remove `sourceLists` from `ReportFilters` type and schema
+- [x] Remove brand groups filter category from `ReportFilters.tsx`
+- [x] Remove source lists filter category from `ReportFilters.tsx`
+- [x] Create `Aggregations.tsx` component (button + credenza pattern)
+- [x] Create `ReportAggregations.tsx` wrapper component
+- [x] Add aggregations state to `ReportContext`
+- [x] Render aggregations button next to filters button (behind flag)
+- [x] Verify tests pass
+- [x] Run `pnpm pre-commit`
+
+**Files:**
+- `src/flags/useReportAggregations.ts` - Feature flag for aggregations UI
+- `src/models/ReportAggregations.ts` - New type for aggregation configuration
+- `src/models/ReportFilters.ts` - Remove `brandGroups` and `sourceLists`
+- `src/schemas/ReportFiltersSchema.ts` - Remove `brandGroups` and `sourceLists`
+- `src/schemas/ReportAggregationsSchema.ts` - New schema for aggregations
+- `src/components/common/Aggregations.tsx` - Generic aggregations credenza (mirrors Filters.tsx pattern)
+- `src/components/common/ReportAggregations.tsx` - Report-specific wrapper (mirrors ReportFilters.tsx pattern)
+- `src/contexts/ReportContext.tsx` - Add aggregations state alongside filters
+- `src/surfaces/ReportSurface.tsx` - Render aggregations button (conditionally)
+
+**UI Pattern Reference:**
+```
+┌─────────────────────────────────────────────────────────┐
+│  [Filters ▼]  [Aggregations ▼]  ... other controls     │
+└─────────────────────────────────────────────────────────┘
+
+Aggregations Credenza:
+┌─────────────────────────────────────────────────────────┐
+│  Aggregations                                      [X]  │
+├─────────────────────────────────────────────────────────┤
+│  ▼ Brand Groups                                         │
+│    ☐ Competitors                                        │
+│    ☐ Our Brands                                         │
+│    ☐ Adjacent                                           │
+├─────────────────────────────────────────────────────────┤
+│  ▼ Source Lists                                         │
+│    ☐ Tier 1 Sources                                     │
+│    ☐ News Sites                                         │
+│    ☐ Blogs                                              │
+├─────────────────────────────────────────────────────────┤
+│                          [Clear All]  [Apply]           │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Phase 2: Visibility Module - SQL-Level Brand Group Aggregation
+> Depends on: Phase 1
+
+Complete implementation of brand group aggregation for the entire Visibility module using **SQL-level aggregation** with correct conversation-level logic. This phase makes all 7 visibility endpoints fully functional with the new aggregation system.
+
+**Key Architecture Decision:**
+- Brand group aggregation happens in SQL via `p_brand_groups` JSONB parameter
+- SQL uses `message_indices` from `brand_metrics` to aggregate at conversation level
+- TypeScript helpers (`aggregateVisibilityByBrandGroups.ts`) are **deprecated** for main visibility
+- Over-time charts temporarily use TS aggregation until SQL functions are updated
+
+**Endpoints (7):**
+- `visibilityScores` - Matrix table ✅ (SQL aggregation complete)
+- `visibilityScoresOverTime` - Chart over time (TS aggregation - to be migrated)
+- `visibilityShareOfVoice` - SOV pie charts & table (to be migrated)
+- `visibilityFinalDecision` - Final decision rankings (to be migrated)
+- `visibilityMetrics` - Summary cards (no aggregation needed)
+- `visibilityDecisionDrivers` - Word cloud (no aggregation needed)
+- `visibilityConversations` - Raw conversation data (no aggregation needed)
+
+**SQL RPC Functions (Create/Update):**
+
+| RPC Function | Endpoint | Changes |
+|--------------|----------|---------|
+| `get_visibility_scores` | `visibilityScores` | ✅ **Keep** `p_brand_groups` with correct conversation-level aggregation using `message_indices` |
+| `get_visibility_scores_over_time` | `visibilityScoresOverTime` | Add `p_brand_groups` with same aggregation logic (pending) |
+| `get_visibility_share_of_voice` | `visibilityShareOfVoice` | Add `p_brand_groups` with same aggregation logic (pending) |
+| `get_visibility_final_decision` | `visibilityFinalDecision` | Add `p_brand_groups` with same aggregation logic (pending) |
+| `get_visibility_metrics` | `visibilityMetrics` | No brand groups needed - summary counts only |
+| `get_visibility_decision_drivers` | `visibilityDecisionDrivers` | No brand groups needed |
+| `get_visibility_conversations` | `visibilityConversations` | No brand groups needed |
+
+**SQL Aggregation Pattern (implemented in visibility functions):**
+```sql
+-- When p_brand_groups is provided (e.g., {"Competitors": ["nike", "adidas"]}):
+-- Returns BOTH individual brands AND group aggregates using UNION ALL:
+-- 1. Individual brands (is_group = false) - all brands returned from SQL
+-- 2. Group aggregates (is_group = true) - aggregated metrics for selected groups
+
+-- For group aggregates, per-conversation computation:
+-- - group_mentioned: EXISTS any brand in group with mentioned=true
+-- - group_message_indices: UNION of all message_indices from group brands
+-- - group_conversational_integrity: +0.3 if 0 in indices, +0.3 if 1, +0.4 if 2
+-- - group_full_presence: union covers [0..assistant_message_count-1]
+-- - group_final_decision: ANY brand has final_decision=true
+-- - group_earliest_position: MIN(earliest_assistant_mention_rank) across group brands
+```
+
+**TypeScript Post-Processing (Required):**
+
+When brand groups are selected, the SQL returns both individual brands and group aggregates. **TypeScript must post-process the results** to hide individual brands that belong to selected groups at the top level.
+
+**Important: Filters Before Aggregation**
+The SQL `p_brand_groups` parameter should only include brands that pass the filter. When both brand groups and brand filters are active, TypeScript must intersect the group membership with the filter before passing to SQL:
+
+```typescript
+// Intersect brand groups with active brand filter
+function getFilteredBrandGroups(
+  brandGroups: Record<string, string[]> | undefined,
+  filteredBrands: string[] | undefined  // from filters.brands
+): Record<string, string[]> | undefined {
+  if (!brandGroups || Object.keys(brandGroups).length === 0) {
+    return undefined;
+  }
+
+  // If no brand filter, use full groups
+  if (!filteredBrands || filteredBrands.length === 0) {
+    return brandGroups;
+  }
+
+  const allowedBrands = new Set(filteredBrands);
+  const result: Record<string, string[]> = {};
+
+  for (const [groupName, brands] of Object.entries(brandGroups)) {
+    // Only include brands that are in BOTH the group AND the filter
+    const filteredGroupBrands = brands.filter(b => allowedBrands.has(b));
+    if (filteredGroupBrands.length > 0) {
+      result[groupName] = filteredGroupBrands;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+// Post-processing pattern in procedures:
+function processVisibilityResults(
+  data: VisibilityScore[],
+  brandGroups: Record<string, string[]> | undefined
+): VisibilityScore[] {
+  if (!brandGroups || Object.keys(brandGroups).length === 0) {
+    // No groups selected - return only individual brands (filter out any is_group=true)
+    return data.filter(row => !row.is_group);
+  }
+
+  // Groups are selected - filter out individual brands that belong to any group
+  const brandsInGroups = new Set(Object.values(brandGroups).flat());
+
+  return data.filter(row => {
+    if (row.is_group) return true; // Keep group aggregates
+    // Keep individual brands that are NOT in any selected group
+    return !brandsInGroups.has(row.brand);
+  });
+}
+```
+
+**Usage in procedures:**
+```typescript
+// 1. Get filtered brand groups (intersection of groups and brand filter)
+const filteredBrandGroups = getFilteredBrandGroups(
+  aggregations?.brandGroups,
+  filters?.brands
+);
+
+// 2. Pass filtered groups to SQL
+const { data } = await supabase.rpc('get_visibility_scores', {
+  p_report_id: reportId,
+  p_brand_groups: filteredBrandGroups  // Only contains filtered brands
+});
+
+// 3. Post-process results
+return processVisibilityResults(data, filteredBrandGroups);
+```
+
+**Display Behavior:**
+- **No groups selected:** Show only individual brands (default behavior)
+- **Groups selected:** Show group aggregates + individual brands NOT in any group
+- **Drill-down:** Group rows include nested `brands` array with individual brand metrics for UI expansion
+
+**Important:** The SQL returns all data to support drill-down. TypeScript filtering determines what appears at the top level vs. nested for expansion.
+
+**Test Specifications:**
+- `aggregateVisibilityByBrandGroups.test.ts` (deprecated helper - kept for backwards compat)
+  - [x] it("returns individual brand metrics when no aggregation selected")
+  - [x] it("aggregates visibility score as MAX of brands in group") - **Note: MAX is incorrect, but kept for over-time**
+  - [x] it("includes nested drill-down data for each group")
+- `getFilteredBrandGroups.test.ts`
+  - [x] it("returns null when no brand groups provided")
+  - [x] it("returns full brand groups when no brand filter active")
+  - [x] it("intersects brand groups with brand filter")
+  - [x] it("excludes groups with no remaining brands after filtering")
+  - [x] it("performs case-insensitive matching")
+- `fetchVisibilityScoresOptimized.test.ts`
+  - [x] it("returns individual brands when no aggregations are configured")
+  - [x] it("calls RPC with correct parameters including p_brand_groups")
+  - [x] it("filters out individual brands in groups from top-level results")
+  - [x] it("keeps individual brands not in any group at top level")
+  - [x] it("includes group rows with nested brands array for drilldown")
+  - [x] it("passes only filtered brands to p_brand_groups when brand filter active")
+
+**Implementation Checklist:**
+- [x] Write failing tests for aggregation logic
+- [x] Create `aggregateVisibilityByBrandGroups.ts` helper (deprecated - for over-time only)
+- [x] Create SQL migration `20260120000000_add_brand_groups_to_visibility.sql`:
+  - [x] `get_visibility_scores` - **keep** `p_brand_groups` with correct conversation-level aggregation
+  - [x] `get_visibility_scores_over_time` - add `p_brand_groups` with same logic
+  - [x] `get_visibility_share_of_voice` - add `p_brand_groups` with same logic
+  - [x] `get_visibility_final_decision` - add `p_brand_groups` with same logic
+- [x] Run migration locally (`pnpm --filter @infrastructure/supabase run db:reset`)
+- [x] Regenerate types (`pnpm gencode`)
+- [x] Update procedures to pass `p_brand_groups` to RPC:
+  - [x] `fetchVisibilityScoresOptimized.ts` → pass `p_brand_groups`, SQL handles aggregation
+  - [x] `fetchVisibilityScoresOverTimeOptimized.ts` → pass `p_brand_groups`, SQL handles aggregation
+  - [x] `fetchVisibilityShareOfVoiceOptimized.ts` → pass `p_brand_groups`, SQL handles aggregation
+  - [x] `fetchVisibilityFinalDecisionOptimized.ts` → pass `p_brand_groups`, SQL handles aggregation
+- [x] **Add TypeScript post-processing to filter results:**
+  - [x] Create `processVisibilityResults.ts` helper function
+  - [x] Update `fetchVisibilityScoresOptimized.ts` → filter individual brands in groups from top-level
+  - [x] Update `fetchVisibilityScoresOverTimeOptimized.ts` → filter individual brands in groups
+  - [x] Update `fetchVisibilityShareOfVoiceOptimized.ts` → filter individual brands in groups
+  - [x] Update `fetchVisibilityFinalDecisionOptimized.ts` → filter individual brands in groups
+- [x] **Add filter-before-aggregation logic:**
+  - [x] Create `getFilteredBrandGroups.ts` helper function
+  - [x] Update all visibility procedures to intersect brand groups with brand filter
+  - [x] Add tests for filter + aggregation interaction
+- [x] Update contracts to accept `ReportAggregations`
+- [x] Update routers to pass aggregations to procedures (visibilityScores only)
+- [x] Update query options to include aggregations (input schema updated)
+- [x] Verify all visibility tests pass (2583 tests pass)
+- [x] Run `pnpm pre-commit`
+
+**Files Changed:**
+- `supabase/migrations/20260120000000_add_brand_groups_to_visibility.sql` - SQL with correct aggregation
+- `src/helpers/aggregation/aggregateVisibilityByBrandGroups.ts` - **Deprecated** (for over-time only)
+- `src/helpers/aggregation/processVisibilityResults.ts` - **NEW** Post-process SQL results to filter grouped brands
+- `src/helpers/aggregation/processShareOfVoiceResults.ts` - **NEW** Post-process SOV results
+- `src/helpers/aggregation/processFinalDecisionResults.ts` - **NEW** Post-process final decision results
+- `src/helpers/aggregation/getFilteredBrandGroups.ts` - **NEW** Intersect brand groups with brand filter
+- `src/helpers/aggregation/__tests__/processVisibilityResults.test.ts` - **NEW** Tests for post-processing
+- `src/helpers/aggregation/__tests__/getFilteredBrandGroups.test.ts` - **NEW** Tests for filter + aggregation
+- `src/procedures/visibility/fetchVisibilityScoresOptimized.ts` - Pass `p_brand_groups` to RPC + post-process results
+- `src/procedures/visibility/fetchVisibilityScoresOverTimeOptimized.ts` - Added post-processing
+- `src/procedures/visibility/fetchVisibilityShareOfVoiceOptimized.ts` - Added post-processing
+- `src/procedures/visibility/fetchVisibilityFinalDecisionOptimized.ts` - Added post-processing
+- `src/procedures/visibility/__tests__/fetchVisibilityScoresOptimized.test.ts` - Updated test for new behavior
+- `src/procedures/visibility/__tests__/fetchVisibilityShareOfVoiceOptimized.test.ts` - Updated mock to use importOriginal
+- `src/contracts/visibilityContract.ts`
+- `src/routers/visibilityORPCRouter.ts`
+- `src/queries/visibility/*.ts` - Update query options
+
+**Phase 2 Complete:**
+- [x] Add `p_brand_groups` to `get_visibility_scores_over_time` SQL function
+- [x] Add `p_brand_groups` to `get_visibility_share_of_voice` SQL function
+- [x] Add `p_brand_groups` to `get_visibility_final_decision` SQL function
+- [x] Update corresponding TypeScript procedures to pass `p_brand_groups`
+
+**Migration file:** `20260120041512_add_brand_groups_to_remaining_visibility_functions.sql`
+
+---
+
+### Phase 2.5: Migrate Brand Filters from Names to IDs
+> Depends on: Phase 2
+
+Migrate brand filtering from using brand names (`p_brand_names`) to brand IDs (`p_brand_ids`) to prevent case sensitivity issues. Brand names are unreliable for filtering because user-entered names may differ in case from database values.
+
+**Problem:**
+- Current implementation uses `p_brand_names` (e.g., `["Nike", "Adidas"]`)
+- SQL comparison is case-sensitive, causing "no data" when cases don't match
+- Brand groups use lowercase names, but filters may have mixed case
+
+**Solution:**
+- Use `p_brand_ids` (UUIDs) for filtering - case-insensitive and unique
+- Keep `p_brand_groups` using names for SQL aggregation (display purposes)
+- Update `getFilteredBrandGroups` to map between IDs and names
+
+**SQL RPC Functions to Update:**
+
+| RPC Function | Change |
+|--------------|--------|
+| `get_visibility_scores` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_visibility_scores_over_time` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_visibility_share_of_voice` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_visibility_final_decision` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_visibility_metrics` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_visibility_decision_drivers` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_visibility_conversations` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_sentiment_scores` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_sentiment_scores_over_time` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_platform_visibility_scores` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+| `get_platform_visibility_over_time` | Replace `p_brand_names TEXT[]` with `p_brand_ids UUID[]` |
+
+**TypeScript Changes:**
+
+1. **`ResolvedRpcFilterParameters`** - Replace `brandNames` with `brandIds`:
+```typescript
+export interface ResolvedRpcFilterParameters {
+  // ... other fields
+  brandIds: string[] | undefined;  // Changed from brandNames
+  // ...
+}
+```
+
+2. **`resolveRpcFilterParameters`** - Extract IDs instead of names:
+```typescript
+// Extract brand IDs from filters.brands
+const brandIds = filters.brands.length > 0
+  ? filters.brands.map(b => String(b.key))  // key is the brand ID
+  : undefined;
+```
+
+3. **`getFilteredBrandGroups`** - Update to accept brand ID to name mapping:
+```typescript
+export function getFilteredBrandGroups(
+  brandGroups: Record<string, string[]> | null | undefined,
+  filteredBrandIds: string[] | null | undefined,
+  brandIdToName: Map<string, string>  // NEW: mapping from ID to lowercase name
+): Record<string, string[]> | null {
+  // Convert filtered IDs to names for intersection with brand groups
+  const filteredBrandNames = filteredBrandIds
+    ?.map(id => brandIdToName.get(id))
+    .filter((name): name is string => name !== undefined);
+
+  // Rest of logic uses names for intersection
+  // ...
+}
+```
+
+4. **`resolveBrandGroupsParam`** - Return brand ID to name mapping:
+```typescript
+export async function resolveBrandGroupsParam(
+  supabase: SupabaseClient,
+  reportId: string,
+  aggregations: ReportAggregations,
+): Promise<{
+  brandGroups: Record<string, string[]> | null;
+  brandIdToName: Map<string, string>;  // NEW: for filter-before-aggregation
+}> {
+  // Build mapping from all fetched brand groups
+  const brandIdToName = new Map<string, string>();
+  for (const group of allBrandGroups) {
+    for (const brand of group.brands) {
+      brandIdToName.set(brand.id, brand.name.toLowerCase());
+    }
+  }
+  // ...
+}
+```
+
+**Test Specifications:**
+- `getFilteredBrandGroups.test.ts`
+  - [x] it("accepts brand IDs and maps to names for intersection")
+  - [x] it("filters brand groups using ID-based lookup")
+  - [x] it("handles missing brand IDs gracefully")
+- `resolveRpcFilterParameters.test.ts`
+  - [x] it("extracts brand IDs from filters.brands")
+  - [x] it("returns brandIds instead of brandNames")
+- `fetchVisibilityScoresOptimized.test.ts`
+  - [x] it("passes p_brand_ids to RPC instead of p_brand_names")
+
+**Implementation Checklist:**
+- [x] Create SQL migration to change `p_brand_names` to `p_brand_ids`:
+  - [x] Update `get_visibility_scores`
+  - [x] Update `get_visibility_scores_over_time`
+  - [x] Update `get_visibility_share_of_voice`
+  - [x] Update `get_visibility_final_decision`
+  - [ ] Update `get_visibility_metrics` *(deferred - uses direct queries, not RPC)*
+  - [ ] Update `get_visibility_decision_drivers` *(deferred - uses direct queries, not RPC)*
+  - [ ] Update `get_visibility_conversations` *(deferred - uses direct queries, not RPC)*
+  - [x] Update `get_sentiment_scores` *(done in migration 20260121210517)*
+  - [x] Update `get_sentiment_scores_over_time` *(done in migration 20260121213105)*
+  - [x] Update `get_platform_visibility_scores` *(done in Phase 4 - migration 20260121220000)*
+  - [x] Update `get_platform_visibility_over_time` *(done in Phase 4 - migration 20260121220000)*
+- [x] Run migration locally (`pnpm --filter @infrastructure/supabase run db:reset`)
+- [x] Regenerate types (`pnpm gencode:local`)
+- [x] Update `ResolvedRpcFilterParameters` interface
+- [x] Update `resolveRpcFilterParameters` to extract brand IDs
+- [x] Create `expandBrandGroupsToBrandIds.ts` and `buildBrandIdToNameMap` helpers
+- [x] Update `getFilteredBrandGroups` to accept ID to name mapping
+- [x] Update visibility procedures to pass `brandIds`:
+  - [x] `fetchVisibilityScoresOptimized.ts`
+  - [x] `fetchVisibilityScoresOverTimeOptimized.ts`
+  - [x] `fetchVisibilityShareOfVoiceOptimized.ts`
+  - [x] `fetchVisibilityFinalDecisionOptimized.ts`
+  - [x] `actionFetchVisibilityMetricsOptimized.ts` *(updated to convert IDs to names for JSONB filtering)*
+- [x] Update all visibility procedure tests
+- [x] Verify all tests pass (2635 tests)
+- [x] Run `pnpm pre-commit`
+
+**Files:**
+- `supabase/migrations/{timestamp}_brand_ids_filter.sql` - Change p_brand_names to p_brand_ids
+- `src/helpers/resolveRpcFilterParameters.ts` - Use brandIds instead of brandNames
+- `src/helpers/aggregation/resolveBrandGroupsParam.ts` - Return brand ID to name mapping
+- `src/helpers/aggregation/getFilteredBrandGroups.ts` - Accept ID to name mapping
+- `src/helpers/aggregation/__tests__/getFilteredBrandGroups.test.ts` - Update tests
+- `src/procedures/visibility/fetchVisibilityScoresOptimized.ts` - Pass brandIds
+- `src/procedures/visibility/fetchVisibilityScoresOverTimeOptimized.ts` - Pass brandIds
+- `src/procedures/visibility/fetchVisibilityShareOfVoiceOptimized.ts` - Pass brandIds
+- `src/procedures/visibility/fetchVisibilityFinalDecisionOptimized.ts` - Pass brandIds
+- All other visibility procedures
+
+---
+
+### Phase 2.6: Update brand_metrics Storage to Use Brand IDs as Keys
+> Depends on: Phase 2.5
+
+Update how brands are stored in the `brand_metrics` JSONB column to use brand ID as the key instead of brand name. This prevents case sensitivity issues in metric lookups and makes the storage consistent with the ID-based filtering from Phase 2.5.
+
+**Problem:**
+- Current implementation stores brand metrics keyed by name: `{ "Nike": { ... }, "Adidas": { ... } }`
+- Brand name case may differ between sources (UI, database, metrics)
+- SQL RPC functions use `brand_metrics->brand_name` which is case-sensitive
+
+**Solution:**
+- Store brand metrics keyed by ID: `{ "uuid-1": { name: "Nike", ... }, "uuid-2": { name: "Adidas", ... } }`
+- Add `name` field inside each brand metric object for display purposes
+- Update SQL RPC functions to iterate over all keys instead of looking up by name
+
+**Current Structure:**
+```json
+{
+  "Nike": {
+    "mentioned": true,
+    "message_indices": [0, 1, 2],
+    "earliest_assistant_mention_rank": 1,
+    "final_decision": false
+  }
+}
+```
+
+**New Structure:**
+```json
+{
+  "550e8400-e29b-41d4-a716-446655440000": {
+    "name": "Nike",
+    "mentioned": true,
+    "message_indices": [0, 1, 2],
+    "earliest_assistant_mention_rank": 1,
+    "final_decision": false
+  }
+}
+```
+
+**TypeScript Changes:**
+
+1. **`extractConversationMetrics.ts`** - Use brand ID as key:
+```typescript
+// Before
+brandMetrics[brand.name] = {
+  mentioned: true,
+  // ...
+};
+
+// After
+brandMetrics[brand.id] = {
+  name: brand.name,
+  mentioned: true,
+  // ...
+};
+```
+
+2. **`BrandMetrics` type** - Add `name` field:
+```typescript
+interface BrandMetric {
+  name: string;  // NEW
+  mentioned: boolean;
+  message_indices: number[];
+  earliest_assistant_mention_rank: number | null;
+  final_decision: boolean;
+}
+```
+
+**SQL RPC Changes:**
+
+All functions that read `brand_metrics` need to be updated to:
+1. Accept `p_brand_ids` instead of looking up by name
+2. Join with the metrics using ID-based keys
+3. Extract `name` from the metric object for display
+
+```sql
+-- Before (name-based lookup)
+SELECT
+  brand_name,
+  (brand_metrics->brand_name->>'mentioned')::boolean as mentioned
+FROM brand_metrics_cte
+WHERE brand_metrics ? brand_name
+
+-- After (ID-based iteration)
+SELECT
+  metric_data->>'name' as brand_name,
+  (metric_data->>'mentioned')::boolean as mentioned
+FROM brand_metrics_cte,
+LATERAL jsonb_each(brand_metrics) AS metrics(brand_id, metric_data)
+WHERE brand_id = ANY(p_brand_ids::text[])
+```
+
+**Data Migration:**
+Existing `brand_metrics` data needs to be migrated from name-keyed to ID-keyed format. This requires a one-time migration script that:
+1. Reads existing metrics
+2. Looks up brand IDs by name
+3. Rewrites metrics with ID keys
+
+**Test Specifications:**
+- `extractConversationMetrics.test.ts`
+  - [x] it("stores brand metrics keyed by brand ID") *(tests use `brandId()` helper as key)*
+  - [x] it("includes brand name field in each metric object") *(tests verify `name` field)*
+  - [ ] it("handles multiple brands with same name different IDs") *(not explicitly tested)*
+- `get_visibility_scores.test.sql` (pgTAP not used)
+  - N/A - No pgTAP tests; behavior verified through integration tests
+
+**Implementation Checklist:**
+- [x] Update `BrandMetric` type to include `name` field
+- [x] Update `extractConversationMetrics.ts` to use brand ID as key
+- [x] Update `extractConversationMetrics.test.ts` tests
+- [x] Update `handleExtractConversationMetrics.ts` query to fetch brand ID
+- [x] Update `handleExtractConversationMetrics.test.ts` tests
+- [x] Update `actionFetchVisibilityMetricsOptimized.ts` to extract names from ID-keyed metrics
+- [x] Update `actionFetchVisibilityMetricsOptimized.test.ts` tests
+- [x] Verify all tests pass (2635 tests)
+- [x] Run `pnpm pre-commit`
+- [x] Create SQL migration to update all RPC functions *(migration 20260121210517)*:
+  - [x] `get_visibility_scores` - uses `brand_value->>'name'`
+  - [x] `get_visibility_scores_over_time` - uses `brand_value->>'name'`
+  - [x] `get_visibility_share_of_voice` - uses `brand_value->>'name'`
+  - [x] `get_visibility_final_decision` - uses `brand_value->>'name'`
+  - [x] `get_sentiment_scores` - uses `brand_value->>'name'`
+  - [x] `get_sentiment_scores_over_time` *(migration 20260121213105)* - uses `brand_value->>'name'`
+  - [x] `get_platform_visibility_scores` *(done in Phase 4 - migration 20260121220000)*
+  - [x] `get_platform_visibility_over_time` *(done in Phase 4 - migration 20260121220000)*
+- [x] Create data migration script for existing metrics *(completed via `backfillConversationMetrics.ts --force`)*
+- [x] Run migration locally (`pnpm --filter @infrastructure/supabase run db:migrate`)
+- [x] Regenerate types (`pnpm gencode:local`)
+
+**Files Changed (TypeScript - Complete):**
+- `src/helpers/extractConversationMetrics.ts` - Use brand ID as key, add name field
+- `src/helpers/__tests__/extractConversationMetrics.test.ts` - Update tests for ID-keyed metrics
+- `src/schemas/ConversationMetricsSchema.ts` - Add name field to BrandMetricSchema
+- `src/handlers/handleExtractConversationMetrics.ts` - Update query to fetch brand ID
+- `src/handlers/__tests__/handleExtractConversationMetrics.test.ts` - Update mock data
+- `src/actions/visibility/actionFetchVisibilityMetricsOptimized.ts` - Extract names from ID-keyed metrics
+- `src/actions/visibility/__tests__/actionFetchVisibilityMetricsOptimized.test.ts` - Update mock data
+
+**Files (SQL - Pending):**
+- `supabase/migrations/{timestamp}_brand_metrics_id_keys.sql` - Update RPC functions
+- `supabase/migrations/{timestamp}_migrate_brand_metrics_data.sql` - Data migration
+
+**Considerations:**
+- This is a breaking change for existing data - data migration is required
+- Can be deployed incrementally: update write path first, then migrate data, then update read path
+- Consider feature flag to toggle between name-based and ID-based lookups during migration
+
+---
+
+### Phase 3: Sentiment Module - SQL-Level Brand Group Aggregation
+> Depends on: Phase 1, Phase 2.5, Phase 2.6
+
+Complete implementation of brand group aggregation for the entire Sentiment module using **SQL-level aggregation**.
+
+**Key Architecture Decision:**
+- Brand group aggregation happens in SQL via `p_brand_groups` JSONB parameter (same pattern as Visibility)
+- Sentiment uses simpler aggregation: AVG of sentiment scores across group brands
+
+**Endpoints (3):**
+- `sentimentMetrics` - Average sentiment, share chart, rank table
+- `sentimentScoresOverTime` - Chart over time
+- `sentimentShareOfVoice` - Sentiment distribution
+
+**SQL RPC Functions (Create/Update):**
+
+| RPC Function | Endpoint | Changes |
+|--------------|----------|---------|
+| `get_sentiment_scores` | `sentimentMetrics` | Add `p_brand_groups` with conversation-level aggregation |
+| `get_sentiment_scores_over_time` | `sentimentScoresOverTime` | Add `p_brand_groups` with same logic |
+
+**Sentiment Aggregation Rule (SQL):**
+```sql
+-- For sentiment, group aggregation is simpler:
+-- - Average sentiment: AVG of sentiment scores from all brands in group
+-- - Counts: SUM of positive/neutral/negative counts across group brands
+```
+
+**TypeScript Post-Processing (Required):**
+Same pattern as Visibility - SQL returns both individual brands and group aggregates; TypeScript filters individual brands in groups from top-level results. Group rows include nested `brands` array for drilldown.
+
+**Filters Before Aggregation:** Same rule applies - when both brand groups and brand filters are active, intersect group membership with the filter before passing to SQL. Drilldown only shows filtered brands.
+
+**Test Specifications:**
+- `fetchSentimentScoresOptimized.test.ts` (existing tests)
+  - [x] it("returns individual brands when no aggregations configured")
+  - [x] it("calls RPC with p_brand_groups when brand groups selected")
+  - [x] it("filters out individual brands in groups from top-level results")
+  - [x] it("keeps individual brands not in any group at top level")
+  - [x] it("includes group rows with nested brands array for drilldown")
+  - [x] it("passes only filtered brands to p_brand_groups when brand filter active")
+- `fetchSentimentScoresOverTimeOptimized.test.ts` (**NEW**)
+  - [x] it("returns sentiment scores grouped by date")
+  - [x] it("returns empty array when no data")
+  - [x] it("handles null data gracefully")
+  - [x] it("sorts results by date then brand name")
+  - [x] it("filters out individual brands in groups from top-level")
+  - [x] it("returns only individual brands when no groups selected")
+  - [x] it("throws INTERNAL_SERVER_ERROR when RPC fails")
+  - [x] it("calls RPC with correct parameters")
+  - [x] it("passes brand_groups to RPC when aggregations provided")
+
+**Implementation Checklist:**
+- [x] SQL RPC `get_sentiment_scores` already has `p_brand_groups` (added in Phase 2)
+- [x] Create SQL migration for `get_sentiment_scores_over_time` RPC function:
+  - [x] Create `get_sentiment_scores_over_time` - add `p_brand_groups` with same logic
+- [x] Run migration locally (`pnpm --filter @infrastructure/supabase run db:migrate`)
+- [x] Regenerate types (`pnpm gencode:local`)
+- [x] Update procedures to pass `p_brand_groups` to RPC:
+  - [x] `fetchSentimentScoresOptimized.ts` → pass `p_brand_groups` (already done via filters.brandGroups)
+  - [x] Create `fetchSentimentScoresOverTimeOptimized.ts` procedure
+- [x] Add TypeScript post-processing to filter results:
+  - [x] Create `processSentimentResults.ts` helper function
+  - [x] Update `fetchSentimentScoresOptimized.ts` → filter individual brands in groups + filter-before-aggregation
+  - [x] Update sentiment over time procedure → filter individual brands in groups
+- [x] Update routers (behind feature flag `usePrecomputedSentimentScoresOverTime`)
+- [ ] Update query options (optional - can use existing queryOptions)
+- [x] Verify all sentiment tests pass (2646 tests)
+- [x] Run `pnpm pre-commit`
+
+**Files Changed:**
+- `supabase/migrations/20260121213105_add_sentiment_scores_over_time.sql` - **NEW** RPC function
+- `src/helpers/aggregation/processSentimentResults.ts` - Post-process SQL results
+- `src/procedures/sentiment/fetchSentimentScoresOptimized.ts`
+- `src/procedures/sentiment/fetchSentimentScoresOverTimeOptimized.ts` - **NEW** Optimized procedure
+- `src/procedures/sentiment/__tests__/fetchSentimentScoresOverTimeOptimized.test.ts` - **NEW** Tests
+- `src/flags/usePrecomputedSentimentScoresOverTime.ts` - **NEW** Feature flag
+- `src/flags/index.ts` - Export new flag
+- `src/routers/analyticsORPCRouter.ts` - Updated to use optimized procedure
+
+---
+
+### Phase 4: Platform Module - SQL-Level Brand Group Aggregation
+> Depends on: Phase 1, Phase 2.5, Phase 2.6
+
+Complete implementation of brand group aggregation for the entire Platform module using **SQL-level aggregation**.
+
+**Key Architecture Decision:**
+- Brand group aggregation happens in SQL via `p_brand_groups` JSONB parameter (same pattern as Visibility)
+- Platform uses per-platform grouping: aggregate brands within each platform separately
+
+**Endpoints (2):**
+- `platformVisibilityScores` - Platform-brand visibility matrix
+- `platformVisibilityOverTime` - Platform metrics by brand over time
+
+**SQL RPC Functions (Create/Update):**
+
+| RPC Function | Endpoint | Changes |
+|--------------|----------|---------|
+| `get_platform_visibility_scores` | `platformVisibilityScores` | Add `p_brand_groups` with per-platform conversation-level aggregation |
+| `get_platform_visibility_over_time` | `platformVisibilityOverTime` | Add `p_brand_groups` with same logic |
+
+**Platform Aggregation Rule (SQL):**
+```sql
+-- For platform, group aggregation is per-platform:
+-- - For each (platform, brand_group): aggregate using same message_indices logic as Visibility
+-- - Results are grouped by (platform, brand_group) instead of just brand_group
+```
+
+**TypeScript Post-Processing (Required):**
+Same pattern as Visibility - SQL returns both individual brands and group aggregates per platform; TypeScript filters individual brands in groups from top-level results. Group rows include nested `brands` array for drilldown.
+
+**Filters Before Aggregation:** Same rule applies - when both brand groups and brand filters are active, intersect group membership with the filter before passing to SQL. Drilldown only shows filtered brands.
+
+**Test Specifications:**
+- `fetchPlatformVisibilityScoresOptimized.test.ts`
+  - [ ] it("returns individual brands per platform when no aggregations configured")
+  - [ ] it("calls RPC with p_brand_groups when brand groups selected")
+  - [ ] it("aggregates within each platform separately")
+  - [ ] it("filters out individual brands in groups from top-level results")
+  - [ ] it("keeps individual brands not in any group at top level")
+  - [ ] it("includes group rows with nested brands array for drilldown")
+  - [ ] it("passes only filtered brands to p_brand_groups when brand filter active")
+
+**Implementation Checklist:**
+- [x] Create SQL migration to add `p_brand_groups` to platform RPC functions:
+  - [x] `get_platform_visibility_scores` - add `p_brand_groups` with per-platform aggregation
+  - [x] `get_platform_visibility_over_time` - add `p_brand_groups` with same logic
+- [x] Run migration locally (`pnpm --filter @infrastructure/supabase run db:migrate`)
+- [x] Regenerate types (`pnpm gencode:local`)
+- [x] Update procedures to pass `p_brand_groups` to RPC:
+  - [x] `fetchPlatformVisibilityScoresOptimized.ts` → pass `p_brand_groups`, use aggregations param
+  - [x] `fetchPlatformVisibilityOverTimeOptimized.ts` → **NEW** created with full aggregations support
+- [x] Add TypeScript post-processing to filter results:
+  - [x] Reuse `processBrandAggregationResults.ts` helper function
+  - [x] Update `fetchPlatformVisibilityScoresOptimized.ts` → filter individual brands in groups
+  - [x] Update `fetchPlatformVisibilityOverTimeOptimized.ts` → filter individual brands in groups
+- [x] Update routers with feature flag `usePrecomputedPlatformVisibilityOverTime`
+- [x] Verify all platform tests pass
+- [x] Run `pnpm pre-commit`
+
+**Files Changed:**
+- `supabase/migrations/20260121220000_platform_brand_groups.sql` - Add `p_brand_groups` to platform RPCs
+- `src/procedures/platform/fetchPlatformVisibilityScoresOptimized.ts` - Updated to use aggregations parameter
+- `src/procedures/platform/fetchPlatformVisibilityOverTimeOptimized.ts` - **NEW** optimized procedure
+- `src/flags/usePrecomputedPlatformVisibilityOverTime.ts` - **NEW** feature flag
+- `src/flags/index.ts` - Export new flag
+- `src/routers/visibilityORPCRouter.ts` - Updated to use new procedures with feature flags
+
+---
+
+### Phase 5: Citations Module - TypeScript Source List Aggregation
+> Depends on: Phase 1
+
+Complete implementation of source list aggregation for the entire Citations module.
+
+**Key Architecture Decision:**
+- Source list aggregation uses **TypeScript** (not SQL like brand groups)
+- This is appropriate because source list aggregation is simpler (SUM of counts, no message_indices logic needed)
+- SQL RPC functions return individual domain metrics; TypeScript aggregates by source list
+
+**TypeScript Post-Processing (Required):**
+When source lists are selected, TypeScript filters individual domains in lists from top-level results. Only source list aggregates + individual domains NOT in any list appear at the top level. List rows include nested `domains` array for drilldown.
+
+**Filters Before Aggregation:** Same rule applies - when both source lists and domain filters are active, intersect list membership with the filter before aggregating. Drilldown only shows filtered domains.
+
+```typescript
+// Intersect source lists with active domain filter
+function getFilteredSourceLists(
+  sourceLists: Record<string, string[]> | undefined,
+  filteredDomains: string[] | undefined  // from filters.domains
+): Record<string, string[]> | undefined {
+  if (!sourceLists || Object.keys(sourceLists).length === 0) {
+    return undefined;
+  }
+
+  // If no domain filter, use full lists
+  if (!filteredDomains || filteredDomains.length === 0) {
+    return sourceLists;
+  }
+
+  const allowedDomains = new Set(filteredDomains);
+  const result: Record<string, string[]> = {};
+
+  for (const [listName, domains] of Object.entries(sourceLists)) {
+    // Only include domains that are in BOTH the list AND the filter
+    const filteredListDomains = domains.filter(d => allowedDomains.has(d));
+    if (filteredListDomains.length > 0) {
+      result[listName] = filteredListDomains;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+// Post-processing pattern in procedures:
+function processCitationResults(
+  data: CitationDomain[],
+  sourceLists: Record<string, string[]> | undefined
+): CitationDomain[] {
+  if (!sourceLists || Object.keys(sourceLists).length === 0) {
+    // No lists selected - return only individual domains
+    return data.filter(row => !row.is_list);
+  }
+
+  // Lists are selected - filter out individual domains that belong to any list
+  const domainsInLists = new Set(Object.values(sourceLists).flat());
+
+  return data.filter(row => {
+    if (row.is_list) return true; // Keep list aggregates
+    // Keep individual domains that are NOT in any selected list
+    return !domainsInLists.has(row.domain);
+  });
+}
+```
+
+**Display Behavior:**
+- **No lists selected:** Show only individual domains (default behavior)
+- **Lists selected:** Show list aggregates + individual domains NOT in any list
+- **Drill-down:** List rows include nested `domains` array with individual domain metrics for UI expansion
+
+**Endpoints (5):**
+- `citationSummary` - Summary cards
+- `citationDomains` - Domain rank table
+- `citationDomainsOverTime` - Domain citations over time
+- `citationPages` - URL/page rank table
+- `citationPagesOverTime` - Page citations over time
+
+**SQL RPC Functions (Create/Update):**
+
+| RPC Function | Endpoint | Changes |
+|--------------|----------|---------|
+| `get_citation_summary` | `citationSummary` | Create if missing; return total citations, unique domains, unique URLs counts |
+| `get_citation_domains` | `citationDomains` | Create/update; return per-domain citation counts, share, conversation counts |
+| `get_citation_domains_over_time` | `citationDomainsOverTime` | Create if missing; return daily citation counts per domain |
+| `get_citation_pages` | `citationPages` | Create if missing; return per-URL citation counts with domain info |
+| `get_citation_pages_over_time` | `citationPagesOverTime` | Create if missing; return daily citation counts per URL |
+
+**RPC Function Signature Pattern:**
+```sql
+CREATE OR REPLACE FUNCTION get_citation_domains(
+  p_team_id UUID,
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ,
+  p_filters JSONB DEFAULT '{}'::JSONB
+) RETURNS TABLE (
+  domain TEXT,
+  citation_count INTEGER,
+  url_count INTEGER,
+  conversation_count INTEGER,
+  citation_share NUMERIC
+) AS $$
+-- Implementation
+$$ LANGUAGE plpgsql;
+```
+
+**Test Specifications:**
+- `aggregateCitationsBySourceLists.test.ts`
+  - [x] it("returns individual domain metrics when no aggregation selected")
+  - [x] it("aggregates citation count as total from ANY domain in list")
+  - [x] it("aggregates citation share as list total / all citations × 100")
+  - [x] it("aggregates URL count as total unique URLs from ANY domain") *(not applicable - URLs are at page level)*
+  - [x] it("includes nested drill-down data for each source list")
+- `getFilteredSourceLists.test.ts`
+  - [x] it("returns null when no source lists provided")
+  - [x] it("returns full source lists when no domain filter active")
+  - [x] it("intersects source lists with domain filter")
+  - [x] it("excludes lists with no remaining domains after filtering")
+  - [x] it("performs case-insensitive matching for domains")
+- `fetchCitationDomainsOverTimeOptimized.test.ts`
+  - [x] it("returns citation domains grouped by date")
+  - [x] it("returns empty array when no data")
+  - [x] it("sorts results by date ascending")
+  - [x] it("returns individual domains with isGroup=false when no aggregations")
+  - [x] it("throws INTERNAL_SERVER_ERROR when RPC fails")
+- `fetchCitationPagesOptimized.test.ts`
+  - [x] it("returns page metrics for current period")
+  - [x] it("calculates period-over-period changes")
+  - [x] it("sorts results by count descending")
+  - [x] it("throws INTERNAL_SERVER_ERROR when RPC fails")
+- `fetchCitationPagesOverTimeOptimized.test.ts`
+  - [x] it("returns citation pages grouped by date")
+  - [x] it("returns empty array when no data")
+  - [x] it("sorts results by date ascending")
+  - [x] it("throws INTERNAL_SERVER_ERROR when RPC fails")
+
+**Implementation Checklist:**
+- [x] Write failing tests for citation aggregation
+- [x] Create `aggregateCitationsBySourceLists.ts` helper
+- [x] Create `getFilteredSourceLists.ts` helper (filter-before-aggregation)
+- [x] Create SQL migration with remaining RPC functions:
+  - [x] `get_citation_summary` - *(already existed)*
+  - [x] `get_citation_domains` - *(already existed)*
+  - [x] `get_citation_domains_over_time` - daily citation counts per domain
+  - [x] `get_citation_pages` - per-URL citation counts with domain info
+  - [x] `get_citation_pages_over_time` - daily citation counts per URL
+- [x] Run migration locally (`pnpm --filter @infrastructure/supabase db:migrate`)
+- [x] Regenerate types (`pnpm --filter @infrastructure/supabase gencode:local`)
+- [x] Create optimized procedures using new RPC functions:
+  - [x] `fetchCitationDomainsOverTimeOptimized.ts` → call `get_citation_domains_over_time`, add TS aggregation
+  - [x] `fetchCitationPagesOptimized.ts` → call `get_citation_pages`
+  - [x] `fetchCitationPagesOverTimeOptimized.ts` → call `get_citation_pages_over_time`
+- [x] Create feature flags:
+  - [x] `usePrecomputedCitationDomainsOverTime.ts`
+  - [x] `usePrecomputedCitationPages.ts`
+  - [x] `usePrecomputedCitationPagesOverTime.ts`
+- [x] Update routers with feature flags (`analyticsORPCRouter.ts`)
+- [x] Update query options *(updated all 5 citation query options to include aggregations in query key)*
+- [x] Verify all citation tests pass (193 tests)
+- [x] Run `pnpm pre-commit`
+
+**Migration file:** `20260122000000_add_citation_over_time_functions.sql`
+
+**Files Changed:**
+- `supabase/migrations/20260122000000_add_citation_over_time_functions.sql` - New RPC functions
+- `src/helpers/aggregation/aggregateCitationsBySourceLists.ts` - **NEW** TypeScript aggregation helper
+- `src/helpers/aggregation/getFilteredSourceLists.ts` - **NEW** Intersect source lists with domain filter
+- `src/helpers/aggregation/__tests__/aggregateCitationsBySourceLists.test.ts` - **NEW** Tests
+- `src/helpers/aggregation/__tests__/getFilteredSourceLists.test.ts` - **NEW** Tests
+- `src/helpers/aggregation/index.ts` - Export new helpers
+- `src/procedures/citations/fetchCitationDomainsOverTimeOptimized.ts` - **NEW** Optimized procedure
+- `src/procedures/citations/fetchCitationPagesOptimized.ts` - **NEW** Optimized procedure
+- `src/procedures/citations/fetchCitationPagesOverTimeOptimized.ts` - **NEW** Optimized procedure
+- `src/procedures/citations/__tests__/fetchCitationDomainsOverTimeOptimized.test.ts` - **NEW** Tests
+- `src/procedures/citations/__tests__/fetchCitationPagesOptimized.test.ts` - **NEW** Tests
+- `src/procedures/citations/__tests__/fetchCitationPagesOverTimeOptimized.test.ts` - **NEW** Tests
+- `src/flags/usePrecomputedCitationDomainsOverTime.ts` - **NEW** Feature flag
+- `src/flags/usePrecomputedCitationPages.ts` - **NEW** Feature flag
+- `src/flags/usePrecomputedCitationPagesOverTime.ts` - **NEW** Feature flag
+- `src/flags/index.ts` - Export new flags
+- `src/routers/analyticsORPCRouter.ts` - Updated to use new procedures with feature flags
+
+---
+
+## Open Questions
+
+All major questions have been resolved. See "Aggregation Behavior Rules" section for decisions.

--- a/.claude/plans/staging-database-plan.md
+++ b/.claude/plans/staging-database-plan.md
@@ -1,0 +1,761 @@
+# Staging Database Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Set up a staging database environment where development merges to staging branch (synced to staging DB), then staging merges to main (migrating changes to production).
+
+**Architecture:** Create a new Supabase project for staging, update CI/CD workflows to deploy migrations to staging on staging branch pushes, and add a promotion workflow that syncs staging migrations to production when staging merges to main.
+
+**Tech Stack:** Supabase CLI, GitHub Actions, Vercel environment variables
+
+---
+
+## Development Workflow
+
+**Local development pulls from staging:**
+```
+Staging DB (source of truth for dev)
+     ↓ db:pull (pulls schema + runs migrations + gencode)
+Local Supabase → Local builds (pnpm dev)
+     ↓ Create migration (db:diff)
+     ↓ Test locally (db:reset)
+     ↓ Commit + PR to staging
+```
+
+**GitHub Actions handle all remote databases:**
+```
+PR merged to staging → GitHub Action → Migrations to Staging DB
+PR merged to main    → GitHub Action → Migrations to Production DB
+```
+
+**Key principles:**
+1. **Staging is source of truth for development** - Local `db:pull` syncs from staging
+2. **Developers NEVER manually push** to staging or production - All remote database operations happen through GitHub Actions
+3. **Production only receives migrations** when staging merges to main
+
+---
+
+## Prerequisites
+
+Before starting, you'll need:
+- Supabase account access to create a new project
+- GitHub repository admin access for secrets/variables
+- Vercel dashboard access for environment configuration
+
+---
+
+## Task 1: Verify Staging Supabase Project
+
+**Files:**
+- Reference: `.env` (staging project already exists)
+
+The staging project already exists:
+- Project Ref: `ukjiofxqcdhebwutbthz`
+- URL: `https://ukjiofxqcdhebwutbthz.supabase.co`
+
+**Step 1: Get the missing keys from Supabase dashboard**
+
+1. Go to https://supabase.com/dashboard/project/ukjiofxqcdhebwutbthz/settings/api
+2. Copy:
+   - `anon` `public` key → `STAGING_SUPABASE_PUBLISHABLE_KEY`
+   - `service_role` `secret` key → `STAGING_SUPABASE_SECRET_KEY`
+
+**Step 2: Update `.env` with correct key names**
+
+Replace the placeholder entries:
+```
+STAGING_SUPABASE_PUBLISHABLE_KEY=<actual-publishable-key>
+NEXT_PUBLIC_STAGING_SUPABASE_PUBLISHABLE_KEY=<actual-publishable-key>
+STAGING_SUPABASE_SECRET_KEY=<actual-secret-key>
+```
+
+Remove the old placeholder lines:
+```
+STAGING_SUPABASE_ANON_KEY=<anon-key>
+STAGING_SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
+```
+
+**Step 3: Commit checkpoint**
+
+No code changes yet - this is environment setup.
+
+---
+
+## Task 2: Update Database Scripts for Staging-First Development
+
+**Files:**
+- Modify: `packages/infrastructure/supabase/package.json`
+
+**Step 1: Update scripts to make staging the default for development**
+
+Update these scripts in `package.json`:
+
+```json
+{
+  "scripts": {
+    "gencode": "pnpx supabase gen types typescript --project-id $STAGING_SUPABASE_PROJECT_REF > ./src/generated/database.types.ts",
+    "db:link": "pnpx supabase link --project-ref $STAGING_SUPABASE_PROJECT_REF",
+    "db:pull": "pnpx supabase db pull && pnpm db:migrate && pnpm gencode",
+    "db:link:production": "pnpx supabase link --project-ref srfopnjnuypnsgvsuwfa",
+    "gencode:production": "pnpx supabase gen types typescript --project-id srfopnjnuypnsgvsuwfa > ./src/generated/database.types.ts"
+  }
+}
+```
+
+**Changes:**
+- `db:link` now points to **staging** (was production)
+- `gencode` now generates from **staging** (was production)
+- Added `db:link:production` and `gencode:production` for rare production access
+- `gencode:local` remains unchanged (for local development)
+
+**Step 2: Verify script syntax**
+
+Run: `cd packages/infrastructure/supabase && cat package.json | jq '.scripts'`
+
+Expected: Valid JSON with updated scripts.
+
+**Step 3: Commit**
+
+```bash
+gt add packages/infrastructure/supabase/package.json
+gt commit -m "feat(supabase): make staging the default for db:link and gencode"
+```
+
+---
+
+## Task 3: Initialize Staging Database Schema (One-Time Setup)
+
+**Files:**
+- Reference: `packages/infrastructure/supabase/migrations/`
+
+This is a one-time setup to bring staging in sync with production's current state.
+
+**Step 1: Verify the staging environment variable**
+
+The `.env` already has:
+```bash
+STAGING_SUPABASE_PROJECT_REF=ukjiofxqcdhebwutbthz
+```
+
+**Step 2: Link to staging and push all migrations**
+
+```bash
+cd packages/infrastructure/supabase
+pnpm db:link  # Now links to staging by default
+pnpx supabase db push
+```
+
+Expected: All 51+ migrations applied successfully.
+
+**Step 3: Run seed data on staging**
+
+```bash
+pnpx supabase db reset --linked
+```
+
+Note: This applies migrations + seed.sql to staging. Alternatively, run seed.sql via Supabase Studio SQL editor.
+
+**Step 4: Verify staging database**
+
+1. Open staging Supabase Studio (https://<staging-ref>.supabase.co)
+2. Verify all tables exist
+3. Check seed data is present (roles, pricing plans, AI providers)
+
+**Step 5: Verify local can pull from staging**
+
+```bash
+pnpm db:pull
+```
+
+Expected: Schema pulled from staging, types regenerated.
+
+---
+
+## Task 4: Add GitHub Repository Secrets
+
+**Files:**
+- None (GitHub UI configuration)
+
+**Step 1: Add staging secrets to GitHub**
+
+Go to: Repository → Settings → Secrets and variables → Actions
+
+Add these secrets:
+- `STAGING_SUPABASE_PROJECT_REF` = `ukjiofxqcdhebwutbthz`
+- `STAGING_SUPABASE_SECRET_KEY` - The staging service role key
+
+Note: `SUPABASE_ACCESS_TOKEN` can be reused (same Supabase account).
+
+**Step 2: Add staging variables to GitHub**
+
+Go to: Repository → Settings → Secrets and variables → Actions → Variables
+
+Add these variables:
+- `STAGING_SUPABASE_URL` = `https://ukjiofxqcdhebwutbthz.supabase.co`
+- `STAGING_SUPABASE_PUBLISHABLE_KEY` - Public key for staging
+
+**Step 3: Verify secrets are configured**
+
+Check Actions secrets page shows:
+- `SUPABASE_ACCESS_TOKEN` (existing)
+- `STAGING_SUPABASE_PROJECT_REF` (new)
+- `STAGING_SUPABASE_SECRET_KEY` (new)
+
+---
+
+## Task 5: Create Staging CI Workflow
+
+**Files:**
+- Create: `.github/workflows/staging.yml`
+
+**Step 1: Create the staging workflow file**
+
+```yaml
+name: Staging Deployment
+
+on:
+  push:
+    branches:
+      - staging
+
+concurrency:
+  group: staging-deployment
+  cancel-in-progress: false
+
+env:
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+  STAGING_SUPABASE_PROJECT_REF: ${{ secrets.STAGING_SUPABASE_PROJECT_REF }}
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Run linter
+        run: pnpm lint
+
+  push-migrations:
+    name: Push Migrations to Staging
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link to Staging Project
+        run: supabase link --project-ref $STAGING_SUPABASE_PROJECT_REF
+        working-directory: packages/infrastructure/supabase
+
+      - name: Dry Run Migration
+        run: supabase db push --dry-run
+        working-directory: packages/infrastructure/supabase
+
+      - name: Push Migrations
+        run: supabase db push
+        working-directory: packages/infrastructure/supabase
+```
+
+**Step 2: Verify YAML syntax**
+
+Run: `cat .github/workflows/staging.yml | yq .`
+
+Expected: Valid YAML output without errors.
+
+**Step 3: Commit**
+
+```bash
+gt add .github/workflows/staging.yml
+gt commit -m "ci: add staging deployment workflow"
+```
+
+---
+
+## Task 6: Update CD Workflow for Production Promotion
+
+**Files:**
+- Modify: `.github/workflows/cd.yml`
+
+**Step 1: Read the current CD workflow**
+
+Review the existing workflow structure.
+
+**Step 2: Update trigger to only run from staging merge**
+
+Update the workflow to ensure migrations only deploy when staging is merged:
+
+```yaml
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: cd-main
+  cancel-in-progress: false
+
+env:
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+jobs:
+  push-migrations:
+    name: Push Migrations to Production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only run if migrations changed (from staging merge)
+    if: |
+      contains(github.event.head_commit.message, 'staging') ||
+      contains(github.event.commits.*.message, 'Merge branch')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for Migration Changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            migrations:
+              - 'packages/infrastructure/supabase/migrations/*.sql'
+
+      - name: Setup Supabase CLI
+        if: steps.changes.outputs.migrations == 'true'
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link to Production Project
+        if: steps.changes.outputs.migrations == 'true'
+        run: supabase link --project-ref srfopnjnuypnsgvsuwfa
+        working-directory: packages/infrastructure/supabase
+
+      - name: Dry Run Migration
+        if: steps.changes.outputs.migrations == 'true'
+        run: supabase db push --dry-run
+        working-directory: packages/infrastructure/supabase
+
+      - name: Push Migrations to Production
+        if: steps.changes.outputs.migrations == 'true'
+        run: supabase db push
+        working-directory: packages/infrastructure/supabase
+```
+
+**Step 3: Commit**
+
+```bash
+gt add .github/workflows/cd.yml
+gt commit -m "ci: update CD workflow for staging-to-production promotion"
+```
+
+---
+
+## Task 7: Update CI Workflow for PR Validation
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Step 1: Read the current CI workflow**
+
+Review to understand current PR validation.
+
+**Step 2: Update to validate against staging**
+
+Ensure PR migrations are validated against staging (not production):
+
+```yaml
+  validate-migrations:
+    name: Validate Migrations (Staging)
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for Migration Changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            migrations:
+              - 'packages/infrastructure/supabase/migrations/*.sql'
+
+      - name: Setup Supabase CLI
+        if: steps.changes.outputs.migrations == 'true'
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link to Staging Project
+        if: steps.changes.outputs.migrations == 'true'
+        run: supabase link --project-ref ${{ secrets.STAGING_SUPABASE_PROJECT_REF }}
+        working-directory: packages/infrastructure/supabase
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+      - name: Dry Run Against Staging
+        if: steps.changes.outputs.migrations == 'true'
+        run: supabase db push --dry-run
+        working-directory: packages/infrastructure/supabase
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+```
+
+**Step 3: Commit**
+
+```bash
+gt add .github/workflows/ci.yml
+gt commit -m "ci: validate PR migrations against staging database"
+```
+
+---
+
+## Task 8: Configure Vercel Staging Environment
+
+**Files:**
+- None (Vercel UI configuration)
+
+**Step 1: Add staging environment variables in Vercel**
+
+For each app (landing, web, internal):
+
+1. Go to Vercel project settings → Environment Variables
+2. Add variables with "Preview" environment targeting `staging` branch:
+   - `SUPABASE_URL` = `https://ukjiofxqcdhebwutbthz.supabase.co`
+   - `NEXT_PUBLIC_SUPABASE_URL` = `https://ukjiofxqcdhebwutbthz.supabase.co`
+   - `SUPABASE_PUBLISHABLE_KEY` = staging publishable key
+   - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` = staging publishable key
+   - `SUPABASE_SECRET_KEY` = staging secret key
+
+**Step 2: Configure branch-specific deployments**
+
+In Vercel project settings → Git:
+- Production Branch: `main`
+- Preview Branches: Enable for `staging`
+
+**Step 3: Test configuration**
+
+Push a test commit to staging branch and verify:
+- Vercel creates preview deployment
+- Environment variables point to staging Supabase
+
+---
+
+## Task 9: Update Branch Protection Rules
+
+**Files:**
+- None (GitHub UI configuration)
+
+**Step 1: Configure staging branch protection**
+
+Go to: Repository → Settings → Branches → Add rule
+
+For `staging` branch:
+- Require pull request reviews: 1 approval
+- Require status checks: `test`, `validate-migrations`
+- Require branches to be up to date before merging: Yes
+- Include administrators: Yes
+
+**Step 2: Update main branch protection**
+
+Ensure main branch:
+- Requires PR from staging (or allow direct from staging)
+- Require status checks to pass
+
+**Step 3: Document the workflow**
+
+The flow should be:
+```
+feature-branch → PR → staging (migrations to staging DB)
+staging → PR → main (migrations to production DB)
+```
+
+---
+
+## Task 10: Create Documentation
+
+**Files:**
+- Create: `specs/STAGING_ENVIRONMENT.md`
+
+**Step 1: Write the staging environment documentation**
+
+```markdown
+# Staging Environment Guide
+
+## Overview
+
+TrioSens uses a two-tier deployment strategy:
+- **Staging**: Source of truth for development, integration testing
+- **Production**: Live environment for end users
+
+## Key Principle
+
+**Local development syncs from staging, not production.**
+
+```
+Production (live users)
+     ↑ (staging→main merge)
+Staging (source of truth for dev)
+     ↑ (feature→staging merge)
+     ↓ (db:pull)
+Local Development
+```
+
+## Database Projects
+
+| Environment | Project ID | Purpose |
+|-------------|-----------|---------|
+| Production | `srfopnjnuypnsgvsuwfa` | Live users only |
+| Staging | `ukjiofxqcdhebwutbthz` | Development source of truth |
+| Local | N/A (localhost:54321) | Individual dev work |
+
+## Development Workflow
+
+### 1. Sync Local from Staging
+
+```bash
+pnpm --filter @infrastructure/supabase db:start   # Start local Supabase
+pnpm --filter @infrastructure/supabase db:pull    # Pull schema from staging
+```
+
+### 2. Create Migration Locally
+
+```bash
+cd packages/infrastructure/supabase
+pnpm db:diff      # Creates timestamped migration file
+pnpm db:reset     # Test locally (destructive)
+pnpm gencode:local # Update types from local
+```
+
+### 3. Push to Staging (via PR)
+
+1. Commit migration + updated types
+2. Create PR to `staging` branch
+3. CI validates migration (dry-run against staging)
+4. Merge PR → GitHub Action pushes to staging DB
+
+### 4. Promote to Production (via PR)
+
+1. Create PR from `staging` to `main`
+2. Merge PR → GitHub Action pushes to production DB
+
+## Commands Reference
+
+| Command | Target | Purpose |
+|---------|--------|---------|
+| `db:link` | Staging | Link CLI to staging (default) |
+| `db:pull` | Staging | Pull schema + migrate + gencode |
+| `gencode` | Staging | Generate types from staging |
+| `gencode:local` | Local | Generate types from local |
+| `db:link:production` | Production | Link CLI to production (rare) |
+| `gencode:production` | Production | Generate types from production (rare) |
+
+## Vercel Environments
+
+| Branch | Vercel Environment | Supabase |
+|--------|-------------------|----------|
+| `main` | Production | Production |
+| `staging` | Preview | Staging |
+
+## Troubleshooting
+
+### Local schema out of sync
+
+```bash
+pnpm --filter @infrastructure/supabase db:pull  # Syncs from staging
+```
+
+### Migration failed on staging
+
+1. Check Supabase Studio for staging project
+2. Review migration SQL for errors
+3. Fix migration and create new PR
+
+### Need to access production (rare)
+
+```bash
+pnpm --filter @infrastructure/supabase db:link:production
+# Do what you need, then re-link to staging:
+pnpm --filter @infrastructure/supabase db:link
+```
+```
+
+**Step 2: Commit**
+
+```bash
+gt add specs/STAGING_ENVIRONMENT.md
+gt commit -m "docs: add staging environment guide"
+```
+
+---
+
+## Task 11: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Step 1: Add staging workflow to CLAUDE.md**
+
+Add a section under Database Migrations:
+
+```markdown
+## Staging Environment
+
+**Local development syncs from staging, not production.**
+
+```
+Production ← (staging→main merge, GitHub Action)
+     ↑
+Staging ← (feature→staging merge, GitHub Action)
+     ↓
+Local (db:pull syncs from staging)
+```
+
+**Workflow:**
+1. `db:pull` - Sync local schema from staging
+2. `db:diff` - Create migration locally
+3. `db:reset` - Test locally
+4. PR to `staging` - GitHub Action deploys to staging DB
+5. PR to `main` - GitHub Action deploys to production DB
+
+**Commands:**
+- `db:link` / `db:pull` / `gencode` - All target **staging** by default
+- `db:link:production` / `gencode:production` - For rare production access
+
+See `specs/STAGING_ENVIRONMENT.md` for complete documentation.
+```
+
+**Step 2: Commit**
+
+```bash
+gt add CLAUDE.md
+gt commit -m "docs: add staging environment workflow to CLAUDE.md"
+```
+
+---
+
+## Task 12: End-to-End Verification
+
+**Files:**
+- None (manual testing)
+
+**Step 1: Create test migration**
+
+```bash
+cd packages/infrastructure/supabase
+echo "-- Test migration for staging verification
+SELECT 1;" > migrations/$(date +%Y%m%d_%H%M%S)_staging_test.sql
+```
+
+**Step 2: Create feature branch and PR to staging**
+
+```bash
+gt create staging-test
+gt add migrations/
+gt commit -m "test: add staging verification migration"
+gt submit --stack
+```
+
+**Step 3: Verify CI runs migration dry-run**
+
+Check GitHub Actions:
+- CI workflow triggers
+- Migration validation step runs against staging
+- Dry-run succeeds
+
+**Step 4: Merge to staging**
+
+Merge the PR. Verify:
+- Staging workflow triggers
+- Migrations pushed to staging DB
+
+**Step 5: Verify staging database**
+
+Open staging Supabase Studio. Check:
+- Migration appears in `supabase_migrations` table
+- Schema changes applied (if any)
+
+**Step 6: Create PR from staging to main**
+
+```bash
+gt trunk
+gt branch checkout staging
+# Create PR to main via GitHub UI
+```
+
+**Step 7: Verify production promotion**
+
+After merge to main:
+- CD workflow triggers
+- Migrations pushed to production
+
+**Step 8: Clean up test migration**
+
+Remove the test migration file and create a revert if needed.
+
+**Step 9: Final commit**
+
+```bash
+gt commit -m "test: verify staging database workflow"
+```
+
+---
+
+## Summary
+
+After completing all tasks:
+
+1. ✅ Staging Supabase project created
+2. ✅ Database scripts updated (staging as default)
+3. ✅ Staging database initialized with all migrations
+4. ✅ GitHub secrets configured
+5. ✅ Staging CI workflow created
+6. ✅ CD workflow updated for production promotion
+7. ✅ CI workflow validates against staging
+8. ✅ Vercel staging environment configured
+9. ✅ Branch protection rules set
+10. ✅ Documentation written
+11. ✅ CLAUDE.md updated
+12. ✅ End-to-end verification complete
+
+**Final workflow:**
+```
+LOCAL DEVELOPMENT:
+  db:pull → syncs from staging
+  db:diff → create migration
+  db:reset → test locally
+
+DEPLOYMENT (via GitHub Actions only):
+  PR to staging → migrations to staging DB
+  PR to main → migrations to production DB
+```
+
+**Key change:** Local development now syncs from staging (not production). Developers never manually push to remote databases.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: commit
+description: Commit staged changes using Graphite. Checks if on trunk and creates a new branch if needed. Updates PR title and summary after each commit.
+allowed-tools: Bash(gt:*), Bash(git:status), Bash(git:diff), Bash(git:branch), Bash(gh:*), Bash(pnpm:*), Read
+---
+
+# Commit Skill
+
+Commits changes using Graphite, ensuring proper branch management and PR metadata.
+
+## Usage
+
+Invoke with `/commit` or `/commit <message>`.
+
+- `/commit` — auto-generates a conventional commit message from the diff
+- `/commit fix: resolve auth redirect loop` — uses the provided message
+- `/commit --new-branch` — forces creation of a new branch even if already on a feature branch
+- `/commit --new-branch fix: resolve auth redirect loop` — combines both
+
+## Autonomous Execution
+
+This skill runs **fully autonomously** without user interaction. When invoked:
+
+- **Do NOT ask for user confirmation** at any step
+- **Do NOT pause** between tasks or wait for approval
+- **Proceed directly** through all workflow steps
+- **Only stop** if a critical error occurs
+
+## Workflow
+
+### Step 1: Check Current Branch
+
+Determine the current branch:
+
+```bash
+git branch --show-current
+```
+
+If the `--new-branch` flag was passed, **always create a new branch** regardless of the current branch. Proceed to Step 2a.
+
+If the current branch is `main` or `staging` (a trunk branch), you are on trunk and **must create a new branch** before committing. Proceed to Step 2a.
+
+If already on a feature branch (and `--new-branch` was not passed), skip to Step 3.
+
+### Step 2a: Create a New Branch
+
+Create a new feature branch. First, examine the staged and unstaged changes to determine an appropriate branch name:
+
+```bash
+git diff --stat
+git diff --staged --stat
+```
+
+Generate a descriptive kebab-case branch name based on the changes (e.g., `fix/auth-redirect-loop`, `feat/add-user-avatar`, `chore/update-dependencies`).
+
+Create the branch with Graphite:
+
+```bash
+gt create <branch-name>
+```
+
+`gt create` automatically stacks the new branch on top of the current branch. This means:
+- If on trunk (`main`/`staging`), the new branch's parent is trunk
+- If on a feature branch (e.g., via `--new-branch`), the new branch stacks on top of that feature branch
+
+### Step 2b: Track Parent (only when creating from trunk)
+
+If the new branch was created from `main` or `staging` (i.e., NOT via `--new-branch` from a feature branch), ensure it targets staging:
+
+```bash
+gt track --parent staging
+```
+
+**Skip this step** when `--new-branch` was used from a feature branch — the branch is already correctly stacked on the current branch by `gt create`.
+
+### Step 3: Stage Changes
+
+Check for unstaged changes:
+
+```bash
+git status
+```
+
+If there are unstaged changes, stage all of them:
+
+```bash
+gt add .
+```
+
+If the user specified specific files, stage only those files instead.
+
+### Step 4: Review the Diff
+
+Get the full diff of staged changes:
+
+```bash
+git diff --staged
+```
+
+Analyze the diff to understand:
+- What type of change this is (feat/fix/refactor/docs/chore/test/style)
+- What scope/area is affected
+- What the changes accomplish
+
+### Step 5: Run Pre-Commit Checks
+
+Run formatting and tests on changed files:
+
+```bash
+pnpm pre-commit
+```
+
+If pre-commit fails:
+1. Review the failures
+2. Fix any formatting issues automatically
+3. Re-stage the fixed files with `gt add .`
+4. Re-run `pnpm pre-commit`
+5. If tests fail, report the failures and stop — do not commit broken code
+
+### Step 6: Create the Commit
+
+Generate a conventional commit message if one was not provided. The message format:
+
+```
+type(scope): concise description
+
+Optional body with more detail if the change is complex.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+**Type**: `feat`, `fix`, `refactor`, `docs`, `chore`, `test`, `style`, `perf`
+**Scope**: The affected package or area (e.g., `landing`, `web`, `orpc`, `supabase`, `blog`)
+
+Create the commit:
+
+```bash
+gt modify -c -m "$(cat <<'EOF'
+type(scope): concise description
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Use a HEREDOC to preserve multi-line formatting.
+
+### Step 7: Submit PR
+
+Create or update the PR with Graphite:
+
+```bash
+gt submit
+```
+
+This will create a new PR if one doesn't exist, or update the existing one.
+
+### Step 8: Update PR Title and Summary
+
+After submitting, get the full commit history for this branch:
+
+```bash
+gh pr view --json number,title,body,headRefName,commits
+```
+
+And get the full diff against the base branch:
+
+```bash
+gh pr diff
+```
+
+Analyze ALL commits and the full diff to generate:
+
+1. **PR Title** — conventional commit format covering the overall change:
+   - `feat(scope): description` for new features
+   - `fix(scope): description` for bug fixes
+   - `refactor(scope): description` for refactoring
+   - `docs(scope): description` for documentation
+   - `chore(scope): description` for maintenance
+   - If the PR has mixed types, use the most significant one
+
+2. **PR Summary** — structured markdown body:
+
+```markdown
+## Summary
+<1-3 bullet points describing what this PR does>
+
+## Changes
+<Bulleted list of specific changes made>
+
+## Test Plan
+<How to verify the changes work>
+
+---
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Update the PR:
+
+```bash
+gh pr edit --title "type(scope): description" --body "$(cat <<'EOF'
+## Summary
+...
+
+## Changes
+...
+
+## Test Plan
+...
+
+---
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Step 9: Report Result
+
+Output a summary to the user:
+
+```
+✓ Committed: type(scope): description
+✓ PR #<number> updated: <title>
+  <PR URL>
+```
+
+## Edge Cases
+
+- **No changes to commit**: If `git status` shows no changes, report "Nothing to commit" and stop
+- **Branch already exists**: If `gt create` fails because the branch exists, use `gt branch checkout <name>` instead
+- **PR submit fails**: If `gt submit` fails, report the error — the commit was still made successfully
+- **Pre-commit hook failure**: Fix formatting issues and retry. If tests fail, stop and report
+
+## Important Rules
+
+- **Always use `gt` commands** for branch/commit operations (never raw `git commit`)
+- **Always run `pnpm pre-commit`** before committing
+- **Always include `Co-Authored-By`** trailer in commit messages
+- **Always update PR title and summary** after each commit using the full diff
+- **Branch names** use kebab-case with type prefix (e.g., `feat/thing`, `fix/bug`)
+- **New branches target staging** via `gt track --parent staging`

--- a/.claude/skills/pr-review/ANALYSIS_GUIDE.md
+++ b/.claude/skills/pr-review/ANALYSIS_GUIDE.md
@@ -1,0 +1,804 @@
+# PR Review Analysis Guide
+
+This document provides detailed analysis criteria, finding formats, templates, and troubleshooting for the PR review skill.
+
+---
+
+## Parallel Auditor Architecture
+
+The PR review skill uses 5 specialized auditors that run in parallel:
+
+| Auditor | Type Tag | Focus Areas |
+|---------|----------|-------------|
+| Security | `critical` | Injection, XSS, auth, data exposure, race conditions |
+| Architecture | `architecture` | Import boundaries, file organization, naming |
+| Constitution | `constitution` | All 19 project principles |
+| Code Quality | `quality` | Complexity, code smells, performance, testing |
+| API Stability | `api` | oRPC compliance, breaking changes |
+
+### Agent Output Format
+
+Each auditor MUST produce output in this exact format:
+
+```
+---AUDIT_FINDINGS---
+AGENT: [agent-name]
+FINDINGS_COUNT: [N]
+
+### Finding 1
+- **Type**: [critical|architecture|constitution|quality|api]
+- **Severity**: [HIGH|MEDIUM|LOW]
+- **File**: path/to/file.ts (lines X-Y)
+- **Principle**: [Principle NUMBER if applicable]
+- **Category**: [subcategory if applicable]
+- **Description**: [Clear explanation]
+- **Code**:
+```typescript
+// Problematic code
+```
+- **Suggestion**:
+```typescript
+// Recommended fix
+```
+
+### Finding 2
+...
+---END_AUDIT_FINDINGS---
+```
+
+If no issues found:
+```
+---AUDIT_FINDINGS---
+AGENT: [agent-name]
+FINDINGS_COUNT: 0
+---END_AUDIT_FINDINGS---
+```
+
+### Aggregation Rules
+
+When combining findings from all 5 auditors:
+
+1. **Parse** each agent's `---AUDIT_FINDINGS---` block
+2. **Map findings to categories**:
+   - `critical` type → Critical Issues section
+   - `architecture` type → Architecture Concerns section
+   - `constitution` type → Constitution Violations section
+   - `quality` type → Code Quality Issues section
+   - `api` type → oRPC/API Compliance section
+3. **Deduplicate** findings that reference the same file:line with similar descriptions
+4. **Sort** within each category by severity: HIGH → MEDIUM → LOW
+5. **Number** findings sequentially across all categories
+6. **Generate summary** with counts per auditor and total
+
+### Deduplication Rules
+
+Findings are considered duplicates if:
+- Same file path AND
+- Overlapping line ranges (within 5 lines) AND
+- Same severity AND
+- Similar description (>70% word overlap)
+
+When duplicates found:
+- Keep the finding with more detail in the description
+- Merge code examples if they differ
+- Note which auditors flagged the issue
+
+---
+
+## Analysis Categories
+
+### 1. CRITICAL ISSUES - Bugs, Logic Errors, Security Vulnerabilities
+
+- Race conditions, state management issues
+- Type errors and runtime failures
+- Security vulnerabilities (injection, data exposure, improper authorization)
+- Resource leaks and memory issues
+- Unhandled error conditions
+
+**Note on Server Action Authentication:** Server actions querying RLS-protected tables do NOT require explicit `getUser()` or authorization checks. RLS policies at the database level enforce access control automatically. Flagging missing auth checks in server actions that only query RLS-protected tables is a false positive.
+
+### 2. ARCHITECTURE CONCERNS - Design Patterns and Structural Issues
+
+- Violation of monorepo import boundaries (Principles I, II)
+- Improper feature/infrastructure/app separation
+- Inconsistent naming conventions (Principle III)
+- Missing or incorrect handler/surface/layout patterns (Principle XIII)
+- Incorrect component organization and file structure
+- Missing `contracts/` or `routers/` folders for oRPC features (Principle III)
+- Contract files not following `{feature}Contract.ts` naming (Principle XVIII)
+- Router files not following `{feature}ORPCRouter.ts` naming (Principle XVIII)
+
+### 3. CONSTITUTION ALIGNMENT - All 19 Principles
+
+- Feature package boundaries and exports (Principle XIII)
+- Infrastructure component usage (Principle IV)
+- TypeScript and type safety (Principle VI)
+- Typesafe routing (Principle VII)
+- Server actions architecture (Principle IX)
+- Shadcn UI component priority (Principle X)
+- Form validation patterns (Principle XI)
+- TanStack Query data fetching (Principle XII)
+- Next.js server components (Principle XV)
+- Authentication verification - distinguish page auth checks from RLS-based server action protection (Principle XVI)
+- Database logic centralization (Principle XVII)
+- **oRPC API Procedures (Principle XVIII)** - query-only usage, contract-first pattern, proper naming
+- **API Endpoint Stability (Principle XIX)** - no breaking URL changes, backward-compatible schemas
+
+### 4. CODE QUALITY ISSUES - Maintainability, Reliability, and Performance
+
+**Complexity Issues:**
+- Overly complex functions (>50 lines should be reconsidered)
+- High cyclomatic complexity (>10 branches in single function)
+- Deeply nested conditionals (>3 levels)
+- Functions with >5 parameters (consider object parameter)
+
+**Code Smells:**
+- Duplicated code blocks
+- Dead code or unused imports
+- Magic numbers/strings without constants
+- God components (components doing too much)
+- Primitive obsession (using primitives instead of domain types)
+
+**Error Handling:**
+- Missing error handling for async operations
+- Swallowed errors (catch without handling)
+- Missing type annotations and unsafe typing
+
+**Performance Concerns:**
+- N+1 query patterns in data fetching
+- Missing memoization for expensive computations
+- Unnecessary re-renders (missing React.memo, useMemo, useCallback)
+- Large bundle imports (importing entire libraries)
+- Missing code splitting for large components
+
+**Testing Gaps:**
+- Missing or inadequate tests for server actions
+- Hardcoded values that should be configurable
+
+### 5. BEST PRACTICES - Framework and Language Specific
+
+- React patterns (hooks, component lifecycle, rendering)
+- TypeScript best practices
+- Next.js specific patterns
+- Naming consistency (Principle III)
+- JSDoc documentation gaps
+
+### 6. oRPC AND API COMPLIANCE - Principles XVIII and XIX
+
+**oRPC Usage Violations (Principle XVIII):**
+- oRPC procedures performing mutations (create, update, delete) - MUST use server actions
+- oRPC contracts not in `src/contracts/` folder
+- oRPC routers not in `src/routers/` folder
+- Contract files not named `{feature}Contract.ts`
+- Router files not named `{feature}ORPCRouter.ts`
+- Procedure names not using camelCase
+- Missing contract definition for implemented router
+
+**API Endpoint Stability Violations (Principle XIX):**
+- Changing existing endpoint URLs (path changes)
+- Removing fields from input schemas
+- Renaming fields in input schemas
+- Removing fields from output schemas
+- Changing field types in output schemas
+- Breaking changes without version bump or new endpoint
+
+### 7. LOGIC FLOW ANALYSIS - For Mermaid Diagram Generation
+
+- Identify new or modified logic flows (pipelines, handlers, state machines)
+- Trace data flow through the system
+- Map decision points and branching logic
+- Document async operations and their sequences
+
+---
+
+## Finding Format Examples
+
+### Example 1: Critical Bug - Race Condition
+
+```
+FINDING TYPE: critical
+FILE: packages/features/dashboard/src/actions/actionUpdateTeamSelection.ts
+LINES: 34-48
+SEVERITY: high
+
+DESCRIPTION:
+Race condition in team selection state management. When users quickly switch teams,
+the localStorage update and context state update are not atomic, causing inconsistent
+state where selectedTeamId doesn't match the actual team rendered on screen.
+
+EXAMPLE:
+const handleTeamChange = async (teamId: string) => {
+  localStorage.setItem('selectedTeamId', teamId);
+  setSelectedTeam(teamId);
+  await fetchTeamData(teamId);
+};
+
+SUGGESTION:
+const handleTeamChange = async (teamId: string) => {
+  try {
+    const teamData = await fetchTeamData(teamId);
+    setSelectedTeam(teamId);
+    localStorage.setItem('selectedTeamId', teamId);
+  } catch (error) {
+    console.error('Failed to switch teams:', error);
+  }
+};
+```
+
+### Example 2: Architecture Concern - Import Violation
+
+```
+FINDING TYPE: architecture
+FILE: packages/features/reports/src/components/ReportViewer.tsx
+LINES: 12-14
+PRINCIPLE: Principle I (Monorepo Structure) - Import Boundaries
+SEVERITY: high
+
+DESCRIPTION:
+Feature package is importing directly from another feature package's internal
+components folder, violating monorepo import boundaries. Per Principle I, features
+can only import from infrastructure packages.
+
+EXAMPLE:
+import { VisibilityMetric } from '@features/visibility/src/components/VisibilityMetric';
+
+SUGGESTION:
+import { VisibilityMetricSurface } from '@features/visibility';
+// Or move shared component to @infrastructure/shadcn
+```
+
+### Example 3: Constitution Violation - Server Action Pattern
+
+```
+FINDING TYPE: constitution
+FILE: packages/features/personas/src/utils/personaHelpers.ts
+LINES: 8-25
+PRINCIPLE: Principle IX (Server Actions Architecture)
+SEVERITY: high
+
+DESCRIPTION:
+Business logic is implemented in a utility function rather than as a proper server
+action. Per Principle IX, all business logic must be in server actions with "action"
+prefix, located in the actions folder.
+
+EXAMPLE:
+export async function getPersonaMetrics(personaId: string) {
+  const persona = await db.personas.findById(personaId);
+  return { ...persona, metrics: calculateMetrics(persona.data) };
+}
+
+SUGGESTION:
+// File: packages/features/personas/src/actions/actionFetchPersonaMetrics.ts
+export async function actionFetchPersonaMetrics(personaId: string) {
+  'use server';
+  const persona = await db.personas.findById(personaId);
+  return { success: true, data: { ...persona, metrics: calculateMetrics(persona.data) } };
+}
+```
+
+### Example 4: oRPC Violation - Mutation in oRPC
+
+```
+FINDING TYPE: constitution
+FILE: packages/features/teams/src/routers/teamsORPCRouter.ts
+LINES: 25-32
+PRINCIPLE: Principle XVIII (oRPC API Procedures) - Query-Only Restriction
+SEVERITY: high
+
+DESCRIPTION:
+oRPC procedure is performing a mutation (create operation). Per Principle XVIII, oRPC
+procedures are permitted ONLY for read operations (queries). All write operations
+(create, update, delete) MUST use server actions per Principle IX.
+
+EXAMPLE:
+// In teamsORPCRouter.ts
+const createTeamProcedure = os.createTeam
+  .use(authMiddleware)
+  .handler(({ input }) => actionCreateTeam(input.name));
+
+export const teamsORPCRouter = os.router({
+  createTeam: createTeamProcedure,  // VIOLATION: mutation via oRPC
+});
+
+SUGGESTION:
+// Remove from oRPC router - mutations should use server actions directly
+// In component, use useMutation with the server action:
+import { useMutation } from "@tanstack/react-query";
+import { actionCreateTeam } from "@features/teams";
+
+const mutation = useMutation({
+  mutationFn: (name: string) => actionCreateTeam(name),
+});
+```
+
+### Example 5: oRPC Violation - Incorrect File Naming
+
+```
+FINDING TYPE: architecture
+FILE: packages/features/reports/src/api/reportsRouter.ts
+LINES: 1-15
+PRINCIPLE: Principle XVIII (oRPC API Procedures) - Naming Conventions
+SEVERITY: medium
+
+DESCRIPTION:
+oRPC router file does not follow required naming convention. Per Principle XVIII,
+router files must be named `{feature}ORPCRouter.ts` and placed in `src/routers/` folder.
+Found: `src/api/reportsRouter.ts`
+Expected: `src/routers/reportsORPCRouter.ts`
+
+SUGGESTION:
+1. Rename file from `reportsRouter.ts` to `reportsORPCRouter.ts`
+2. Move from `src/api/` to `src/routers/`
+3. Update all imports referencing this file
+```
+
+### Example 6: API Stability Violation - Breaking Schema Change
+
+```
+FINDING TYPE: constitution
+FILE: packages/features/teams/src/contracts/teamsContract.ts
+LINES: 18-25
+PRINCIPLE: Principle XIX (API Endpoint Stability)
+SEVERITY: critical
+
+DESCRIPTION:
+Breaking change detected in output schema. The `memberCount` field was renamed to
+`membersCount` and `createdAt` field type changed from `string` to `Date`. Per
+Principle XIX, output schemas may add fields but must not remove or change the
+type of existing fields. This breaks backward compatibility for API consumers.
+
+EXAMPLE:
+// BEFORE (production):
+.output(z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  memberCount: z.number(),  // REMOVED/RENAMED
+  createdAt: z.string(),    // TYPE CHANGED
+}))
+
+// AFTER (PR):
+.output(z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  membersCount: z.number(), // Breaking: field renamed
+  createdAt: z.date(),      // Breaking: type changed
+}))
+
+SUGGESTION:
+// Preserve backward compatibility:
+.output(z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  memberCount: z.number(),           // Keep original
+  membersCount: z.number().optional(), // Add new (optional for transition)
+  createdAt: z.string(),             // Keep original type
+}))
+// Or create a new versioned endpoint: /v2/teams/{teamId}
+```
+
+### Example 7: Code Quality - High Complexity
+
+```
+FINDING TYPE: quality
+FILE: packages/features/reports/src/actions/actionGenerateReport.ts
+LINES: 45-120
+SEVERITY: medium
+
+DESCRIPTION:
+Function has high cyclomatic complexity with 12 conditional branches. This makes
+the code difficult to test and maintain. Consider breaking into smaller, focused
+functions.
+
+EXAMPLE:
+export async function actionGenerateReport(params: ReportParams) {
+  if (params.type === 'daily') {
+    if (params.includeMetrics) {
+      if (params.format === 'pdf') { /* ... */ }
+      else if (params.format === 'csv') { /* ... */ }
+      else { /* ... */ }
+    } else {
+      if (params.format === 'pdf') { /* ... */ }
+      // ... more nesting
+    }
+  } else if (params.type === 'weekly') {
+    // ... similar nesting
+  }
+  // ... continues with more branches
+}
+
+SUGGESTION:
+// Extract strategy pattern or use composition:
+const reportStrategies = {
+  daily: generateDailyReport,
+  weekly: generateWeeklyReport,
+  monthly: generateMonthlyReport,
+};
+
+const formatters = {
+  pdf: formatAsPdf,
+  csv: formatAsCsv,
+  json: formatAsJson,
+};
+
+export async function actionGenerateReport(params: ReportParams) {
+  const strategy = reportStrategies[params.type];
+  const formatter = formatters[params.format];
+  const data = await strategy(params);
+  return formatter(data, params.includeMetrics);
+}
+```
+
+### Example 8: Performance - N+1 Query Pattern
+
+```
+FINDING TYPE: quality
+FILE: packages/features/teams/src/actions/actionFetchTeamsWithMembers.ts
+LINES: 12-25
+SEVERITY: high
+
+DESCRIPTION:
+N+1 query pattern detected. For each team, a separate query fetches members.
+With 100 teams, this results in 101 database queries instead of 2.
+
+EXAMPLE:
+const teams = await supabase.from('teams').select('*');
+
+// N+1: One query per team
+const teamsWithMembers = await Promise.all(
+  teams.map(async (team) => {
+    const members = await supabase
+      .from('team_members')
+      .select('*')
+      .eq('team_id', team.id);
+    return { ...team, members };
+  })
+);
+
+SUGGESTION:
+// Single query with join:
+const { data: teams } = await supabase
+  .from('teams')
+  .select(`
+    *,
+    team_members (
+      id,
+      user_id,
+      role,
+      users (id, email, name)
+    )
+  `);
+```
+
+---
+
+## Markdown Output Template
+
+Use this template for the final review comment:
+
+```markdown
+**AI-Driven Deep Code Review Complete**
+
+## Summary
+
+Found **[TOTAL_COUNT]** issue(s) from 5 parallel auditors:
+
+### Auditor Results
+| Auditor | Findings |
+|---------|----------|
+| Security | [N] |
+| Architecture | [N] |
+| Constitution | [N] |
+| Code Quality | [N] |
+| API Stability | [N] |
+
+### Issue Breakdown by Severity
+| Severity | Count | Categories |
+|----------|-------|------------|
+| HIGH | [N] | [list affected categories] |
+| MEDIUM | [N] | [list affected categories] |
+| LOW | [N] | [list affected categories] |
+
+## Quick Navigation
+
+- [Critical Issues](#critical-issues-findings)
+- [Architecture Concerns](#architecture-concerns-findings)
+- [Code Quality Issues](#code-quality-findings)
+- [Constitution Violations](#constitution-violations-findings)
+- [oRPC/API Compliance](#orpc-api-compliance-findings)
+
+---
+
+## Critical Issues Findings
+
+Found **[COUNT]** critical issue(s):
+
+### Issue 1: [Issue Title]
+
+| Attribute | Value |
+|-----------|-------|
+| **File** | `path/to/file.ts` (lines X-Y) |
+| **Severity** | HIGH |
+| **Principle** | [Principle if applicable] |
+| **Impact** | [Brief impact description] |
+
+**Description:**
+Clear explanation of the critical issue and why it matters.
+
+<details>
+<summary>View Code</summary>
+
+**Problem Code:**
+\`\`\`typescript
+// Current problematic code
+\`\`\`
+
+**Recommended Fix:**
+\`\`\`typescript
+// Suggested fixed code
+\`\`\`
+
+</details>
+
+[... additional critical issues ...]
+
+---
+
+## Architecture Concerns Findings
+
+Found **[COUNT]** architecture issue(s):
+
+### Issue X: [Issue Title]
+[Same format as above]
+
+---
+
+## Code Quality Findings
+
+Found **[COUNT]** quality issue(s):
+
+### Issue Y: [Issue Title]
+[Same format as above]
+
+---
+
+## Constitution Violations Findings
+
+Found **[COUNT]** constitution issue(s):
+
+### Issue Z: [Issue Title]
+[Same format as above - include Principle field]
+
+---
+
+## oRPC/API Compliance Findings
+
+Found **[COUNT]** oRPC/API issue(s):
+
+### Issue A: [Issue Title]
+[Same format - always include Principle XVIII or XIX reference]
+
+---
+
+## Logic Flow Diagram
+
+[Include mermaid diagram if applicable - see guidelines below]
+
+---
+
+## Recommendations
+
+### Immediate Actions (Critical/High)
+1. [Specific actionable item]
+2. [Specific actionable item]
+
+### Should Address (Medium)
+1. [Specific actionable item]
+
+### Consider Later (Low)
+1. [Specific actionable item]
+
+---
+
+*Review generated: [TIMESTAMP]*
+*Auditors: Security, Architecture, Constitution, Code Quality, API Stability*
+*Constitution version: 1.31.0 (19 principles)*
+*Review findings are recommendations - use your judgment when deciding on fixes*
+```
+
+### Template Rules
+
+- Sort findings by category (critical -> architecture -> quality -> constitution -> oRPC/API)
+- Within each category, sort by severity (high -> medium -> low)
+- Use severity indicators: HIGH, MEDIUM, LOW
+- Include file paths with line numbers in attribute tables
+- Always provide both problem code and recommended fix
+- Use collapsible `<details>` blocks for code to reduce visual clutter
+- Use fenced code blocks with `typescript` language tag
+- Add severity breakdown table in summary
+- Add quick navigation table of contents for reviews with 5+ issues
+- Include prioritized recommendations (Immediate/Should Address/Consider Later)
+- Include constitution version and timestamp in footer
+- Deduplicate similar findings during analysis
+
+### If No Issues Found
+
+```markdown
+**AI-Driven Deep Code Review Complete**
+
+## Summary
+
+No issues found! All 5 auditors (Security, Architecture, Constitution, Code Quality, API Stability) completed their analysis and found no concerns.
+
+The code changes look good.
+
+---
+
+*Review generated: [TIMESTAMP]*
+*Auditors: Security, Architecture, Constitution, Code Quality, API Stability*
+*Constitution version: 1.31.0 (19 principles)*
+*Review findings are recommendations - use your judgment when deciding on fixes*
+```
+
+---
+
+## Mermaid Diagram Guidelines
+
+### When to Include
+
+- Multi-step pipelines or workflows
+- Request/response handling flows
+- State machines or state transitions
+- Data transformation pipelines
+- Async operation sequences
+- Decision trees with multiple branches
+- Event-driven flows
+
+### When to Skip
+
+- Single-file bug fixes
+- Style/UI-only changes
+- Configuration updates
+- Documentation changes
+- Simple CRUD operations
+
+### Diagram Types
+
+Use `flowchart TD` (top-down) for most flows, or `flowchart LR` (left-right) for linear pipelines.
+
+**Pipeline Flow Example:**
+```mermaid
+flowchart TD
+    A[User Request] --> B{Authenticated?}
+    B -->|Yes| C[Validate Input]
+    B -->|No| D[Return 401]
+    C --> E{Valid?}
+    E -->|Yes| F[Process Request]
+    E -->|No| G[Return 400]
+    F --> H[Save to Database]
+    H --> I[Return Success]
+```
+
+**State Machine Example:**
+```mermaid
+stateDiagram-v2
+    [*] --> Pending
+    Pending --> Processing: Start Job
+    Processing --> Completed: Success
+    Processing --> Failed: Error
+    Failed --> Processing: Retry
+    Completed --> [*]
+```
+
+**Sequence Flow Example:**
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+    participant Database
+    Client->>Server: POST /api/create
+    Server->>Database: INSERT record
+    Database-->>Server: Record ID
+    Server-->>Client: 201 Created
+```
+
+### Best Practices
+
+- Use descriptive node labels that match function/component names in the code
+- Include decision diamonds for conditional logic
+- Show error paths with dashed lines or distinct styling
+- Group related steps in subgraphs when helpful
+- Keep diagrams focused - one diagram per major flow, not the entire system
+
+---
+
+## Troubleshooting
+
+### Bash Parse Errors
+**Cause**: Complex multi-line scripts or special characters being escaped
+**Solution**: Run commands individually rather than as combined scripts. Avoid `!` in jq expressions (use positive matching instead of `!= "removed"`).
+
+### "Body cannot be blank" or Empty Response Error
+**Cause**: Empty or malformed JSON body in curl request
+**Solution**: Ensure the generated content is properly JSON-escaped (newlines as `\n`, quotes as `\"`).
+
+### GitHub API Authentication Issues
+**Cause**: GITHUB_TOKEN not set, invalid, or expired
+**Solution**:
+1. Verify token is set: `test -n "$GITHUB_TOKEN" && echo "Token set"`
+2. Test token validity: `curl -s -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user`
+3. Ensure token has `repo` scope for private repos or `public_repo` for public repos
+
+### Failed to Post Comment (401/403 Error)
+**Cause**: Authentication failure or insufficient permissions
+**Solution**:
+1. Verify token is valid: `curl -s -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user | jq .login`
+2. Check PR exists: `curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>" | jq .number`
+3. Ensure the PR number is correct
+
+### Failed to Update PR Title/Description (403/422 Error)
+**Cause**: Permission issue, invalid JSON, or invalid content
+**Solution**:
+1. Verify user has write access to the repository
+2. Check PR is not locked or merged
+3. Ensure token has appropriate permissions (repo scope)
+4. Verify generated JSON is valid (use `jq` to validate)
+5. Check for special characters that need escaping in JSON
+
+### Markdown Not Rendering Correctly on GitHub
+**Cause**: Markdown formatting issues in Task 3 output
+**Solution**:
+1. Verify code blocks use triple backticks with language tag: \`\`\`typescript
+2. Check all section headers use proper markdown: ## Header, ### Subheader
+3. Ensure empty lines between sections
+4. Use proper severity indicators: HIGH, MEDIUM, LOW
+
+### Mermaid Diagram Not Rendering
+**Cause**: Invalid mermaid syntax or formatting issues
+**Solution**:
+1. Ensure mermaid code block uses \`\`\`mermaid tag
+2. Validate syntax at https://mermaid.live/
+3. Check for unescaped special characters in node labels
+4. Ensure no extra whitespace before/after the mermaid block
+5. Use simple node IDs (letters/numbers) and put labels in brackets
+
+### Large PR Takes Too Long
+**Cause**: Too many files to analyze
+**Solution**: Focus on key files (.ts, .tsx) and skip generated/config files. Consider breaking into focused reviews per component category.
+
+---
+
+## Operating Principles
+
+### AI-Driven Analysis
+
+- **Semantic Understanding**: AI analyzes code meaning, not just patterns
+- **Context Awareness**: Full file and project context informs analysis
+- **Deep Bug Detection**: Focuses on logic errors, edge cases, race conditions
+- **Constitution Knowledge**: Understands all 19 principles and their implications (v1.31.0)
+- **oRPC Compliance**: Validates query-only usage, contract naming, folder structure
+- **API Stability Detection**: Identifies breaking changes in schemas and endpoints
+- **Code Quality Metrics**: Evaluates complexity, code smells, performance patterns
+- **Direct Markdown Generation**: AI produces final markdown output ready for GitHub
+- **Smart Deduplication**: Automatically merges similar findings during analysis
+- **Intelligent Sorting**: Organizes findings by severity and category
+- **Intelligent Suggestions**: Fixes are contextually appropriate and well-reasoned
+- **Smart Title Generation**: Creates meaningful, descriptive titles reflecting actual changes
+- **Comprehensive Description**: Generates well-structured PR descriptions with all necessary sections
+- **Logic Flow Visualization**: Creates mermaid diagrams to visualize complex logic flows when applicable
+
+### Review Guidelines
+
+- **Constructive Tone**: Provide helpful, specific feedback that guides improvement
+- **Priority-Based**: Focus on critical issues first (bugs, security, architecture)
+- **Context-Aware**: Comments reflect understanding of codebase, patterns, and project goals
+- **Actionable**: Every finding includes specific, concrete suggestions for improvement
+- **Educational**: Explain why issues matter and how fixes align with standards
+- **Complete Output**: Generate polished, publication-ready markdown (no preprocessing needed)
+- **Descriptive Metadata**: PR titles and descriptions clearly communicate the PR's purpose and changes
+- **Visual Documentation**: Include mermaid diagrams to help reviewers understand logic flows at a glance
+
+### Error Handling
+
+- **Graceful Degradation**: Continue review even if some operations fail
+- **Clear Messages**: Provide helpful guidance when issues occur
+- **Direct API Calls**: All GitHub interactions use curl with GitHub REST API (no external CLI dependencies)

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: pr-review
+description: AI-driven deep code review of pull requests with intelligent bug detection, architecture analysis, constitution compliance checking, and mermaid logic flow diagrams. Supports standard mode (post to GitHub) and local mode (create task list). Use when reviewing PRs, analyzing code changes, or checking architecture compliance.
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Task, TaskOutput, TaskCreate, TaskUpdate
+---
+
+# PR Review Skill
+
+This skill provides comprehensive pull request analysis with deep semantic understanding of code changes using **parallel specialized auditors**.
+
+## Capabilities
+
+1. **Parallel Sub-Agent Architecture** - 5 specialized auditors run concurrently for faster, deeper analysis:
+   - Security Auditor - Injection vulnerabilities, auth gaps, data exposure, race conditions
+   - Architecture Auditor - Import boundaries, monorepo structure, file organization, naming
+   - Constitution Auditor - All 21 project principles compliance verification
+   - Code Quality Auditor - Complexity, code smells, performance, testing gaps
+   - API Stability Auditor - oRPC compliance (Principle XVIII), breaking changes (Principle XIX)
+2. **Smart Aggregation** - Findings merged, deduplicated, and sorted by severity
+3. **PR Metadata Updates** - Automatically updates PR title and description (never just recommends)
+4. **Logic Flow Visualization** - Mermaid diagrams for complex workflows
+5. **Local Mode** - Create task list for local fixes instead of posting to GitHub
+
+## Usage Modes
+
+### Standard Mode (default)
+Posts review directly to GitHub PR:
+- `/pr-review` or `/pr-review 123`
+
+### Local Mode (`--local`)
+Creates a task list of issues to fix locally without posting to GitHub:
+- `/pr-review --local` or `/pr-review 123 --local`
+
+Use local mode when you want to:
+- Fix issues before requesting a formal review
+- Self-review changes before pushing
+- Iterate on fixes without cluttering PR comments
+
+## Quick Start
+
+When a pull request needs review, ask Claude to:
+- "Review this pull request"
+- "Analyze the changes in this PR"
+- "Check if these changes follow our constitution"
+- "Review this PR locally" (uses `--local` mode)
+
+Claude will automatically use this skill to perform comprehensive analysis.
+
+## Autonomous Execution
+
+This skill runs **fully autonomously** without user interaction. When invoked:
+
+- **Do NOT ask for user confirmation** at any step
+- **Do NOT pause** between tasks or wait for approval
+- **Proceed directly** through all workflow tasks
+- **Only stop** if a critical error occurs (gh CLI not authenticated, invalid PR number, or API failure)
+
+Execute the entire workflow from start to finish:
+- **Standard mode**: Posts review to GitHub automatically
+- **Local mode**: Creates task list for local fixes (no GitHub posting)
+
+## Operating Constraints
+
+- **GitHub CLI Required**: Must have `gh` authenticated and be in a git repository
+- **Parallel Execution**: Uses Task tool to launch 5 specialized auditors concurrently
+- **AI-Driven Analysis**: All findings generated through semantic analysis
+- **Constitution Knowledge**: Understands all 21 project principles (v1.35.0)
+- **Completion Criteria**: See [WORKFLOW.md](WORKFLOW.md) Tasks 7 and 8 for success criteria
+
+## Specialized Auditors
+
+| Auditor | Focus Area | Key Checks |
+|---------|------------|------------|
+| **Security** | Vulnerabilities | Injection, XSS, auth gaps, data exposure, race conditions |
+| **Architecture** | Structure | Import boundaries, file organization, naming conventions |
+| **Constitution** | 21 Principles | Full compliance with all project principles |
+| **Code Quality** | Maintainability | Complexity, code smells, performance, testing |
+| **API Stability** | oRPC/APIs | Principle XVIII & XIX, breaking changes |
+
+Each auditor runs independently via the Task tool and returns findings in a structured format for aggregation.
+
+## Workflow
+
+For the detailed workflow with parallel auditors, see [WORKFLOW.md](WORKFLOW.md).
+
+## Analysis Guide
+
+For analysis criteria, finding formats, and templates, see [ANALYSIS_GUIDE.md](ANALYSIS_GUIDE.md).
+
+## Output
+
+The skill **directly updates** the PR (not just recommends):
+1. **PR Title** - Updated via `gh pr edit --title` with conventional commit format
+2. **PR Description** - Updated via `gh pr edit --body` with structured markdown
+3. **Review Comment** - Posted via `gh pr comment` with categorized findings

--- a/.claude/skills/pr-review/WORKFLOW.md
+++ b/.claude/skills/pr-review/WORKFLOW.md
@@ -1,0 +1,597 @@
+# PR Review Workflow
+
+This document details the workflow for performing AI-driven code reviews with **parallel specialized auditors**. Both modes execute all 8 numbered tasks; in local mode, Task 2's GitHub posting step is skipped.
+
+## IMPORTANT: Autonomous Execution Mode
+
+**Execute this entire workflow autonomously without user interaction.**
+
+- **Do NOT ask for confirmation** before executing any task or command
+- **Do NOT pause** between tasks to await user approval
+- **Proceed immediately** from one task to the next
+- **Complete all 8 tasks** in sequence without stopping (in local mode, Task 2's posting step is skipped)
+
+**Standard mode (default):**
+- **Do NOT ask** before posting comments or updating the PR
+- **ALWAYS update** the PR title and description directly - never just recommend updates
+
+**Local mode (`--local` flag):**
+- **Do NOT post** any comments or updates to GitHub
+- **Create a task list** using TaskCreate for each finding that needs to be fixed
+- Use this mode when the user wants to fix issues locally before posting a review
+
+Only halt execution if a **critical error** occurs:
+- `gh` CLI is not authenticated or unavailable
+- PR number is invalid or PR does not exist
+- GitHub API returns persistent failures (after retries)
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Detecting Local Mode
+
+Parse `$ARGUMENTS` to detect if `--local` flag is present:
+- If `--local` is present: Run in local mode (create task list, skip GitHub posting)
+- Otherwise: Run in standard mode (post to GitHub)
+
+Examples:
+- `--local` → local mode, current branch PR
+- `123 --local` → local mode, PR #123
+- `--local 123` → local mode, PR #123
+- `123` → standard mode, PR #123
+- (empty) → standard mode, current branch PR
+
+## Important: Bash Execution Guidelines
+
+**Do NOT copy-paste the bash code blocks as single scripts.** Instead, run each command individually or in small groups. The examples below show the logical steps; Claude should execute them as separate Bash tool calls.
+
+---
+
+## Review Workflow Tasks
+
+> **Note:** Tasks 1, 3-6 execute identically in both modes. Tasks 2, 7, and 8 have mode-specific behavior (Task 2 is skipped in local mode).
+
+### Task 1: Validate Prerequisites and Gather PR Metadata
+
+Run these commands **individually** (not as a single script):
+
+**Step 1.1: Check prerequisites**
+```bash
+command -v gh && git rev-parse --git-dir && gh auth status
+```
+
+**Step 1.2: Get PR metadata as JSON**
+```bash
+gh pr view --json number,title,author,state,baseRefName,headRefName --jq '{number: .number, title: .title, author: .author.login, state: .state, base: .baseRefName, head: .headRefName}'
+```
+
+**Step 1.3: Get changed files list**
+```bash
+gh pr view --json files --jq '.files[].path'
+```
+
+Note: Store the PR number from Step 1.2 for use in subsequent commands (e.g., `PR_NUMBER=568`).
+
+**Success Criteria**: GitHub CLI is available and authenticated, git repository exists, PR metadata retrieved (number, title, author, state, base, head, changed files).
+
+---
+
+### Task 2: Post Starting Comment (Standard Mode Only)
+
+**In local mode, skip the GitHub posting step below and proceed directly to Task 3.**
+
+In standard mode, post a starting comment to indicate the AI review is in progress. Replace `<PR_NUMBER>` with the actual PR number from Task 1:
+
+```bash
+gh pr comment <PR_NUMBER> --body "**AI-Driven Deep Code Review Starting**
+
+The AI-powered review process is now analyzing this pull request using **5 parallel specialized auditors**:
+
+| Auditor | Focus |
+|---------|-------|
+| Security | Vulnerabilities, injection, auth gaps |
+| Architecture | Import boundaries, file organization |
+| Constitution | 21 project principles compliance |
+| Code Quality | Complexity, code smells, performance |
+| API Stability | oRPC compliance, breaking changes |
+
+Review findings will be posted shortly once all auditors complete their analysis."
+```
+
+**Success Criteria**:
+- Standard mode: Starting comment is posted to PR
+- Local mode: Task skipped, proceed to Task 3
+
+---
+
+### Task 3: Prepare Shared Context
+
+Read all files that will be shared with the auditor agents.
+
+#### Step 3.1: Read the Project Constitution
+
+Use the `Read` tool to read:
+- File: `constitution.md`
+
+Store the constitution content for the Constitution Auditor.
+
+#### Step 3.2: Read Changed Files
+
+For each file in the changed files list from Task 1, use the `Read` tool to read its full content. Focus on files with these extensions: `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.sql`, `.md`.
+
+Skip reading:
+- `package.json`, `package-lock.json`, `pnpm-lock.yaml`
+- Files in `node_modules/`
+- Binary files or images
+
+Store all file contents for the auditor agents.
+
+#### Step 3.3: Get PR Diff for Context
+
+Run this command to get the PR diff (replace `<PR_NUMBER>` with the actual number):
+
+```bash
+gh pr diff <PR_NUMBER>
+```
+
+Store the diff output for the auditor agents.
+
+**Success Criteria**: Constitution, all changed source files, and PR diff are read and stored for agents.
+
+---
+
+### Task 4: Launch Parallel Auditors
+
+**CRITICAL**: Launch ALL 5 agents in a **SINGLE message** with multiple Task tool calls. This enables parallel execution.
+
+Each agent receives:
+1. The list of changed files with their content
+2. The PR diff
+3. Agent-specific context (Constitution Auditor also gets constitution.md)
+
+**Launch these 5 agents simultaneously:**
+
+#### Agent 1: Security Auditor
+```
+Task tool call:
+- subagent_type: "general-purpose"
+- description: "Security audit PR"
+- run_in_background: true
+- prompt: |
+    You are a Security Auditor. Analyze these code changes for security vulnerabilities.
+
+    ## Instructions
+    Read the agent instructions at: .claude/skills/pr-review/agents/security-auditor.md
+
+    ## Changed Files
+    [Include file contents here]
+
+    ## PR Diff
+    [Include diff here]
+
+    Produce output in the specified ---AUDIT_FINDINGS--- format.
+```
+
+#### Agent 2: Architecture Auditor
+```
+Task tool call:
+- subagent_type: "general-purpose"
+- description: "Architecture audit PR"
+- run_in_background: true
+- prompt: |
+    You are an Architecture Auditor. Analyze these code changes for structural issues.
+
+    ## Instructions
+    Read the agent instructions at: .claude/skills/pr-review/agents/architecture-auditor.md
+
+    ## Changed Files
+    [Include file contents here]
+
+    ## PR Diff
+    [Include diff here]
+
+    Produce output in the specified ---AUDIT_FINDINGS--- format.
+```
+
+#### Agent 3: Constitution Auditor
+```
+Task tool call:
+- subagent_type: "general-purpose"
+- description: "Constitution audit PR"
+- run_in_background: true
+- prompt: |
+    You are a Constitution Auditor. Verify compliance with all 21 project principles.
+
+    ## Instructions
+    Read the agent instructions at: .claude/skills/pr-review/agents/constitution-auditor.md
+
+    ## Constitution
+    [Include constitution.md content here]
+
+    ## Changed Files
+    [Include file contents here]
+
+    ## PR Diff
+    [Include diff here]
+
+    Produce output in the specified ---AUDIT_FINDINGS--- format.
+```
+
+#### Agent 4: Code Quality Auditor
+```
+Task tool call:
+- subagent_type: "general-purpose"
+- description: "Quality audit PR"
+- run_in_background: true
+- prompt: |
+    You are a Code Quality Auditor. Analyze code for maintainability and performance.
+
+    ## Instructions
+    Read the agent instructions at: .claude/skills/pr-review/agents/code-quality-auditor.md
+
+    ## Changed Files
+    [Include file contents here]
+
+    ## PR Diff
+    [Include diff here]
+
+    Produce output in the specified ---AUDIT_FINDINGS--- format.
+```
+
+#### Agent 5: API Stability Auditor
+```
+Task tool call:
+- subagent_type: "general-purpose"
+- description: "API stability audit PR"
+- run_in_background: true
+- prompt: |
+    You are an API Stability Auditor. Check oRPC compliance and breaking changes.
+
+    ## Instructions
+    Read the agent instructions at: .claude/skills/pr-review/agents/api-stability-auditor.md
+
+    ## Changed Files
+    [Include file contents here]
+
+    ## PR Diff
+    [Include diff here]
+
+    Produce output in the specified ---AUDIT_FINDINGS--- format.
+```
+
+**Success Criteria**: All 5 Task tool calls made in a single message with `run_in_background: true`.
+
+---
+
+### Task 5: Collect Agent Results
+
+Use the `TaskOutput` tool to retrieve results from each agent. Wait for all agents to complete.
+
+```
+For each agent task_id from Task 4:
+  TaskOutput(task_id=<agent_task_id>, block=true)
+```
+
+Parse each agent's output to extract the `---AUDIT_FINDINGS---` block.
+
+**Success Criteria**: All 5 agent outputs collected with their findings.
+
+---
+
+### Task 6: Aggregate and Generate Review
+
+Combine all agent findings into the final review output.
+
+#### Step 6.1: Aggregate Findings
+
+1. **Parse** each agent's `---AUDIT_FINDINGS---` block
+2. **Merge** findings into categories:
+   - Critical Issues (security findings with HIGH severity)
+   - Architecture Concerns (architecture findings)
+   - Code Quality Issues (quality findings)
+   - Constitution Violations (constitution findings)
+   - oRPC/API Compliance (api findings)
+3. **Deduplicate** similar findings across agents
+4. **Sort** within each category by severity (HIGH → MEDIUM → LOW)
+
+#### Step 6.2: Generate PR Title and Description
+
+Based on the aggregated analysis, generate:
+
+**PR Title Format**: `type(scope): description`
+- `type`: feat, fix, refactor, docs, test, perf, chore, ci
+- `scope`: affected area (e.g., reports, dashboard, auth)
+- `description`: brief summary (max ~50 chars, lowercase, imperative mood)
+
+**PR Description Structure**:
+1. **Summary** (1-2 sentences)
+2. **Changes** (bullet list)
+3. **Logic Flow Diagram** (mermaid - if applicable)
+4. **Files Changed** (grouped by category)
+5. **Testing Notes** (if applicable)
+
+#### Step 6.3: Generate Final Review Comment
+
+Produce the final markdown review using the template from [ANALYSIS_GUIDE.md](ANALYSIS_GUIDE.md).
+
+**Output Format**:
+```
+---GENERATED_PR_TITLE---
+[Your generated title here]
+---END_GENERATED_PR_TITLE---
+
+---GENERATED_PR_BODY---
+[Your generated description markdown here]
+---END_GENERATED_PR_BODY---
+
+[Final markdown review comment for GitHub]
+```
+
+**Success Criteria**: Aggregated findings, PR title, PR body, and review comment generated.
+
+---
+
+### Task 7: Output Review Results
+
+This task differs based on the execution mode. Execute Task 7A for standard mode or Task 7B for local mode based on the detected mode from argument parsing.
+
+---
+
+#### Task 7A: Standard Mode - Post Review to GitHub
+
+**CRITICAL: Always update the PR title and description. Never just recommend updates.**
+
+After completing aggregation in Task 6, run these commands **individually** to post the review. Replace `<PR_NUMBER>` with the actual number.
+
+**Step 7.1: Update PR title (MANDATORY)**
+
+Always update the PR title with the generated conventional commit format title:
+
+```bash
+gh pr edit <PR_NUMBER> --title "<GENERATED_TITLE>"
+```
+
+**Step 7.2: Update PR description (MANDATORY)**
+
+Always replace the PR description with the generated body. Use a heredoc to preserve formatting:
+
+```bash
+gh pr edit <PR_NUMBER> --body "$(cat <<'EOF'
+<GENERATED_PR_BODY_HERE>
+EOF
+)"
+```
+
+**Step 7.3: Post review comment**
+
+Use a heredoc to preserve formatting:
+
+```bash
+gh pr comment <PR_NUMBER> --body "$(cat <<'EOF'
+<GENERATED_REVIEW_COMMENT_HERE>
+EOF
+)"
+```
+
+**Success Criteria**: PR title updated, PR description replaced, review comment posted to GitHub PR. All three actions are mandatory.
+
+---
+
+#### Task 7B: Local Mode - Create Task List for Fixes
+
+**Do NOT post anything to GitHub in local mode.**
+
+Instead, create a task list using the TaskCreate tool for each finding that needs to be fixed.
+
+**Step 7B.1: Create tasks for each finding**
+
+For each finding from the aggregated review (Task 6), invoke the TaskCreate tool. The YAML below shows the field names and values to use (invoke the tool directly, not via bash):
+
+```yaml
+# TaskCreate tool parameters:
+TaskCreate:
+  subject: "[SEVERITY] Category: Brief description"
+  description: |
+    **File**: path/to/file.ts:line
+    **Auditor**: Security/Architecture/Constitution/Code Quality/API Stability
+    **Severity**: HIGH/MEDIUM/LOW
+
+    **Issue**: Detailed description of the problem
+
+    **Suggested Fix**: How to resolve this issue
+
+    **Reference**: Link to relevant principle or guideline if applicable
+  activeForm: "Fixing [brief description]"
+```
+
+**Task naming convention:**
+- `[HIGH] Security: SQL injection vulnerability in user input`
+- `[MEDIUM] Architecture: Feature importing from another feature`
+- `[LOW] Code Quality: Missing error handling in async function`
+
+**Step 7B.2: Group tasks by priority**
+
+Create tasks in order of severity:
+1. HIGH severity findings first (critical/blocking issues)
+2. MEDIUM severity findings (should fix before merge)
+3. LOW severity findings (nice to have improvements)
+
+**Step 7B.3: Add summary task**
+
+After creating individual finding tasks, create a summary task:
+
+```yaml
+# TaskCreate tool parameters:
+TaskCreate:
+  subject: "PR Review Summary: X findings to address"
+  description: |
+    **PR**: #<PR_NUMBER> - <PR_TITLE>
+    **Branch**: <HEAD_BRANCH> → <BASE_BRANCH>
+
+    **Findings Summary**:
+    - HIGH: X findings
+    - MEDIUM: Y findings
+    - LOW: Z findings
+    - Total: N findings
+
+    **Suggested PR Title**: <GENERATED_TITLE>
+
+    **Next Steps**:
+    1. Address HIGH severity issues first
+    2. Fix MEDIUM severity issues
+    3. Consider LOW severity improvements
+    4. Run `/pr-review` (without --local) when ready for GitHub posting
+  activeForm: "Reviewing PR findings"
+```
+
+**Success Criteria**: Task list created with all findings. Each finding has its own task with file location, description, and suggested fix.
+
+---
+
+### Task 8: Summary
+
+Display a final summary to the user (as text output, not a bash command). This task differs based on the execution mode.
+
+---
+
+#### Task 8A: Standard Mode Summary
+
+Include:
+- PR number, title, author, branch
+- Number of files analyzed
+- Auditor results summary (findings per auditor)
+- Actions taken (title updated, description updated, comment posted)
+
+**Example summary format**:
+
+```
+## AI-Driven PR Review Complete
+
+**PR**: #568 - feat(auth): add login validation
+**Author**: username
+**Branch**: feature-branch -> main
+**Status**: OPEN
+
+### Auditor Results
+| Auditor | Findings |
+|---------|----------|
+| Security | 2 |
+| Architecture | 1 |
+| Constitution | 3 |
+| Code Quality | 4 |
+| API Stability | 0 |
+| **Total** | **10** |
+
+### Actions Completed
+1. Ran 5 parallel auditors on X changed files
+2. Aggregated and deduplicated findings
+3. Updated PR title with conventional commit format
+4. Updated PR description with comprehensive summary
+5. Posted detailed review comment to GitHub
+```
+
+**Success Criteria**: Summary displayed with PR metadata, auditor results, and completed actions.
+
+---
+
+#### Task 8B: Local Mode Summary
+
+Include:
+- PR number, title, author, branch
+- Number of files analyzed
+- Auditor results summary (findings per auditor)
+- Task list summary (number of tasks created)
+- Next steps for the user
+
+**Example summary format**:
+
+```
+## AI-Driven PR Review Complete (Local Mode)
+
+**PR**: #568 - feat(auth): add login validation
+**Author**: username
+**Branch**: feature-branch -> main
+**Status**: OPEN
+
+### Auditor Results
+| Auditor | Findings |
+|---------|----------|
+| Security | 2 |
+| Architecture | 1 |
+| Constitution | 3 |
+| Code Quality | 4 |
+| API Stability | 0 |
+| **Total** | **10** |
+
+### Tasks Created
+- 2 HIGH severity tasks
+- 4 MEDIUM severity tasks
+- 4 LOW severity tasks
+- 1 Summary task
+- **Total**: 11 tasks
+
+### Next Steps
+1. Review the task list with `/tasks`
+2. Address HIGH severity issues first
+3. Work through MEDIUM and LOW severity items
+4. Run `/pr-review` (without --local) when ready to post to GitHub
+```
+
+**Success Criteria**: Summary displayed with PR metadata, auditor results, task list summary, and next steps for local fixes.
+
+---
+
+## Workflow Diagram
+
+### Standard Mode
+```mermaid
+flowchart TD
+    T1[Task 1: Prerequisites & Metadata] --> T2[Task 2: Post Starting Comment]
+    T2 --> T3[Task 3: Prepare Shared Context]
+    T3 --> T4[Task 4: Launch 5 Parallel Auditors]
+
+    T4 --> A1[Security Auditor]
+    T4 --> A2[Architecture Auditor]
+    T4 --> A3[Constitution Auditor]
+    T4 --> A4[Code Quality Auditor]
+    T4 --> A5[API Stability Auditor]
+
+    A1 --> T5[Task 5: Collect Results]
+    A2 --> T5
+    A3 --> T5
+    A4 --> T5
+    A5 --> T5
+
+    T5 --> T6[Task 6: Aggregate & Generate]
+    T6 --> T7A[Task 7A: Post to GitHub]
+    T7A --> T8A[Task 8A: Summary]
+```
+
+### Local Mode (`--local`)
+
+```mermaid
+flowchart TD
+    T1[Task 1: Prerequisites & Metadata] --> T2[Task 2: Skipped]
+    T2 -.-> T3[Task 3: Prepare Shared Context]
+    T3 --> T4[Task 4: Launch 5 Parallel Auditors]
+    style T2 fill:#f5f5f5,stroke:#999,stroke-dasharray: 5 5
+
+    T4 --> A1[Security Auditor]
+    T4 --> A2[Architecture Auditor]
+    T4 --> A3[Constitution Auditor]
+    T4 --> A4[Code Quality Auditor]
+    T4 --> A5[API Stability Auditor]
+
+    A1 --> T5[Task 5: Collect Results]
+    A2 --> T5
+    A3 --> T5
+    A4 --> T5
+    A5 --> T5
+
+    T5 --> T6[Task 6: Aggregate & Generate]
+    T6 --> T7B[Task 7B: Create Task List]
+    T7B --> T8B[Task 8B: Local Summary]
+```

--- a/.claude/skills/pr-review/agents/api-stability-auditor.md
+++ b/.claude/skills/pr-review/agents/api-stability-auditor.md
@@ -1,0 +1,150 @@
+# API Stability Auditor
+
+You are an API stability auditor. Your sole responsibility is to verify oRPC compliance and detect breaking API changes per Principles XVIII and XIX.
+
+## Focus Areas
+
+### Principle XVIII: oRPC API Procedures
+
+#### Query-Only Restriction (CRITICAL)
+oRPC procedures are permitted ONLY for read operations. Flag ANY oRPC procedure that performs:
+- Create operations
+- Update operations
+- Delete operations
+- Any state-modifying action
+
+Mutations MUST use server actions per Principle IX.
+
+#### Contract-First Pattern
+Verify proper contract-first development:
+- **Contracts Location**: `src/contracts/{feature}Contract.ts`
+- **Routers Location**: `src/routers/{feature}ORPCRouter.ts`
+- **Contract Definition**: Using `oc.router()` from `@orpc/contract`
+- **Router Implementation**: Using `implement(contract)` from `@orpc/server`
+
+#### Naming Conventions
+- Contract files: `{feature}Contract.ts` (e.g., `teamsContract.ts`)
+- Router files: `{feature}ORPCRouter.ts` (e.g., `teamsORPCRouter.ts`)
+- Procedure names: camelCase (e.g., `teamReports`, `reportBrands`)
+
+### Principle XIX: API Endpoint Stability
+
+#### Breaking Changes Detection
+Flag any changes that break backward compatibility:
+
+**URL Breaking Changes (CRITICAL)**
+- Changing existing endpoint paths
+- Removing endpoints
+- Renaming route segments
+
+**Input Schema Breaking Changes (HIGH)**
+- Removing input fields
+- Renaming input fields
+- Changing required fields to have different types
+- Making optional fields required
+
+**Output Schema Breaking Changes (HIGH)**
+- Removing output fields
+- Changing output field types
+- Renaming output fields
+
+#### Allowed Changes (Non-Breaking)
+- Adding new optional input fields
+- Adding new output fields
+- Adding new endpoints
+- Adding new procedures
+
+### Infrastructure Locations
+
+Verify correct import paths:
+- Base procedures: `@infrastructure/orpc/src/server/`
+- Client configuration: `@infrastructure/orpc/src/client/`
+- Feature contracts: `@features/*/src/contracts/`
+- Feature routers: `@features/*/src/routers/`
+
+## Input
+
+You will receive:
+1. **Changed Files Content** - Full content of modified source files
+2. **PR Diff** - The actual changes being made
+
+Focus on files in:
+- `src/contracts/` directories
+- `src/routers/` directories
+- Any file importing from `@orpc/*` or `@infrastructure/orpc`
+
+## Output Format
+
+Produce findings in this exact format:
+
+```
+---AUDIT_FINDINGS---
+AGENT: api-stability-auditor
+FINDINGS_COUNT: [N]
+
+### Finding 1
+- **Type**: api
+- **Severity**: [HIGH|MEDIUM|LOW]
+- **File**: path/to/file.ts (lines X-Y)
+- **Principle**: Principle [XVIII|XIX]
+- **Category**: [mutation-in-orpc|contract-location|router-location|naming|breaking-url|breaking-input|breaking-output]
+- **Description**: [Clear explanation of the API compliance issue]
+- **Code**:
+```typescript
+// Problematic code
+```
+- **Suggestion**:
+```typescript
+// Compliant implementation
+```
+
+### Finding 2
+...
+---END_AUDIT_FINDINGS---
+```
+
+If no API issues found:
+```
+---AUDIT_FINDINGS---
+AGENT: api-stability-auditor
+FINDINGS_COUNT: 0
+---END_AUDIT_FINDINGS---
+```
+
+## Severity Guidelines
+
+- **HIGH**: Mutation in oRPC procedure, breaking schema changes, breaking URL changes
+- **MEDIUM**: Wrong file location, naming convention violations
+- **LOW**: Minor naming inconsistencies, import path suggestions
+
+## Examples
+
+### Mutation in oRPC (HIGH - Principle XVIII)
+```typescript
+// VIOLATION: oRPC performing mutation
+const createTeamProcedure = os.createTeam
+  .use(authMiddleware)
+  .handler(({ input }) => actionCreateTeam(input.name));
+```
+
+### Breaking Output Change (HIGH - Principle XIX)
+```typescript
+// BEFORE (production)
+.output(z.object({
+  id: z.string(),
+  memberCount: z.number(),  // Exists in production
+}))
+
+// AFTER (PR) - VIOLATION: field renamed
+.output(z.object({
+  id: z.string(),
+  membersCount: z.number(),  // Breaking: renamed from memberCount
+}))
+```
+
+### Wrong Contract Location (MEDIUM - Principle XVIII)
+```typescript
+// VIOLATION: Contract not in src/contracts/ folder
+// Found at: src/api/teamsContract.ts
+// Should be: src/contracts/teamsContract.ts
+```

--- a/.claude/skills/pr-review/agents/architecture-auditor.md
+++ b/.claude/skills/pr-review/agents/architecture-auditor.md
@@ -1,0 +1,94 @@
+# Architecture Auditor
+
+You are an architecture-focused code auditor. Your sole responsibility is to analyze code changes for structural and architectural issues in this monorepo.
+
+## Focus Areas
+
+Analyze the provided code changes for these architectural concerns:
+
+### Monorepo Import Boundaries (Principles I & II)
+- **Feature-to-Feature Imports** - Features importing directly from other features (VIOLATION)
+- **Deep Path Imports** - Importing from feature internal paths like `@features/x/src/components/...`
+- **Correct Pattern**: Features can ONLY import from:
+  - Infrastructure packages: `@infrastructure/*`
+  - Their own internal paths
+  - Public exports from other features (Surface/Handler/Layout patterns only)
+
+### File Organization (Principle III)
+- **Missing Folders** - Required folders not present: `actions/`, `queries/`, `mutations/`, `contracts/`, `routers/`, `components/`, `surfaces/`, `schemas/`, `layouts/`
+- **Misplaced Files** - Files in wrong folders (e.g., server action not in `actions/`)
+- **Naming Violations**:
+  - Server actions must be `action{Name}.ts` in `actions/` folder
+  - Query options must be `get{Name}QueryOptions.ts` in `queries/` folder
+  - Mutation options must be `get{Name}MutationOptions.ts` in `mutations/` folder
+  - Contracts must be `{feature}Contract.ts` in `contracts/` folder
+  - Routers must be `{feature}ORPCRouter.ts` in `routers/` folder
+
+### Feature Exposure Patterns (Principle XIII)
+- **Invalid Exports** - Exposing internal components/functions that should not be public
+- **Missing Surfaces** - UI components accessed outside package without Surface wrapper
+- **Missing Handlers** - API logic accessed without Handler function wrapper
+- **Suffix Requirements**:
+  - Surface components must have `Surface` suffix
+  - Layout components must have `Layout` suffix
+  - Handler functions must have `handle` prefix
+
+### Component Organization
+- **File Extension Misuse** - Using `.tsx` when no JSX present (should be `.ts`)
+- **Multiple Exports** - Feature files with multiple exports (should have one default export)
+- **God Components** - Components doing too much (mixing data fetching, state, UI, business logic)
+
+### Infrastructure Usage (Principle IV)
+- **Duplicate Implementations** - Re-implementing functionality that exists in `@infrastructure/*`
+- **Missing Infrastructure Usage** - Not using available infrastructure packages
+
+## Input
+
+You will receive:
+1. **Changed Files Content** - Full content of modified source files
+2. **PR Diff** - The actual changes being made
+
+Focus ONLY on architecture issues. Ignore security, code quality, and style concerns.
+
+## Output Format
+
+Produce findings in this exact format:
+
+```
+---AUDIT_FINDINGS---
+AGENT: architecture-auditor
+FINDINGS_COUNT: [N]
+
+### Finding 1
+- **Type**: architecture
+- **Severity**: [HIGH|MEDIUM|LOW]
+- **File**: path/to/file.ts (lines X-Y)
+- **Principle**: [Principle I|II|III|IV|XIII]
+- **Description**: [Clear explanation of the architectural violation]
+- **Code**:
+```typescript
+// Problematic import or structure
+```
+- **Suggestion**:
+```typescript
+// Correct architectural pattern
+```
+
+### Finding 2
+...
+---END_AUDIT_FINDINGS---
+```
+
+If no architecture issues found:
+```
+---AUDIT_FINDINGS---
+AGENT: architecture-auditor
+FINDINGS_COUNT: 0
+---END_AUDIT_FINDINGS---
+```
+
+## Severity Guidelines
+
+- **HIGH**: Import boundary violation, feature-to-feature import, missing required folder structure
+- **MEDIUM**: Naming convention violation, misplaced files, missing Surface/Handler wrappers
+- **LOW**: File extension misuse, minor organizational improvements

--- a/.claude/skills/pr-review/agents/code-quality-auditor.md
+++ b/.claude/skills/pr-review/agents/code-quality-auditor.md
@@ -1,0 +1,102 @@
+# Code Quality Auditor
+
+You are a code quality auditor. Your sole responsibility is to analyze code changes for maintainability, reliability, and performance issues.
+
+## Focus Areas
+
+Analyze the provided code changes for these quality concerns:
+
+### Complexity Issues
+- **Long Functions** - Functions exceeding 50 lines (should be refactored)
+- **High Cyclomatic Complexity** - More than 10 branches in a single function
+- **Deep Nesting** - More than 3 levels of nested conditionals/loops
+- **Too Many Parameters** - Functions with more than 5 parameters (use object parameter)
+- **God Components** - React components doing too much (data fetching + state + UI + business logic)
+
+### Code Smells
+- **Duplicated Code** - Copy-pasted logic that should be extracted
+- **Dead Code** - Unused functions, variables, imports
+- **Magic Numbers/Strings** - Hardcoded values that should be constants
+- **Primitive Obsession** - Using primitives instead of domain types
+- **Feature Envy** - Functions that access other objects' data excessively
+- **Long Parameter Lists** - Should use parameter objects
+
+### Error Handling
+- **Missing Error Handling** - Async operations without try/catch or .catch()
+- **Swallowed Errors** - Empty catch blocks or catch without proper handling
+- **Generic Error Messages** - Errors that don't provide useful context
+- **Missing Type Guards** - Unsafe type narrowing
+
+### TypeScript Quality
+- **Missing Type Annotations** - Important functions without return types
+- **Unsafe Type Assertions** - Using `as` without proper validation
+- **Type Widening Issues** - Types that are too broad (but NOT `any`/`unknown` - that's constitution)
+
+### Performance Concerns
+- **N+1 Query Patterns** - Fetching related data in loops
+- **Missing Memoization** - Expensive computations without useMemo/useCallback
+- **Unnecessary Re-renders** - Missing React.memo for pure components
+- **Large Bundle Imports** - Importing entire libraries instead of specific modules
+- **Missing Code Splitting** - Large components that should be lazy-loaded
+
+### Testing Gaps
+- **Missing Tests** - New server actions or complex logic without tests
+- **Insufficient Coverage** - Tests that don't cover edge cases or error paths
+- **Hardcoded Test Values** - Values that should be configurable or factored
+
+### React-Specific Issues
+- **Missing Keys** - Lists without proper key props
+- **Inline Object/Function Props** - Creating new references on every render
+- **State Management Issues** - Derived state that should be computed
+- **Effect Dependencies** - Missing or incorrect useEffect dependencies
+
+## Input
+
+You will receive:
+1. **Changed Files Content** - Full content of modified source files
+2. **PR Diff** - The actual changes being made
+
+Focus ONLY on code quality issues. Ignore security, architecture, and constitution concerns.
+
+## Output Format
+
+Produce findings in this exact format:
+
+```
+---AUDIT_FINDINGS---
+AGENT: code-quality-auditor
+FINDINGS_COUNT: [N]
+
+### Finding 1
+- **Type**: quality
+- **Severity**: [HIGH|MEDIUM|LOW]
+- **File**: path/to/file.ts (lines X-Y)
+- **Category**: [complexity|smell|error-handling|typescript|performance|testing|react]
+- **Description**: [Clear explanation of the quality issue and its impact]
+- **Code**:
+```typescript
+// Problematic code
+```
+- **Suggestion**:
+```typescript
+// Improved implementation
+```
+
+### Finding 2
+...
+---END_AUDIT_FINDINGS---
+```
+
+If no quality issues found:
+```
+---AUDIT_FINDINGS---
+AGENT: code-quality-auditor
+FINDINGS_COUNT: 0
+---END_AUDIT_FINDINGS---
+```
+
+## Severity Guidelines
+
+- **HIGH**: N+1 queries, swallowed errors, missing error handling on critical paths, severe complexity
+- **MEDIUM**: Missing memoization, code smells, moderate complexity, missing tests
+- **LOW**: Minor style improvements, optional optimizations, documentation gaps

--- a/.claude/skills/pr-review/agents/constitution-auditor.md
+++ b/.claude/skills/pr-review/agents/constitution-auditor.md
@@ -1,0 +1,122 @@
+# Constitution Auditor
+
+You are a constitution compliance auditor. Your sole responsibility is to verify code changes comply with the 21 project principles defined in the TrioSens Constitution.
+
+## The 21 Principles
+
+Review changes against ALL applicable principles:
+
+### Structural Principles
+- **I. Monorepo Structure** - Three package types (Infrastructure, Features, Apps) with strict import boundaries
+- **II. Feature-Based Architecture** - Features as standalone packages, only importing from infrastructure
+- **III. Feature Package Naming** - Standardized naming and directory structure (actions/, queries/, mutations/, contracts/, routers/, components/, surfaces/, schemas/, layouts/)
+- **IV. Infrastructure Package Priority** - Prioritize @infrastructure/shadcn, @infrastructure/navigation, @infrastructure/supabase
+- **V. pnpm Catalog Protocol** - Dependencies via pnpm catalog, no direct declarations
+
+### TypeScript & Routing
+- **VI. TypeScript Standardization** - Use @infrastructure/typescript-config, database types from supabase, no `any` or `unknown`
+- **VII. Typesafe Routing** - Use @infrastructure/navigation (useTypedRouter, redirect, Link), never direct next/navigation
+
+### Development Patterns
+- **VIII. Test-Driven Development** - Tests before implementation, Vitest framework, comprehensive coverage
+- **IX. Server Actions Architecture** - ⚠️ DEPRECATED - Use oRPC procedures instead; legacy actions in actions folder return `ServerActionResult<T>`
+- **X. Shadcn UI Components Priority** - Mandatory for common UI patterns
+- **XI. Form Validation and UI** - Zod schemas + TanStack Form + shadcn Field components
+- **XII. TanStack Query Data Fetching** - useQuery with query options, never useEffect for data loading
+- **XII-A. TanStack Mutation** - useMutation with server actions for all data modifications
+
+### Feature Exposure & Data
+- **XIII. Feature Exposure Patterns** - Surface, Handler, Layout patterns for public API
+- **XIV. DataTable Component Priority** - Use @infrastructure/shadcn datatable
+- **XV. Next.js Server Components** - Pages as server components, client components only for interactivity
+- **XVI. Authentication Verification** - Auth in pages/layouts; RLS protection for server actions (no redundant getUser())
+- **XVII. Database Logic Centralization** - All DB logic in @infrastructure/supabase, JSON columns validated with zod
+
+### API Principles
+- **XVIII. oRPC API Procedures** - Unified mechanism for ALL server communication (queries + mutations), contract-first pattern, proper naming ({feature}Contract.ts, {feature}ORPCRouter.ts)
+- **XIX. API Endpoint Stability** - No breaking URL/schema changes without versioning
+
+### Feature & Configuration Principles
+- **XX. Feature Flags Architecture** - Use @vercel/flags SDK, flags in `flags/` folder, camelCase with "use" prefix, kebab-case keys
+- **XXI. Timezone Handling** - Local Input, Local Display principle; use local timezone methods for date iteration and display
+
+## Key Compliance Checks
+
+### Server Action Compliance (Principle IX) ⚠️ DEPRECATED
+> New code should use oRPC procedures (Principle XVIII) instead.
+
+Legacy server actions (if still in use):
+- Has "use server" directive
+- Function name starts with "action"
+- Located in `actions/` folder
+- Returns `ServerActionResult<T>`
+- One exported function per file
+
+### oRPC Compliance (Principle XVIII)
+- oRPC is the unified mechanism for ALL server communication (queries AND mutations)
+- Contracts in `src/contracts/{feature}Contract.ts`
+- Routers in `src/routers/{feature}ORPCRouter.ts`
+- Procedures in `src/procedures/` folder
+- Procedure names in camelCase
+- Throw `ORPCError` for errors (not `ServerActionResult`)
+
+### Data Fetching Compliance (Principle XII)
+- Uses TanStack Query hooks (useQuery, useMutation)
+- NO useEffect for data loading
+- Query options in dedicated files
+
+### Routing Compliance (Principle VII)
+- Uses @infrastructure/navigation imports
+- NO direct next/navigation or next/link imports
+
+## Input
+
+You will receive:
+1. **Changed Files Content** - Full content of modified source files
+2. **PR Diff** - The actual changes being made
+3. **Constitution** - Full constitution document for reference
+
+Focus ONLY on constitution principle violations. Ignore general security and code quality concerns unless they directly violate a principle.
+
+## Output Format
+
+Produce findings in this exact format:
+
+```
+---AUDIT_FINDINGS---
+AGENT: constitution-auditor
+FINDINGS_COUNT: [N]
+
+### Finding 1
+- **Type**: constitution
+- **Severity**: [HIGH|MEDIUM|LOW]
+- **File**: path/to/file.ts (lines X-Y)
+- **Principle**: Principle [NUMBER] ([NAME])
+- **Description**: [Clear explanation of how the code violates the principle]
+- **Code**:
+```typescript
+// Code that violates the principle
+```
+- **Suggestion**:
+```typescript
+// Code that complies with the principle
+```
+
+### Finding 2
+...
+---END_AUDIT_FINDINGS---
+```
+
+If no constitution violations found:
+```
+---AUDIT_FINDINGS---
+AGENT: constitution-auditor
+FINDINGS_COUNT: 0
+---END_AUDIT_FINDINGS---
+```
+
+## Severity Guidelines
+
+- **HIGH**: Core principle violation (import boundaries, server action architecture, oRPC misuse)
+- **MEDIUM**: Pattern violation (missing Surface wrapper, wrong folder location, naming issues)
+- **LOW**: Minor convention deviation, missing but optional patterns

--- a/.claude/skills/pr-review/agents/security-auditor.md
+++ b/.claude/skills/pr-review/agents/security-auditor.md
@@ -1,0 +1,85 @@
+# Security Auditor
+
+You are a security-focused code auditor. Your sole responsibility is to analyze code changes for security vulnerabilities.
+
+## Focus Areas
+
+Analyze the provided code changes for these security concerns:
+
+### Critical Security Issues
+- **SQL/NoSQL Injection** - Unsanitized user input in database queries
+- **XSS (Cross-Site Scripting)** - Unescaped output, dangerouslySetInnerHTML misuse
+- **Authentication Gaps** - Missing auth checks in routes/pages, session issues
+- **Authorization Bypass** - Improper access control, privilege escalation paths
+- **Sensitive Data Exposure** - Secrets in code, PII leaks, insecure storage
+- **CSRF Vulnerabilities** - Missing CSRF tokens on state-changing operations
+
+### Logic Security Issues
+- **Race Conditions** - TOCTOU bugs, concurrent state modification
+- **Insecure Randomness** - Predictable IDs, weak token generation
+- **Path Traversal** - User-controlled file paths without validation
+- **Deserialization Risks** - Untrusted JSON/data parsing without validation
+- **Command Injection** - User input in shell commands or child processes
+
+### Framework-Specific Issues (Next.js/React)
+- **Server Action Security** - Direct object access, missing input validation
+- **API Route Protection** - Missing auth middleware, exposed endpoints
+- **Client-Side Secrets** - API keys or secrets exposed to browser
+- **Redirect Vulnerabilities** - Open redirects in navigation logic
+
+## RLS Consideration
+
+**Important**: Server actions that query Supabase tables with Row Level Security (RLS) do NOT require explicit `getUser()` checks. RLS enforcement is automatic. Only flag missing auth if:
+1. The table does NOT have RLS enabled
+2. The operation bypasses RLS (using service role client)
+3. Auth is needed for business logic (not just data protection)
+
+## Input
+
+You will receive:
+1. **Changed Files Content** - Full content of modified source files
+2. **PR Diff** - The actual changes being made
+
+Focus ONLY on security issues. Ignore code quality, architecture, and style concerns.
+
+## Output Format
+
+Produce findings in this exact format:
+
+```
+---AUDIT_FINDINGS---
+AGENT: security-auditor
+FINDINGS_COUNT: [N]
+
+### Finding 1
+- **Type**: critical
+- **Severity**: [HIGH|MEDIUM|LOW]
+- **File**: path/to/file.ts (lines X-Y)
+- **Description**: [Clear explanation of the security risk and potential impact]
+- **Code**:
+```typescript
+// Problematic code snippet
+```
+- **Suggestion**:
+```typescript
+// Recommended secure implementation
+```
+
+### Finding 2
+...
+---END_AUDIT_FINDINGS---
+```
+
+If no security issues found:
+```
+---AUDIT_FINDINGS---
+AGENT: security-auditor
+FINDINGS_COUNT: 0
+---END_AUDIT_FINDINGS---
+```
+
+## Severity Guidelines
+
+- **HIGH**: Exploitable vulnerability, data breach risk, auth bypass
+- **MEDIUM**: Potential vulnerability requiring specific conditions
+- **LOW**: Security best practice violation, defense-in-depth improvement

--- a/.claude/skills/update-pr-title/SKILL.md
+++ b/.claude/skills/update-pr-title/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: update-pr-title
+description: Updates the PR title based on the changes in the PR using conventional commit format.
+allowed-tools: Bash(gh:*), Bash(git:*), Read
+---
+
+# Update PR Title Skill
+
+Updates the current PR's title based on analysis of the changes.
+
+## Usage
+
+Invoke with `/update-pr-title` or `/update-pr-title <PR-number>`.
+
+## Workflow
+
+1. **Get PR info**: Run `gh pr view` to get the current PR (or specified PR number)
+2. **Get diff**: Run `gh pr diff` to see the changes
+3. **Analyze**: Review the diff to understand what changed
+4. **Generate title**: Create a conventional commit-style title:
+   - `feat(scope): description` for new features
+   - `fix(scope): description` for bug fixes
+   - `refactor(scope): description` for refactoring
+   - `docs(scope): description` for documentation
+   - `chore(scope): description` for maintenance
+5. **Update**: Run `gh pr edit --title "new title"` to update the PR
+
+## Execution
+
+Run autonomously without user confirmation. Execute all steps and report the result.
+
+### Step 1: Get PR Information
+
+```bash
+gh pr view --json number,title,headRefName
+```
+
+If a PR number was provided as an argument, use:
+```bash
+gh pr view <PR-number> --json number,title,headRefName
+```
+
+### Step 2: Get the Diff
+
+```bash
+gh pr diff
+```
+
+### Step 3: Analyze and Update
+
+After analyzing the diff:
+1. Determine the primary type of change (feat/fix/refactor/docs/chore)
+2. Identify the scope (affected area/package)
+3. Write a concise description of the change
+4. Update the PR:
+
+```bash
+gh pr edit --title "type(scope): description"
+```
+
+## Output
+
+Report the old title and new title after updating.

--- a/.claude/skills/vercel-react-best-practices
+++ b/.claude/skills/vercel-react-best-practices
@@ -1,0 +1,1 @@
+../../.agents/skills/vercel-react-best-practices

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: worktree
+description: Create a git worktree with Graphite tracking and local config setup for isolated feature work.
+allowed-tools: Bash(git:*), Bash(gt:*), Bash(gh:*), Bash(ln:*), Bash(ls:*), Bash(pnpm:*), Bash(mkdir:*), Bash(test:*), Read
+---
+
+# Worktree Skill
+
+Creates a git worktree with Graphite tracking, symlinked env files, and installed dependencies.
+
+## Usage
+
+Invoke with `/worktree <branch-name>` and optionally `--parent <branch>`.
+
+- `/worktree my-feature` — new branch `my-feature`, tracked to `staging`
+- `/worktree my-feature --parent main` — new branch tracked to `main`
+- `/worktree existing-branch` — checks out existing branch into worktree (no `-b`)
+- `/worktree` — prompts for branch name (only interactive step)
+
+## Autonomous Execution
+
+This skill runs **fully autonomously** without user interaction (except when no branch name is provided). When invoked:
+
+- **Do NOT ask for user confirmation** at any step
+- **Do NOT pause** between tasks or wait for approval
+- **Proceed directly** through all workflow steps
+- **Only stop** if a critical error occurs
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Extract the branch name and optional `--parent` flag from the arguments.
+
+- If no branch name is provided, prompt the user for one. This is the **only** interactive step.
+- Default parent: `staging`
+
+### Step 2: Validate Preconditions
+
+Determine the repo root (all paths are relative to it):
+
+```bash
+git rev-parse --show-toplevel
+```
+
+Check if the worktree path already exists:
+
+```bash
+test -d .worktrees/<name>
+```
+
+If it exists, report an error with a removal hint and stop:
+
+```
+Error: .worktrees/<name> already exists.
+To remove it: git worktree remove .worktrees/<name>
+```
+
+Check if the branch exists locally:
+
+```bash
+git branch --list <name>
+```
+
+If the branch exists, check it's not already checked out in another worktree:
+
+```bash
+git worktree list
+```
+
+If the branch is checked out elsewhere, report which worktree has it and stop.
+
+For **new branches only**, check if a PR already exists for this branch name (to avoid reusing a name that has an existing PR):
+
+```bash
+gh pr list --head <name> --state all --json number,title,state --limit 1
+```
+
+If a PR is found, automatically append a numeric suffix to find a unique name. Try `<name>-v2`, then `<name>-v3`, etc., checking each with `gh pr list` until a name with no existing PR is found. Use the unique name as the branch name for all subsequent steps (worktree directory name stays as the original `<name>`). Report the rename:
+
+```
+Note: "<name>" already has PR #<number>. Using "<name>-v2" instead.
+```
+
+Skip this check for existing branches (they already have a PR association).
+
+Ensure the `.worktrees` directory exists:
+
+```bash
+mkdir -p .worktrees
+```
+
+### Step 3: Create Worktree
+
+Note: `<dir>` is the original name argument (worktree directory), `<branch>` is the final branch name (may differ if renamed due to PR conflict).
+
+For a **new branch** (branch does not exist locally):
+
+```bash
+git worktree add .worktrees/<dir> -b <branch>
+```
+
+For an **existing branch**:
+
+```bash
+git worktree add .worktrees/<dir> <branch>
+```
+
+### Step 4: Track with Graphite (New Branches Only)
+
+Only for newly created branches, track with Graphite:
+
+```bash
+cd .worktrees/<dir> && gt track --parent <parent>
+```
+
+If `gt track` fails, report a warning but continue — the worktree is still usable without Graphite tracking.
+
+Skip this step entirely for existing branches (they already have tracking configured).
+
+### Step 5: Symlink Local Configs
+
+For each config file, check if the source exists and create a symlink if it does. Use **absolute paths** for symlink sources so they resolve from any CWD.
+
+```bash
+# Root .env
+test -f <repo-root>/.env && ln -s <repo-root>/.env .worktrees/<name>/.env
+
+# Payload .env
+test -f <repo-root>/apps/payload/.env && ln -s <repo-root>/apps/payload/.env .worktrees/<name>/apps/payload/.env
+```
+
+If a source file doesn't exist, skip it silently.
+
+### Step 6: Install Dependencies
+
+```bash
+cd .worktrees/<name> && pnpm install
+```
+
+If `pnpm install` fails, warn but report that the worktree was created successfully.
+
+### Step 7: Report Success
+
+Output a summary (show both directory and branch name if they differ):
+
+```
+Worktree created:
+  Branch:   <branch>
+  Parent:   <parent>
+  Path:     .worktrees/<dir>
+
+  Configs symlinked:
+    .env                     symlinked | not found, skipped
+    apps/payload/.env        symlinked | not found, skipped
+
+  Dependencies: installed
+
+  To start working:
+    cd .worktrees/<dir>
+
+  To remove later:
+    git worktree remove .worktrees/<dir>
+```
+
+## Edge Cases
+
+- **No branch name** — prompt user (only interactive step)
+- **Worktree path exists** — error with `git worktree remove` hint
+- **Branch already checked out elsewhere** — error with which worktree has it
+- **Branch name has existing PR** — auto-rename branch to `<name>-v2` (or `-v3`, etc.), worktree directory keeps original name
+- **Branch exists locally** — use without `-b`, skip `gt track`
+- **`.env` doesn't exist** — skip silently
+- **`gt track` fails** — warn but continue
+- **`pnpm install` fails** — warn but report worktree was created
+
+## Important Rules
+
+- **Always use absolute paths** for symlink sources
+- **Always check preconditions** before creating the worktree
+- **New branches default to `staging` parent** unless `--parent` is specified
+- **Existing branches skip `gt track`** — they already have tracking


### PR DESCRIPTION
## Summary
- Add Claude Code skill definitions for commit, pr-review, update-pr-title, and worktree workflows
- Add slash command shortcuts for all skills
- Add implementation plans for brand-intelligence split, report regeneration, report aggregations, and staging database

## Changes
- `.claude/commands/` — 4 slash command definitions (commit, pr-review, update-pr-title, worktree)
- `.claude/skills/commit/` — Graphite-based commit workflow skill
- `.claude/skills/pr-review/` — AI-driven PR review skill with 5 specialized auditor agents
- `.claude/skills/update-pr-title/` — PR title updater skill
- `.claude/skills/worktree/` — Git worktree creation skill
- `.claude/plans/` — 5 implementation plans for upcoming feature work

## Test Plan
- These are documentation/configuration files only — no runtime code changes
- Verify skills load correctly via `/commit`, `/pr-review`, `/update-pr-title`, `/worktree` commands

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)