### PR TITLE
ci: fix checkout depth, upgrade pnpm action, add turbo cache, and pin react-doctor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 10
+      - uses: pnpm/action-setup@v4
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v6
@@ -39,6 +37,15 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Cache Turborepo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            turbo-${{ runner.os }}-
 
       - name: Run Biome CI
         run: pnpx biome ci .
@@ -53,7 +60,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
 
       - name: Test
-        run: pnpm test:changed
+        run: pnpm turbo run test --filter='...[origin/${{ github.base_ref }}]' --output-logs=errors-only
 
   react-doctor:
     name: React Doctor
@@ -86,4 +93,4 @@ jobs:
           fi
 
       - name: Run React Doctor
-        run: npx -y react-doctor@latest . --project landing,web --diff ${{ steps.fetch-base.outputs.ref }} --verbose --fail-on error
+        run: npx -y react-doctor@0.0.30 . --project landing,web --diff ${{ steps.fetch-base.outputs.ref }} --verbose --fail-on error


### PR DESCRIPTION
## Summary

Critical CI pipeline fixes addressing issues #83, #85, and #86. Upgrades action versions, adds Turborepo caching, improves test filtering, and pins react-doctor for reproducibility.

## Changes

- **Checkout depth**: Changed from `fetch-depth: 2` to `fetch-depth: 0` (full history) to support Turbo's git-based change detection
- **pnpm action**: Upgraded `pnpm/action-setup` from v3 to v4, removing hardcoded `version: 10` (now reads from `packageManager` field in root `package.json`)
- **Turborepo cache**: Added `actions/cache@v4` step to cache `.turbo` directory across CI runs
- **Test command**: Replaced `pnpm test:changed` with `pnpm turbo run test --filter='...[origin/${{ github.base_ref }}]' --output-logs=errors-only` for more accurate change detection
- **React Doctor**: Pinned version from `@latest` to `@0.0.30` for reproducible CI runs

## Files Changed

| File | Changes |
|------|---------|
| `.github/workflows/ci.yml` | All CI fixes |

## Testing Notes

- CI workflow changes — verify by running the PR CI pipeline itself
- No application code changes