### PR TITLE
fix(gsd): replace silent git fallback with ensure-branch CLI in execute-phase

### DIFF
--- a/.claude/get-shit-done/bin/lib/commands.cjs
+++ b/.claude/get-shit-done/bin/lib/commands.cjs
@@ -20,12 +20,10 @@ function runGt(args, cwd) {
   }
 }
 
-/** Check if a branch is tracked by Graphite via `gt log short`. */
+/** Check if a branch is tracked by Graphite via `gt branch info`. */
 function isGtTracked(cwd, branch) {
-  const result = runGt(['log', 'short', '--branch', branch], cwd);
-  if (result.exitCode === 0) return true;
-  if (result.stderr.includes('untracked') || result.stderr.includes('Cannot perform')) return false;
-  return false;
+  const result = runGt(['branch', 'info', branch], cwd);
+  return result.exitCode === 0;
 }
 
 /** Ensure a branch exists and is Graphite-tracked. Creates, tracks, or checks out as needed. */

--- a/.claude/get-shit-done/workflows/execute-phase.md
+++ b/.claude/get-shit-done/workflows/execute-phase.md
@@ -35,8 +35,10 @@ Check `branching_strategy` from init:
 
 **"phase" or "milestone":** Use pre-computed `branch_name` from init:
 ```bash
-gt create "$BRANCH_NAME" 2>/dev/null || git checkout "$BRANCH_NAME"
+BRANCH_RESULT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" ensure-branch "$BRANCH_NAME" --parent staging)
 ```
+
+Parse JSON result. If `success` is `false`, report the error from the `error` field and halt execution. Do NOT fall back to raw git commands.
 
 All subsequent commits go to this branch. User handles merging via `gt submit`.
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

## Changes

-

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:changed` passes
- [ ] `pnpm typecheck` passes
- [ ] Tested manually on relevant platform (web/mobile/API)
