### PR TITLE
fix(ui): resolve Biome noAssignInExpressions lint errors in theme-sync test

### DIFF
--- a/packages/infrastructure/ui/src/__tests__/theme-sync.test.ts
+++ b/packages/infrastructure/ui/src/__tests__/theme-sync.test.ts
@@ -10,8 +10,7 @@ import { describe, expect, it } from "vitest";
 function extractHslTokens(css: string): Map<string, string> {
   const tokens = new Map<string, string>();
   const regex = /--(color-[\w-]+|radius-[\w-]+):\s*(hsl\([^)]+\)|\d+px)/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(css)) !== null) {
+  for (let match = regex.exec(css); match !== null; match = regex.exec(css)) {
     tokens.set(match[1], match[2]);
   }
   return tokens;
@@ -30,8 +29,7 @@ function extractSharedTokens(css: string, selector: ":root" | ".dark"): Map<stri
   const block = blockMatch[1];
   const rawTokens = new Map<string, string>();
   const regex = /--([\w-]+):\s*([^;]+);/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(block)) !== null) {
+  for (let match = regex.exec(block); match !== null; match = regex.exec(block)) {
     rawTokens.set(match[1], match[2].trim());
   }
 


### PR DESCRIPTION
## Summary
- Fixes 2 Biome `noAssignInExpressions` violations in `theme-sync.test.ts` that caused `pnpm pre-commit` to fail

## Changes
- Refactored `while ((match = regex.exec(...)) !== null)` to `for` loop pattern in `extractHslTokens()`
- Refactored same pattern in `extractSharedTokens()`
- Removed now-unnecessary standalone `let match` declarations

## Test Plan
- `pnpm --filter @infrastructure/ui test` — 2 tests pass
- `pnpm lint` — no lint errors
- `pnpm pre-commit` — all checks pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)