### PR TITLE
fix(ci): lowercase GitHub environment names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    environment: ${{ github.base_ref == 'main' && 'Production' || github.base_ref == 'staging' && 'Staging' || 'Preview' }}
+    environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'preview' }}
     concurrency:
       group: ci-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Lowercase GitHub Actions environment names to match GitHub's naming convention (`production`/`staging`/`preview` instead of `Production`/`Staging`/`Preview`)

## Changes
- Updated `environment` expression in `.github/workflows/ci.yml` to use lowercase environment names

## Test Plan
- [ ] CI workflow runs successfully with the updated environment names
- [ ] Verify GitHub environments are configured with lowercase names

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)