### PR TITLE
test(web): add tests for Home page and UserList components

### DIFF
--- a/apps/web/app/page.test.tsx
+++ b/apps/web/app/page.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Home from "./page";
+
+vi.mock("@/components/user-list", () => ({
+  UserList: () => <div data-testid="user-list">Mocked UserList</div>,
+}));
+
+describe("Home page", () => {
+  it("renders heading and subtitle", () => {
+    render(<Home />);
+    expect(screen.getByText("Monorepo Template")).toBeDefined();
+    expect(
+      screen.getByText("A production-ready monorepo with Next.js, Expo, and Hono")
+    ).toBeDefined();
+  });
+
+  it("renders three app cards with correct titles", () => {
+    render(<Home />);
+    expect(screen.getByText("Web")).toBeDefined();
+    expect(screen.getByText("Mobile")).toBeDefined();
+    expect(screen.getByText("API")).toBeDefined();
+  });
+
+  it("renders card descriptions with ports", () => {
+    render(<Home />);
+    expect(screen.getByText(/port 3000/)).toBeDefined();
+    expect(screen.getByText(/port 8081/)).toBeDefined();
+    expect(screen.getByText(/port 3001/)).toBeDefined();
+  });
+
+  it("renders tech stack items", () => {
+    render(<Home />);
+    expect(screen.getByText("App Router")).toBeDefined();
+    expect(screen.getByText("React Native 0.81")).toBeDefined();
+    expect(screen.getByText("Type-safe RPC")).toBeDefined();
+    expect(screen.getByText("React Compiler")).toBeDefined();
+    expect(screen.getByText("UniWind")).toBeDefined();
+    expect(screen.getByText("Zod validation")).toBeDefined();
+  });
+
+  it("renders shared infrastructure badges", () => {
+    render(<Home />);
+    expect(screen.getByText("api-client")).toBeDefined();
+    expect(screen.getByText("navigation")).toBeDefined();
+    expect(screen.getByText("ui")).toBeDefined();
+    expect(screen.getByText("ui-web")).toBeDefined();
+    expect(screen.getByText("utils")).toBeDefined();
+    expect(screen.getByText("typescript-config")).toBeDefined();
+  });
+
+  it("renders tooling badges", () => {
+    render(<Home />);
+    expect(screen.getByText("Turborepo")).toBeDefined();
+    expect(screen.getByText("pnpm")).toBeDefined();
+    expect(screen.getByText("Biome")).toBeDefined();
+    expect(screen.getByText("Vitest")).toBeDefined();
+    expect(screen.getByText("Playwright")).toBeDefined();
+  });
+
+  it("renders quick start commands", () => {
+    render(<Home />);
+    expect(screen.getByText("Quick Start")).toBeDefined();
+    expect(screen.getByText("pnpm install")).toBeDefined();
+    expect(screen.getByText("pnpm dev")).toBeDefined();
+    expect(screen.getByText("pnpm build")).toBeDefined();
+    expect(screen.getByText("pnpm test")).toBeDefined();
+  });
+
+  it("renders Users from API section with mocked UserList", () => {
+    render(<Home />);
+    expect(screen.getByText("Users from API")).toBeDefined();
+    expect(screen.getByTestId("user-list")).toBeDefined();
+  });
+
+  it("renders Get Started and Documentation buttons", () => {
+    render(<Home />);
+    expect(screen.getByText("Get Started")).toBeDefined();
+    expect(screen.getByText("Documentation")).toBeDefined();
+  });
+
+  it("renders correct total number of Card components", () => {
+    const { container } = render(<Home />);
+    const cards = container.querySelectorAll('[data-slot="card"]');
+    expect(cards).toHaveLength(7);
+  });
+});

--- a/apps/web/components/user-list.test.tsx
+++ b/apps/web/components/user-list.test.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { UserList } from "./user-list";
+
+vi.mock("@/lib/api", () => ({
+  apiClient: {
+    users: {
+      list: vi.fn(),
+    },
+  },
+}));
+
+import { apiClient } from "@/lib/api";
+
+const mockedList = vi.mocked(apiClient.users.list);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("UserList", () => {
+  it("shows loading state while fetching", () => {
+    mockedList.mockReturnValue(new Promise(() => {}));
+    render(<UserList />, { wrapper: createWrapper() });
+    expect(screen.getByText("Loading users...")).toBeDefined();
+  });
+
+  it("shows error message when API call fails", async () => {
+    mockedList.mockRejectedValue(new Error("Network error"));
+    render(<UserList />, { wrapper: createWrapper() });
+    expect(await screen.findByText(/Failed to load users/)).toBeDefined();
+  });
+
+  it("shows empty message when no users returned", async () => {
+    mockedList.mockResolvedValue([]);
+    render(<UserList />, { wrapper: createWrapper() });
+    expect(await screen.findByText("No users found.")).toBeDefined();
+  });
+
+  it("renders user name, email, and ID", async () => {
+    mockedList.mockResolvedValue([{ id: 1, name: "Alice", email: "alice@example.com" }]);
+    render(<UserList />, { wrapper: createWrapper() });
+    expect(await screen.findByText("Alice")).toBeDefined();
+    expect(screen.getByText("alice@example.com")).toBeDefined();
+    expect(screen.getByText("ID: 1")).toBeDefined();
+  });
+
+  it("renders correct number of user cards", async () => {
+    mockedList.mockResolvedValue([
+      { id: 1, name: "Alice", email: "alice@example.com" },
+      { id: 2, name: "Bob", email: "bob@example.com" },
+      { id: 3, name: "Charlie", email: "charlie@example.com" },
+    ]);
+    render(<UserList />, { wrapper: createWrapper() });
+    await screen.findByText("Alice");
+    expect(screen.getByText("Bob")).toBeDefined();
+    expect(screen.getByText("Charlie")).toBeDefined();
+    expect(screen.getAllByText(/^ID: \d+$/)).toHaveLength(3);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "@tailwindcss/postcss": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "babel-plugin-react-compiler": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.1.18
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.9
@@ -6858,9 +6861,7 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}


### PR DESCRIPTION
## Summary
- Add test coverage for the web app's Home page and UserList component (15 tests total)
- Add `@testing-library/react` as a dev dependency for the web app

## Changes
- `apps/web/package.json` — add `@testing-library/react` dev dependency
- `apps/web/app/page.test.tsx` — 10 tests covering headings, app cards, tech stack badges, infrastructure/tooling badges, quick start commands, buttons, and Card count
- `apps/web/components/user-list.test.tsx` — 5 tests covering loading state, error handling, empty state, user rendering, and card count

## Test plan
- [x] `pnpm --filter @repo/web test` — all 15 tests pass
- [x] `pnpm lint` — no issues
- [x] `pnpm pre-commit` — passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)