### PR TITLE
fix(ci): use Production env for main PRs, Staging for all others

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    environment: ${{ github.base_ref != 'main' && 'Staging' || '' }}
+    environment: ${{ github.base_ref == 'main' && 'Production' || 'Staging' }}
     concurrency:
       group: ci-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Fix CI environment selection so PRs to `main` use the Production GitHub environment and PRs to `staging` (or other branches) use the Staging environment
- Previously, PRs to `main` received no environment, causing the build to lack `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`

## Changes
- Updated `.github/workflows/ci.yml` environment condition from `github.base_ref != 'main' && 'Staging' || ''` to `github.base_ref == 'main' && 'Production' || 'Staging'`

## Test Plan
- [ ] Verify a "Production" GitHub environment exists in repo settings with the correct vars
- [ ] Open a PR targeting `staging` — confirm it picks up Staging env vars
- [ ] Open a PR targeting `main` — confirm it picks up Production env vars

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)