### PR TITLE
feat(woostack-review): nest repo config under "review" key

### DIFF
--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -179,8 +179,8 @@ jobs:
       # findings.prosecutor.json (inclusive bias), defender pass writes
       # findings.defender.json (exclusive bias) + runs intersect-findings.sh
       # to produce the final findings.json, then posts the review.
-      # `disable_adversarial: true` in .woostack/config.json short-circuits the
-      # prosecutor step (the intersect script then falls back to defender-only).
+      # `review.disable_adversarial: true` in .woostack/config.json short-circuits
+      # the prosecutor step (the intersect script then falls back to defender-only).
       - name: Read disable_adversarial flag
         id: adv
         shell: bash

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -40,7 +40,7 @@ The legacy `@review` trigger phrase still works; `/woostack-review` is an alias 
 
 `prefetch.sh` short-circuits the review with a single one-line PR comment when either condition holds (before fetching the diff, so token cost is ~zero):
 
-- **PR author matches `authors_skip`.** Default list: `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`. Override with `review.authors_skip` in `.woostack/config.json`; explicit `"authors_skip": []` opts out entirely.
+- **PR author matches `authors_skip`.** Default list: `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`. Override with `review.authors_skip` in `.woostack/config.json`; explicit `"review": { "authors_skip": [] }` opts out entirely.
 - **PR title matches `release_rollup_pattern`** (Python regex). Default: `^(staging|release|chore\(release\))`. Override with any string; explicit empty string opts out.
 
 The skip comment carries a `<!-- woostack-review:skipped -->` marker; subsequent triggers on the same PR detect the marker and re-skip silently (no comment spam). To force a full review of a skipped PR, post `/woostack-review force`.
