### PR TITLE
chore(ci): use frozen lockfile in CI and exclude GSD from biome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run Biome CI
         run: pnpx biome ci .

--- a/biome.json
+++ b/biome.json
@@ -57,6 +57,7 @@
       "!**/*.config.js",
       "!**/*.config.mjs",
       "!**/.claude/skills",
+      "!**/.claude/get-shit-done",
       "!**/src/generated"
     ]
   }


### PR DESCRIPTION
## Summary
- Use `--frozen-lockfile` for `pnpm install` in CI to ensure reproducible, deterministic builds
- Exclude `.claude/get-shit-done/` from Biome linting (third-party GSD tooling)

## Changes
- `.github/workflows/ci.yml`: Add `--frozen-lockfile` flag to `pnpm install` step
- `biome.json`: Add `!**/.claude/get-shit-done` to file excludes

## Test Plan
- [ ] CI pipeline runs successfully with frozen lockfile
- [ ] Biome no longer reports errors on GSD tooling files

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)