### PR TITLE
fix(ci): map CI environment to PR target branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    environment: Staging
+    environment: ${{ github.base_ref == 'main' && 'Production' || github.base_ref == 'staging' && 'Staging' || 'Preview' }}
     concurrency:
       group: ci-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    environment: ${{ github.base_ref == 'main' && 'Production' || 'Staging' }}
+    environment: Staging
     concurrency:
       group: ci-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Fix CI environment selection so each PR target branch maps to the correct GitHub environment
- The old expression `github.base_ref != 'main' && 'Staging' || ''` evaluated to empty string for main-targeting PRs, giving them no environment and no vars

## Changes
- **main** → Production environment
- **staging** → Staging environment  
- **everything else** → Preview environment

## Test Plan
- [ ] Add `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` to Production and Preview GitHub environments
- [ ] PR targeting `staging` → uses Staging env vars
- [ ] PR targeting `main` → uses Production env vars
- [ ] PR targeting other branches → uses Preview env vars

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)