### PR TITLE
chore: add typecheck to pre-commit script and fix pre-existing type errors

### DIFF
--- a/apps/web/components/__tests__/user-list.test.tsx
+++ b/apps/web/components/__tests__/user-list.test.tsx
@@ -47,7 +47,9 @@ describe("UserList", () => {
   });
 
   it("renders user name, email, and ID", async () => {
-    mockedList.mockResolvedValue([{ id: 1, name: "Alice", email: "alice@example.com" }]);
+    mockedList.mockResolvedValue([
+      { id: "1", name: "Alice", email: "alice@example.com", createdAt: "2024-01-01T00:00:00Z" },
+    ]);
     render(<UserList />, { wrapper: createWrapper() });
     expect(await screen.findByText("Alice")).toBeDefined();
     expect(screen.getByText("alice@example.com")).toBeDefined();
@@ -56,9 +58,9 @@ describe("UserList", () => {
 
   it("renders correct number of user cards", async () => {
     mockedList.mockResolvedValue([
-      { id: 1, name: "Alice", email: "alice@example.com" },
-      { id: 2, name: "Bob", email: "bob@example.com" },
-      { id: 3, name: "Charlie", email: "charlie@example.com" },
+      { id: "1", name: "Alice", email: "alice@example.com", createdAt: "2024-01-01T00:00:00Z" },
+      { id: "2", name: "Bob", email: "bob@example.com", createdAt: "2024-01-02T00:00:00Z" },
+      { id: "3", name: "Charlie", email: "charlie@example.com", createdAt: "2024-01-03T00:00:00Z" },
     ]);
     render(<UserList />, { wrapper: createWrapper() });
     await screen.findByText("Alice");

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gencode": "turbo gencode",
     "lint": "turbo lint",
     "lint:fix": "turbo lint:fix",
-    "pre-commit": "pnpm install && pnpm format:unsafe && pnpm test:changed",
+    "pre-commit": "pnpm install && pnpm format:unsafe && pnpm typecheck && pnpm test:changed",
     "reset": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' + && find . -name '.next' -type d -prune -exec rm -rf '{}' + && find . -name 'dist' -type d -prune -exec rm -rf '{}' + && find . -name '.turbo' -type d -prune -exec rm -rf '{}' + && git clean -fd -e '*.env*' -e '.env*'",
     "sort:package.json": "pnpm -r --workspace-root exec -- pnpx sort-package-json",
     "test": "turbo test",

--- a/packages/infrastructure/ui/package.json
+++ b/packages/infrastructure/ui/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@infrastructure/typescript-config": "workspace:*",
+    "@types/node": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,6 +555,9 @@ importers:
       '@infrastructure/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.2.3
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.18


### PR DESCRIPTION
## Summary
- Adds `pnpm typecheck` to the pre-commit script so type errors are caught before committing
- Fixes pre-existing typecheck failures in `@infrastructure/ui` and `apps/web` that were previously undetected

## Changes
- Add `pnpm typecheck` between `format:unsafe` and `test:changed` in root `pre-commit` script
- Fix `@infrastructure/ui` theme-sync test: add `@types/node` devDependency, replace `__dirname` with `import.meta.url`, narrow regex match group types for `noUncheckedIndexedAccess`
- Fix `apps/web` user-list test: use string IDs and add `createdAt` field to match `UserSchema`

## Test Plan
- [x] `pnpm typecheck` passes across all 11 packages
- [x] `pnpm pre-commit` passes end-to-end
- [x] `@infrastructure/ui` tests pass
- [x] `apps/web` tests pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)