### PR TITLE
feat(brand): scaffold Brand Kit app with flash-free theme toggle

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -9,8 +9,8 @@ Requirements for initial release. Each maps to roadmap phases.
 
 ### Foundation
 
-- [ ] **FOUN-01**: Standalone Next.js app at `apps/brand` with dev server on port 3002
-- [ ] **FOUN-02**: Light/dark theme toggle that switches the entire page via `.dark` class on `<html>`
+- [x] **FOUN-01**: Standalone Next.js app at `apps/brand` with dev server on port 3002
+- [x] **FOUN-02**: Light/dark theme toggle that switches the entire page via `.dark` class on `<html>`
 - [ ] **FOUN-03**: Sticky sidebar or top nav with anchor links to each section
 
 ### Colors
@@ -70,8 +70,8 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| FOUN-01 | Phase 1 | Pending |
-| FOUN-02 | Phase 1 | Pending |
+| FOUN-01 | Phase 1 | Complete |
+| FOUN-02 | Phase 1 | Complete |
 | FOUN-03 | Phase 4 | Pending |
 | COLR-01 | Phase 2 | Pending |
 | COLR-02 | Phase 2 | Pending |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -10,28 +10,28 @@ See: .planning/PROJECT.md (updated 2026-03-02)
 ## Current Position
 
 Phase: 1 of 4 (Foundation)
-Plan: 0 of ? in current phase
-Status: Ready to plan
-Last activity: 2026-03-02 — Roadmap created; ready to begin Phase 1 planning
+Plan: 1 of 1 in current phase
+Status: In progress
+Last activity: 2026-03-03 — Plan 01-01 complete; apps/brand scaffolded with flash-free theme toggle
 
-Progress: [░░░░░░░░░░] 0%
+Progress: [█░░░░░░░░░] 10%
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 0
-- Average duration: -
-- Total execution time: -
+- Total plans completed: 1
+- Average duration: ~30 min
+- Total execution time: ~30 min
 
 **By Phase:**
 
 | Phase | Plans | Total | Avg/Plan |
 |-------|-------|-------|----------|
-| - | - | - | - |
+| 01-foundation | 1 | ~30 min | ~30 min |
 
 **Recent Trend:**
-- Last 5 plans: -
-- Trend: -
+- Last 5 plans: 01-01 (~30 min)
+- Trend: Baseline established
 
 *Updated after each plan completion*
 
@@ -42,21 +42,22 @@ Progress: [░░░░░░░░░░] 0%
 Decisions are logged in PROJECT.md Key Decisions table.
 Recent decisions affecting current work:
 
-- [Pre-phase]: Use `apps/landing` (not `apps/web`) as structural reference — landing has no auth/API/navigation infrastructure that brand doesn't need
-- [Pre-phase]: `next-themes@0.4.6` is the only new dependency — add to pnpm workspace catalog
-- [Pre-phase]: Phase 1 must lock in 5 scaffolding-time pitfalls before any content work begins (see research/SUMMARY.md Critical Pitfalls)
+- [01-01]: Use `apps/landing` (not `apps/web`) as structural template — landing has no auth/API/navigation infrastructure that brand doesn't need
+- [01-01]: `next-themes@0.4.6` added to pnpm workspace catalog; referenced as `catalog:` in apps/brand package.json
+- [01-01]: ThemeProvider `attribute="class"` required to match `@custom-variant dark (&:where(.dark, .dark *))` in shared CSS
+- [01-01]: mounted guard pattern in ThemeToggle prevents hydration mismatch without SSR theme detection complexity
+- [01-01]: All 5 scaffolding-time pitfalls from CONTEXT.md locked in: @source directive, transpilePackages, ThemeProvider config, mounted guard, catalog entry
 
 ### Pending Todos
 
-None yet.
+None.
 
 ### Blockers/Concerns
 
-- [Pre-phase]: Verify `next-themes` version in pnpm catalog before Phase 1 — it must be added as a new catalog entry
-- [Pre-phase]: Turbopack (Next.js 16 default dev server) does not honor `transpilePackages` — test both `pnpm --filter brand dev` AND `pnpm --filter brand build` during Phase 1
+None — Phase 1 Plan 01 completed without blockers. Both `pnpm --filter brand build` and human verification passed cleanly.
 
 ## Session Continuity
 