@@ -103,7 +103,7 @@ Prefetch auto-discovers project rule files (`AGENTS.md`, `CLAUDE.md`, `.cursorru
 
 ## Per-repo Configuration (`.woostack/config.json`)
 
-Drop an optional `.woostack/config.json` in the consumer repo to tune the review without forking the skill. **Review settings nest under a top-level `review` object** so the file can hold sibling config namespaces for other woostack tools without collision; keys outside `review` are ignored by the review loader. Prefetch parses the `review` block into `$OUTDIR/config.json` (canonical copy, flattened); downstream stages read from there. Missing file = defaults (`severity_floor: high`). **All keys are optional — specify only the ones you want to override; the rest keep their built-in defaults.** Invalid JSON or unknown keys → loud `::error file=.woostack/config.json,line=N::<msg>` annotation and the workflow fails (no silent fallback).
+Drop an optional `.woostack/config.json` in the consumer repo to tune the review without forking the skill. **Review settings nest under a top-level `review` object** so the file can hold sibling config namespaces for other woostack tools without collision; keys outside `review` are ignored by the review loader. Prefetch parses the `review` block into `$OUTDIR/config.json` (canonical copy, flattened); downstream stages read from there. Missing file = defaults (`severity_floor: high`). **All keys are optional — specify only the ones you want to override; the rest keep their built-in defaults.** Invalid JSON, a non-object `review`, or an unknown key *inside* `review` → loud `::error file=.woostack/config.json,line=N::<msg>` annotation and the workflow fails (no silent fallback). Sibling top-level keys outside `review` are ignored, not errors.
 
 > **Transition note:** review keys placed at the top level (the pre-nesting layout) are still accepted but emit a deprecation `::warning`. Migrate them under `review`.
 

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -40,7 +40,7 @@ The legacy `@review` trigger phrase still works; `/woostack-review` is an alias 
 
 `prefetch.sh` short-circuits the review with a single one-line PR comment when either condition holds (before fetching the diff, so token cost is ~zero):
 
-- **PR author matches `authors_skip`.** Default list: `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`. Override with `"authors_skip": [...]` in `.woostack/config.json`; explicit `"authors_skip": []` opts out entirely.
+- **PR author matches `authors_skip`.** Default list: `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`. Override with `review.authors_skip` in `.woostack/config.json`; explicit `"authors_skip": []` opts out entirely.
 - **PR title matches `release_rollup_pattern`** (Python regex). Default: `^(staging|release|chore\(release\))`. Override with any string; explicit empty string opts out.
 
 The skip comment carries a `<!-- woostack-review:skipped -->` marker; subsequent triggers on the same PR detect the marker and re-skip silently (no comment spam). To force a full review of a skipped PR, post `/woostack-review force`.
@@ -80,7 +80,7 @@ Reviews stay useful across PRs through a single plain-markdown file in the consu
 
 ### Noise control (`severity_floor`)
 
-`severity_floor` **defaults to `high`** — by default only high-priority findings surface. Widen it per-repo in `.woostack/config.json` (`"severity_floor": "low"` or `"medium"`). The validator applies the floor after its own severity check.
+`severity_floor` **defaults to `high`** — by default only high-priority findings surface. Widen it per-repo in `.woostack/config.json` (`review.severity_floor` set to `"low"` or `"medium"`). The validator applies the floor after its own severity check.
 
 ## Knowledge Aggregation
 
@@ -103,45 +103,49 @@ Prefetch auto-discovers project rule files (`AGENTS.md`, `CLAUDE.md`, `.cursorru
 
 ## Per-repo Configuration (`.woostack/config.json`)
 
-Drop an optional `.woostack/config.json` in the consumer repo to tune the review without forking the skill. Prefetch parses it into `$OUTDIR/config.json` (canonical copy); downstream stages read from there. Missing file = defaults (`severity_floor: high`). **All keys are optional — specify only the ones you want to override; the rest keep their built-in defaults.** Invalid JSON or unknown keys → loud `::error file=.woostack/config.json,line=N::<msg>` annotation and the workflow fails (no silent fallback).
+Drop an optional `.woostack/config.json` in the consumer repo to tune the review without forking the skill. **Review settings nest under a top-level `review` object** so the file can hold sibling config namespaces for other woostack tools without collision; keys outside `review` are ignored by the review loader. Prefetch parses the `review` block into `$OUTDIR/config.json` (canonical copy, flattened); downstream stages read from there. Missing file = defaults (`severity_floor: high`). **All keys are optional — specify only the ones you want to override; the rest keep their built-in defaults.** Invalid JSON or unknown keys → loud `::error file=.woostack/config.json,line=N::<msg>` annotation and the workflow fails (no silent fallback).
+
+> **Transition note:** review keys placed at the top level (the pre-nesting layout) are still accepted but emit a deprecation `::warning`. Migrate them under `review`.
 
 Minimal example — override one knob, everything else stays default:
 
 ```json
-{ "severity_floor": "medium" }
+{ "review": { "severity_floor": "medium" } }
 ```
 
 Full schema (every key shown; all optional):
 
 ```json
 {
-  "angles": {
-    "force": ["database"],
-    "skip": ["seo"]
-  },
-  "severity_floor": "high",
-  "ignore": [
-    "**/*.generated.ts",
-    "migrations/*.sql"
-  ],
-  "project_rules": [
-    "constitution.md",
-    "docs/standards/*.md"
-  ],
-  "authors_skip": [
-    "dependabot[bot]",
-    "renovate[bot]"
-  ],
-  "release_rollup_pattern": "^(staging|release|chore\\(release\\))",
-  "models": {
-    "fast": "anthropic/claude-haiku-4-5",
-    "standard": "openai/gpt-5",
-    "deep": "anthropic/claude-opus-4-7"
-  },
-  "fix_commands": ["pnpm lint:fix", "pnpm format"],
-  "disable_adversarial": false,
-  "chunking": {
-    "max_loc": 4000
+  "review": {
+    "angles": {
+      "force": ["database"],
+      "skip": ["seo"]
+    },
+    "severity_floor": "high",
+    "ignore": [
+      "**/*.generated.ts",
+      "migrations/*.sql"
+    ],
+    "project_rules": [
+      "constitution.md",
+      "docs/standards/*.md"
+    ],
+    "authors_skip": [
+      "dependabot[bot]",
+      "renovate[bot]"
+    ],
+    "release_rollup_pattern": "^(staging|release|chore\\(release\\))",
+    "models": {
+      "fast": "anthropic/claude-haiku-4-5",
+      "standard": "openai/gpt-5",
+      "deep": "anthropic/claude-opus-4-7"
+    },
+    "fix_commands": ["pnpm lint:fix", "pnpm format"],
+    "disable_adversarial": false,
+    "chunking": {
+      "max_loc": 4000
+    }
   }
 }
 ```
@@ -213,7 +217,7 @@ When prefetch resolves a PR number AND finds an open PR, it produces the full ar
 | `raw_findings.json` | `merge-findings.sh` | validator passes | Merged, chunk-collapsed findings |
 | `findings.json` | `intersect-findings.sh` | Stage 5 posting | Final validated set |
 | `validator-metrics.json` | `intersect-findings.sh` | observability | `prosecutor_count`, `defender_count`, `kept_count`, `disagreement_count`, `mode`, `degraded` |
-| `findings.metrics.json` | `intersect-findings.sh` | metrics fold, telemetry | Per-angle signal/noise breakdown. Emitted **only when `metrics: true`** in config. Keyed by angle: `raw_count`, `prosecutor_kept`, `defender_kept`, `kept`, `dropped_by_defender`, `dropped_by_prosecutor`, `blocking_count`, `nonblocking_count`, `severity` |
+| `findings.metrics.json` | `intersect-findings.sh` | metrics fold, telemetry | Per-angle signal/noise breakdown. Emitted **only when `review.metrics: true`** in config. Keyed by angle: `raw_count`, `prosecutor_kept`, `defender_kept`, `kept`, `dropped_by_defender`, `dropped_by_prosecutor`, `blocking_count`, `nonblocking_count`, `severity` |
 
 **If no PR number resolved (local mode):**
 
@@ -432,7 +436,7 @@ re-reviews quiet.
 
 ### Stage 6.5 — Fold per-angle metrics (local hosts, opt-in)
 
-Only when the consumer repo sets `metrics: true` in `.woostack/config.json`. The
+Only when the consumer repo sets `review.metrics: true` in `.woostack/config.json`. The
 per-run `findings.metrics.json` (written by `intersect-findings.sh`) is folded into a
 rolling, **per-clone** aggregate at `.woostack/metrics.json`. The fold script also
 ensures that path is gitignored — the aggregate is local data, never committed

--- a/skills/woostack-review/scripts/load-config.sh
+++ b/skills/woostack-review/scripts/load-config.sh
@@ -4,10 +4,22 @@
 # Invalid JSON or invalid schema -> loud GitHub-style ::error annotation and
 # non-zero exit (per issue #11 acceptance bullet 4).
 #
+# Config nesting: review settings live under a top-level `review` object so the
+# file can hold sibling namespaces for other woostack tools (build, bootstrap)
+# without collision. Sibling top-level keys are ignored by this loader. The
+# emitted canonical JSON is still FLAT (review keys hoisted to top level) so
+# downstream stages read `.severity_floor`, `.angles`, etc. unchanged.
+#
+#   { "review": { "severity_floor": "medium", "angles": { "skip": ["seo"] } } }
+#
+# Legacy (transition): a file with review keys at the top level and no `review`
+# object is still accepted; it emits a non-fatal deprecation notice. Remove the
+# legacy path once consumers have migrated to the nested form.
+#
 # Noise control: severity_floor defaults to "high" so only high-priority
 # findings surface unless the consumer widens it (low | medium) in config.json.
 #
-# Schema (all keys optional):
+# Schema under `review` (all keys optional):
 #   angles.force        list[str] subset of angle enum
 #   angles.skip         list[str] subset of angle enum (bugs/security protected)
 #   severity_floor      "low" | "medium" | "high" (case-insensitive)
@@ -63,7 +75,8 @@ src, dst = sys.argv[1], sys.argv[2]
 
 VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture"}
 VALID_FLOORS = {"low", "medium", "high"}
-TOP_KEYS = {
+# Keys recognized inside the `review` block (and the legacy top-level form).
+REVIEW_KEYS = {
     "angles", "severity_floor", "ignore", "project_rules",
     "authors_skip", "release_rollup_pattern", "models", "fix_commands",
     "disable_adversarial", "metrics", "chunking",
@@ -108,11 +121,31 @@ except json.JSONDecodeError as exc:
 if not isinstance(raw, dict):
     loud("top-level JSON must be an object, got {}".format(type(raw).__name__))
 
-unknown = sorted(set(raw.keys()) - TOP_KEYS)
-if unknown:
-    loud("unknown top-level key(s): {}".format(", ".join(unknown)))
+# Resolve the review config block. Canonical form nests it under `review`;
+# sibling top-level namespaces (e.g. build/bootstrap config) are left alone.
+# Legacy form puts review keys at the top level — accepted with a deprecation
+# notice during the transition.
+if "review" in raw:
+    rc = raw["review"]
+    if not isinstance(rc, dict):
+        loud("`review` must be an object, got {}".format(type(rc).__name__))
+    unknown = sorted(set(rc.keys()) - REVIEW_KEYS)
+    if unknown:
+        loud("unknown `review` key(s): {}".format(", ".join(unknown)))
+else:
+    rc = raw
+    legacy_review = sorted(set(rc.keys()) & REVIEW_KEYS)
+    unknown = sorted(set(rc.keys()) - REVIEW_KEYS)
+    if unknown:
+        loud("unknown top-level key(s): {} (review settings now nest under `review`)".format(", ".join(unknown)))
+    if legacy_review:
+        sys.stderr.write(
+            "::warning file=.woostack/config.json::review settings at the top level are deprecated; "
+            "nest them under a `review` object, e.g. {\"review\": {...}}\n"
+        )
 
 out = {}
+raw = rc
 
 if "angles" in raw:
     angles = raw["angles"]


### PR DESCRIPTION
## What

Review settings in `.woostack/config.json` now nest under a top-level `review` object so the file can hold sibling config namespaces for other woostack tools (build, bootstrap) without collision. Keys outside `review` are ignored by the review loader.

```json
{ "review": { "severity_floor": "medium", "angles": { "skip": ["seo"] } } }
```

## How

- `scripts/load-config.sh` selects the `review` block and still emits a **flat** canonical `$OUTDIR/config.json`. Single change point — every downstream stage (`prefetch`, `detect-angles`, `chunk-diff`, `intersect-findings`, `metrics-fold`, `reusable-review.yml`) reads `.severity_floor`/`.angles`/etc. unchanged.
- **Transition:** review keys at the top level (pre-nesting layout) are still accepted but emit a deprecation `::warning`. Remove the legacy path once consumers migrate.
- Docs (`SKILL.md`) and the `reusable-review.yml` comment updated to the nested form.

## Tested

Parser paths verified: nested, sibling-namespace-ignored, legacy-warn, `review` not-object error, unknown-review-key error, unknown-top-level error, empty/missing-file defaults, full-schema round-trip → flat output confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)