### PR TITLE
chore(woostack-review): scrub legacy `woo-review` brand

### DIFF
--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -27,7 +27,7 @@ Every artifact you write under `$OUTDIR/findings.*.json` (default `/tmp/pr-revie
 - **Enabled angles** (one per line): `/tmp/pr-review/angles.txt`
 - **Project rules** (optional, present only if discovered): `/tmp/pr-review/rules.md`
 - **Per-repo config** (always present, defaults to `{"severity_floor":"high"}`): `/tmp/pr-review/config.json` — parsed from `.woostack/config.json` in the consumer repo.
-- **Incremental base SHA** (always present, may be empty): `/tmp/pr-review/last_sha.txt` — non-empty means `diff.txt` covers only the new commits since the last woo-review pass. Treat findings as scoped to those commits.
+- **Incremental base SHA** (always present, may be empty): `/tmp/pr-review/last_sha.txt` — non-empty means `diff.txt` covers only the new commits since the last woostack-review pass. Treat findings as scoped to those commits.
 - **Prior unresolved review threads** (always present, may be `[]`): `/tmp/pr-review/prior-findings.json` — array of `{file, line, title, author}` for any unresolved thread on the PR. Consumed by the posting stage for the event-floor gate; angle workers MUST ignore this file. No per-entry `blocking` flag — any non-empty list floors the review event to `REQUEST_CHANGES` (conservative "do not APPROVE while threads open" rule).
 - **Cross-PR memory** (optional, present only if the consumer repo has `.woostack/memory.md`): `/tmp/pr-review/memory.md` — a plain-markdown list of gotchas and previously-accepted issues the team curates. Treat it as additional rubric: do NOT re-flag an issue the memory file already records as known/accepted. See *Cross-PR memory* below.
 - **Chunk manifest** (optional, present only when the diff exceeds `chunking.max_loc`): `/tmp/pr-review/chunks.txt` (one chunk id per line) and `/tmp/pr-review/chunks.json` (manifest: `[{id, files, loc, diff_path, boundary}]`). Each chunk also has its own diff at `/tmp/pr-review/diff.chunk-<id>.txt`. When a worker is dispatched with a chunk id (env `CHUNK` non-empty), it MUST read the chunk-specific diff and write findings to `/tmp/pr-review/findings.<angle>.<chunk>.json`. In the GitHub Action this swap happens transparently — `diff.txt` is replaced with the chunk's diff before the worker runs, and the worker's output is renamed afterwards. When `chunks.txt` is absent, chunking did not activate and the diff fits a single worker (no overhead).
@@ -288,7 +288,7 @@ gh api "repos/${GITHUB_REPOSITORY}/pulls/$PR_NUMBER/reviews" \
 The `pr_review_body.txt` should contain:
 - A 1-2 sentence high-level summary of the findings.
 - The `${STATUS_LINE}`.
-- Credits line (*Audited by woo-review...*).
+- Credits line (*Audited by woostack-review...*).
 - A hidden HTML comment `<!-- woostack-review:sha=${HEAD_SHA} -->` as the last line. This is the watermark the next run's prefetch step reads to enable incremental review.
 - **DO NOT** update the main PR description or title.
 

--- a/skills/woostack-review/scripts/fetch-threads.sh
+++ b/skills/woostack-review/scripts/fetch-threads.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Fetches every UNRESOLVED review thread on a PR (any author) with full comment
 # bodies, the thread GraphQL node-id (for reply + resolve), and the diff hunk.
-# Used by the `woo-review address <PR#>` verb (local hosts only).
+# Used by the `woostack-review address <PR#>` verb (local hosts only).
 #
 # Inputs (env): GITHUB_REPOSITORY, PR_NUMBER, OUTDIR (default /tmp/pr-review).
 # Output: $OUTDIR/address-threads.json — an array of:

--- a/skills/woostack-review/scripts/install.sh
+++ b/skills/woostack-review/scripts/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Install dependencies for woo-review skill
+# Install dependencies for woostack-review skill
 
 set -euo pipefail
 
-echo "🔍 Checking dependencies for woo-review..."
+echo "🔍 Checking dependencies for woostack-review..."
 
 # 1. Check for gh CLI
 if ! command -v gh &> /dev/null; then

--- a/skills/woostack-review/scripts/merge-findings.sh
+++ b/skills/woostack-review/scripts/merge-findings.sh
@@ -57,7 +57,7 @@ for f in "${FILES[@]}"; do
   #   3. Sanitize: strip bare control bytes (U+0000–U+001F except \t\n\r),
   #      replace invalid `\<char>` escapes with the literal char, retry with
   #      strict=False.
-  # Only sub-agents authored by woo-review write these files; recovery is
+  # Only sub-agents authored by woostack-review write these files; recovery is
   # tolerant of LLM-introduced noise, NOT of attacker-supplied JSON. The
   # downstream finding schema still validates structure.
   RECOVERED="$(python3 - "$f" <<'PY' 2>/dev/null || true

--- a/skills/woostack-review/scripts/prefetch.sh
+++ b/skills/woostack-review/scripts/prefetch.sh
@@ -7,7 +7,7 @@
 #               and rules.md when project-rule files (AGENTS.md / CLAUDE.md / .cursorrules /
 #               .windsurfrules / GEMINI.md) are discovered.
 #
-# Incremental mode (INPUT_INCREMENTAL=auto, default): if a prior woo-review marker
+# Incremental mode (INPUT_INCREMENTAL=auto, default): if a prior woostack-review marker
 # `<!-- woostack-review:sha=<oid> -->` is found in any prior review body, diff
 # <last_sha>...HEAD via the GitHub compare API instead of the full PR diff. A
 # `--full` substring in COMMENT_BODY (issue_comment trigger) overrides to off.
@@ -54,7 +54,7 @@ EVENT_NAME="${EVENT_NAME:-}"
 EVENT_ACTION="${EVENT_ACTION:-}"
 # GITHUB_REPOSITORY is set by CI but unset on local hosts. Resolve it once here
 # (via gh) so the later bare ${GITHUB_REPOSITORY} uses don't trip `set -u` and
-# abort a local /woo-review run with "GITHUB_REPOSITORY: unbound variable".
+# abort a local /woostack-review run with "GITHUB_REPOSITORY: unbound variable".
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo)}"
 export GITHUB_REPOSITORY
 # Hardcoded — not exposed as a knob. Fed into a jq test() regex below; allowing