-Last session: 2026-03-02
-Stopped at: Roadmap created — no plans written yet
+Last session: 2026-03-03
+Stopped at: Completed 01-foundation/01-01-PLAN.md — apps/brand scaffold with flash-free theme toggle
 Resume file: None

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -4,6 +4,7 @@
   "parallelization": true,
   "commit_docs": true,
   "model_profile": "balanced",
+  "branching_strategy": "phase",
   "workflow": {
     "research": true,
     "plan_check": true,

--- a/.planning/phases/01-foundation/01-01-SUMMARY.md
+++ b/.planning/phases/01-foundation/01-01-SUMMARY.md
@@ -1,0 +1,139 @@
+---
+phase: 01-foundation
+plan: 01
+subsystem: ui
+tags: [nextjs, tailwind, next-themes, shadcn, react-compiler, typescript]
+
+# Dependency graph
+requires: []
+provides:
+  - apps/brand Next.js app scaffold at port 3002
+  - Flash-free light/dark theme toggle via next-themes
+  - Full Tailwind v4 + @infrastructure/ui-web integration
+  - Production build and typecheck passing
+affects: [02-design-tokens, 03-components, 04-typography]
+
+# Tech tracking
+tech-stack:
+  added: [next-themes@0.4.6, lucide-react (icons)]
+  patterns:
+    - next-themes ThemeProvider in root layout with attribute="class" and suppressHydrationWarning on <html>
+    - mounted guard pattern in client theme-toggle to prevent hydration mismatch
+    - @source directive in globals.css for @infrastructure/ui-web Tailwind scanning
+    - New Next.js app cloned from apps/landing as structural template
+
+key-files:
+  created:
+    - apps/brand/package.json
+    - apps/brand/next.config.ts
+    - apps/brand/tsconfig.json
+    - apps/brand/postcss.config.mjs
+    - apps/brand/app/globals.css
+    - apps/brand/vitest.config.ts
+    - apps/brand/components.json
+    - apps/brand/app/layout.tsx
+    - apps/brand/app/page.tsx
+    - apps/brand/components/theme-toggle.tsx
+  modified:
+    - pnpm-workspace.yaml (added next-themes to catalog)
+
+key-decisions:
+  - "Use apps/landing as structural template — it has no auth/API/navigation infrastructure that brand doesn't need"
+  - "next-themes@0.4.6 added to pnpm workspace catalog as canonical version entry"
+  - "ThemeProvider attribute='class' required to match @custom-variant dark (&:where(.dark, .dark *)) in shared CSS"
+  - "mounted guard pattern chosen to prevent hydration mismatch without SSR theme detection complexity"
+
+patterns-established:
+  - "New web app template: copy apps/landing config files, change name and port, add app-specific deps"
+  - "Theme toggle: useTheme() + mounted guard + placeholder div until client hydrates"
+  - "Tailwind scanning: each consuming app must add @source for @infrastructure/ui-web in globals.css"
+
+requirements-completed: [FOUN-01, FOUN-02]
+
+# Metrics
+duration: ~30min
+completed: 2026-03-03
+---
+
+# Phase 1 Plan 01: Brand App Scaffold Summary
+
+**Next.js 16 brand app at port 3002 with flash-free theme toggle using next-themes, Tailwind v4 via @infrastructure/ui-web, and React Compiler enabled**
+
+## Performance
+
+- **Duration:** ~30 min
+- **Started:** 2026-03-03T05:20:00Z (estimated)
+- **Completed:** 2026-03-03T05:57:22Z
+- **Tasks:** 3 (2 auto + 1 human-verify)
+- **Files modified:** 11
+
+## Accomplishments
+- Scaffolded `apps/brand` as a fully configured Next.js 16 app at port 3002 with all required config files
+- Implemented flash-free light/dark theme toggle using next-themes with mounted guard pattern
+- Confirmed production build and typecheck pass; human verified no FOUC and no hydration warnings
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Scaffold apps/brand config files and install dependencies** - `484b40b` (chore)
+2. **Task 2: Create layout, page shell, and theme toggle component** - `5d7e98c` (feat)
+3. **Task 3: Verify theme toggle works (human-verify checkpoint)** - no code commit (verification only)
+
+**Plan metadata:** `eeb3aeb` (docs: complete brand scaffold plan)
+
+## Files Created/Modified
+- `pnpm-workspace.yaml` - Added `next-themes: "0.4.6"` to catalog UI Components group
+- `apps/brand/package.json` - App manifest with next-themes, lucide-react, and infrastructure deps; dev server on port 3002
+- `apps/brand/next.config.ts` - Next.js config with reactCompiler and transpilePackages for @infrastructure/ui + @infrastructure/ui-web
+- `apps/brand/tsconfig.json` - Extends @infrastructure/typescript-config/nextjs.json with path aliases
+- `apps/brand/postcss.config.mjs` - @tailwindcss/postcss plugin config
+- `apps/brand/app/globals.css` - Imports @infrastructure/ui/globals.css and @source directive for ui-web
+- `apps/brand/vitest.config.ts` - Vitest with jsdom environment and passWithNoTests
+- `apps/brand/components.json` - shadcn config with base-vega style and @infrastructure/ui utils alias
+- `apps/brand/app/layout.tsx` - Root layout with ThemeProvider (attribute="class"), Inter font, suppressHydrationWarning on html
+- `apps/brand/app/page.tsx` - Server component shell with "Brand Kit" heading and ThemeToggle in header
+- `apps/brand/components/theme-toggle.tsx` - Client component with useTheme(), mounted guard, Sun/Moon icons
+
+## Decisions Made
+- Used `apps/landing` as the structural template (not `apps/web`) — landing has no auth/API/navigation infrastructure that brand doesn't need
+- Added `next-themes@0.4.6` to pnpm workspace catalog before referencing as `catalog:` in package.json (required pattern for pnpm workspaces)
+- `attribute="class"` on ThemeProvider is required — matches the `@custom-variant dark (&:where(.dark, .dark *))` directive in `@infrastructure/ui/globals.css`
+- mounted guard pattern in ThemeToggle (show placeholder `<div className="size-9" />` until client hydrates) prevents hydration mismatch without SSR theme detection complexity
+
+## Deviations from Plan
+
+None - plan executed exactly as written. All 5 critical pitfalls from CONTEXT.md were addressed as specified.
+
+## Issues Encountered
+None - build, typecheck, and human verification all passed on first attempt.
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- `apps/brand` is fully scaffolded and ready to receive design system content in Phase 2
+- Production build passes, typecheck passes, theme toggling is flash-free
+- All 5 scaffolding-time pitfalls locked in: @source directive, transpilePackages, ThemeProvider config, mounted guard, next-themes catalog entry
+
+## Self-Check: PASSED
+
+- FOUND: apps/brand/package.json
+- FOUND: apps/brand/next.config.ts
+- FOUND: apps/brand/tsconfig.json
+- FOUND: apps/brand/postcss.config.mjs
+- FOUND: apps/brand/app/globals.css
+- FOUND: apps/brand/vitest.config.ts
+- FOUND: apps/brand/components.json
+- FOUND: apps/brand/app/layout.tsx
+- FOUND: apps/brand/app/page.tsx
+- FOUND: apps/brand/components/theme-toggle.tsx
+- FOUND: .planning/phases/01-foundation/01-01-SUMMARY.md
+- FOUND commit: 484b40b (Task 1)
+- FOUND commit: 5d7e98c (Task 2)
+- FOUND commit: eeb3aeb (metadata)
+- Build: pnpm --filter brand build exits 0
+
+---
+*Phase: 01-foundation*
+*Completed: 2026-03-03*

--- a/apps/brand/app/globals.css
+++ b/apps/brand/app/globals.css
@@ -1,0 +1,3 @@
+@import "@infrastructure/ui/globals.css";
+
+@source "../node_modules/@infrastructure/ui-web/src";

--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -1,10 +1,11 @@
+import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Brand Kit",
   description: "Design system reference for the monorepo",
 };
