### PR TITLE
feat(rate-limit): add @infrastructure/rate-limit package

### DIFF
--- a/packages/infrastructure/rate-limit/package.json
+++ b/packages/infrastructure/rate-limit/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@infrastructure/rate-limit",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "hono": "catalog:"
+  },
+  "devDependencies": {
+    "@infrastructure/typescript-config": "workspace:*",
+    "hono": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/infrastructure/rate-limit/src/__tests__/memory-store.test.ts
+++ b/packages/infrastructure/rate-limit/src/__tests__/memory-store.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryStore } from "../memory-store";
+
+describe("MemoryStore", () => {
+  let store: MemoryStore;
+  const windowMs = 60_000;
+
+  beforeEach(() => {
+    store = new MemoryStore();
+    vi.useRealTimers();
+  });
+
+  it("increments count for a new key", async () => {
+    const result = await store.increment("ip-1", windowMs);
+    expect(result.count).toBe(1);
+    expect(result.resetAt).toBeGreaterThan(Date.now() - 1000);
+  });
+
+  it("increments on subsequent calls within the window", async () => {
+    await store.increment("ip-1", windowMs);
+    const result = await store.increment("ip-1", windowMs);
+    expect(result.count).toBe(2);
+
+    const result3 = await store.increment("ip-1", windowMs);
+    expect(result3.count).toBe(3);
+  });
+
+  it("resets count after window expires", async () => {
+    vi.useFakeTimers();
+
+    await store.increment("ip-1", windowMs);
+    await store.increment("ip-1", windowMs);
+
+    vi.advanceTimersByTime(windowMs + 1);
+
+    const result = await store.increment("ip-1", windowMs);
+    expect(result.count).toBe(1);
+  });
+
+  it("tracks different keys independently", async () => {
+    await store.increment("ip-1", windowMs);
+    await store.increment("ip-1", windowMs);
+    const result = await store.increment("ip-2", windowMs);
+
+    expect(result.count).toBe(1);
+  });
+
+  it("reset() clears a specific key", async () => {
+    await store.increment("ip-1", windowMs);
+    await store.increment("ip-1", windowMs);
+
+    await store.reset("ip-1");
+
+    const result = await store.increment("ip-1", windowMs);
+    expect(result.count).toBe(1);
+  });
+
+  it("evicts expired entries when store exceeds MAX_ENTRIES", async () => {
+    vi.useFakeTimers();
+
+    const tinyWindow = 1; // 1ms window so entries expire almost immediately
+
+    // Fill the store with entries that will expire quickly
+    for (let i = 0; i < 10_001; i++) {
+      await store.increment(`key-${i}`, tinyWindow);
+    }
+
+    // Advance time so all existing entries have expired
+    vi.advanceTimersByTime(2);
+
+    // This increment triggers cleanup because size > MAX_ENTRIES
+    const result = await store.increment("fresh-key", windowMs);
+    expect(result.count).toBe(1);
+
+    // After cleanup, expired entries should be removed.
+    // A previously inserted key should start fresh if re-inserted.
+    const result2 = await store.increment("key-0", windowMs);
+    expect(result2.count).toBe(1);
+  });
+
+  it("evicts oldest active entries when store exceeds MAX_ENTRIES", async () => {
+    vi.useFakeTimers();
+
+    const longWindow = 600_000; // entries won't expire during the test
+
+    // Fill the store beyond MAX_ENTRIES with non-expiring entries
+    for (let i = 0; i < 10_001; i++) {
+      await store.increment(`key-${i}`, longWindow);
+    }
+
+    // Trigger cleanup with one more insert — all entries are active,
+    // so the overflow eviction path must evict the oldest entries
+    const result = await store.increment("overflow-key", longWindow);
+    expect(result.count).toBe(1);
+
+    // key-0 was the oldest and should have been evicted
+    const result2 = await store.increment("key-0", longWindow);
+    expect(result2.count).toBe(1); // fresh entry, not count=2
+  });
+});

