### PR TITLE
feat(api): integrate security and error-tracking middleware + update CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,6 +69,14 @@ pnpm --filter supabase-db reset   # Reset DB (reapply migrations + seed)
   - `@infrastructure/utils` — Cross-platform utility functions
   - `@infrastructure/supabase` — Supabase clients (server, browser, SSR), auth hooks/context (AuthProvider, useAuth, useUser), storage utilities, Hono/Next.js middleware, generated DB types
   - `@infrastructure/typescript-config` — Shared TypeScript configs (base, library, nextjs, react-native)
+  - `@infrastructure/observability` — Structured logging (`createLogger`, pino) and OpenTelemetry middleware (`otelMiddleware`) for Hono; request ID propagation via `x-request-id`
+  - `@infrastructure/security` — Hono middleware for security headers (`securityHeaders`), CSRF protection (`csrfProtection`), and request body size limiting (`bodyLimit`)
+  - `@infrastructure/error-tracking` — `ErrorReporter` interface with `ConsoleReporter` default; `createErrorBoundary()` Hono error handler; `reportError`/`reportMessage` convenience functions
+  - `@infrastructure/rate-limit` — Sliding window rate limiter with `MemoryStore`; `createRateLimiter()` Hono middleware with `X-RateLimit-*` headers
+  - `@infrastructure/cache` — `CacheStore` interface with `MemoryCacheStore` (LRU + TTL); `createCache()` factory with key prefix support
+  - `@infrastructure/feature-flags` — Flag evaluation (`evaluateFlag`) with user targeting, percentage rollout (deterministic hash); `MemoryFlagStore`; Supabase migration for `feature_flags` table
+  - `@infrastructure/jobs` — `defineJob()` factory with Zod schema validation for background job definitions
+  - `@infrastructure/notifications` — `NotificationService` with `NotificationChannel` interface; `ConsoleChannel` default adapter for dev
 
 ## Key Patterns
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,9 @@
     "@orpc/server": "catalog:",
     "@features/users": "workspace:*",
     "@infrastructure/api-client": "workspace:*",
+    "@infrastructure/error-tracking": "workspace:*",
     "@infrastructure/observability": "workspace:*",
+    "@infrastructure/security": "workspace:*",
     "@infrastructure/supabase": "workspace:*",
     "hono": "catalog:",
     "zod": "catalog:"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,6 @@
-import { type Logger, createLogger, otelMiddleware } from "@infrastructure/observability";
+import { ConsoleReporter, createErrorBoundary } from "@infrastructure/error-tracking";
+import { createLogger, type Logger, otelMiddleware } from "@infrastructure/observability";
+import { bodyLimit, securityHeaders } from "@infrastructure/security";
 import { supabaseMiddleware } from "@infrastructure/supabase/middleware/hono";
 import { RPCHandler } from "@orpc/server/fetch";
 import { Hono } from "hono";
@@ -16,9 +18,15 @@ const supabasePublishableKey = requireEnv("SUPABASE_PUBLISHABLE_KEY");
 
 const logger: Logger = createLogger({ serviceName: "api" });
 
+const errorReporter = new ConsoleReporter();
+
 const app = new Hono();
 
+app.onError(createErrorBoundary({ reporter: errorReporter }));
+
 app.use("*", otelMiddleware({ logger }));
