### PR TITLE
ci: add E2E tests to CI pipeline with test filtering and react-doctor fixes (#93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,46 @@ jobs:
 
       - name: Run React Doctor
         run: npx -y react-doctor@0.0.30 . --project landing,web --diff ${{ steps.fetch-base.outputs.ref }} --verbose --fail-on error
+
+  e2e:
+    name: E2E Tests
+    if: github.event_name == 'pull_request'
+    needs: tests
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    concurrency:
+      group: e2e-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Turborepo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            turbo-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        run: pnpx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
     needs: tests
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    environment: ${{ github.head_ref == 'main' && 'Production' || 'Staging' }}
     concurrency:
       group: e2e-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,36 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
+      - name: Resolve catalog versions for react-doctor
+        run: |
+          node -e "
+            const fs = require('fs');
+            const lines = fs.readFileSync('pnpm-workspace.yaml', 'utf8').split('\n');
+            const catalog = {};
+            let inCatalog = false;
+            for (const line of lines) {
+              if (/^catalog:/.test(line)) { inCatalog = true; continue; }
+              if (inCatalog && /^\S/.test(line)) { inCatalog = false; }
+              if (inCatalog) {
+                const m = line.match(/^\s+(.+?):\s*['\"](.+?)['\"]/);
+                if (m) catalog[m[1]] = m[2];
+              }
+            }
+            for (const app of ['apps/web', 'apps/landing']) {
+              const pkgPath = app + '/package.json';
+              const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+              for (const depType of ['dependencies', 'devDependencies']) {
+                if (!pkg[depType]) continue;
+                for (const [name, ver] of Object.entries(pkg[depType])) {
+                  if (ver === 'catalog:' && catalog[name]) {
+                    pkg[depType][name] = catalog[name];
+                  }
+                }
+              }
+              fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+            }
+          "
+
       - name: Fetch base branch for diff
         id: fetch-base
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,20 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
 
+      - name: Fetch base ref for test filtering
+        id: fetch-base
+        if: github.event_name == 'pull_request'
+        run: |
+          BASE_REF="${{ github.base_ref }}"
+          if git fetch origin "$BASE_REF" 2>/dev/null; then
+            echo "filter=--filter='...[origin/$BASE_REF]'" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Base ref '$BASE_REF' not found, running all tests"
+            echo "filter=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Test
-        run: pnpm turbo run test --filter='...[origin/${{ github.base_ref }}]' --output-logs=errors-only
+        run: pnpm turbo run test ${{ steps.fetch-base.outputs.filter }} --output-logs=errors-only
 
   react-doctor:
     name: React Doctor

--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -8,7 +8,7 @@ test.describe("Home Page", () => {
 
   test("should display sign-in form", async ({ page }) => {
     await page.goto("/sign-in");
-    await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
+    await expect(page.locator('[data-slot="card-title"]', { hasText: "Sign In" })).toBeVisible();
     await expect(page.getByLabel("Email")).toBeVisible();
     await expect(page.getByLabel("Password")).toBeVisible();
   });

--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -1,21 +1,23 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("Home Page", () => {
-  test("should display the title", async ({ page }) => {
+  test("should redirect to sign-in page", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: "Monorepo Template" })).toBeVisible();
+    await expect(page).toHaveURL(/\/sign-in/);
   });
 
-  test("should display feature cards", async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByText("Next.js")).toBeVisible();
-    await expect(page.getByText("Expo")).toBeVisible();
-    await expect(page.getByText("Hono + oRPC")).toBeVisible();
+  test("should display sign-in form", async ({ page }) => {
+    await page.goto("/sign-in");
+    await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Password")).toBeVisible();
   });
 
-  test("should have action buttons", async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByRole("button", { name: "Get Started" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Documentation" })).toBeVisible();
+  test("should display sign-in actions", async ({ page }) => {
+    await page.goto("/sign-in");
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Google/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Apple/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /GitHub/ })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Adds E2E test job (Playwright) to CI pipeline, running after unit tests pass on PRs
- Fixes test filtering when Graphite-managed base branch refs don't exist in checkout
- Fixes E2E job missing `environment` field, causing empty Supabase env vars
- Fixes react-doctor CI failure by resolving pnpm `catalog:` versions before scanning
- Fixes E2E test selector to match CardTitle's `<div>` element (not a heading)

## Changes
- Add `e2e` job: installs Playwright chromium, runs `pnpm test:e2e`, passes Supabase env vars
- Add `environment` field to E2E job to access GitHub environment variables
- Add explicit base ref fetch step before test filtering with fallback to running all tests
- Add catalog version resolution step in react-doctor job (react-doctor doesn't understand `catalog:` protocol)
- Update `home.spec.ts` to use `data-slot="card-title"` selector instead of `getByRole("heading")`

## Test Plan
- Verify CI `tests` job passes (base ref fetch fix)
- Verify CI `e2e` job passes (correct test assertions + environment variables + CardTitle selector)
- Verify CI `react-doctor` job passes (catalog: versions resolved before scanning)

Closes #93

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)