### PR TITLE
fix(ci): simplify environment selection logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    environment: ${{ github.head_ref == 'main' && 'Production' || github.head_ref == 'staging' && 'Staging' || 'Preview' }}
+    environment: ${{ github.head_ref == 'main' && 'Production' || 'Staging' }}
     concurrency:
       group: ci-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -20,7 +20,7 @@ jobs:
           echo "base_ref: ${{ github.base_ref }}"
           echo "head_ref: ${{ github.head_ref }}"
           echo "event_name: ${{ github.event_name }}"
-          echo "environment: ${{ github.head_ref == 'main' && 'Production' || github.head_ref == 'staging' && 'Staging' || 'Preview' }}"
+          echo "environment: ${{ github.head_ref == 'main' && 'Production' || 'Staging' }}"
 
       - name: Check out code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    environment: ${{ github.base_ref == 'main' && 'Production' || github.base_ref == 'staging' && 'Staging' || 'Preview' }}
+    environment: ${{ github.head_ref == 'main' && 'Production' || github.head_ref == 'staging' && 'Staging' || 'Preview' }}
     concurrency:
       group: ci-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -20,7 +20,7 @@ jobs:
           echo "base_ref: ${{ github.base_ref }}"
           echo "head_ref: ${{ github.head_ref }}"
           echo "event_name: ${{ github.event_name }}"
-          echo "environment: ${{ github.base_ref == 'main' && 'Production' || github.base_ref == 'staging' && 'Staging' || 'Preview' }}"
+          echo "environment: ${{ github.head_ref == 'main' && 'Production' || github.head_ref == 'staging' && 'Staging' || 'Preview' }}"
 
       - name: Check out code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,19 @@ jobs:
     name: Tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    environment: ${{ github.base_ref == 'main' && 'production' || github.base_ref == 'staging' && 'staging' || 'preview' }}
+    environment: ${{ github.base_ref == 'main' && 'Production' || github.base_ref == 'staging' && 'Staging' || 'Preview' }}
     concurrency:
       group: ci-${{ github.event.pull_request.number }}
       cancel-in-progress: true
 
     steps:
+      - name: Debug context
+        run: |
+          echo "base_ref: ${{ github.base_ref }}"
+          echo "head_ref: ${{ github.head_ref }}"
+          echo "event_name: ${{ github.event_name }}"
+          echo "environment: ${{ github.base_ref == 'main' && 'Production' || github.base_ref == 'staging' && 'Staging' || 'Preview' }}"
+
       - name: Check out code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Simplify CI environment expression: use `Production` for PRs from `main`, default to `Staging` for everything else
- Switch from `github.base_ref` to `github.head_ref` for environment determination
- Add temporary debug step to verify GitHub context values resolve correctly

## Changes
- Replaced three-way `environment` expression with a simpler two-way: `github.head_ref == 'main' && 'Production' || 'Staging'`
- Added "Debug context" step to echo `base_ref`, `head_ref`, `event_name`, and computed environment

## Test Plan
- [ ] Check the "Debug context" step output in CI logs to confirm values resolve as expected
- [ ] Remove the debug step once verified

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)