@@ -17,9 +18,9 @@ export const metadata = {
  */
 export default function RootLayout({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>

--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -1,0 +1,32 @@
+import { Inter } from "next/font/google";
+import { ThemeProvider } from "next-themes";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata = {
+  title: "Brand Kit",
+  description: "Design system reference for the monorepo",
+};
+
+/**
+ * Root layout for the Brand Kit app.
+ * Wraps all pages with the next-themes ThemeProvider for flash-free light/dark toggling.
+ * suppressHydrationWarning is required on <html> because next-themes modifies the
+ * element's class attribute after hydration to apply the resolved theme.
+ */
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={inter.className}>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/brand/app/page.tsx
+++ b/apps/brand/app/page.tsx
@@ -1,0 +1,19 @@
+import { ThemeToggle } from "@/components/theme-toggle";
+
+/**
+ * Brand Kit home page — the shell landing point for the design system reference.
+ * Phase 2+ will populate the main area with color swatches, typography, and components.
+ */
+export default function Page() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="flex items-center justify-between border-b border-border px-6 py-4">
+        <h1 className="text-lg font-semibold">Brand Kit</h1>
+        <ThemeToggle />
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-12">
+        <p className="text-muted-foreground">Design system content coming in Phase 2.</p>
+      </main>
+    </div>
+  );
+}

--- a/apps/brand/components.json
+++ b/apps/brand/components.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-vega",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "app/globals.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@infrastructure/ui",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "registries": {}
+}

