### PR TITLE
chore(ci): bump actions/checkout and actions/setup-node to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -24,7 +24,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "pnpm"


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions dependencies to their latest major versions (v4 → v6)

## Changes
- Bump `actions/checkout` from v4 to v6
- Bump `actions/setup-node` from v4 to v6

## Test Plan
- CI workflow runs successfully with updated action versions

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)