### PR TITLE
fix(web): allow build without Supabase env vars

### DIFF
--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -3,10 +3,17 @@ import { createSSRBrowserClient } from "@infrastructure/supabase/browser-ssr";
 import { createSSRServerClient } from "@infrastructure/supabase/server-ssr";
 
 function getSupabaseConfig() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
-  if (!url) throw new Error("NEXT_PUBLIC_SUPABASE_URL is required");
-  if (!key) throw new Error("NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY is required");
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+  const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? "";
+  if (!url || !key) {
+    if (typeof window !== "undefined") {
+      throw new Error(
+        "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY are required",
+      );
+    }
+    // During build/SSR prerendering, return empty strings so static pages
+    // (like /_not-found) can be generated without Supabase env vars.
+  }
   return { url, key };
 }
 


### PR DESCRIPTION
## Summary
- Fix `next build` crash when `NEXT_PUBLIC_SUPABASE_URL` is unset (e.g. CI without env secrets)
- Static pages like `/_not-found` go through the root layout → `<Providers>` → `createBrowserSupabase()`, which threw when env vars were missing

## Changes
- `apps/web/lib/supabase.ts`: Only throw the missing-env-var error at runtime in the browser (`typeof window !== "undefined"`); during SSR/build prerendering, return empty strings so the Supabase client is created but never makes real requests

## Test Plan
- [ ] `pnpm --filter web build` succeeds without `NEXT_PUBLIC_SUPABASE_URL` set
- [ ] `pnpm --filter web dev` still throws if env vars are missing in the browser
- [ ] CI build passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)