+app.use("*", securityHeaders());
+app.use("*", bodyLimit({ maxSize: 1_048_576 }));
 
 app.use(
   "*",

--- a/packages/infrastructure/cache/src/index.ts
+++ b/packages/infrastructure/cache/src/index.ts
@@ -1,4 +1,4 @@
-export type { CacheStore, CacheOptions } from "./types";
-export { MemoryCacheStore } from "./memory-store";
-export type { MemoryCacheStoreOptions } from "./memory-store";
 export { Cache, createCache } from "./cache";
+export type { MemoryCacheStoreOptions } from "./memory-store";
+export { MemoryCacheStore } from "./memory-store";
+export type { CacheOptions, CacheStore } from "./types";

--- a/packages/infrastructure/error-tracking/src/__tests__/middleware.test.ts
+++ b/packages/infrastructure/error-tracking/src/__tests__/middleware.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
 import { createErrorBoundary } from "../middleware";
 import type { ErrorReporter } from "../types";
 

--- a/packages/infrastructure/error-tracking/src/console-reporter.ts
+++ b/packages/infrastructure/error-tracking/src/console-reporter.ts
@@ -29,8 +29,6 @@ export class ConsoleReporter implements ErrorReporter {
       case "warning":
         console.warn("[ErrorTracking]", JSON.stringify(entry));
         break;
-      case "fatal":
-      case "error":
       default:
         console.error("[ErrorTracking]", JSON.stringify(entry));
         break;

--- a/packages/infrastructure/error-tracking/src/index.ts
+++ b/packages/infrastructure/error-tracking/src/index.ts
@@ -2,25 +2,18 @@ import { ConsoleReporter } from "./console-reporter";
 import type { ErrorContext, ErrorLevel } from "./types";
 
 export { ConsoleReporter } from "./console-reporter";
-export { createErrorBoundary } from "./middleware";
 export type { ErrorBoundaryOptions } from "./middleware";
+export { createErrorBoundary } from "./middleware";
 export type { ErrorContext, ErrorLevel, ErrorReporter } from "./types";
 
 const defaultReporter = new ConsoleReporter();
 
 /** Convenience function to report an error using the default ConsoleReporter. */
-export function reportError(
-  error: Error,
-  context?: ErrorContext,
-): void {
+export function reportError(error: Error, context?: ErrorContext): void {
   defaultReporter.captureException(error, context);
 }
 
 /** Convenience function to report a message using the default ConsoleReporter. */
-export function reportMessage(
-  message: string,
-  level?: ErrorLevel,
-  context?: ErrorContext,
-): void {
+export function reportMessage(message: string, level?: ErrorLevel, context?: ErrorContext): void {
   defaultReporter.captureMessage(message, level, context);
 }

--- a/packages/infrastructure/error-tracking/src/middleware.ts
+++ b/packages/infrastructure/error-tracking/src/middleware.ts
@@ -28,7 +28,7 @@ export function createErrorBoundary(options: ErrorBoundaryOptions): ErrorHandler
           ...(requestId ? { requestId } : {}),
         },
       },
-      500,
+      500
     );
   };
 }

