### PR TITLE
feat(#140): port the cloud review GitHub Action into woo-stack

### DIFF
--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -1,0 +1,240 @@
+name: Parallel AI Review
+on:
+  workflow_call:
+    inputs:
+      provider:
+        description: 'Explicit provider: anthropic | openai | google | openrouter.'
+        type: string
+        required: false
+      model:
+        description: 'Model identifier passed to the chosen runner.'
+        type: string
+        required: false
+      trigger_phrase:
+        description: 'Phrase that triggers a review when posted in a PR comment.'
+        type: string
+        required: false
+        default: '@review'
+      max_turns:
+        description: 'Maximum agent turns.'
+        type: string
+        required: false
+        default: '30'
+      skip_labels:
+        description: 'Comma-separated list of PR labels that force-skip the review.'
+        type: string
+        required: false
+      prompt_override:
+        description: 'Optional path (relative to the consumer repo) to a custom prompt.'
+        type: string
+        required: false
+      disable_angles:
+        description: 'Comma-separated list of review angles to skip.'
+        type: string
+        required: false
+      react_doctor_version:
+        description: 'npm version of react-doctor to invoke.'
+        type: string
+        required: false
+        default: 'latest'
+      impeccable_version:
+        description: 'npm version of impeccable CLI to invoke.'
+        type: string
+        required: false
+        default: 'latest'
+      incremental:
+        description: 'Review scope: auto (re-use prior SHA marker, diff new commits only) or off (full PR diff). PR-comment `--full` overrides to off.'
+        type: string
+        required: false
+        default: 'auto'
+    secrets:
+      anthropic_token:
+        required: false
+      anthropic_api_key:
+        required: false
+      openai_api_key:
+        required: false
+      google_api_key:
+        required: false
+      gemini_api_key:
+        required: false
+      openrouter_api_key:
+        required: false
+
+# Cancel superseded runs on the same PR so rapid pushes do not queue parallel
+# expensive AI passes.
+concurrency:
+  group: woo-stack-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      angles: ${{ steps.woo.outputs.angles_json }}
+      chunks: ${{ steps.woo.outputs.chunks_json }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Self-references pinned to the current tag. Bump in lockstep with releases.
+      - id: woo
+        uses: howarewoo/woo-stack@main
+        with:
+          mode: detect
+          disable_angles: ${{ inputs.disable_angles }}
+          incremental: ${{ inputs.incremental }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: review-artifacts
+          path: /tmp/pr-review/
+          retention-days: 1
+
+  review:
+    needs: detect
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    if: needs.detect.outputs.angles != '[]' && needs.detect.outputs.angles != ''
+    # Two-dim matrix (issue #14): angles × chunks. When chunking does not
+    # activate, `chunks` is `[""]` and the matrix collapses to one job per
+    # angle (current behaviour, zero overhead). When it activates,
+    # `chunks` is `["chunk-0", "chunk-1", ...]` and the matrix fans out as
+    # angles × chunks so each worker stays inside the model context window.
+    strategy:
+      fail-fast: false
+      matrix:
+        angle: ${{ fromJson(needs.detect.outputs.angles) }}
+        chunk: ${{ fromJson(needs.detect.outputs.chunks) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download base artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: review-artifacts
+          path: /tmp/pr-review/
+      - uses: howarewoo/woo-stack@main
+        with:
+          mode: review
+          angle: ${{ matrix.angle }}
+          chunk: ${{ matrix.chunk }}
+          provider: ${{ inputs.provider }}
+          model: ${{ inputs.model }}
+          anthropic_token: ${{ secrets.anthropic_token }}
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          openai_api_key: ${{ secrets.openai_api_key }}
+          google_api_key: ${{ secrets.google_api_key }}
+          gemini_api_key: ${{ secrets.gemini_api_key }}
+          openrouter_api_key: ${{ secrets.openrouter_api_key }}
+          trigger_phrase: ${{ inputs.trigger_phrase }}
+          max_turns: ${{ inputs.max_turns }}
+          skip_labels: ${{ inputs.skip_labels }}
+          prompt_override: ${{ inputs.prompt_override }}
+          react_doctor_version: ${{ inputs.react_doctor_version }}
+          impeccable_version: ${{ inputs.impeccable_version }}
+      # Artifact name includes the chunk suffix so multiple chunk jobs for the
+      # same angle cannot collide on upload. `chunk` is `""` in the un-chunked
+      # case → suffix collapses to `-all`; the merge step globs `findings-*`.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: findings-${{ matrix.angle }}-${{ matrix.chunk || 'all' }}
+          path: /tmp/pr-review/findings.${{ matrix.angle }}*.json
+          retention-days: 1
+          if-no-files-found: ignore
+
+  validate:
+    needs: [detect, review]
+    # Validator runs on partial review failures too — fail-fast is off so a single
+    # angle failure must not prevent posting findings from the angles that did succeed.
+    # Only skip if detection failed/cancelled or the whole run was cancelled.
+    if: always() && needs.detect.result == 'success' && needs.review.result != 'cancelled'
+    runs-on: ubuntu-latest
+    # `contents: read` is sufficient — the validator runs the LLM step against
+    # untrusted PR content and never writes the repo. It only needs to post the
+    # review (`pull-requests: write`).
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download base artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: review-artifacts
+          path: /tmp/pr-review/
+      - name: Download findings
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        continue-on-error: true
+        with:
+          pattern: findings-*
+          path: /tmp/pr-review/
+          merge-multiple: true
+
+      # Adversarial validator (issue #13): prosecutor pass writes
+      # findings.prosecutor.json (inclusive bias), defender pass writes
+      # findings.defender.json (exclusive bias) + runs intersect-findings.sh
+      # to produce the final findings.json, then posts the review.
+      # `disable_adversarial: true` in .woo-stack/config.json short-circuits the
+      # prosecutor step (the intersect script then falls back to defender-only).
+      - name: Read disable_adversarial flag
+        id: adv
+        shell: bash
+        run: |
+          if [ -f /tmp/pr-review/config.json ]; then
+            disabled="$(jq -r '.disable_adversarial // false' /tmp/pr-review/config.json)"
+          else
+            disabled=false
+          fi
+          echo "disabled=$disabled" >> "$GITHUB_OUTPUT"
+          echo "adversarial validator disabled=$disabled"
+
+      - name: Validate (prosecutor pass)
+        if: steps.adv.outputs.disabled != 'true'
+        uses: howarewoo/woo-stack@main
+        with:
+          mode: validate-prosecutor
+          disable_angles: ${{ inputs.disable_angles }}
+          provider: ${{ inputs.provider }}
+          model: ${{ inputs.model }}
+          anthropic_token: ${{ secrets.anthropic_token }}
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          openai_api_key: ${{ secrets.openai_api_key }}
+          google_api_key: ${{ secrets.google_api_key }}
+          gemini_api_key: ${{ secrets.gemini_api_key }}
+          openrouter_api_key: ${{ secrets.openrouter_api_key }}
+          max_turns: ${{ inputs.max_turns }}
+          skip_labels: ${{ inputs.skip_labels }}
+          prompt_override: ${{ inputs.prompt_override }}
+
+      - name: Validate (defender pass + intersect + post)
+        uses: howarewoo/woo-stack@main
+        with:
+          mode: validate
+          disable_angles: ${{ inputs.disable_angles }}
+          provider: ${{ inputs.provider }}
+          model: ${{ inputs.model }}
+          anthropic_token: ${{ secrets.anthropic_token }}
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          openai_api_key: ${{ secrets.openai_api_key }}
+          google_api_key: ${{ secrets.google_api_key }}
+          gemini_api_key: ${{ secrets.gemini_api_key }}
+          openrouter_api_key: ${{ secrets.openrouter_api_key }}
+          max_turns: ${{ inputs.max_turns }}
+          skip_labels: ${{ inputs.skip_labels }}
+          prompt_override: ${{ inputs.prompt_override }}
+
+      - name: Upload validator metrics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: validator-metrics
+          path: |
+            /tmp/pr-review/validator-metrics.json
+            /tmp/pr-review/findings.metrics.json
+          retention-days: 7
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ Instructions for AI coding agents working in this repository. Compatible with Cl
 
 A **published collection of skills**, not a codebase. It packages the decisions for building new web + mobile + API projects so any agent can install it (`npx skills add howarewoo/woo-stack`) and bootstrap fresh projects at the latest framework versions. The four skills are: `woo-stack-bootstrap`, `woo-stack-build`, `woo-stack-review`, and `woo-stack-address-comments`.
 
-There is no application source code, no app lockfile, no build, no CI in this repo by design. (`skills-lock.json` pins the *dev* skills this repo consumes to review itself — see [Skills](#skills) — it is not an app lockfile.)
+There is no application source code, no app lockfile, no build, and no CI that runs on this repo's own events, by design. (`skills-lock.json` pins the *dev* skills this repo consumes to review itself — see [Skills](#skills) — it is not an app lockfile.)
+
+The one exception is the `woo-stack-review` cloud delivery: `action.yml` (a composite GitHub Action) and `.github/workflows/reusable-review.yml` (a `workflow_call`-only reusable workflow) ship from this repo so consumers can run the review in their own CI via `uses: howarewoo/woo-stack@<ref>`. Neither runs on this repo's push/PR events — they are *shipped assets*, not CI for woo-stack. Both drive the same `skills/woo-stack-review/` scripts and prompts as the chat-host skill. Do not delete them as stray workflows.
 
 ## Repo layout
 
@@ -37,10 +39,11 @@ woo-stack/
 │   │   └── prompts/           Review angle prompts
 │   └── woo-stack-address-comments/
 │       └── SKILL.md           Thin delegator to woo-stack-review address verb
+├── action.yml         Composite GitHub Action — cloud delivery of woo-stack-review
 ├── .agents/skills/    Dev skills this repo consumes (managed by skills-lock.json)
 ├── .claude/           CLAUDE.md symlink + skill symlinks
 ├── skills-lock.json   Pins the dev skills above
-└── .github/           Issue + PR templates (no workflows)
+└── .github/           Issue + PR templates + reusable-review.yml (workflow_call only)
 ```
 
 ## Two modes
@@ -87,7 +90,7 @@ The output is a fresh repo in a different directory. **Do not** add code, packag
 Apply in both modes:
 
 - **No fabricated versions.** When the skill or a generated project needs a version, run `npm view <pkg> version` (or equivalent). Do not invent numbers.
-- **No hidden tools.** This repo has no CI and no app test runner. Don't pretend they exist; don't add them without justification.
+- **No hidden tools.** This repo has no CI that runs on its own events and no app test runner. Don't pretend they exist; don't add them without justification. (`action.yml` + `.github/workflows/reusable-review.yml` are consumer-facing shipped assets, not self-CI — see [What this repo is](#what-this-repo-is).)
 - **Respect branch protection.** `main` is protected and requires PRs. Push changes to a feature branch and open a PR; never force-push to `main`.
 - **Cross-link, don't duplicate.** If a fact lives in `architecture.md`, link to it from `patterns.md`; don't restate.
 - **Reference frameworks by name, not version**, except in [references/frameworks.md](skills/woo-stack-bootstrap/references/frameworks.md), which may pin exact versions when an incompatibility forces it.
@@ -124,7 +127,7 @@ Feature branches are cut from `staging`, never `main`. PRs target `staging`. `st
 ## What NOT to do
 
 - Do not regenerate `apps/`, `packages/`, `pnpm-workspace.yaml`, or root build configs in this repo. They were removed deliberately.
-- Do not propose adding a working CI workflow here. The skill describes the CI a downstream project should run; this repo has nothing to test.
+- Do not add a CI workflow that runs on this repo's own push/PR events — woo-stack has nothing to test. (The shipped `reusable-review.yml` is `workflow_call`-only and `action.yml` is a composite action consumers reference; neither triggers on this repo. Leave them in place.)
 - Do not rename files under `skills/woo-stack-bootstrap/references/` without updating every cross-link and the SKILL.md table.
 - Do not move or rename any of the four SKILL.md files (`skills/woo-stack-bootstrap/SKILL.md`, `skills/woo-stack-build/SKILL.md`, `skills/woo-stack-review/SKILL.md`, `skills/woo-stack-address-comments/SKILL.md`) — `npx skills add` resolves skills by those paths.
 - Do not commit `.env*`, secrets, or generated files.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,377 @@
+name: 'woo-stack-review (CI extension)'
+description: 'CI extension of the woo-stack-review skill. Runs the same swarm — detect → parallel angle workers → skeptical validator → batched GitHub Review — dispatched to the first-party action of the chosen provider (Anthropic, OpenAI, Google, OpenRouter via opencode).'
+author: 'woo-stack-review'
+
+branding:
+  icon: 'check-circle'
+  color: 'purple'
+
+outputs:
+  angles:
+    description: 'Comma-separated list of enabled review angles.'
+    value: ${{ steps.angles.outputs.angles }}
+  angles_json:
+    description: 'JSON array of enabled review angles.'
+    value: ${{ steps.angles.outputs.angles_json }}
+  chunks_json:
+    description: 'JSON array of chunk IDs when the diff exceeds chunking.max_loc (issue #14). When chunking does not activate the value is `[""]` — one empty-string chunk, so consumers can always use it as the second dimension of a strategy matrix.'
+    value: ${{ steps.angles.outputs.chunks_json }}
+
+inputs:
+  provider:
+    description: 'Explicit provider: anthropic | openai | google | openrouter. Leave empty to auto-detect from the first non-empty API key.'
+    required: false
+    default: ''
+  model:
+    description: 'Model identifier passed to the chosen runner. For openrouter, use the openrouter/<model> form.'
+    required: false
+    default: ''
+  openai_effort:
+    description: 'OpenAI Codex reasoning_effort passthrough (minimal | low | medium | high). Maps to the deep-tier validator role; leave empty for Codex default.'
+    required: false
+    default: ''
+  mode:
+    description: 'Execution mode: full (sequential) | detect | review | validate-prosecutor | validate. The adversarial validator runs as two passes: validate-prosecutor first (writes findings.prosecutor.json), then validate (writes findings.defender.json, runs intersect-findings.sh, and posts the review). The validate step sets WOO_REVIEW_SEQUENTIAL_VALIDATE=1 so validator.md runs its Step 3/4 orchestration; in the chat-host swarm (SKILL.md Stage 4b) that flag is unset and the defender is a pure worker that exits after findings.defender.json.'
+    required: false
+    default: 'full'
+  angle:
+    description: 'Specific angle to run (required if mode=review)'
+    required: false
+    default: ''
+  chunk:
+    description: 'Specific chunk id to run (e.g. `chunk-0`). Pairs with `angle` when mode=review to fan out angles × chunks for oversized diffs (issue #14). Empty string runs against the full diff (default).'
+    required: false
+    default: ''
+
+  # Credentials — only the one for the chosen provider is required.
+  anthropic_token:
+    description: 'Claude Code OAuth token (preferred for Anthropic).'
+    required: false
+    default: ''
+  anthropic_api_key:
+    description: 'Anthropic API key (alternative to anthropic_token).'
+    required: false
+    default: ''
+  openai_api_key:
+    description: 'OpenAI API key (used by openai/codex-action).'
+    required: false
+    default: ''
+  google_api_key:
+    description: 'Google API key for Gemini API (alias of gemini_api_key).'
+    required: false
+    default: ''
+  gemini_api_key:
+    description: 'Gemini API key (alternative to google_api_key).'
+    required: false
+    default: ''
+  openrouter_api_key:
+    description: 'OpenRouter API key (used by opencode).'
+    required: false
+    default: ''
+
+  # Review behavior.
+  trigger_phrase:
+    description: 'Phrase that triggers a review when posted in a PR comment.'
+    required: false
+    default: '@review'
+  max_turns:
+    description: 'Maximum agent turns (Anthropic; other runners use their own equivalent).'
+    required: false
+    default: '30'
+  skip_labels:
+    description: 'Comma-separated list of PR labels that force-skip the review.'
+    required: false
+    default: ''
+  prompt_override:
+    description: 'Optional path (relative to the consumer repo) to a custom prompt that replaces the bundled per-provider prompt. The shared _header.md contract is still prepended.'
+    required: false
+    default: ''
+  disable_angles:
+    description: 'Comma-separated list of review angles to skip (seo, aeo, design, react, database, tests, api, infra, observability, types, i18n, docs, deps). `bugs` and `security` are always on and cannot be disabled.'
+    required: false
+    default: ''
+  react_doctor_version:
+    description: 'npm version of react-doctor to invoke via npx (used by the react angle).'
+    required: false
+    default: 'latest'
+  impeccable_version:
+    description: 'npm version of impeccable CLI to invoke via npx (used by the design angle).'
+    required: false
+    default: 'latest'
+  incremental:
+    description: 'Review scope: `auto` re-uses the prior review SHA marker (if any) and diffs only new commits; `off` forces a full re-review of the PR diff. A PR-comment trigger containing `--full` overrides to off.'
+    required: false
+    default: 'auto'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Pin OUTDIR for CI
+      # CI matrix jobs run on isolated runners, so the per-project derivation in
+      # resolve-outdir.sh is unnecessary here. Pin the canonical path that this
+      # action's artifact steps, the chunk-swap logic, and the agent allowlist
+      # (Write(/tmp/pr-review/**)) all hardcode, keeping CI byte-identical.
+      shell: bash
+      run: echo "OUTDIR=/tmp/pr-review" >> "$GITHUB_ENV"
+
+    - name: Resolve provider
+      id: detect
+      shell: bash
+      env:
+        INPUT_PROVIDER: ${{ inputs.provider }}
+        INPUT_ANTHROPIC_TOKEN: ${{ inputs.anthropic_token }}
+        INPUT_ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        INPUT_OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        INPUT_GOOGLE_API_KEY: ${{ inputs.google_api_key }}
+        INPUT_GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
+        INPUT_OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
+      run: bash "${{ github.action_path }}/skills/woo-stack-review/scripts/detect-provider.sh"
+
+    - name: Resolve PR number
+      id: pr
+      shell: bash
+      env:
+        EVENT_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.number }}
+      run: |
+        echo "number=$EVENT_NUMBER" >> "$GITHUB_OUTPUT"
+
+    - name: Prefetch diff, metadata, rules, config, memory
+      id: prefetch
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.pr.outputs.number }}
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_ACTION: ${{ github.event.action }}
+        INPUT_SKIP_LABELS: ${{ inputs.skip_labels }}
+        INPUT_INCREMENTAL: ${{ inputs.incremental }}
+        COMMENT_BODY: ${{ github.event.comment.body }}
+      run: bash "${{ github.action_path }}/skills/woo-stack-review/scripts/prefetch.sh"
+
+    - name: Detect review angles
+      id: angles
+      if: steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'detect' || inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      shell: bash
+      env:
+        GITHUB_WORKSPACE: ${{ github.workspace }}
+        INPUT_DISABLE_ANGLES: ${{ inputs.disable_angles }}
+      run: |
+        if [ "${{ inputs.mode }}" = "validate" ] || [ "${{ inputs.mode }}" = "validate-prosecutor" ]; then
+          if [ -f "/tmp/pr-review/angles.txt" ]; then
+            CSV=$(paste -sd "," /tmp/pr-review/angles.txt)
+            echo "angles=$CSV" >> "$GITHUB_OUTPUT"
+            echo "Loaded angles from angles.txt: $CSV"
+          else
+            bash "${{ github.action_path }}/skills/woo-stack-review/scripts/detect-angles.sh"
+          fi
+        else
+          bash "${{ github.action_path }}/skills/woo-stack-review/scripts/detect-angles.sh"
+        fi
+
+    - name: Merge findings (validate modes)
+      if: steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      shell: bash
+      run: bash "${{ github.action_path }}/skills/woo-stack-review/scripts/merge-findings.sh"
+
+    - name: Setup Node.js (for react-doctor + impeccable CLIs)
+      if: |
+        steps.prefetch.outputs.skip != 'true' && (
+          (inputs.mode == 'full' && (contains(steps.angles.outputs.angles, 'react') || contains(steps.angles.outputs.angles, 'design'))) ||
+          (inputs.mode == 'review' && (contains(inputs.angle, 'react') || contains(inputs.angle, 'design')))
+        )
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version: '22'
+
+    - name: Swap chunked diff (issue #14)
+      id: chunk-swap
+      if: inputs.chunk != '' && steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review')
+      shell: bash
+      env:
+        CHUNK: ${{ inputs.chunk }}
+      run: |
+        set -euo pipefail
+        SRC="/tmp/pr-review/diff.${CHUNK}.txt"
+        if [ ! -s "$SRC" ]; then
+          echo "::error::chunked diff $SRC missing or empty — chunk-diff.sh may not have run"
+          exit 1
+        fi
+        if [ -f /tmp/pr-review/diff.txt ] && [ ! -f /tmp/pr-review/diff.full.txt.bak ]; then
+          cp /tmp/pr-review/diff.txt /tmp/pr-review/diff.full.txt.bak
+        fi
+        cp "$SRC" /tmp/pr-review/diff.txt
+        echo "Chunk swap: diff.txt now points at $SRC ($(wc -l < /tmp/pr-review/diff.txt) lines)"
+
+    - name: Load prompt
+      id: load-prompt
+      if: steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review' || inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      shell: bash
+      env:
+        PROVIDER: ${{ steps.detect.outputs.provider }}
+        ACTION_PATH: ${{ github.action_path }}/skills/woo-stack-review
+        # The adversarial validator runs as two passes against the same `raw_findings.json`.
+        # `validate-prosecutor` mode loads validator-prosecutor.md (inclusive bias);
+        # `validate` mode loads validator.md (defender bias) which runs the intersect
+        # script + posts the final review. See issue #13.
+        INPUT_PROMPT_OVERRIDE: ${{ (inputs.mode == 'validate' && format('{0}/skills/woo-stack-review/prompts/validator.md', github.action_path)) || (inputs.mode == 'validate-prosecutor' && format('{0}/skills/woo-stack-review/prompts/validator-prosecutor.md', github.action_path)) || inputs.prompt_override }}
+        PR_NUMBER: ${{ steps.pr.outputs.number }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        EVENT_NAME: ${{ github.event_name }}
+        COMMENT_BODY: ${{ github.event.comment.body }}
+        ENABLED_ANGLES: ${{ (inputs.mode == 'review' && inputs.angle) || steps.angles.outputs.angles }}
+        MODE: ${{ inputs.mode }}
+        ANGLE: ${{ inputs.angle }}
+      run: bash "${{ github.action_path }}/skills/woo-stack-review/scripts/load-prompt.sh"
+
+    # --- Provider runners (mutually exclusive) ---
+
+    - name: Run review (Anthropic)
+      id: run-anthropic
+      if: steps.detect.outputs.provider == 'anthropic' && steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review' || inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      uses: anthropics/claude-code-action@537ffff2eff706bd7e3e1c3daf2d4b39067a9f85 # v1
+      with:
+        claude_code_oauth_token: ${{ inputs.anthropic_token }}
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        prompt: ${{ steps.load-prompt.outputs.prompt }}
+        claude_args: |
+          --model ${{ inputs.model || 'claude-sonnet-4-6' }}
+          --max-turns ${{ inputs.max_turns }}
+        show_full_output: true
+        # Constrained allow-list — the prompt is partially built from untrusted
+        # PR diff + comment content, so we restrict Bash to the specific tools
+        # the worker needs (gh, jq, npx, common file ops) instead of Bash(*).
+        # mcp__* and WebFetch are scoped to read-only domains.
+        settings: |
+          {
+            "permissions": {
+              "allow": [
+                "Bash(gh:*)",
+                "Bash(jq:*)",
+                "Bash(npx:*)",
+                "Bash(node:*)",
+                "Bash(cat:*)",
+                "Bash(ls:*)",
+                "Bash(grep:*)",
+                "Bash(sed:*)",
+                "Bash(head:*)",
+                "Bash(tail:*)",
+                "Bash(wc:*)",
+                "Bash(find:*)",
+                "Bash(mkdir:*)",
+                "Bash(mv:*)",
+                "Bash(cp:*)",
+                "Bash(test:*)",
+                "Bash(echo:*)",
+                "Bash(printf:*)",
+                "Bash(date:*)",
+                "Bash(env)",
+                "Bash(pwd)",
+                "Read",
+                "Write(/tmp/pr-review/**)",
+                "Edit(/tmp/pr-review/**)",
+                "Glob",
+                "Grep"
+              ],
+              "deny": [
+                "Bash(curl:*)",
+                "Bash(wget:*)",
+                "Bash(nc:*)",
+                "Bash(ssh:*)",
+                "Bash(scp:*)",
+                "Bash(rsync:*)",
+                "Bash(bash:*)",
+                "Bash(sh:*)",
+                "Bash(eval:*)",
+                "Bash(source:*)",
+                "Bash(.:*)",
+                "Bash(env:*)",
+                "Bash(printenv:*)",
+                "Bash(export:*)"
+              ]
+            }
+          }
+      env:
+        WOO_REVIEW_ACTION_PATH: ${{ github.action_path }}/skills/woo-stack-review
+        WOO_REVIEW_SEQUENTIAL_VALIDATE: ${{ inputs.mode == 'validate' && '1' || '' }}
+        ENABLED_ANGLES: ${{ (inputs.mode == 'review' && inputs.angle) || steps.angles.outputs.angles }}
+        IMPECCABLE_VERSION: ${{ inputs.impeccable_version }}
+        REACT_DOCTOR_VERSION: ${{ inputs.react_doctor_version }}
+
+    - name: Run review (OpenAI Codex)
+      id: run-openai
+      if: steps.detect.outputs.provider == 'openai' && steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review' || inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1 (== v1.8 as of 2026-04-29)
+      with:
+        openai-api-key: ${{ inputs.openai_api_key }}
+        model: ${{ inputs.model || 'gpt-5' }}
+        effort: ${{ inputs.openai_effort }}
+        prompt: ${{ steps.load-prompt.outputs.prompt }}
+        sandbox: workspace-write
+        safety-strategy: drop-sudo
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        WOO_REVIEW_ACTION_PATH: ${{ github.action_path }}/skills/woo-stack-review
+        WOO_REVIEW_SEQUENTIAL_VALIDATE: ${{ inputs.mode == 'validate' && '1' || '' }}
+        ENABLED_ANGLES: ${{ (inputs.mode == 'review' && inputs.angle) || steps.angles.outputs.angles }}
+        IMPECCABLE_VERSION: ${{ inputs.impeccable_version }}
+        REACT_DOCTOR_VERSION: ${{ inputs.react_doctor_version }}
+
+    - name: Run review (Google Gemini)
+      id: run-google
+      if: steps.detect.outputs.provider == 'google' && steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review' || inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      uses: google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489 # v0
+      with:
+        gemini_api_key: ${{ inputs.gemini_api_key }}
+        google_api_key: ${{ inputs.google_api_key }}
+        gemini_model: ${{ inputs.model || 'gemini-3-5-flash' }}
+        prompt: ${{ steps.load-prompt.outputs.prompt }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        WOO_REVIEW_ACTION_PATH: ${{ github.action_path }}/skills/woo-stack-review
+        WOO_REVIEW_SEQUENTIAL_VALIDATE: ${{ inputs.mode == 'validate' && '1' || '' }}
+        ENABLED_ANGLES: ${{ (inputs.mode == 'review' && inputs.angle) || steps.angles.outputs.angles }}
+        IMPECCABLE_VERSION: ${{ inputs.impeccable_version }}
+        REACT_DOCTOR_VERSION: ${{ inputs.react_doctor_version }}
+
+    - name: Run review (OpenRouter via opencode)
+      id: run-opencode
+      if: steps.detect.outputs.provider == 'openrouter' && steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review' || inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      # TODO: pin to commit SHA once sst/opencode publishes a verifiable github-v1.15.10 ref.
+      # The repo appears to have moved to anomalyco/opencode; verify upstream before pinning.
+      uses: sst/opencode/github@v1.15.10
+      with:
+        model: ${{ inputs.model || 'openrouter/deepseek/deepseek-v4-flash' }}
+        prompt: ${{ steps.load-prompt.outputs.prompt }}
+        share: 'false'
+      env:
+        OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        WOO_REVIEW_ACTION_PATH: ${{ github.action_path }}/skills/woo-stack-review
+        WOO_REVIEW_SEQUENTIAL_VALIDATE: ${{ inputs.mode == 'validate' && '1' || '' }}
+        ENABLED_ANGLES: ${{ (inputs.mode == 'review' && inputs.angle) || steps.angles.outputs.angles }}
+        IMPECCABLE_VERSION: ${{ inputs.impeccable_version }}
+        REACT_DOCTOR_VERSION: ${{ inputs.react_doctor_version }}
+
+    - name: Rename chunked findings (issue #14)
+      if: always() && inputs.chunk != '' && steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review')
+      shell: bash
+      env:
+        ANGLE: ${{ inputs.angle }}
+        CHUNK: ${{ inputs.chunk }}
+      run: |
+        set -euo pipefail
+        # Restore the unchunked diff so any follow-on step in the same job
+        # (e.g. log dumps) sees the original artifact, not the chunk.
+        if [ -f /tmp/pr-review/diff.full.txt.bak ]; then
+          mv /tmp/pr-review/diff.full.txt.bak /tmp/pr-review/diff.txt
+        fi
+        # Workers wrote findings.<angle>.json — rename so multiple chunk jobs
+        # for the same angle do not clobber each other on artifact merge.
+        if [ -n "${ANGLE:-}" ] && [ -f "/tmp/pr-review/findings.${ANGLE}.json" ]; then
+          mv "/tmp/pr-review/findings.${ANGLE}.json" "/tmp/pr-review/findings.${ANGLE}.${CHUNK}.json"
+          echo "Renamed findings.${ANGLE}.json -> findings.${ANGLE}.${CHUNK}.json"
+        fi

--- a/skills/woo-stack-review/SKILL.md
+++ b/skills/woo-stack-review/SKILL.md
@@ -461,7 +461,7 @@ A high `raw` with a high `drop` rate is a noise candidate; a high `keep` rate is
 detect ─► fan-out (parallel sub-agents, one per angle) ─► merge ─► skeptical validator ─► post
 ```
 
-This mirrors the cloud GitHub Action exactly (`.github/workflows/reusable-review.yml`), just with sub-agents standing in for GHA matrix jobs.
+This mirrors the cloud GitHub Action exactly — the first-party composite action `action.yml` and the reusable workflow `.github/workflows/reusable-review.yml`, both shipped from this repo — just with sub-agents standing in for GHA matrix jobs.
 
 ## Companion GitHub Action
 
@@ -477,14 +477,14 @@ on:
 
 jobs:
   review:
-    uses: howarewoo/woo-review/.github/workflows/reusable-review.yml@v0.1.0
+    uses: howarewoo/woo-stack/.github/workflows/reusable-review.yml@main
     with:
       provider: anthropic
     secrets:
       anthropic_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
 
-Zero local setup required in the consumer repo — the action ships its own prompts, scripts, and Node tools.
+Pin `@main` to a release tag once one is cut. Zero local setup required in the consumer repo — the action ships its own prompts and scripts (`skills/woo-stack-review/`) and installs the `react-doctor` / `impeccable` CLIs via `npx` at run time.
 
 ## Best Practices
 


### PR DESCRIPTION
Addresses the **reusable workflow migration** item of #140. With `woo-stack-review` now first-party, the cloud delivery (composite action + reusable workflow) moves out of the deprecated `howarewoo/woo-review` repo and into this one.

## What moved
- **`action.yml`** (377 lines) — composite GitHub Action. Internal paths rewritten `skills/woo-review/` → `skills/woo-stack-review/`; branding strings updated. AI steps still use marketplace actions (`claude-code-action`, `codex-action`, `run-gemini-cli`, `opencode`); everything else runs the already-ported `skills/woo-stack-review/` scripts + prompts. **No bespoke Node code to port.**
- **`.github/workflows/reusable-review.yml`** (240 lines) — `workflow_call`-only reusable workflow. `uses: howarewoo/woo-review@v0.1.0` → `howarewoo/woo-stack@main`; `.woo-review/` → `.woo-stack/`; concurrency group renamed.
- **`skills/woo-stack-review/SKILL.md`** — companion-action snippet now points at `howarewoo/woo-stack/.github/workflows/reusable-review.yml@main`.
- **`AGENTS.md`** — explicit exception: these are `workflow_call`-only shipped assets (for *consumer* CI), never triggered by this repo's own events, so the "no CI workflow here" rule doesn't apply. Documented so they aren't removed as stray workflows.

## Preserved deliberately
- Env var *names* `WOO_REVIEW_ACTION_PATH` / `WOO_REVIEW_SEQUENTIAL_VALIDATE` — the ported scripts/prompts and SKILL.md Stage 0 still key on them. Only the path *value* (`/skills/woo-review` → `/skills/woo-stack-review`) changed.
- All marketplace action SHA pins.

## Decisions
- **`@main`**, not a tag — woo-stack has no release tags yet. SKILL.md notes to pin to a tag once one is cut.
- `self-test.yml` from the old repo **not** ported — it's genuine self-CI for the old repo's structure; out of scope and against repo policy.

## Test plan (static — no app test runner by design)
- [x] `action.yml` and `reusable-review.yml` parse as YAML
- [x] `actionlint` clean on the reusable workflow
- [x] Reusable workflow trigger is `workflow_call` only (does not run on this repo)
- [x] `using: composite` intact; all marketplace `uses:` pins preserved
- [x] All 5 scripts + 2 prompts the action references resolve under `skills/woo-stack-review/`
- [x] No stray lowercase `woo-review` path/URL left in either file; env var names intact

## Follow-ups still open in #140
- Deprecate the `howarewoo/woo-review` repo (notice / archive) — coupled to this; once merged, `@main` resolves here.
- `woo-stack-build` SKILL `description` — kept intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)