### PR TITLE
chore(ci): replace broad dependabot groups with 12 targeted groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,70 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      production:
-        dependency-type: "production"
-      development:
-        dependency-type: "development"
+      react-core:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      expo-react-native:
+        patterns:
+          - "expo*"
+          - "react-native*"
+          - "@react-navigation/*"
+          - "@babel/*"
+          - "jest-expo"
+          - "@testing-library/react-native"
+      nextjs:
+        patterns:
+          - "next"
+          - "babel-plugin-react-compiler"
+      orpc:
+        patterns:
+          - "@orpc/*"
+      supabase:
+        patterns:
+          - "@supabase/*"
+          - "supabase"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      styling:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "uniwind"
+          - "postcss"
+          - "class-variance-authority"
+          - "clsx"
+          - "tailwind-merge"
+      ui-components:
+        patterns:
+          - "@base-ui/*"
+          - "@radix-ui/*"
+          - "lucide-react"
+          - "sonner"
+      testing:
+        patterns:
+          - "vitest"
+          - "@testing-library/react"
+          - "@playwright/test"
+          - "jsdom"
+          - "jest"
+          - "@types/jest"
+      linting-and-build:
+        patterns:
+          - "@biomejs/biome"
+          - "turbo"
+          - "tsx"
+          - "typescript"
+          - "@types/node"
+      hono:
+        patterns:
+          - "hono"
+          - "@hono/*"
+      zod:
+        patterns:
+          - "zod"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Replace the 2 broad `production`/`development` Dependabot groups with 12 targeted groups
- Produces smaller, easier-to-review dependency update PRs
- Isolates high-risk updates (pinned React, Zod v4 breaking changes, tightly-coupled oRPC)

## Changes
- **react-core**: `react`, `react-dom`, `@types/react*` — pinned to exact 19.1.0 for RN compatibility
- **expo-react-native**: Expo, React Native, React Navigation, Babel, jest-expo — tightly coupled
- **nextjs**: `next`, `babel-plugin-react-compiler` — coordinated web framework updates
- **orpc**: `@orpc/*` — all packages must stay at same version
- **supabase**: `@supabase/*`, `supabase` — backend service ecosystem
- **tanstack**: `@tanstack/*` — data fetching layer
- **styling**: Tailwind, PostCSS, UniWind, CVA, clsx, tailwind-merge — cross-platform styling
- **ui-components**: Base UI, Radix UI, lucide-react, sonner — shadcn/ui dependencies
- **testing**: Vitest, Testing Library, Playwright, Jest, jsdom — test frameworks
- **linting-and-build**: Biome, Turbo, tsx, TypeScript, `@types/node` — DX tooling
- **hono**: `hono`, `@hono/*` — API server framework
- **zod**: Isolated due to v4 breaking API changes

## Test Plan
- [x] YAML validates correctly
- [x] `pnpm pre-commit` passes (format, typecheck, tests)
- [ ] Confirm groups render correctly on GitHub Dependabot settings page after merge

---
🤖 Generated with [Claude Code](https://claude.ai/code)