--- a/apps/brand/components/theme-toggle.tsx
+++ b/apps/brand/components/theme-toggle.tsx
@@ -1,8 +1,22 @@
 "use client";
 
+import { Button } from "@infrastructure/ui-web";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+
+const emptySubscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+/**
+ * Returns true once the component has mounted on the client.
+ * Uses useSyncExternalStore so the React Compiler can optimise the component
+ * (avoids the setState-in-useEffect pattern that the compiler cannot handle).
+ */
+function useIsMounted() {
+  return useSyncExternalStore(emptySubscribe, getSnapshot, getServerSnapshot);
+}
 
 /**
  * ThemeToggle toggles between light and dark mode using the next-themes hook.
@@ -11,27 +25,21 @@ import { useEffect, useState } from "react";
  * server HTML and the first client render are identical.
  */
 export function ThemeToggle() {
-  const [mounted, setMounted] = useState(false);
-  const { theme, setTheme } = useTheme();
-
-  useEffect(() => setMounted(true), []);
+  const mounted = useIsMounted();
+  const { resolvedTheme, setTheme } = useTheme();
 
   if (!mounted) {
     return <div className="size-9" />;
   }
 
   return (
-    <button
-      type="button"
+    <Button
+      variant="outline"
+      size="icon"
       aria-label="Toggle theme"
-      className="flex size-9 items-center justify-center rounded-md border border-border bg-background text-foreground hover:bg-accent"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
     >
-      {theme === "dark" ? (
-        <Sun className="size-4" />
-      ) : (
-        <Moon className="size-4" />
-      )}
-    </button>
+      {resolvedTheme === "dark" ? <Sun className="size-4" /> : <Moon className="size-4" />}
+    </Button>
   );
 }

--- a/apps/brand/components/theme-toggle.tsx
+++ b/apps/brand/components/theme-toggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+/**
+ * ThemeToggle toggles between light and dark mode using the next-themes hook.
+ * The mounted guard prevents a hydration mismatch: before the client has
+ * resolved which theme is active we render a same-size placeholder, so the
+ * server HTML and the first client render are identical.
+ */
+export function ThemeToggle() {
+  const [mounted, setMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return <div className="size-9" />;
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="Toggle theme"
+      className="flex size-9 items-center justify-center rounded-md border border-border bg-background text-foreground hover:bg-accent"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+    >
+      {theme === "dark" ? (
+        <Sun className="size-4" />
+      ) : (
+        <Moon className="size-4" />
+      )}
+    </button>
+  );
+}

--- a/apps/brand/next.config.ts
+++ b/apps/brand/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactCompiler: true,
+  transpilePackages: ["@infrastructure/ui", "@infrastructure/ui-web"],
+};
+
+export default nextConfig;

--- a/apps/brand/package.json
+++ b/apps/brand/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "brand",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev --port 3002",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@infrastructure/ui": "workspace:*",
+    "@infrastructure/ui-web": "workspace:*",
+    "lucide-react": "catalog:",
+    "next": "catalog:",
+    "next-themes": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@infrastructure/typescript-config": "workspace:*",
+    "@tailwindcss/postcss": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "babel-plugin-react-compiler": "catalog:",
+    "jsdom": "catalog:",
+    "postcss": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/brand/postcss.config.mjs
+++ b/apps/brand/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/apps/brand/tsconfig.json
+++ b/apps/brand/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@infrastructure/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/brand/vitest.config.ts
+++ b/apps/brand/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    passWithNoTests: true,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ catalogs:
     next:
       specifier: 16.1.6
       version: 16.1.6
