### PR TITLE
Pivot repo from boilerplate to spec-only

### DIFF
--- a/.agents/skills/woo-review/SKILL.md
+++ b/.agents/skills/woo-review/SKILL.md
@@ -86,6 +86,10 @@ models:                        # per-tier overrides; inputs.model still wins
 fix_commands:                  # reserved for --loop mode (issue #15)
   - pnpm lint:fix
   - pnpm format
+disable_adversarial: false     # cost-sensitive opt-out for the prosecutor+
+                               # defender validator (issue #13). When true,
+                               # only the defender pass runs and its output
+                               # becomes findings.json directly.
 ```
 
 **Precedence**: for the angle set, `angles.force` beats `angles.skip` when the same angle is listed in both. For model resolution, the action input `inputs.model` beats `models.<tier>` which beats the table default in `prompts/_header.md`. `ignore` is applied to both file paths and the per-file diff sections before angle gates evaluate.
@@ -201,7 +205,7 @@ Per-provider resolution (full table in `_header.md`):
 - **Per-call routing** (Claude Code `Task`, opencode `@subagent`): honor each prompt's `tier:` verbatim. Maximum savings.
 - **Single model per session** (Codex Action, Gemini CLI): pin the run to the `standard` tier — covers every angle safely. `tier:` becomes informational. Split into multiple jobs if you want fast-tier savings on rubric angles or deep-tier validation.
 
-### Stage 4 — Merge + Skeptical Validation
+### Stage 4 — Merge + Adversarial Validation
 
 After every sub-agent has finished:
 
@@ -210,14 +214,34 @@ bash "$WOO_REVIEW_ACTION_PATH/scripts/merge-findings.sh"
 # Produces /tmp/pr-review/raw_findings.json
 ```
 
