### PR TITLE
ci: add push triggers, security audit, gencode drift check, and CodeQL workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize]
+  push:
+    branches: [main, staging]
 
 jobs:
   tests:
@@ -11,17 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.head_ref == 'main' && 'Production' || 'Staging' }}
     concurrency:
-      group: ci-${{ github.event.pull_request.number }}
+      group: ci-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
 
     steps:
-      - name: Debug context
-        run: |
-          echo "base_ref: ${{ github.base_ref }}"
-          echo "head_ref: ${{ github.head_ref }}"
-          echo "event_name: ${{ github.event_name }}"
-          echo "environment: ${{ github.head_ref == 'main' && 'Production' || 'Staging' }}"
-
       - name: Check out code
         uses: actions/checkout@v6
         with:
@@ -47,6 +42,15 @@ jobs:
             turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
             turbo-${{ runner.os }}-
 
+      - name: Security audit
+        run: pnpm audit --audit-level=high
+        continue-on-error: true
+
+      - name: Check generated files are up to date
+        run: |
+          pnpm gencode
+          git diff --exit-code -- packages/infrastructure/api-client/src/generated/
+
       - name: Run Biome CI
         run: pnpx biome ci .
 
@@ -64,6 +68,7 @@ jobs:
 
   react-doctor:
     name: React Doctor
+    if: github.event_name == 'pull_request'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [main, staging]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/packages/infrastructure/api-client/src/generated/router-types.d.ts
+++ b/packages/infrastructure/api-client/src/generated/router-types.d.ts
@@ -16,80 +16,40 @@ export type Router = {
     message: import("zod").ZodString;
   }, import("zod/v4/core").$strip>, Record<never, never>, Record<never, never>>;
   users: {
-    list: import("@orpc/server").DecoratedProcedure<
-      {
-        requestId?: string;
-      } & Record<never, never>,
-      {
-        requestId?: string;
-      },
-      import("@orpc/contract").Schema<unknown, unknown>,
-      import("zod").ZodArray<
-        import("zod").ZodObject<
-          {
-            id: import("zod").ZodString;
-            name: import("zod").ZodString;
-            email: import("zod").ZodEmail;
-            createdAt: import("zod").ZodISODateTime;
-          },
-          import("zod/v4/core").$strip
-        >
-      >,
-      Record<never, never>,
-      Record<never, never>
-    >;
-    get: import("@orpc/server").DecoratedProcedure<
-      {
-        requestId?: string;
-      } & Record<never, never>,
-      {
-        requestId?: string;
-      },
-      import("zod").ZodObject<
-        {
-          id: import("zod").ZodString;
-        },
-        import("zod/v4/core").$strip
-      >,
-      import("zod").ZodNullable<
-        import("zod").ZodObject<
-          {
-            id: import("zod").ZodString;
-            name: import("zod").ZodString;
-            email: import("zod").ZodEmail;
-            createdAt: import("zod").ZodISODateTime;
-          },
-          import("zod/v4/core").$strip
-        >
-      >,
-      Record<never, never>,
-      Record<never, never>
-    >;
-    create: import("@orpc/server").DecoratedProcedure<
-      {
-        requestId?: string;
-      } & Record<never, never>,
-      {
-        requestId?: string;
-      },
-      import("zod").ZodObject<
-        {
-          name: import("zod").ZodString;
-          email: import("zod").ZodEmail;
-        },
-        import("zod/v4/core").$strip
-      >,
-      import("zod").ZodObject<
-        {
-          id: import("zod").ZodString;
-          name: import("zod").ZodString;
-          email: import("zod").ZodEmail;
-          createdAt: import("zod").ZodISODateTime;
-        },
-        import("zod/v4/core").$strip
-      >,
-      Record<never, never>,
-      Record<never, never>
-    >;
+    list: import("@orpc/server").DecoratedProcedure<{
+      requestId?: string;
+    } & Record<never, never>, {
+      requestId?: string;
+    }, import("@orpc/contract").Schema<unknown, unknown>, import("zod").ZodArray<import("zod").ZodObject<{
+      id: import("zod").ZodString;
+      name: import("zod").ZodString;
+      email: import("zod").ZodEmail;
+      createdAt: import("zod").ZodISODateTime;
+    }, import("zod/v4/core").$strip>>, Record<never, never>, Record<never, never>>;
+    get: import("@orpc/server").DecoratedProcedure<{
+      requestId?: string;
+    } & Record<never, never>, {
+      requestId?: string;
+    }, import("zod").ZodObject<{
+      id: import("zod").ZodString;
+    }, import("zod/v4/core").$strip>, import("zod").ZodNullable<import("zod").ZodObject<{
+      id: import("zod").ZodString;
+      name: import("zod").ZodString;
+      email: import("zod").ZodEmail;
+      createdAt: import("zod").ZodISODateTime;
+    }, import("zod/v4/core").$strip>>, Record<never, never>, Record<never, never>>;
+    create: import("@orpc/server").DecoratedProcedure<{
+      requestId?: string;
+    } & Record<never, never>, {
+      requestId?: string;
+    }, import("zod").ZodObject<{
+      name: import("zod").ZodString;
+      email: import("zod").ZodEmail;
+    }, import("zod/v4/core").$strip>, import("zod").ZodObject<{
+      id: import("zod").ZodString;
+      name: import("zod").ZodString;
+      email: import("zod").ZodEmail;
+      createdAt: import("zod").ZodISODateTime;
+    }, import("zod/v4/core").$strip>, Record<never, never>, Record<never, never>>;
   };
 };


### PR DESCRIPTION
## Summary

Improves CI reliability and security posture by adding push triggers for `main`/`staging`, a generated-file staleness check, dependency security auditing, CodeQL SAST, and gating react-doctor to PR-only events.

## Changes

- **Push triggers**: CI now runs on pushes to `main` and `staging` branches, not just PRs
- **Concurrency fix**: Concurrency group falls back to `github.sha` when no PR number exists (push events)
- **Debug step removed**: Removed temporary debug context step (#96)
- **Security audit**: Added `pnpm audit --audit-level=high` step with `continue-on-error: true` (#92)
- **Gencode drift check**: Runs `pnpm gencode` and verifies generated files haven't drifted (#91)
- **React-doctor guard**: Gated to `pull_request` events only, preventing failures on push (#97)
- **CodeQL workflow**: New SAST workflow scanning JavaScript/TypeScript on PR, push, and weekly schedule (#92)
- **Router types**: Regenerated `router-types.d.ts` to match current TypeScript output format

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Push trigger, concurrency fix, debug removal, audit + gencode steps, react-doctor guard |
| `.github/workflows/codeql.yml` | New CodeQL SAST workflow |
| `packages/infrastructure/api-client/src/generated/router-types.d.ts` | Whitespace reformatting (regenerated) |

## Testing Notes

- PR CI should pass with gencode drift check, audit, biome, typecheck, build, test
- Debug step should no longer appear in CI logs
- React-doctor should only run on PRs, not push events
- CodeQL workflow should initialize and run on PRs

Closes #91, closes #92, closes #96, closes #97

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)