+    next-themes:
+      specifier: 0.4.6
+      version: 0.4.6
     postcss:
       specifier: 8.5.6
       version: 8.5.6
@@ -224,6 +227,70 @@ importers:
       tsx:
         specifier: 4.21.0
         version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  apps/brand:
+    dependencies:
+      '@infrastructure/ui':
+        specifier: workspace:*
+        version: link:../../packages/infrastructure/ui
+      '@infrastructure/ui-web':
+        specifier: workspace:*
+        version: link:../../packages/infrastructure/ui-web
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.564.0(react@19.1.0)
+      next:
+        specifier: 'catalog:'
+        version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-themes:
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react:
+        specifier: 'catalog:'
+        version: 19.1.0
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@infrastructure/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/infrastructure/typescript-config
+      '@tailwindcss/postcss':
+        specifier: 'catalog:'
+        version: 4.1.18
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.2.3
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 5.1.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      babel-plugin-react-compiler:
+        specifier: 'catalog:'
+        version: 1.0.0
+      jsdom:
+        specifier: 'catalog:'
+        version: 28.0.0
+      postcss:
+        specifier: 'catalog:'
+        version: 8.5.6
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.1.18
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -4743,6 +4810,12 @@ packages:
 
   nested-error-stacks@2.0.1:
     resolution: {integrity: sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.1.6:
     resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
@@ -10895,6 +10968,11 @@ snapshots:
     optional: true
 
   nested-error-stacks@2.0.1: {}
+
+  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ catalog:
   sonner: "2.0.7"
   "@radix-ui/react-slot": "1.1.1"
   lucide-react: "0.564.0"
+  next-themes: "0.4.6"
 
   # Next.js
   next: "16.1.6"


### PR DESCRIPTION
## Summary

- Scaffolds `apps/brand` — a Next.js 16 design system reference app at port 3002
- Implements flash-free light/dark theme toggle using next-themes with `useSyncExternalStore` mounted guard
- Adds `next-themes@0.4.6` to pnpm workspace catalog

## Changes

- New `apps/brand` Next.js app with React Compiler, Tailwind v4, and `@infrastructure/ui-web`
- Root layout with `ThemeProvider` (attribute="class", defaultTheme="system")
- Theme toggle component using shadcn `Button` and `resolvedTheme` for correct system theme handling
- Standard config files (tsconfig, postcss, vitest, components.json) following existing monorepo patterns
- Planning docs updated: FOUN-01 and FOUN-02 marked complete

## Logic Flow

```mermaid
flowchart TD
    A[RootLayout] --> B[ThemeProvider attribute=class]
    B --> C[Page - Server Component]
    C --> D[ThemeToggle - Client Component]
    D --> E{mounted?}
    E -->|No| F[Placeholder div size-9]
    E -->|Yes| G[Button with Sun/Moon icon]
    G --> H{Click}
    H --> I[setTheme resolvedTheme=dark ? light : dark]
```

## Files Changed

**New App** (`apps/brand/`)
| File | Purpose |
|------|---------|
| `package.json` | Dependencies via catalog:/workspace:* |
| `next.config.ts` | React Compiler + transpilePackages |
| `tsconfig.json` | Extends @infrastructure/typescript-config |
| `app/globals.css` | Shared theme import + @source directive |
| `app/layout.tsx` | Root layout with ThemeProvider |
| `app/page.tsx` | Page shell with header and theme toggle |
| `components/theme-toggle.tsx` | Client component with useSyncExternalStore |
| `postcss.config.mjs` | @tailwindcss/postcss config |
| `vitest.config.ts` | Vitest with jsdom + passWithNoTests |
| `components.json` | shadcn base-vega config |

**Workspace**
- `pnpm-workspace.yaml` — added `next-themes: "0.4.6"` to catalog

**Planning**
- `.planning/REQUIREMENTS.md` — FOUN-01, FOUN-02 marked complete
- `.planning/STATE.md` — progress update
- `.planning/config.json` — added branching_strategy
- `.planning/phases/01-foundation/01-01-SUMMARY.md` — plan summary

## Testing Notes

- `pnpm --filter brand build` passes
- `pnpm typecheck` passes
- `pnpm lint` passes
- React Doctor score: 99/100
- Theme toggle manually verified: no FOUC, no hydration warnings

🤖 Generated with [Claude Code](https://claude.ai/code)