### PR TITLE
refactor(gsd): extract runGt helper and fix CI base ref fallback

### DIFF
--- a/.claude/get-shit-done/bin/lib/commands.cjs
+++ b/.claude/get-shit-done/bin/lib/commands.cjs
@@ -3,9 +3,22 @@
  */
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const { safeReadFile, loadConfig, isGitIgnored, assertNotProtectedBranch, execGit, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, resolveModelInternal, MODEL_PROFILES, output, error, findPhaseInternal } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
+
+function runGt(args, cwd) {
+  try {
+    execFileSync('gt', args, { cwd, stdio: 'pipe', encoding: 'utf-8' });
+    return { exitCode: 0, stdout: '', stderr: '' };
+  } catch (err) {
+    return {
+      exitCode: err.status ?? 1,
+      stdout: (err.stdout ?? '').toString().trim(),
+      stderr: (err.stderr ?? '').toString().trim(),
+    };
+  }
+}
 
 function cmdGenerateSlug(text, raw) {
   if (!text) {
@@ -243,34 +256,11 @@ function cmdCommit(cwd, message, files, raw, amend) {
     execGit(cwd, ['add', file]);
   }
 
-  // Commit using Graphite
-  let commitResult;
-  if (amend) {
-    // gt modify --no-edit amends the current branch's commit
-    try {
-      execSync('gt modify --no-edit', { cwd, stdio: 'pipe', encoding: 'utf-8' });
-      commitResult = { exitCode: 0, stdout: '', stderr: '' };
-    } catch (err) {
-      commitResult = {
-        exitCode: err.status ?? 1,
-        stdout: (err.stdout ?? '').toString().trim(),
-        stderr: (err.stderr ?? '').toString().trim(),
-      };
-    }
-  } else {
-    // gt create -m "message" creates a new stacked branch with the commit
-    const escaped = message.replace(/'/g, "'\\''");
-    try {
-      execSync("gt create -m '" + escaped + "'", { cwd, stdio: 'pipe', encoding: 'utf-8' });
-      commitResult = { exitCode: 0, stdout: '', stderr: '' };
-    } catch (err) {
-      commitResult = {
-        exitCode: err.status ?? 1,
-        stdout: (err.stdout ?? '').toString().trim(),
-        stderr: (err.stderr ?? '').toString().trim(),
-      };
-    }
-  }
+  // Commit using Graphite (execFileSync avoids shell interpretation)
+  const gtArgs = amend
+    ? ['modify', '--no-edit']
+    : ['create', '-m', message];
+  const commitResult = runGt(gtArgs, cwd);
 
   if (commitResult.exitCode !== 0) {
     if (commitResult.stdout.includes('nothing to commit') || commitResult.stderr.includes('nothing to commit') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,20 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Fetch base branch for diff
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
+        id: fetch-base
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          if git fetch origin "$BASE_REF":"$BASE_REF" 2>/dev/null; then
+            echo "ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Base ref '$BASE_REF' not found, falling back to staging"
+            git fetch origin staging:staging
+            echo "ref=staging" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: millionco/react-doctor@main
         with:
-          diff: ${{ github.event.pull_request.base.ref }}
+          diff: ${{ steps.fetch-base.outputs.ref }}
           verbose: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on: "error"


### PR DESCRIPTION
## Summary
- Extract `runGt()` helper to replace duplicated `execSync` shell strings with safe `execFileSync` array args
- Fix React Doctor CI job failing when Graphite `graphite-base/N` refs don't exist on remote

## Changes
- Replace `execSync` shell strings with `execFileSync` array arguments in GSD commands (eliminates shell escaping concerns)
- Extract duplicated try/catch error handling into a shared `runGt()` helper function
- Add fallback logic in CI workflow: if the PR base ref can't be fetched, fall back to `staging` for the react-doctor diff

## Test Plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm pre-commit` passes
- [ ] CI react-doctor job succeeds with the base ref fallback

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)