@@ -73,7 +73,7 @@ if [ "$TEST_MODE" = "1" ] && [ "${GITHUB_ACTIONS:-}" = "true" ]; then
 fi
 # Trigger-comment parsing (issue #19 + existing --full override). Two channels:
 #   1. `--full` substring → INCREMENTAL=off (legacy `@review --full` syntax).
-#   2. `/woo-review [force|recheck]` slash command:
+#   2. `/woostack-review [force|recheck]` slash command:
 #        force   → bypass authors_skip + release_rollup_pattern (FORCE_BYPASS=1)
 #        recheck → INCREMENTAL=auto (default; explicit override of --full)
 #        (none)  → INCREMENTAL=off (full re-review)
@@ -85,29 +85,29 @@ if [ "$EVENT_NAME" = "issue_comment" ]; then
     INCREMENTAL="off"
     echo "Incremental: forced to 'off' by --full in trigger comment"
   fi
-  if printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woo-review([[:space:]]|$)'; then
+  if printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woostack-review([[:space:]]|$)'; then
     HAS_FORCE=0; HAS_RECHECK=0
-    if printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woo-review[[:space:]]+(force|recheck[[:space:]]+force)([[:space:]]|$)'; then
+    if printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woostack-review[[:space:]]+(force|recheck[[:space:]]+force)([[:space:]]|$)'; then
       HAS_FORCE=1
-    elif printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woo-review[[:space:]]+force([[:space:]]|$)'; then
+    elif printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woostack-review[[:space:]]+force([[:space:]]|$)'; then
       HAS_FORCE=1
     fi
-    if printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woo-review[[:space:]]+(recheck|force[[:space:]]+recheck)([[:space:]]|$)'; then
+    if printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woostack-review[[:space:]]+(recheck|force[[:space:]]+recheck)([[:space:]]|$)'; then
       HAS_RECHECK=1