--- a/packages/infrastructure/notifications/src/__tests__/console-channel.test.ts
+++ b/packages/infrastructure/notifications/src/__tests__/console-channel.test.ts
@@ -22,7 +22,7 @@ describe("ConsoleChannel", () => {
 
     expect(spy).toHaveBeenCalledOnce();
     expect(spy).toHaveBeenCalledWith(
-      '[notification] to=user@example.com subject="Test Subject" body="Test body content"',
+      '[notification] to=user@example.com subject="Test Subject" body="Test body content"'
     );
 
     spy.mockRestore();

--- a/packages/infrastructure/notifications/src/__tests__/service.test.ts
+++ b/packages/infrastructure/notifications/src/__tests__/service.test.ts
@@ -10,10 +10,7 @@ describe("NotificationService", () => {
     metadata: { priority: "high" },
   };
 
-  function createMockChannel(
-    name: string,
-    success = true,
-  ): NotificationChannel {
+  function createMockChannel(name: string, success = true): NotificationChannel {
     return {
       name,
       send: vi.fn(async () => ({ channel: name, success })),
@@ -22,9 +19,7 @@ describe("NotificationService", () => {
 
   it("throws when no channels are configured", async () => {
     const service = new NotificationService();
-    await expect(service.send(notification)).rejects.toThrow(
-      "No notification channels configured",
-    );
+    await expect(service.send(notification)).rejects.toThrow("No notification channels configured");
   });
 
   it("dispatches to a single channel", async () => {

--- a/packages/infrastructure/notifications/src/console-channel.ts
+++ b/packages/infrastructure/notifications/src/console-channel.ts
@@ -1,8 +1,4 @@
-import type {
-  Notification,
-  NotificationChannel,
-  NotificationResult,
-} from "./types";
+import type { Notification, NotificationChannel, NotificationResult } from "./types";
 
 /** A notification channel that logs to the console. Useful for local development. */
 export class ConsoleChannel implements NotificationChannel {
@@ -11,7 +7,7 @@ export class ConsoleChannel implements NotificationChannel {
   /** Send a notification by logging it to `console.log`. */
   async send(notification: Notification): Promise<NotificationResult> {
     console.log(
-      `[notification] to=${notification.to} subject="${notification.subject}" body="${notification.body}"`,
+      `[notification] to=${notification.to} subject="${notification.subject}" body="${notification.body}"`
     );
     return { channel: this.name, success: true };
   }

--- a/packages/infrastructure/notifications/src/service.ts
+++ b/packages/infrastructure/notifications/src/service.ts
@@ -1,8 +1,4 @@
-import type {
-  Notification,
-  NotificationChannel,
-  NotificationResult,
-} from "./types";
+import type { Notification, NotificationChannel, NotificationResult } from "./types";
 
 /** Dispatches notifications through one or more configured channels. */
 export class NotificationService {
@@ -20,7 +16,7 @@ export class NotificationService {
   async send(notification: Notification): Promise<NotificationResult[]> {
     if (this.channels.length === 0) {
       throw new Error(
-        "No notification channels configured. Add at least one channel before sending.",
+        "No notification channels configured. Add at least one channel before sending."
       );
     }
 
@@ -29,15 +25,14 @@ export class NotificationService {
         try {
           return await channel.send(notification);
         } catch (err) {
-          const message =
-            err instanceof Error ? err.message : "Unknown error";
+          const message = err instanceof Error ? err.message : "Unknown error";
           return {
             channel: channel.name,
             success: false,
             error: message,
           } satisfies NotificationResult;
         }
-      }),
+      })
     );
 
     return results;

--- a/packages/infrastructure/observability/src/__tests__/middleware.test.ts
+++ b/packages/infrastructure/observability/src/__tests__/middleware.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
-import type { Logger } from "pino";
 import { Hono } from "hono";
+import type { Logger } from "pino";
+import { describe, expect, it, vi } from "vitest";
 import { otelMiddleware } from "../middleware";
 
 function createMockLogger() {
@@ -47,9 +47,7 @@ describe("otelMiddleware", () => {
     const requestId = res.headers.get("x-request-id");
     expect(requestId).toBeTruthy();
     // UUID v4 format
-    expect(requestId).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
-    );
+    expect(requestId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
   });
 
   it("makes requestId available via c.get('requestId')", async () => {

--- a/packages/infrastructure/observability/src/__tests__/tracer.test.ts
+++ b/packages/infrastructure/observability/src/__tests__/tracer.test.ts
@@ -25,7 +25,7 @@ describe("withSpan", () => {
     await expect(
       withSpan("error-span", async () => {
         throw new Error("boom");
-      }),
+      })
     ).rejects.toThrow("boom");
   });
 });

--- a/packages/infrastructure/observability/src/index.ts
+++ b/packages/infrastructure/observability/src/index.ts
@@ -1,4 +1,4 @@
-export { createLogger, type LoggerOptions } from "./logger";
 export type { Logger } from "pino";
+export { createLogger, type LoggerOptions } from "./logger";
 export { otelMiddleware } from "./middleware";
 export { getTracer, withSpan } from "./tracer";

--- a/packages/infrastructure/observability/src/middleware.ts
+++ b/packages/infrastructure/observability/src/middleware.ts
@@ -1,5 +1,5 @@
-import type { Logger } from "pino";
 import type { MiddlewareHandler } from "hono";
+import type { Logger } from "pino";
 
 declare module "hono" {
   interface ContextVariableMap {

--- a/packages/infrastructure/observability/src/tracer.ts
+++ b/packages/infrastructure/observability/src/tracer.ts
@@ -1,5 +1,5 @@
-import { SpanStatusCode, trace } from "@opentelemetry/api";
 import type { Span, Tracer } from "@opentelemetry/api";
+import { SpanStatusCode, trace } from "@opentelemetry/api";
 
 const DEFAULT_TRACER_NAME = "app";
 

--- a/packages/infrastructure/rate-limit/src/__tests__/middleware.test.ts
+++ b/packages/infrastructure/rate-limit/src/__tests__/middleware.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
 import { createRateLimiter } from "../middleware";
 
 function createApp(max: number) {

--- a/packages/infrastructure/security/src/__tests__/body-limit.test.ts
+++ b/packages/infrastructure/security/src/__tests__/body-limit.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
 import { bodyLimit } from "../body-limit";
 
 function createApp(maxSize?: number) {

--- a/packages/infrastructure/security/src/__tests__/csrf.test.ts
+++ b/packages/infrastructure/security/src/__tests__/csrf.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
 import { csrfProtection } from "../csrf";
 
 const ALLOWED_ORIGINS = ["http://localhost:3000", "http://localhost:3001"];
@@ -88,10 +88,7 @@ describe("csrfProtection", () => {
 
   it("strips trailing slashes from allowed origins for comparison", async () => {
     const app = new Hono();
-    app.use(
-      "*",
-      csrfProtection({ allowedOrigins: ["http://localhost:3000/"] })
-    );
+    app.use("*", csrfProtection({ allowedOrigins: ["http://localhost:3000/"] }));
     app.post("/", (c) => c.text("ok"));
 
     const res = await app.request("/", {

--- a/packages/infrastructure/security/src/__tests__/headers.test.ts
+++ b/packages/infrastructure/security/src/__tests__/headers.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
 import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
 import { securityHeaders } from "../headers";
 
 function createApp(options?: Parameters<typeof securityHeaders>[0]) {

--- a/packages/infrastructure/security/src/csrf.ts
+++ b/packages/infrastructure/security/src/csrf.ts
@@ -9,9 +9,7 @@ const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  * of allowed origins.
  */
 export function csrfProtection(options: CsrfProtectionOptions): MiddlewareHandler {
-  const allowedOrigins = new Set(
-    options.allowedOrigins.map((origin) => origin.replace(/\/$/, ""))
-  );
+  const allowedOrigins = new Set(options.allowedOrigins.map((origin) => origin.replace(/\/$/, "")));
 
   return async (c, next) => {
     if (!STATE_CHANGING_METHODS.has(c.req.method)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,9 +238,15 @@ importers:
       '@infrastructure/api-client':
         specifier: workspace:*
         version: link:../../packages/infrastructure/api-client
+      '@infrastructure/error-tracking':
+        specifier: workspace:*
+        version: link:../../packages/infrastructure/error-tracking
       '@infrastructure/observability':
         specifier: workspace:*
         version: link:../../packages/infrastructure/observability
+      '@infrastructure/security':
+        specifier: workspace:*
+        version: link:../../packages/infrastructure/security
       '@infrastructure/supabase':
         specifier: workspace:*
         version: link:../../packages/infrastructure/supabase


### PR DESCRIPTION
## Summary
- Wire up `securityHeaders`, `bodyLimit`, and `createErrorBoundary` middleware in the API's Hono chain
- Document all 9 new infrastructure packages in CLAUDE.md
- Apply biome formatting to all new packages

## Changes
- `apps/api/src/app.ts` — added security headers, body limit (1MB), and error boundary middleware
- `apps/api/package.json` — added `@infrastructure/error-tracking` and `@infrastructure/security` dependencies
- `.claude/CLAUDE.md` — documented all new infrastructure packages in Architecture section
- Biome formatting applied across all new packages

## Test Plan
- `pnpm typecheck` — 20/20 packages pass
- `pnpm test` — 20/20 packages pass
- Full pre-commit hook passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)