-Now act as the **Skeptical Validator** by following `prompts/validator.md`:
+Validation runs as an **adversarial pipeline** (issue #13): two opposing-bias `deep`-tier validator passes followed by a deterministic intersection. The intersection (findings BOTH passes agree to keep) is what authors see — this trades 2× validator cost for materially higher signal-to-noise.
+
+Read `disable_adversarial` from `/tmp/pr-review/config.json`:
+
+```bash
+DISABLE_ADV="$(jq -r '.disable_adversarial // false' /tmp/pr-review/config.json 2>/dev/null || echo false)"
+```
+
+**Stage 4a — Prosecutor pass** (skip if `DISABLE_ADV == true`):
+
+Run `prompts/validator-prosecutor.md`. Bias: assume each finding is real; drop only the clearly wrong. Writes `/tmp/pr-review/findings.prosecutor.json` and exits.
+
+**Stage 4b — Defender pass** (`prompts/validator.md`):
 
 1. Dedupe across angles (keep the most actionable description; preserve the winner's `title` / `description` / `fix`).
 2. Defense-attorney audit: try to prove each finding wrong. Drop pedantic / style-only / lint-catchable / "maybe" findings.
 3. Severity check: you MAY downgrade (HIGH → MEDIUM, blocking true → false). You MAY NOT upgrade.
 4. Comment-shape check: every surviving finding has `title` (bold headline ≤60 chars), `description` (issue only, no fix), and `fix` (recommended change in prose). Split overloaded `description` fields when an angle collapsed them.
 5. `fix_type` enforcement: every surviving finding MUST carry `fix_type` (`"suggestion"` or `"prose"`). Downgrade any `fix_type: "suggestion"` that violates the ≤10-line / single-file / self-contained / no-placeholder / no-fence-break rules — set `fix_type: "prose"` and `suggestion: null`. Full rule list lives in `prompts/validator.md` step 7.
-6. Write the surviving array to `/tmp/pr-review/findings.json`.
+6. Writes `/tmp/pr-review/findings.defender.json`.
+
+**Stage 4c — Intersect**:
+
+```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
+```
+
+Produces `/tmp/pr-review/findings.json` — the final validated set — and `/tmp/pr-review/validator-metrics.json` with `prosecutor_count`, `defender_count`, `kept_count`, `disagreement_count`. Intersection key is `(file, line, title-stem)` (same stem as prior-thread dedupe in `_header.md`). When `disable_adversarial: true` is set or `findings.prosecutor.json` is absent, the script copies defender output verbatim and tags metrics `mode: defender-only`. Severity = `min(prosecutor, defender)`, blocking = `prosecutor.blocking AND defender.blocking`, other fields take the defender's copy.
 
 ### Stage 5 — Report
 

--- a/.agents/skills/woo-review/prompts/_header.md
+++ b/.agents/skills/woo-review/prompts/_header.md
@@ -165,10 +165,15 @@ else:
 
 comments = []
 for f in findings:
-    # Inline comment format: bold title, issue description, recommended fix.
+    # Inline comment format: bold title, issue description, recommended fix,
+    # trailing attribution footer naming the severity + angle agent that
+    # flagged the finding (plus a "blocking" tag when blocking == true).
     title = f["title"].strip()
     description = f["description"].strip()
     fix = (f.get("fix") or "").strip()
+    angle = (f.get("angle") or "").strip()
+    severity = (f.get("severity") or "").strip().upper()
+    blocking = bool(f.get("blocking", False))
 
     body = f"**{title}**\n\n{description}"
     if fix:
@@ -188,6 +193,18 @@ for f in findings:
             safe_lines.append(line)
         safe = "\n".join(safe_lines)
         body += f"\n\n```suggestion\n{safe}\n```"
+
+    # Attribution footer: severity + which angle agent found this. Both values
+    # are whitelisted against their known sets so malformed/garbage input
+    # cannot inject text into the rendered comment.
+    footer_parts = []
+    if severity in {"HIGH", "MEDIUM", "LOW"}:
+        sev_tag = f"{severity} · BLOCKING" if blocking else severity
+        footer_parts.append(f"<strong>{sev_tag}</strong>")
+    if angle in {"bugs","security","conventions","seo","aeo","design","react","database"}:
+        footer_parts.append(f"flagged by the <code>{angle}</code> agent")
+    if footer_parts:
+        body += "\n\n<sub>— " + " · ".join(footer_parts) + "</sub>"
 
     comments.append({
         "path": f["file"],
@@ -257,7 +274,7 @@ The validator enforces these rules and will downgrade a violating `fix_type: sug
 
 ### Inline Comment Format (rendered on the PR)
 
-Every inline comment posted to GitHub MUST follow this three-part structure, assembled from the schema fields above:
+Every inline comment posted to GitHub MUST follow this four-part structure, assembled from the schema fields above:
 
 ```
 **<title>**
@@ -265,13 +282,16 @@ Every inline comment posted to GitHub MUST follow this three-part structure, ass
 <description>
 
 Fix: <fix>
+
+<sub>— <strong><severity> · BLOCKING</strong> · flagged by the <code><angle></code> agent</sub>
 ```
 
 - **Title** — bold one-liner, ≤60 characters, no trailing punctuation. Names the problem.
 - **Description** — the issue itself: what is broken, why it matters, with diff-anchored evidence. Do NOT prescribe the fix here.
 - **Fix** — recommended change, prefixed literally with `Fix: `. Required for every finding. The body builder appends a GitHub ```suggestion``` block after the `Fix:` line if and only if `fix_type == "suggestion"` AND `suggestion` is a non-empty string; `fix_type == "prose"` renders the recommendation in prose only.
+- **Attribution footer** — small-print line carrying the finding's `severity` (HIGH / MEDIUM / LOW; suffixed with `· BLOCKING` when `blocking == true`) and the angle agent that flagged it (e.g. `<sub>— <strong>HIGH · BLOCKING</strong> · flagged by the <code>bugs</code> agent</sub>`). The body builder appends this automatically from the finding's `severity` / `blocking` / `angle` fields. Both `severity` and `angle` are whitelisted against their known sets; unknown/missing values are dropped from the footer rather than injecting raw text. If both are missing, the footer is omitted entirely.
 
-The body builder in the posting step (see python snippet above) renders this format automatically from `title` / `description` / `fix` / `fix_type` / `suggestion`. Angle agents and the validator MUST populate `title`, `description`, `fix`, and `fix_type` for every finding.
+The body builder in the posting step (see python snippet above) renders this format automatically from `title` / `description` / `fix` / `fix_type` / `suggestion` / `angle` / `severity` / `blocking`. Angle agents and the validator MUST populate `title`, `description`, `fix`, `fix_type`, `angle`, `severity`, and `blocking` for every finding.
 
 ## Blocking Criteria
 

--- a/.agents/skills/woo-review/prompts/anthropic.md
+++ b/.agents/skills/woo-review/prompts/anthropic.md
@@ -87,16 +87,29 @@ Read `/tmp/pr-review/angles.txt`. Launch **one subagent per enabled angle in the
 
 If the Task tool caps practical parallelism below the angle count, spawn the angles in two waves: `[bugs, security, seo, aeo]` then `[design, react, database]`. Do not skip any enabled angle.
 
-## Step 3 — Validation (Opus 4.7, only if any findings)
+## Step 3 — Adversarial Validation (Opus 4.7, prosecutor + defender)
 
 Skip if every per-angle file is empty / missing; status is `APPROVED`.
 
-Otherwise launch one `claude-opus-4-7` validator subagent with the full diff and the merged findings (concat all `findings.<angle>.json` arrays). For each finding:
+Otherwise this step runs **two** sequential `claude-opus-4-7` validator subagents with opposing biases, then a deterministic intersection (issue #13). The intersection is the high-confidence set of findings the author sees.
 
-1. **Verdict**: YES (confirmed) or NO (false positive) with brief reasoning. Only YES survives.
-2. **Severity / blocking**: confirm or downgrade the `blocking` flag. May downgrade `true → false`. May NOT upgrade `false → true`.
+Read `disable_adversarial` from `/tmp/pr-review/config.json`:
 
-Write surviving findings to `/tmp/pr-review/findings.json` per the schema in `_header.md`.
+```bash
+DISABLE_ADV="$(jq -r '.disable_adversarial // false' /tmp/pr-review/config.json 2>/dev/null || echo false)"
+```
+
+### Step 3a — Prosecutor pass (skip if `DISABLE_ADV == true`)
+
+Launch one `claude-opus-4-7` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator-prosecutor.md` as its prompt. It assumes each finding is real and only drops the clearly-wrong ones. It writes `/tmp/pr-review/findings.prosecutor.json` and EXITS — it MUST NOT post a review.
+
+### Step 3b — Defender pass
+
+Launch one `claude-opus-4-7` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` as its prompt. It applies the strict "defense attorney" filter — drops pedantic / lint-catchable / maybe-issues / placeholder-suggestion findings — and writes `/tmp/pr-review/findings.defender.json`. It then runs `bash $WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh` which produces the final `/tmp/pr-review/findings.json` (intersection of prosecutor + defender; when adversarial is disabled or the prosecutor file is absent, the script copies defender output verbatim). The defender subagent continues into Step 4 below to post the review.
+
+The two passes MUST be sequential — the defender runs the intersect script after writing its output, so the prosecutor's file must already exist when adversarial mode is on.
+
+Per-pass and disagreement counts land in `/tmp/pr-review/validator-metrics.json` for downstream telemetry.
 
 ## Step 4 — Submit Native PR Review
 

--- a/.agents/skills/woo-review/prompts/google.md
+++ b/.agents/skills/woo-review/prompts/google.md
@@ -52,15 +52,31 @@ For each angle listed in `/tmp/pr-review/angles.txt`, in order:
 
 Stay within each angle's scope.
 
-## Phase 3 — Self-Validation
+## Phase 3 — Adversarial Validation (prosecutor + defender, sequential)
 
-Merge all `findings.<angle>.json`. For each finding:
+Merge all `findings.<angle>.json` arrays into `/tmp/pr-review/raw_findings.json` via `$WOO_REVIEW_ACTION_PATH/scripts/merge-findings.sh`.
 
-1. Real, in-diff, this-PR-introduced? If NO → drop.
-2. Confirm or downgrade `blocking`. Never upgrade.
-3. Dedupe across angles.
+Then run TWO opposing-bias validation passes plus a deterministic intersection (issue #13). Gemini CLI has no subagent primitive, so this is sequenced inside the single agentic loop. Read `disable_adversarial` first:
 
-Persist to `/tmp/pr-review/findings.json` per `_header.md` schema.
+```bash
+DISABLE_ADV="$(jq -r '.disable_adversarial // false' /tmp/pr-review/config.json 2>/dev/null || echo false)"
+```
+
+### Phase 3a — Prosecutor pass (skip if `DISABLE_ADV == true`)
+
+Apply `$WOO_REVIEW_ACTION_PATH/prompts/validator-prosecutor.md` against `raw_findings.json`. Bias: assume each finding is real; drop only the demonstrably wrong. Write surviving findings to `/tmp/pr-review/findings.prosecutor.json`.
+
+### Phase 3b — Defender pass
+
+Apply `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` against `raw_findings.json`. Bias: try to prove each finding wrong; drop pedantic / lint-catchable / "maybe" findings. Write surviving findings to `/tmp/pr-review/findings.defender.json`.
+
+### Phase 3c — Intersect
+
+```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
+```
+
+Produces the final `/tmp/pr-review/findings.json` (intersection by `(file, line, title-stem)`). When adversarial is disabled or the prosecutor file is absent, copies defender output verbatim. Per-pass + disagreement counts in `/tmp/pr-review/validator-metrics.json`.
 
 ## Phase 4 — Submit Native PR Review
 

--- a/.agents/skills/woo-review/prompts/openai.md
+++ b/.agents/skills/woo-review/prompts/openai.md
@@ -52,15 +52,31 @@ For each angle listed in `/tmp/pr-review/angles.txt`, in order:
 
 Stay within each angle's scope; do not let `bugs` flag a design issue or vice versa.
 
-## Phase 3 — Self-Validation
+## Phase 3 — Adversarial Validation (prosecutor + defender, sequential)
 
-Merge all `findings.<angle>.json` arrays. For each finding:
+Merge all `findings.<angle>.json` arrays into `/tmp/pr-review/raw_findings.json` (use `$WOO_REVIEW_ACTION_PATH/scripts/merge-findings.sh`).
 
-1. Real, in-diff, this-PR-introduced? If NO → drop.
-2. Confirm or downgrade `blocking`. Never upgrade.
-3. Dedupe across angles: if two angles flag identical `(file, line, description-equivalent)`, keep one (prefer the angle most-specific to the issue type).
+Then run TWO opposing-bias validation passes followed by a deterministic intersection (issue #13). Codex Action has no subagent primitive, so this is sequenced inside the single agentic loop using `bash` to invoke the intersect script. Read `disable_adversarial` first:
 
-Persist surviving findings to `/tmp/pr-review/findings.json` per the schema in `_header.md`.
+```bash
+DISABLE_ADV="$(jq -r '.disable_adversarial // false' /tmp/pr-review/config.json 2>/dev/null || echo false)"
+```
+
+### Phase 3a — Prosecutor pass (skip if `DISABLE_ADV == true`)
+
+Apply `$WOO_REVIEW_ACTION_PATH/prompts/validator-prosecutor.md` against `raw_findings.json`. Bias: assume each finding is real; drop only the demonstrably wrong. Write surviving findings to `/tmp/pr-review/findings.prosecutor.json`.
+
+### Phase 3b — Defender pass
+
+Apply `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` against `raw_findings.json`. Bias: try to prove each finding wrong; drop pedantic / lint-catchable / "maybe" findings; enforce the comment-shape + `fix_type` rules. Write surviving findings to `/tmp/pr-review/findings.defender.json`.
+
+### Phase 3c — Intersect
+
+```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
+```
+
+This produces the final `/tmp/pr-review/findings.json` (intersection by `(file, line, title-stem)`; severity = min, blocking = AND). When `disable_adversarial == true` or the prosecutor file is absent, the script copies defender output verbatim. Per-pass and disagreement counts land in `/tmp/pr-review/validator-metrics.json`.
 
 ## Phase 4 — Submit Native PR Review
 

--- a/.agents/skills/woo-review/prompts/opencode.md
+++ b/.agents/skills/woo-review/prompts/opencode.md
@@ -63,15 +63,29 @@ Each angle agent:
 
 Stay within each angle's scope; do not let one angle flag issues that belong to another.
 
-## Phase 3 — Self-Validation
+## Phase 3 — Adversarial Validation (prosecutor + defender, sequential)
 
-Sequential (do not parallelize validation). Merge all `findings.<angle>.json`. For each finding:
+Merge all `findings.<angle>.json` into `/tmp/pr-review/raw_findings.json` via `$WOO_REVIEW_ACTION_PATH/scripts/merge-findings.sh`. Validation does NOT parallelize; it runs the two opposing-bias passes in sequence, followed by a deterministic intersection (issue #13). Read `disable_adversarial` first:
 
-1. Real, in-diff, this-PR-introduced? If NO → drop.
-2. Confirm or downgrade `blocking`. Never upgrade.
-3. Dedupe across angles.
+```bash
+DISABLE_ADV="$(jq -r '.disable_adversarial // false' /tmp/pr-review/config.json 2>/dev/null || echo false)"
+```
 
-Persist to `/tmp/pr-review/findings.json` per `_header.md`.
+### Phase 3a — Prosecutor pass (skip if `DISABLE_ADV == true`)
+
+If the OpenCode runtime supports per-call routing, spawn a `deep`-tier subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator-prosecutor.md`; otherwise apply the same prompt within the main loop. Bias: assume each finding is real; drop only the demonstrably wrong. Write surviving findings to `/tmp/pr-review/findings.prosecutor.json`.
+
+### Phase 3b — Defender pass
+
+Spawn another `deep`-tier subagent (or continue the main loop) with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md`. Bias: defense attorney — drop pedantic / lint-catchable / "maybe" findings, enforce comment-shape + `fix_type` rules. Write surviving findings to `/tmp/pr-review/findings.defender.json`.
+
+### Phase 3c — Intersect
+
+```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
+```
+
+Produces `/tmp/pr-review/findings.json` (intersection by `(file, line, title-stem)`; severity = min, blocking = AND). When adversarial is disabled or the prosecutor file is absent, copies defender output verbatim. Disagreement counts in `/tmp/pr-review/validator-metrics.json`.
 
 ## Phase 4 — Submit Native PR Review
 

--- a/.agents/skills/woo-review/prompts/validator-prosecutor.md
+++ b/.agents/skills/woo-review/prompts/validator-prosecutor.md
@@ -1,0 +1,60 @@
+---
+tier: deep
+---
+
+# Skeptical Validator Agent — Prosecutor Pass
+
+You are a Senior Software Engineer acting as a **"Prosecutor"** for the code under review. Your bias is the inverse of the Defender (`validator.md`). Where the Defender tries to prove findings WRONG, you assume each finding is REAL and only drop it when it is **clearly, demonstrably** a false positive.
+
+This pass is one half of an adversarial validation pipeline. Your output is intersected with the Defender's output by `scripts/intersect-findings.sh`. A finding survives only if BOTH passes keep it — so your job is to be the **inclusive** vote, the Defender is the **exclusive** vote, and the intersection is what authors see.
+
+## Input Artifacts
+- **Diff**: /tmp/pr-review/diff.txt
+- **Raw Findings**: /tmp/pr-review/raw_findings.json (Concatenated array from all angles)
+- **Project rules** (optional): /tmp/pr-review/rules.md
+- **Per-repo config** (optional): /tmp/pr-review/config.json — read `.severity_floor` only.
+
+## Your Task
+
+### Step 1 — Validation (Prosecutor bias)
+
+1. **Deduplicate**: If multiple angles flagged the same issue, pick the one with the most actionable description. Preserve `title`, `description`, and `fix` from the winning finding.
+2. **Prosecutor Audit**: For each finding in `/tmp/pr-review/raw_findings.json`, assume it is REAL. Try to **justify keeping it**. Drop ONLY if ALL of the following hold:
+   - The finding is verifiably wrong against the diff (e.g. the cited line does not contain the cited code, or the claimed behavior is contradicted by code visible in the diff).
+   - OR it is purely cosmetic style with zero correctness/security/perf impact AND no rule backing.
+   - OR it duplicates another finding kept in the deduped set.
+   - When in doubt: **KEEP**. The Defender pass will drop weak findings; you do not have to.
+3. **Rule-quote Check** (same as Defender — non-negotiable invariant):
+   - If `/tmp/pr-review/rules.md` is absent, DISCARD any finding whose `description` claims a project-rule violation OR whose `rule_quote` is non-null.
+   - If `rule_quote` is null/empty/whitespace, DISCARD.
+   - If `rule_quote` is not a verbatim substring of `rules.md`, DISCARD.
+   - Use `grep -qF "$quote" /tmp/pr-review/rules.md`.
+4. **Severity Check**: You MAY downgrade severity / blocking. You MAY NOT upgrade.
+5. **Severity Floor**: If `.severity_floor` is set in `/tmp/pr-review/config.json`, drop findings strictly below it. Apply AFTER step 4.
+6. **Comment Shape Check**: Same as Defender — `title` (≤60 chars, no trailing punctuation), `description` (issue only), `fix` (recommended change in prose) all populated. Split overloaded `description` into the three fields when an angle collapsed them.
+7. **`fix_type` Enforcement**: Same size + scope cap as Defender. Downgrade `"suggestion"` → `"prose"` (clearing `suggestion`) when any of these hold:
+   - `suggestion` null/empty/whitespace.
+   - `suggestion` exceeds **10 lines**.
+   - `suggestion` contains `...`, `<...>`, `// ...`, `# ...`, `/* ... */`, or any partial-diff placeholder.
+   - `suggestion` contains a line matching `^\s*` + three or more backticks (would prematurely close the GitHub ```suggestion``` fence). Verify with `grep -nE '^[[:space:]]*` + three backticks.
+   - The finding implies a change in more than one file.
+   - The snippet is not a self-contained drop-in for the existing line(s) at `line`.
+   - The change is structural (new function, refactor, file move).
+   - Do NOT discard for this — only downgrade.
+
+Write the surviving JSON array to **`/tmp/pr-review/findings.prosecutor.json`**.
+
+### Step 2 — Exit
+
+DO NOT:
+- Post a PR review.
+- Submit a `gh api ... reviews` call.
+- Edit the PR body or title.
+- Touch `/tmp/pr-review/findings.json` (owned by the intersect script, written after the Defender pass).
+- Write any other file.
+
+After writing `findings.prosecutor.json`, EXIT.
+
+## Why this exists
+
+Single-shot validation is biased by prompt framing. A "prove it wrong" Defender pass drops some real findings; a "prove it right" Prosecutor pass keeps some junk. The intersection (findings BOTH keep) is the high-confidence set worth showing the author. See issue #13 for the design rationale.

--- a/.agents/skills/woo-review/prompts/validator.md
+++ b/.agents/skills/woo-review/prompts/validator.md
@@ -2,9 +2,11 @@
 tier: deep
 ---
 
-# Skeptical Validator Agent
+# Skeptical Validator Agent — Defender Pass
 
-You are a Senior Software Engineer acting as a "Defense Attorney" for the code under review. Your goal is to maximize accuracy by discarding low-value or false-positive findings from optimistic "Angle Agents."
+You are a Senior Software Engineer acting as a **"Defense Attorney"** for the code under review. Your goal is to maximize accuracy by discarding low-value or false-positive findings from optimistic "Angle Agents."
+
+This pass is one half of an adversarial validation pipeline (issue #13). The Prosecutor pass (`validator-prosecutor.md`) runs first with the inverse bias — it assumes findings are real and only drops the clearly-wrong ones. Your output (`findings.defender.json`) is then intersected with the Prosecutor's output (`findings.prosecutor.json`) by `scripts/intersect-findings.sh`, which writes the final `findings.json` you use for posting. Cost-sensitive repos can set `disable_adversarial: true` in `.woo-review.yml` — when present, the intersect script copies your output verbatim to `findings.json` and the Prosecutor pass is skipped upstream.
 
 ## Input Artifacts
 - **Diff**: /tmp/pr-review/diff.txt
@@ -47,11 +49,23 @@ Launch one Haiku subagent. Task:
    - Do NOT discard the finding for this — only downgrade. The `fix` prose remains the recommendation.
    - After enforcement, every finding MUST have `fix_type ∈ {"suggestion", "prose"}` and the `suggestion` field MUST be a non-empty string when `fix_type == "suggestion"` and `null` when `fix_type == "prose"`.
 
-Write the final validated JSON array to /tmp/pr-review/findings.json.
+Write the defender-validated JSON array to **`/tmp/pr-review/findings.defender.json`** — NOT `findings.json`. The final `findings.json` is produced by the intersect script in Step 3.
 
-### Step 3 — Post Native PR Review
+### Step 3 — Intersect with Prosecutor pass
+
+Run the deterministic intersection script. It reads `findings.prosecutor.json` + `findings.defender.json`, applies the merge rules (severity = min, blocking = AND, defender's prose wins), writes `/tmp/pr-review/findings.json`, and emits per-pass counts to `/tmp/pr-review/validator-metrics.json`.
+
+```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
+```
+
+Notes:
+- If `disable_adversarial: true` is set in `/tmp/pr-review/config.json`, OR if `findings.prosecutor.json` is missing/empty (e.g. the Prosecutor pass was not scheduled), the script copies your defender output verbatim to `findings.json` and tags the metrics as `mode: defender-only`. No special handling required from you.
+- After this step, `findings.json` is the single source of truth for Step 4. Do not re-read `findings.defender.json` for posting.
+
+### Step 4 — Post Native PR Review
 Follow _header.md exactly. Compute BLOCKING_COUNT, NONBLOCKING_COUNT, HIGH_COUNT, MEDIUM_COUNT, LOW_COUNT. Build STATUS_LINE.
-- Use the findings from /tmp/pr-review/findings.json.
+- Use the findings from `/tmp/pr-review/findings.json` (the intersected set, not your defender output).
 - Submit a single native GitHub PR Review (Batch) including all inline comments and the summary/status line.
 - Determine review event: APPROVE (0 findings), REQUEST_CHANGES (blocking > 0), or COMMENT (non-blocking > 0). The REQUEST_CHANGES event is the only blocking signal — do not apply or remove labels.
 - **DO NOT** update the PR description, title, or labels.

--- a/.agents/skills/woo-review/scripts/intersect-findings.sh
+++ b/.agents/skills/woo-review/scripts/intersect-findings.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# intersect-findings.sh — adversarial validator merge step (issue #13).
+#
+# Inputs (in $OUTDIR, defaults to /tmp/pr-review):
+#   findings.prosecutor.json   array — output of validator-prosecutor.md
+#   findings.defender.json     array — output of validator.md (defender)
+#   config.json                {disable_adversarial?: bool, ...}
+#
+# Outputs:
+#   findings.json              final validated findings (intersection, or
+#                              copy of defender output when adversarial is off)
+#   validator-metrics.json     {prosecutor_count, defender_count,
+#                               kept_count, disagreement_count,
+#                               dropped_by_defender, dropped_by_prosecutor,
+#                               mode: "adversarial" | "defender-only"}
+#
+# Intersection key: (file, line, title_stem) where title_stem is lowercase
+# alphanumeric truncated to 40 chars — same key used by prior-thread dedupe
+# in _header.md so the two stay consistent.
+#
+# When `disable_adversarial: true` is set in config.json, OR
+# findings.prosecutor.json is missing/empty, intersection is skipped and
+# findings.defender.json is copied verbatim to findings.json. This is the
+# cost-sensitive opt-out described in issue #13's acceptance criteria.
+#
+# Merge rules for findings present in BOTH passes:
+#   - severity: take the LOWER (more conservative) of the two values
+#               (LOW < MEDIUM < HIGH).
+#   - blocking: AND of the two (`true` only if both passes say blocking).
+#   - other fields (title, description, fix, suggestion, fix_type, rule_quote):
+#     prefer the DEFENDER's copy — it ran the stricter shape + fix_type checks
+#     so its rewrites are the canonical version.
+
+set -euo pipefail
+
+OUTDIR="${OUTDIR:-/tmp/pr-review}"
+PROSECUTOR="$OUTDIR/findings.prosecutor.json"
+DEFENDER="$OUTDIR/findings.defender.json"
+FINAL="$OUTDIR/findings.json"
+METRICS="$OUTDIR/validator-metrics.json"
+CONFIG="$OUTDIR/config.json"
+
+# Resolve disable_adversarial from config.json (default false).
+disable_adversarial="false"
+if [ -f "$CONFIG" ]; then
+  v="$(jq -r '.disable_adversarial // false' "$CONFIG" 2>/dev/null || echo false)"
+  case "$v" in true|false) disable_adversarial="$v" ;; *) disable_adversarial="false" ;; esac
+fi
+
+# Defender output is mandatory. If absent we cannot post a review at all —
+# upstream is broken and we should fail loudly.
+if [ ! -s "$DEFENDER" ]; then
+  echo "::error::intersect-findings: $DEFENDER missing or empty — defender validator did not run" >&2
+  exit 1
+fi
+if ! jq -e 'type == "array"' "$DEFENDER" >/dev/null 2>&1; then
+  echo "::error::intersect-findings: $DEFENDER is not a JSON array" >&2
+  exit 1
+fi
+
+defender_count="$(jq 'length' "$DEFENDER")"
+
+# Defender-only path (adversarial disabled OR prosecutor file missing).
+prosecutor_present="false"
+if [ -s "$PROSECUTOR" ] && jq -e 'type == "array"' "$PROSECUTOR" >/dev/null 2>&1; then
+  prosecutor_present="true"
+fi
+
+if [ "$disable_adversarial" = "true" ] || [ "$prosecutor_present" = "false" ]; then
+  mode="defender-only"
+  reason="$disable_adversarial"
+  if [ "$disable_adversarial" != "true" ]; then
+    echo "::warning::intersect-findings: prosecutor findings absent — falling back to defender-only output" >&2
+  fi
+  cp "$DEFENDER" "$FINAL"
+  jq -n \
+    --argjson defender_count "$defender_count" \
+    --arg mode "$mode" \
+    '{
+      mode: $mode,
+      prosecutor_count: null,
+      defender_count: $defender_count,
+      kept_count: $defender_count,
+      disagreement_count: 0,
+      dropped_by_defender: 0,
+      dropped_by_prosecutor: 0
+    }' > "$METRICS"
+  echo "intersect-findings: mode=$mode kept=$defender_count"
+  exit 0
+fi
+
+prosecutor_count="$(jq 'length' "$PROSECUTOR")"
+
+# Intersection via jq. The key is (file, line, title_stem). title_stem matches
+# the _header.md prior-thread dedupe stem so the two systems agree on identity.
+jq -n \
+  --slurpfile p "$PROSECUTOR" \
+  --slurpfile d "$DEFENDER" '
+def title_stem(s): (s // "" | ascii_downcase | gsub("[^a-z0-9]+"; "")) [0:40];
+def key(f): [(f.file // ""), (f.line // 0 | tonumber? // 0), title_stem(f.title)];
+def sev_rank(s):
+  if s == "LOW" then 0
+  elif s == "MEDIUM" then 1
+  elif s == "HIGH" then 2
+  else 1 end;
+def sev_label(n):
+  if n <= 0 then "LOW"
+  elif n == 1 then "MEDIUM"
+  else "HIGH" end;
+
+($p[0]) as $pros
+| ($d[0]) as $def
+| ([$pros[] | { (key(.) | @json): . }] | add // {}) as $pros_map
+| ([$def[]  | { (key(.) | @json): . }] | add // {}) as $def_map
+| [ $def[]
+    | . as $df
+    | (key(.) | @json) as $k
+    | if $pros_map[$k] == null then empty
+      else
+        ($pros_map[$k]) as $pr
+        | $df
+        | .severity = sev_label([sev_rank($df.severity), sev_rank($pr.severity)] | min)
+        | .blocking = (($df.blocking // false) and ($pr.blocking // false))
+      end
+  ]
+' > "$FINAL"
+
+kept_count="$(jq 'length' "$FINAL")"
+# Disagreement: findings either pass kept but the other dropped.
+# Equivalent to (defender_count - kept) + (prosecutor_count - kept).
+dropped_by_defender="$((prosecutor_count - kept_count))"
+dropped_by_prosecutor="$((defender_count - kept_count))"
+if [ "$dropped_by_defender" -lt 0 ]; then dropped_by_defender=0; fi
+if [ "$dropped_by_prosecutor" -lt 0 ]; then dropped_by_prosecutor=0; fi
+disagreement_count="$((dropped_by_defender + dropped_by_prosecutor))"
+
+jq -n \
+  --argjson prosecutor_count "$prosecutor_count" \
+  --argjson defender_count "$defender_count" \
+  --argjson kept_count "$kept_count" \
+  --argjson disagreement_count "$disagreement_count" \
+  --argjson dropped_by_defender "$dropped_by_defender" \
+  --argjson dropped_by_prosecutor "$dropped_by_prosecutor" \
+  '{
+    mode: "adversarial",
+    prosecutor_count: $prosecutor_count,
+    defender_count: $defender_count,
+    kept_count: $kept_count,
+    disagreement_count: $disagreement_count,
+    dropped_by_defender: $dropped_by_defender,
+    dropped_by_prosecutor: $dropped_by_prosecutor
+  }' > "$METRICS"
+
+echo "intersect-findings: mode=adversarial prosecutor=$prosecutor_count defender=$defender_count kept=$kept_count disagreement=$disagreement_count"

--- a/.agents/skills/woo-review/scripts/load-config.sh
+++ b/.agents/skills/woo-review/scripts/load-config.sh
@@ -15,6 +15,8 @@
 #   models.standard     str
 #   models.deep         str
 #   fix_commands        list[str]  (consumed by issue #15 --loop mode)
+#   disable_adversarial bool       (cost-sensitive opt-out for issue #13's
+#                                   prosecutor+defender pipeline; default false)
 
 set -euo pipefail
 
@@ -53,7 +55,7 @@ VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "reac
 VALID_FLOORS = {"low", "medium", "high"}
 TOP_KEYS = {
     "angles", "severity_floor", "ignore", "project_rules",
-    "authors_skip", "models", "fix_commands",
+    "authors_skip", "models", "fix_commands", "disable_adversarial",
 }
 MODEL_TIERS = {"fast", "standard", "deep"}
 
@@ -136,6 +138,12 @@ for key in ("ignore", "project_rules", "authors_skip", "fix_commands"):
     if key in raw:
         require_list_of_strings(raw[key], key)
         out[key] = list(raw[key])
+
+if "disable_adversarial" in raw:
+    val = raw["disable_adversarial"]
+    if not isinstance(val, bool):
+        loud("`disable_adversarial` must be a boolean (true/false), got {}".format(type(val).__name__))
+    out["disable_adversarial"] = val
 
 if "models" in raw:
     models = raw["models"]

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -83,7 +83,7 @@
       "source": "howarewoo/woo-review",
       "sourceType": "github",
       "skillPath": "skills/woo-review/SKILL.md",
-      "computedHash": "0bbf27d631171aa5ecda585cd4a8062a6f1a1d44dfb5099c7f35c8739ab92eee"
+      "computedHash": "0659a4d7db8dfef450fcc576a06344a8c42c1c1e8828adf1e2665eb1f6741d62"
     },
     "writing-plans": {
       "source": "obra/superpowers",

--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -23,6 +23,7 @@ Reference monorepo layout for new projects bootstrapped from this spec. AI agent
 │   │       └── schemas/       Domain schemas
 │   └── infrastructure/        Shared utilities (scoped @infrastructure/*)
 │       ├── api-client/        oRPC client factories, shared base schemas
+│       ├── flags/             Vercel Flags SDK definitions + identify()
 │       ├── navigation/        Platform-agnostic Link + useNavigation
 │       ├── ui/                Design tokens, cn(), shared theme CSS
 │       ├── ui-web/            Shared shadcn/ui components

--- a/spec/bootstrap.md
+++ b/spec/bootstrap.md
@@ -79,6 +79,7 @@ For each `@infrastructure/*` package:
 **Required infrastructure contents:**
 
 - `api-client` — `createApiClient<Router>(baseUrl)`, `createOrpcUtils(client)`, shared base Zod schemas.
+- `flags` — every `flag(...)` definition (Vercel Flags SDK), the shared `identify()` reading Supabase session, and the chosen adapter wiring. See [infrastructure.md#feature-flags](infrastructure.md#feature-flags).
 - `navigation` — `<Link>`, `useNavigation()`, `NavigationProvider`, platform-agnostic types.
 - `ui` — design tokens (`tokens.ts`), `cn()` helper, shared `globals.css` with theme.
 - `ui-web` — shadcn components shared across web apps; barrel exports.

--- a/spec/infrastructure.md
+++ b/spec/infrastructure.md
@@ -24,7 +24,8 @@ Recommended deployment targets, CI/CD, env management, and managed services. Def
 | Realtime | **Supabase Realtime** | Pusher, Ably |
 | Edge functions | **Supabase Edge Functions** (Deno) | Vercel Functions, Cloudflare Workers |
 | Key-value / cache | **Upstash Redis** (via Vercel Marketplace) | Vercel KV |
-| Edge config / feature flags | **Vercel Edge Config** | LaunchDarkly, GrowthBook |
+| Edge config (static) | **Vercel Edge Config** | — |
+| Feature flags / experiments | **Vercel Flags SDK** (`flags` + `@flags-sdk/*` adapters) | LaunchDarkly, GrowthBook, Statsig |
 | Runtime cache | **Vercel Runtime Cache API** | App-level memoization |
 
 **Provision:**
@@ -49,6 +50,25 @@ Recommended deployment targets, CI/CD, env management, and managed services. Def
 - API (`apps/api`): validate JWTs via Supabase's JWKS endpoint or by using the service role for trusted server actions.
 - Row-level security: enable on every table; write policies that scope rows to `auth.uid()`.
 
+## Feature flags
+
+**Vercel Flags SDK** is the default for runtime feature gating, A/B tests, and gradual rollouts across web + mobile + API. It abstracts the provider behind a typed `flag(...)` definition so the backing store (Edge Config, Statsig, LaunchDarkly, GrowthBook) can swap without touching call sites.
+
+| Surface | Adapter |
+|---|---|
+| `apps/web`, `apps/landing` | `flags/next` for server + client components, route handlers, Middleware/Proxy |
+| `apps/api` (Hono) | `flags` core + `@flags-sdk/edge-config` (or chosen provider adapter) |
+| `apps/mobile` | `flags` core with a Resend-style server endpoint that returns evaluated flag values; cache in React Query |
+
+**Integration:**
+- Default backing store: **Vercel Edge Config** via `@flags-sdk/edge-config`. Swap to `@flags-sdk/statsig`, `@flags-sdk/launchdarkly`, or `@flags-sdk/growthbook` when experimentation or targeting needs outgrow Edge Config.
+- Define every flag in a single `packages/infrastructure/flags/` module: `export const myFlag = flag({ key, defaultValue, decide, adapter })`. Co-locate Zod schemas for flag values.
+- Identify users with a stable `identify()` function that reads the Supabase session — never trust client-passed identifiers for gating server-side behavior.
+- Server-side reads only inside Server Components, Route Handlers, or oRPC procedures. Client reads through `useFlag()` are fine but treat results as cosmetic — enforce gates on the server.
+- Precompute flags for Middleware/Proxy with `precompute([...])` to keep rewrites + redirects cacheable.
+- Env: `FLAGS_SECRET` (required, used to sign flag-overrides cookies + `.well-known/vercel/flags` endpoint), plus the chosen adapter's keys (`EDGE_CONFIG`, `STATSIG_SERVER_KEY`, etc.).
+- Expose the discovery endpoint (`/.well-known/vercel/flags`) on `apps/web` so the Vercel Toolbar can surface flags in preview deployments.
+
 ## Email / messaging
 
 | Need | Default |
@@ -57,14 +77,43 @@ Recommended deployment targets, CI/CD, env management, and managed services. Def
 | Webhook delivery | **Inngest** or native Hono routes |
 | Chat / bot platforms | **Vercel Chat SDK** (Slack/Discord/Teams/etc.) |
 
+**Resend integration:**
+- SDK: `resend` package consumed from `apps/api` (server-only — never expose `RESEND_API_KEY` to client bundles).
+- Templates: author with `@react-email/components`, render server-side, send via Resend.
+- Env: `RESEND_API_KEY` on Vercel; per-environment sending domains verified in the Resend dashboard.
+
+## Billing
+
+| Need | Default |
+|---|---|
+| Payments + subscriptions | **Stripe** |
+| Hosted checkout | **Stripe Checkout** |
+| Self-service subscription management | **Stripe Customer Portal** |
+| Webhook handling | Hono route on `apps/api` validating `Stripe-Signature` |
+
+**Stripe integration:**
+- SDK: `stripe` (server) consumed only from `apps/api`. Client surfaces use `@stripe/stripe-js` + `@stripe/react-stripe-js` when embedding Elements; otherwise redirect to Stripe-hosted Checkout / Portal.
+- Env: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` (server); `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` / `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY` (client).
+- Webhook route: verify signature with raw request body — do not parse JSON first. Idempotently upsert subscription / invoice state into Supabase.
+- Test mode keys for `development` + `preview` Vercel environments; live keys only on `production`.
+- Place billing logic in `packages/features/billing/` per [architecture.md](architecture.md). oRPC procedures wrap Stripe SDK calls so web + mobile share contracts.
+
 ## Observability
 
 | Need | Default |
 |---|---|
-| Error tracking | **Sentry** (web + RN + API) |
-| Logs | Vercel runtime logs + Sentry breadcrumbs |
-| Metrics / vitals | Vercel Web Analytics + Speed Insights |
+| Error tracking | **Axiom** (web + RN + API) |
+| Structured logs | **Axiom** (Vercel + Hono + RN SDKs) |
+| Metrics / vitals | **Axiom** dashboards on ingested events |
 | AI agent code review | **Vercel Agent** |
+
+**Axiom integration:**
+- Vercel projects: install the **Axiom Vercel integration** to ship runtime logs + Web Vitals to a dataset automatically.
+- API (`apps/api`): use `@axiomhq/js` or `@axiomhq/winston` to emit structured logs and capture exceptions; tag every event with `service`, `env`, `release`.
+- Web (`apps/web`, `apps/landing`): `@axiomhq/nextjs` for client + server logging and unhandled-error capture.
+- Mobile (`apps/mobile`): `@axiomhq/react-native` or hand-rolled ingest client; flush on background.
+- Env: `AXIOM_TOKEN`, `AXIOM_DATASET`, `AXIOM_ORG_ID` on Vercel + EAS Secrets.
+- Alerts + dashboards configured in Axiom (latency, error rate, web vitals percentiles). One dataset per environment.
 
 ## CI/CD
 
@@ -119,7 +168,8 @@ Notes:
 - Strict CSP on web (`next.config.ts` headers).
 - Vercel Firewall: enable managed rulesets + bot management.
 - API: validate all inputs through Zod (oRPC contracts).
-- Secrets: never log them. Mask in Sentry.
+- Secrets: never log them. Redact at the logger before shipping to Axiom (deny-list `STRIPE_SECRET_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `AXIOM_TOKEN`, auth headers).
+- Stripe webhook endpoints: reject any request whose `Stripe-Signature` fails verification — do not log raw payloads on failure.
 
 ## When to deviate
 


### PR DESCRIPTION
## Summary

- Removes all generated code (`apps/`, `packages/`, `pnpm-workspace.yaml`, lockfile, CI, biome config, etc.) and reframes the repo as a **spec** that AI agents use to bootstrap fresh projects at the latest framework versions. See `54803c3 feat!: pivot repo from boilerplate template to spec-only`.
- Adds `AGENTS.md` (with `.claude/CLAUDE.md` as a symlink) as the single source of agent instructions, plus `spec/{architecture,frameworks,infrastructure,patterns,development,bootstrap}.md`.
- Installs the `obra/superpowers:*`, `howarewoo/woo-review`, and `grill-me` skills under `.agents/skills/` with `.claude/skills/*` symlinks; versions pinned in `skills-lock.json`.
- Adds infrastructure defaults on top of the spec: **Stripe** (billing), **Resend** (transactional email), **Axiom** (observability — replaces Sentry), **Vercel Flags SDK** (feature gating, with `packages/infrastructure/flags/` wired into the architecture + bootstrap docs).
- Tightens security baseline: explicit secret deny-list before shipping logs to Axiom; Stripe webhook signature verification + raw-body rule.

## Test plan

- [ ] Read `AGENTS.md` end-to-end and confirm Mode A vs Mode B distinction is clear.
- [ ] Walk through `spec/bootstrap.md` against a fresh directory mentally — every referenced file/anchor resolves.
- [ ] Confirm cross-links resolve: `spec/bootstrap.md` → `infrastructure.md#feature-flags`, `infrastructure.md` → `architecture.md`.
- [ ] Verify `skills-lock.json` matches what's under `.agents/skills/` (no orphan symlinks under `.claude/skills/`).
- [ ] Confirm no `apps/` or `packages/` directories were re-introduced anywhere on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)