### PR TITLE
feat(cache): add @infrastructure/cache package (#110)

### DIFF
--- a/packages/infrastructure/cache/package.json
+++ b/packages/infrastructure/cache/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@infrastructure/cache",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@infrastructure/typescript-config": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/infrastructure/cache/src/__tests__/cache.test.ts
+++ b/packages/infrastructure/cache/src/__tests__/cache.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { Cache, createCache } from "../cache";
+import { MemoryCacheStore } from "../memory-store";
+
+describe("Cache", () => {
+  it("applies key prefix to get and set", async () => {
+    const store = new MemoryCacheStore();
+    const cache = new Cache({ store, keyPrefix: "app:" });
+
+    await cache.set("user", "Alice");
+    // Accessing store directly to verify prefix was applied
+    expect(await store.get("app:user")).toBe("Alice");
+    expect(await cache.get("user")).toBe("Alice");
+  });
+
+  it("uses default TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const cache = new Cache({ defaultTtlMs: 5_000 });
+      await cache.set("key", "value");
+
+      vi.advanceTimersByTime(4_999);
+      expect(await cache.get("key")).toBe("value");
+
+      vi.advanceTimersByTime(1);
+      expect(await cache.get("key")).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("invalidate removes a key", async () => {
+    const cache = new Cache({ keyPrefix: "test:" });
+    await cache.set("foo", "bar");
+    expect(await cache.get("foo")).toBe("bar");
+
+    await cache.invalidate("foo");
+    expect(await cache.get("foo")).toBeUndefined();
+  });
+
+  it("invalidateByPrefix removes matching keys", async () => {
+    const cache = new Cache({ keyPrefix: "app:" });
+    await cache.set("user:1", "Alice");
+    await cache.set("user:2", "Bob");
+    await cache.set("post:1", "Hello");
+
+    await cache.invalidateByPrefix("user:");
+
+    expect(await cache.get("user:1")).toBeUndefined();
+    expect(await cache.get("user:2")).toBeUndefined();
+    expect(await cache.get("post:1")).toBe("Hello");
+  });
+
+  it("createCache returns a Cache instance", () => {
+    const cache = createCache({ keyPrefix: "x:" });
+    expect(cache).toBeInstanceOf(Cache);
+  });
+});

--- a/packages/infrastructure/cache/src/__tests__/memory-store.test.ts
+++ b/packages/infrastructure/cache/src/__tests__/memory-store.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryCacheStore } from "../memory-store";
+
+describe("MemoryCacheStore", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stores and retrieves values", async () => {
+    const store = new MemoryCacheStore();
+    await store.set("key1", { name: "Alice" }, 10_000);
+    const result = await store.get<{ name: string }>("key1");
+    expect(result).toEqual({ name: "Alice" });
+  });
+
+  it("returns undefined for missing keys", async () => {
+    const store = new MemoryCacheStore();
+    const result = await store.get("nonexistent");
+    expect(result).toBeUndefined();
+  });
+
+  it("expires values after TTL", async () => {
+    const store = new MemoryCacheStore();
+    await store.set("key1", "value1", 5_000);
+
+    vi.advanceTimersByTime(4_999);
+    expect(await store.get("key1")).toBe("value1");
+
+    vi.advanceTimersByTime(1);
+    expect(await store.get("key1")).toBeUndefined();
+  });
+
+  it("evicts oldest entry when max size exceeded", async () => {
+    const store = new MemoryCacheStore({ maxEntries: 3 });
+    await store.set("a", 1, 60_000);
+    await store.set("b", 2, 60_000);
+    await store.set("c", 3, 60_000);
+
+    // Adding a 4th should evict "a" (oldest)
+    await store.set("d", 4, 60_000);
+
+    expect(await store.get("a")).toBeUndefined();
+    expect(await store.get("b")).toBe(2);
+    expect(await store.get("c")).toBe(3);
+    expect(await store.get("d")).toBe(4);
+  });
+
+  it("deletes a specific key", async () => {
+    const store = new MemoryCacheStore();
+    await store.set("key1", "value1", 60_000);
+    await store.delete("key1");
+    expect(await store.get("key1")).toBeUndefined();
+  });
+
+  it("deletes keys by prefix", async () => {
+    const store = new MemoryCacheStore();
+    await store.set("user:1", "Alice", 60_000);
+    await store.set("user:2", "Bob", 60_000);
+    await store.set("post:1", "Hello", 60_000);
+
+    await store.deleteByPrefix("user:");
+
+    expect(await store.get("user:1")).toBeUndefined();
+    expect(await store.get("user:2")).toBeUndefined();
+    expect(await store.get("post:1")).toBe("Hello");
+  });
+
+  it("refreshes LRU order on get", async () => {
+    const store = new MemoryCacheStore({ maxEntries: 3 });
+    await store.set("a", 1, 60_000);
+    await store.set("b", 2, 60_000);
+    await store.set("c", 3, 60_000);
+
+    // Access "a" to make it most recently used
+    await store.get("a");
+
+    // Adding "d" should evict "b" (now the oldest)
+    await store.set("d", 4, 60_000);
+
+    expect(await store.get("a")).toBe(1);
+    expect(await store.get("b")).toBeUndefined();
+  });
+});