-    elif printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woo-review[[:space:]]+recheck([[:space:]]|$)'; then
+    elif printf '%s' "${COMMENT_BODY:-}" | grep -qE '(^|[[:space:]])/woostack-review[[:space:]]+recheck([[:space:]]|$)'; then
       HAS_RECHECK=1
     fi
     if [ "$HAS_FORCE" = "1" ]; then
       FORCE_BYPASS=1
-      echo "Auto-skip bypass: '/woo-review force' detected in trigger comment"
+      echo "Auto-skip bypass: '/woostack-review force' detected in trigger comment"
     fi
     if [ "$HAS_RECHECK" = "1" ]; then
       INCREMENTAL="auto"
-      echo "Incremental: forced to 'auto' by '/woo-review recheck'"
+      echo "Incremental: forced to 'auto' by '/woostack-review recheck'"
     elif [ "$HAS_FORCE" = "0" ]; then
-      # Bare `/woo-review` → full review.
+      # Bare `/woostack-review` → full review.
       INCREMENTAL="off"
-      echo "Incremental: forced to 'off' by bare '/woo-review' trigger"
+      echo "Incremental: forced to 'off' by bare '/woostack-review' trigger"
     fi
   fi
 fi
@@ -125,10 +125,10 @@ emit_skip() {
 # via the `<!-- woostack-review:skipped -->` marker — repeat triggers (synchronize on
 # a dependabot PR, etc.) re-skip silently. Marker scan also picks up prior skip
 # comments authored by the action across re-runs, so the comment is posted at
-# most once per PR until a human types `/woo-review force`.
+# most once per PR until a human types `/woostack-review force`.
 emit_skip_with_comment() {
   local reason="$1"
-  local body="woo-review skipped: ${reason}
+  local body="woostack-review skipped: ${reason}
 
 <!-- woostack-review:skipped -->"
   local existing
@@ -177,7 +177,7 @@ if [ -n "$SKIP_LABELS" ]; then
   done
 fi
 
-# Marker lookup: pull the latest woo-review SHA watermark from prior review bodies.
+# Marker lookup: pull the latest woostack-review SHA watermark from prior review bodies.
 # Empty result means no prior marker → full diff path (first run, or marker absent).
 # Hand-edited / malformed markers also yield empty → silent fallback to full diff.
 LAST_SHA=""
@@ -186,7 +186,7 @@ if [ "$TEST_MODE" = "1" ] && [ -n "${WOO_REVIEW_FAKE_PR_REVIEWS_JSON:-}" ]; then
 else
   REVIEWS_JSON=$(gh pr view "$PR_NUMBER" --json reviews 2>/dev/null || echo '{"reviews":[]}')
 fi
-# Marker trust: only honor reviews authored by woo-review bots. Without this
+# Marker trust: only honor reviews authored by woostack-review bots. Without this
 # filter any PR collaborator could submit a fake review with a forged marker
 # pointing past their own malicious commits, narrowing the next incremental
 # window to exclude them. The login pattern is anchored to the start of the
@@ -228,7 +228,7 @@ echo "Event: $EVENT_NAME, Action: $EVENT_ACTION, Prior bot comments: $TOTAL_BOT_
 # Re-run guard scope: this check only applies inside GitHub Actions, where the
 # review is auto-triggered by GitHub events and "explicit" is a meaningful
 # concept. When invoked from a local host (Claude Code, Gemini CLI, opencode
-# /woo-review skill), the user typed the command — by definition explicit —
+# /woostack-review skill), the user typed the command — by definition explicit —
 # so EVENT_NAME is empty and the gate would otherwise misclassify the run as
 # implicit and skip it whenever any prior bot comment exists on the PR.
 if [ "${GITHUB_ACTIONS:-}" = "true" ] && \
@@ -254,7 +254,7 @@ bash "$SCRIPT_DIR/load-config.sh"
 # Issue #19: auto-skip mechanical bot PRs (renovate / dependabot / etc.) and
 # release-rollup PRs. Effective lists fall back to defaults when the user did
 # not supply them. An explicit empty list (`authors_skip: []`) opts out.
-# `/woo-review force` in a trigger comment bypasses both checks.
+# `/woostack-review force` in a trigger comment bypasses both checks.
 if [ "${FORCE_BYPASS:-}" != "1" ]; then
   AUTHOR_LOGIN=$(jq -r '.author.login // empty' "$OUTDIR/meta.json")
   PR_TITLE=$(jq -r '.title // ""' "$OUTDIR/meta.json")
@@ -267,7 +267,7 @@ if [ "${FORCE_BYPASS:-}" != "1" ]; then
     | if index($login) then "yes" else "no" end
   ' "$OUTDIR/config.json" 2>/dev/null || echo "no")
   if [ -n "$AUTHOR_LOGIN" ] && [ "$SKIP_MATCH" = "yes" ]; then
-    emit_skip_with_comment "author '$AUTHOR_LOGIN' matches authors_skip (override with \`/woo-review force\`)"
+    emit_skip_with_comment "author '$AUTHOR_LOGIN' matches authors_skip (override with \`/woostack-review force\`)"
   fi
 
   # release_rollup_pattern — same precedence. Empty string opts out.
@@ -283,7 +283,7 @@ import re, sys
 pattern, title = sys.argv[1], sys.argv[2]
 sys.exit(0 if re.search(pattern, title) else 1)
 ' "$ROLLUP_PATTERN" "$PR_TITLE" 2>/dev/null; then
-      emit_skip_with_comment "PR title matches release_rollup_pattern (override with \`/woo-review force\`)"
+      emit_skip_with_comment "PR title matches release_rollup_pattern (override with \`/woostack-review force\`)"
     fi
   fi
 fi

--- a/skills/woostack-review/scripts/resolve-outdir.sh
+++ b/skills/woostack-review/scripts/resolve-outdir.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Single source of truth for the default OUTDIR.
 #
-# Sourced (not executed) by every woo-review script. Respect an explicit
+# Sourced (not executed) by every woostack-review script. Respect an explicit
 # OUTDIR override (host sandbox dirs, the GitHub Action's pin, tests); otherwise
 # derive a per-project path so concurrent reviews of different repos on one
 # machine do not share — and clobber — the same /tmp/pr-review tree.

--- a/skills/woostack-review/scripts/resolve-thread.sh
+++ b/skills/woostack-review/scripts/resolve-thread.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Posts a reply to a PR review thread, then (unless RESOLVE=0) resolves it.
-# Used by `woo-review address` after a thread is FIXED or ACCEPTed. CLARIFY
+# Used by `woostack-review address` after a thread is FIXED or ACCEPTed. CLARIFY
 # threads call with RESOLVE=0 (reply only, leave open).
 #
 # Inputs (env):


### PR DESCRIPTION
Closes #146.

Scrubs the legacy `woo-review` brand from the review engine, stacked on #145 (the woostack rename).

## Decision: trigger phrase
Reconciled the three inconsistent spellings — SKILL.md documented `/woostack-review`, the workflow input defaulted to `@review`, but `prefetch.sh` hardcoded `/woo-review`. **Chose rename-only**: the PR-comment trigger is now `/woostack-review` exclusively (old `/woo-review` dropped — repo is unreleased, zero blast radius). `@review` legacy phrase still works via the workflow `trigger_phrase` input.

## Changed (7 files, 28/28)
- `prefetch.sh` — trigger regexes + log lines + skip-comment body + comments → `woostack-review`
- `_header.md` — "last woostack-review pass" + credits bullet now matches the `:165` template
- `fetch-threads.sh`, `install.sh`, `merge-findings.sh`, `resolve-outdir.sh`, `resolve-thread.sh` — comment-only brand fixes

## Deliberately preserved
- README/AGENTS "standalone `howarewoo/woo-review` repo is deprecated" (intentional repo reference)
- CONTRIBUTING "old `.woo-review/` paths" caution (historical)
- `.woostack/` design spec + plan (record of the completed port)
- the `woo-stack-review:*` legacy marker-compat reads from #145

The marker-compat sub-item also tracked in #146 was already resolved in #145.

Verified: zero residual `woo-review` in scripts/prompts, both legacy markers intact, `bash -n` clean on all scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)