--- a/packages/infrastructure/rate-limit/src/__tests__/middleware.test.ts
+++ b/packages/infrastructure/rate-limit/src/__tests__/middleware.test.ts
@@ -1,0 +1,122 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { createRateLimiter } from "../middleware";
+
+function createApp(max: number) {
+  const app = new Hono();
+  app.use("*", createRateLimiter({ max, windowMs: 60_000 }));
+  app.get("/", (c) => c.text("ok"));
+  return app;
+}
+
+describe("createRateLimiter", () => {
+  it("allows requests under the limit", async () => {
+    const app = createApp(5);
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+
+  it("returns 429 when limit exceeded", async () => {
+    const app = createApp(2);
+
+    await app.request("/");
+    await app.request("/");
+    const res = await app.request("/");
+
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Too Many Requests" });
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("sets rate limit headers correctly", async () => {
+    const app = createApp(10);
+
+    const res = await app.request("/");
+
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("9");
+    expect(res.headers.get("X-RateLimit-Reset")).toBeTruthy();
+  });
+
+  it("uses a custom keyGenerator when provided", async () => {
+    const app = new Hono();
+    app.use(
+      "*",
+      createRateLimiter({
+        max: 1,
+        windowMs: 60_000,
+        keyGenerator: (c) => c.req.header("x-api-key") ?? "anon",
+      })
+    );
+    app.get("/", (c) => c.text("ok"));
+
+    // First request with key "abc" — allowed
+    const res1 = await app.request("/", {
+      headers: { "x-api-key": "abc" },
+    });
+    expect(res1.status).toBe(200);
+
+    // Second request with key "abc" — blocked
+    const res2 = await app.request("/", {
+      headers: { "x-api-key": "abc" },
+    });
+    expect(res2.status).toBe(429);
+
+    // First request with a different key "xyz" — allowed (independent bucket)
+    const res3 = await app.request("/", {
+      headers: { "x-api-key": "xyz" },
+    });
+    expect(res3.status).toBe(200);
+  });
+
+  it("extracts key from x-forwarded-for header", async () => {
+    const app = createApp(1);
+
+    const res1 = await app.request("/", {
+      headers: { "x-forwarded-for": "1.2.3.4, 10.0.0.1" },
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/", {
+      headers: { "x-forwarded-for": "1.2.3.4, 10.0.0.1" },
+    });
+    expect(res2.status).toBe(429);
+  });
+
+  it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
+    const app = createApp(1);
+
+    const res1 = await app.request("/", {
+      headers: { "x-real-ip": "5.6.7.8" },
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/", {
+      headers: { "x-real-ip": "5.6.7.8" },
+    });
+    expect(res2.status).toBe(429);
+  });
+
+  it("applies independent rate limits per IP", async () => {
+    const app = createApp(1);
+
+    // IP A gets rate limited
+    const resA1 = await app.request("/", {
+      headers: { "x-forwarded-for": "10.0.0.1" },
+    });
+    expect(resA1.status).toBe(200);
+
+    const resA2 = await app.request("/", {
+      headers: { "x-forwarded-for": "10.0.0.1" },
+    });
+    expect(resA2.status).toBe(429);
+
+    // IP B is unaffected
+    const resB1 = await app.request("/", {
+      headers: { "x-forwarded-for": "10.0.0.2" },
+    });
+    expect(resB1.status).toBe(200);
+  });
+});

--- a/packages/infrastructure/rate-limit/src/index.ts
+++ b/packages/infrastructure/rate-limit/src/index.ts
@@ -1,0 +1,7 @@
+export { MemoryStore } from "./memory-store";
+export { createRateLimiter } from "./middleware";
+export type {
+  RateLimitOptions,
+  RateLimitResult,
+  RateLimitStore,
+} from "./types";

--- a/packages/infrastructure/rate-limit/src/memory-store.ts
+++ b/packages/infrastructure/rate-limit/src/memory-store.ts
@@ -1,0 +1,56 @@
+import type { RateLimitResult, RateLimitStore } from "./types";
+
+const MAX_ENTRIES = 10_000;
+
+interface Entry {
+  count: number;
+  resetAt: number;
+}
+
+/** In-memory sliding window rate limit store. */
+export class MemoryStore implements RateLimitStore {
+  private store = new Map<string, Entry>();
+
+  async increment(key: string, windowMs: number): Promise<RateLimitResult> {
+    const now = Date.now();
+    const existing = this.store.get(key);
+
+    if (existing && now < existing.resetAt) {
+      existing.count += 1;
+      return { count: existing.count, resetAt: existing.resetAt };
+    }
+
+    const entry: Entry = { count: 1, resetAt: now + windowMs };
+    this.store.set(key, entry);
+
+    if (this.store.size > MAX_ENTRIES) {
+      this.cleanup(now);
+    }
+
+    return { count: entry.count, resetAt: entry.resetAt };
+  }
+
+  async reset(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  private cleanup(now: number): void {
+    for (const [k, v] of this.store) {
+      if (now >= v.resetAt) {
+        this.store.delete(k);
+      }
+    }
+
+    // If still over capacity after expiry cleanup, evict oldest entries.
+    // Map iteration order matches insertion order, so the first keys are oldest.
+    if (this.store.size > MAX_ENTRIES) {
+      const excess = this.store.size - MAX_ENTRIES;
+      let removed = 0;
+      for (const key of this.store.keys()) {
+        if (removed >= excess) break;
+        this.store.delete(key);
+        removed += 1;
+      }
+    }
+  }
+}

--- a/packages/infrastructure/rate-limit/src/middleware.ts
+++ b/packages/infrastructure/rate-limit/src/middleware.ts
@@ -1,0 +1,52 @@
+import type { MiddlewareHandler } from "hono";
+import { MemoryStore } from "./memory-store";
+import type { RateLimitOptions } from "./types";
+
+/** Default rate limit window duration in milliseconds (1 minute). */
+const DEFAULT_WINDOW_MS = 60_000;
+
+/** Default maximum number of requests per window. */
+const DEFAULT_MAX_REQUESTS = 100;
+
+/**
+ * Create a Hono rate limiter middleware.
+ *
+ * The default key generator extracts the client IP from the `X-Forwarded-For`
+ * header (first entry), then `X-Real-IP`, and falls back to `"unknown"`. This
+ * assumes a trusted reverse proxy (e.g., nginx, cloud load balancer) that sets
+ * these headers. For direct-to-internet deployments without a reverse proxy,
+ * provide a custom `keyGenerator` that derives the client identity from a
+ * reliable source (e.g., authenticated user ID, Hono's `c.req.raw` connection
+ * info).
+ */
+export function createRateLimiter(options?: RateLimitOptions): MiddlewareHandler {
+  const store = options?.store ?? new MemoryStore();
+  const windowMs = options?.windowMs ?? DEFAULT_WINDOW_MS;
+  const max = options?.max ?? DEFAULT_MAX_REQUESTS;
+  const keyGenerator =
+    options?.keyGenerator ??
+    ((c) => {
+      const forwarded = c.req.header("x-forwarded-for");
+      if (forwarded) {
+        return forwarded.split(",")[0]?.trim() ?? "unknown";
+      }
+      return c.req.header("x-real-ip") ?? "unknown";
+    });
+
+  return async (c, next) => {
+    const key = keyGenerator(c);
+    const result = await store.increment(key, windowMs);
+
+    c.header("X-RateLimit-Limit", String(max));
+    c.header("X-RateLimit-Remaining", String(Math.max(0, max - result.count)));
+    c.header("X-RateLimit-Reset", String(result.resetAt));
+
+    if (result.count > max) {
+      const retryAfterSec = Math.ceil((result.resetAt - Date.now()) / 1000);
+      c.header("Retry-After", String(retryAfterSec));
+      return c.json({ error: "Too Many Requests" }, 429);
+    }
+
+    await next();
+  };
+}

--- a/packages/infrastructure/rate-limit/src/types.ts
+++ b/packages/infrastructure/rate-limit/src/types.ts
@@ -1,0 +1,29 @@
+import type { MiddlewareHandler } from "hono";
+
+/** Result returned by a rate limit store after incrementing a key. */
+export interface RateLimitResult {
+  /** Current request count within the window. */
+  count: number;
+  /** Timestamp (ms since epoch) when the current window resets. */
+  resetAt: number;
+}
+
+/** Storage backend for rate limit state. */
+export interface RateLimitStore {
+  /** Increment the counter for a key within the given window. */
+  increment(key: string, windowMs: number): Promise<RateLimitResult>;
+  /** Reset (delete) the counter for a key. */
+  reset(key: string): Promise<void>;
+}
+
+/** Options for the rate limiter middleware. */
+export interface RateLimitOptions {
+  /** Storage backend. Defaults to an in-memory store. */
+  store?: RateLimitStore;
+  /** Window duration in milliseconds. Defaults to 60000 (1 minute). */
+  windowMs?: number;
+  /** Maximum requests per window. Defaults to 100. */
+  max?: number;
+  /** Function to derive a rate-limit key from the request. Defaults to IP-based. */
+  keyGenerator?: (c: Parameters<MiddlewareHandler>[0]) => string;
+}

--- a/packages/infrastructure/rate-limit/tsconfig.json
+++ b/packages/infrastructure/rate-limit/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@infrastructure/typescript-config/library.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/infrastructure/rate-limit/vitest.config.ts
+++ b/packages/infrastructure/rate-limit/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,21 @@ importers:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/infrastructure/rate-limit:
+    devDependencies:
+      '@infrastructure/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      hono:
+        specifier: 'catalog:'
+        version: 4.11.9
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/infrastructure/supabase:
     dependencies:
       '@supabase/ssr':


### PR DESCRIPTION
## Summary

Add `@infrastructure/rate-limit` — a Hono middleware package providing sliding-window rate limiting with pluggable storage backends.

## Changes

- **`MemoryStore`** — In-memory store with automatic expiry cleanup and oldest-entry eviction at 10k capacity
- **`createRateLimiter()`** — Hono middleware returning `X-RateLimit-*` headers and 429 responses with `Retry-After`
- **Types** — `RateLimitStore` interface for custom backends, `RateLimitOptions`, `RateLimitResult`
- **IP extraction** — Default key generator checks `X-Forwarded-For`, then `X-Real-IP`, with JSDoc documenting trusted-proxy assumption
- **14 tests** — MemoryStore (7 tests: increment, window expiry, independent keys, reset, expiry cleanup, overflow eviction) + middleware (7 tests: under limit, 429, headers, custom keyGenerator, forwarded-for, real-ip fallback, per-IP independence)

## Files Changed

| File | Description |
|------|-------------|
| `packages/infrastructure/rate-limit/src/types.ts` | `RateLimitResult`, `RateLimitStore`, `RateLimitOptions` interfaces |
| `packages/infrastructure/rate-limit/src/memory-store.ts` | `MemoryStore` class with expiry + overflow eviction |
| `packages/infrastructure/rate-limit/src/middleware.ts` | `createRateLimiter()` Hono middleware factory |
| `packages/infrastructure/rate-limit/src/index.ts` | Barrel exports |
| `packages/infrastructure/rate-limit/package.json` | Package config with `hono` peer dep via catalog |
| `packages/infrastructure/rate-limit/tsconfig.json` | Extends `@infrastructure/typescript-config/library.json` |
| `packages/infrastructure/rate-limit/vitest.config.ts` | Vitest config |

## Test Plan

- [x] `pnpm --filter @infrastructure/rate-limit test` — 14 tests pass
- [x] `pnpm typecheck` — all packages clean
- [x] `pnpm lint` — no violations

### Review Iteration History

*Reviewed and auto-fixed in 2 iterations*

| Iteration | Blocking | Non-blocking | Fixed | Skipped |
|-----------|----------|--------------|-------|---------|
| 1 | 6 | 1 | 5 | 0 |
| 2 | 1 | 2 | 1 | 0 |
| 3 | 0 | 2 | - | - |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)