### PR TITLE
feat(jobs): add @infrastructure/jobs package (#112)

### DIFF
--- a/packages/infrastructure/jobs/package.json
+++ b/packages/infrastructure/jobs/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@infrastructure/jobs",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@infrastructure/typescript-config": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/infrastructure/jobs/src/__tests__/define-job.test.ts
+++ b/packages/infrastructure/jobs/src/__tests__/define-job.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { defineJob } from "../define-job";
+
+describe("defineJob", () => {
+  it("creates a job definition with name and handler", () => {
+    const handler = vi.fn(async () => {});
+    const schema = z.object({ userId: z.string() });
+
+    const job = defineJob({
+      name: "send-welcome-email",
+      schema,
+      handler,
+    });
+
+    expect(job.name).toBe("send-welcome-email");
+    expect(job.schema).toBe(schema);
+    expect(job.handler).toBe(handler);
+    expect(job.options).toBeUndefined();
+  });
+
+  it("includes options when provided", () => {
+    const job = defineJob({
+      name: "process-payment",
+      schema: z.object({ amount: z.number() }),
+      handler: async () => {},
+      options: {
+        retryLimit: 3,
+        retryDelay: 5000,
+        retryBackoff: true,
+        expireInMinutes: 30,
+      },
+    });
+
+    expect(job.options).toEqual({
+      retryLimit: 3,
+      retryDelay: 5000,
+      retryBackoff: true,
+      expireInMinutes: 30,
+    });
+  });
+
+  it("schema validates input correctly", () => {
+    const schema = z.object({
+      email: z.email(),
+      name: z.string().min(1),
+    });
+
+    const job = defineJob({
+      name: "send-notification",
+      schema,
+      handler: async () => {},
+    });
+
+    const validResult = job.schema.safeParse({ email: "test@example.com", name: "Alice" });
+    expect(validResult.success).toBe(true);
+
+    const invalidResult = job.schema.safeParse({ email: "not-an-email", name: "" });
+    expect(invalidResult.success).toBe(false);
+  });
+});

--- a/packages/infrastructure/jobs/src/define-job.ts
+++ b/packages/infrastructure/jobs/src/define-job.ts
@@ -1,0 +1,21 @@
+import type { z } from "zod";
+import type { JobDefinition, JobOptions } from "./types";
+
+/**
+ * Creates a type-safe job definition.
+ *
+ * Schema validation happens at enqueue time, not at definition time.
+ */
+export function defineJob<TInput>(params: {
+  name: string;
+  schema: z.ZodType<TInput>;
+  handler: (data: TInput) => Promise<void>;
+  options?: JobOptions;
+}): JobDefinition<TInput> {
+  return {
+    name: params.name,
+    schema: params.schema,
+    handler: params.handler,
+    options: params.options,
+  };
+}

--- a/packages/infrastructure/jobs/src/index.ts
+++ b/packages/infrastructure/jobs/src/index.ts
@@ -1,0 +1,2 @@
+export { defineJob } from "./define-job";
+export type { JobDefinition, JobOptions, ScheduleOptions } from "./types";

--- a/packages/infrastructure/jobs/src/types.ts
+++ b/packages/infrastructure/jobs/src/types.ts
@@ -1,0 +1,23 @@
+import type { z } from "zod";
+
+/** Configuration for job retry and expiration behavior. */
+export interface JobOptions {
+  retryLimit?: number;
+  retryDelay?: number;
+  retryBackoff?: boolean;
+  expireInMinutes?: number;
+}
+
+/** Options for scheduling a job (delay or cron). */
+export interface ScheduleOptions {
+  delay?: number;
+  cron?: string;
+}
+
+/** A fully defined background job with name, schema, handler, and optional config. */
+export interface JobDefinition<TInput = unknown> {
+  name: string;
+  schema: z.ZodType<TInput>;
+  handler: (data: TInput) => Promise<void>;
+  options?: JobOptions;
+}

--- a/packages/infrastructure/jobs/tsconfig.json
+++ b/packages/infrastructure/jobs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@infrastructure/typescript-config/library.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/infrastructure/jobs/vitest.config.ts
+++ b/packages/infrastructure/jobs/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Add `@infrastructure/jobs` package with job definition factory
- `defineJob()` creates typed job definitions with Zod schema validation
- Foundation for background job processing (pg-boss integration later)

## Changes
- New `packages/infrastructure/jobs/` with `defineJob`, `JobDefinition`, `JobOptions`, `ScheduleOptions`
- 3 tests covering basic creation, options, and schema validation

## Test Plan
- `pnpm --filter @infrastructure/jobs test` — 3 tests pass
- `pnpm typecheck` — all packages clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)