--- a/packages/infrastructure/cache/src/cache.ts
+++ b/packages/infrastructure/cache/src/cache.ts
@@ -1,0 +1,45 @@
+import { MemoryCacheStore } from "./memory-store";
+import type { CacheOptions, CacheStore } from "./types";
+
+const DEFAULT_TTL_MS = 60_000;
+
+/**
+ * High-level cache wrapper that adds key prefixing and default TTL
+ * on top of any CacheStore implementation.
+ */
+export class Cache {
+  private readonly store: CacheStore;
+  private readonly defaultTtlMs: number;
+  private readonly keyPrefix: string;
+
+  constructor(options?: CacheOptions) {
+    this.store = options?.store ?? new MemoryCacheStore();
+    this.defaultTtlMs = options?.defaultTtlMs ?? DEFAULT_TTL_MS;
+    this.keyPrefix = options?.keyPrefix ?? "";
+  }
+
+  /** Retrieve a cached value by key. */
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.store.get<T>(this.keyPrefix + key);
+  }
+
+  /** Store a value with an optional TTL (defaults to defaultTtlMs). */
+  async set<T>(key: string, value: T, ttlMs?: number): Promise<void> {
+    return this.store.set<T>(this.keyPrefix + key, value, ttlMs ?? this.defaultTtlMs);
+  }
+
+  /** Remove a specific key from the cache. */
+  async invalidate(key: string): Promise<void> {
+    return this.store.delete(this.keyPrefix + key);
+  }
+
+  /** Remove all keys matching the given prefix. */
+  async invalidateByPrefix(prefix: string): Promise<void> {
+    return this.store.deleteByPrefix(this.keyPrefix + prefix);
+  }
+}
+
+/** Create a new Cache instance with the given options. */
+export function createCache(options?: CacheOptions): Cache {
+  return new Cache(options);
+}

--- a/packages/infrastructure/cache/src/index.ts
+++ b/packages/infrastructure/cache/src/index.ts
@@ -1,0 +1,4 @@
+export type { CacheStore, CacheOptions } from "./types";
+export { MemoryCacheStore } from "./memory-store";
+export type { MemoryCacheStoreOptions } from "./memory-store";
+export { Cache, createCache } from "./cache";

--- a/packages/infrastructure/cache/src/memory-store.ts
+++ b/packages/infrastructure/cache/src/memory-store.ts
@@ -1,0 +1,71 @@
+import type { CacheStore } from "./types";
+
+interface CacheEntry<T = unknown> {
+  value: T;
+  expiresAt: number;
+}
+
+/** Options for MemoryCacheStore. */
+export interface MemoryCacheStoreOptions {
+  /** Maximum number of entries before LRU eviction. Defaults to 1000. */
+  maxEntries?: number;
+}
+
+/**
+ * In-memory cache store with LRU eviction and TTL-based expiration.
+ * Uses a Map to preserve insertion order for LRU tracking.
+ */
+export class MemoryCacheStore implements CacheStore {
+  private readonly map = new Map<string, CacheEntry>();
+  private readonly maxEntries: number;
+
+  constructor(options?: MemoryCacheStoreOptions) {
+    this.maxEntries = options?.maxEntries ?? 1000;
+  }
+
+  async get<T>(key: string): Promise<T | undefined> {
+    const entry = this.map.get(key);
+    if (!entry) {
+      return undefined;
+    }
+
+    if (Date.now() >= entry.expiresAt) {
+      this.map.delete(key);
+      return undefined;
+    }
+
+    // Move to end for LRU (most recently used)
+    this.map.delete(key);
+    this.map.set(key, entry);
+
+    return entry.value as T;
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    // Delete first so re-insertion moves to end
+    this.map.delete(key);
+
+    // Evict oldest entry if at capacity
+    if (this.map.size >= this.maxEntries) {
+      const oldestKey = this.map.keys().next().value as string;
+      this.map.delete(oldestKey);
+    }
+
+    this.map.set(key, {
+      value,
+      expiresAt: Date.now() + ttlMs,
+    });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.map.delete(key);
+  }
+
+  async deleteByPrefix(prefix: string): Promise<void> {
+    for (const key of [...this.map.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.map.delete(key);
+      }
+    }
+  }
+}

--- a/packages/infrastructure/cache/src/types.ts
+++ b/packages/infrastructure/cache/src/types.ts
@@ -1,0 +1,21 @@
+/** Interface for cache storage backends. */
+export interface CacheStore {
+  /** Retrieve a value by key. Returns undefined if missing or expired. */
+  get<T>(key: string): Promise<T | undefined>;
+  /** Store a value with a TTL in milliseconds. */
+  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  /** Delete a specific key. */
+  delete(key: string): Promise<void>;
+  /** Delete all keys that start with the given prefix. */
+  deleteByPrefix(prefix: string): Promise<void>;
+}
+
+/** Options for creating a Cache instance. */
+export interface CacheOptions {
+  /** The underlying store implementation. Defaults to MemoryCacheStore. */
+  store?: CacheStore;
+  /** Default TTL in milliseconds when not specified per-call. Defaults to 60000 (1 minute). */
+  defaultTtlMs?: number;
+  /** Prefix prepended to all keys. Defaults to empty string. */
+  keyPrefix?: string;
+}

--- a/packages/infrastructure/cache/tsconfig.json
+++ b/packages/infrastructure/cache/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@infrastructure/typescript-config/library.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/infrastructure/cache/vitest.config.ts
+++ b/packages/infrastructure/cache/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary
- Add `@infrastructure/cache` package with LRU + TTL caching
- `MemoryCacheStore` with configurable max entries and eviction
- `createCache()` factory with key prefix and default TTL support

## Changes
- New `packages/infrastructure/cache/` with `CacheStore` interface, `MemoryCacheStore`, `Cache` wrapper
- Supports `get`, `set`, `delete`, `deleteByPrefix` operations
- 12 tests (memory-store: 7, cache: 5)

## Test Plan
- `pnpm --filter @infrastructure/cache test` — 12 tests pass
- `pnpm typecheck` — all packages clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)