### PR TITLE
docs(woostack-review): enforce terse cross-PR memory entries

### DIFF
--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -395,7 +395,7 @@ Before writing anything:
 
 1. **Read the existing `.woostack/memory.md`** (it was already loaded to `$OUTDIR/memory.md` in Stage 1; re-read the repo copy in case it changed).
 2. **Check coverage.** If an existing entry already captures this learning — even phrased differently, or scoped more narrowly/broadly — do **NOT** append a duplicate. If the existing entry is close but the new dismissal generalizes it (e.g. the same pattern in a second file), edit that entry to widen its scope rather than adding a near-duplicate.
-3. **Only when the learning is genuinely new**, append one short bullet phrased as a reusable rule, then stop.
+3. **Only when the learning is genuinely new**, append one terse bullet phrased as a reusable rule — one line, `<pattern>: <reason>`, ideally ≤100 chars, no preamble or narration — then stop.
 
 ```bash
 mkdir -p .woostack
@@ -403,7 +403,7 @@ mkdir -p .woostack
 printf -- '- %s\n' "<general pattern>: <why it is accepted / what not to re-flag>" >> .woostack/memory.md
 ```
 
-Phrase entries as patterns, not instances — prefer "Generated `*.pb.go` files are intentional; do not flag their style" over "dismissed line 42 in user.pb.go". The local skill writes this file directly — no post-session hook, no permission-isolated job. Only record on an explicit dismissal or a stated gotcha — never auto-record every finding. Do NOT write memory in CI: the GitHub Action's validator job holds `contents: read` and posts the review only; memory is curated locally and by humans editing the file. Memory is read back as review context on the next run (Stage 1) and the validator drops findings it records.
+Phrase entries as terse patterns, not instances — prefer "Generated `*.pb.go` files are intentional; do not flag their style" over "dismissed line 42 in user.pb.go". One line per entry, no narration. The local skill writes this file directly — no post-session hook, no permission-isolated job. Only record on an explicit dismissal or a stated gotcha — never auto-record every finding. Do NOT write memory in CI: the GitHub Action's validator job holds `contents: read` and posts the review only; memory is curated locally and by humans editing the file. Memory is read back as review context on the next run (Stage 1) and the validator drops findings it records.
 
 ## Addressing Reviews (`woostack-review address <PR#>`, local hosts)
 

--- a/skills/woostack-review/prompts/address.md
+++ b/skills/woostack-review/prompts/address.md
@@ -61,10 +61,12 @@ different verdict (any of FIX / ACCEPT / CLARIFY).
   (and the live `.woostack/memory.md`): if an existing entry already covers
   this learning — even phrased differently or more broadly — do NOT add a
   duplicate; widen the existing entry instead. Only when the learning is
-  genuinely new, stage it (as a **pattern, not an instance**) for the memory
-  write — which runs in the after-phases step below, alongside the reply, so it
-  never lands ahead of a rejected push. Only a final ACCEPT (accept-by-design)
-  writes memory. A "won't-fix because transient / out-of-scope" is not a
+  genuinely new, stage it for the memory write — which runs in the after-phases
+  step below, alongside the reply, so it never lands ahead of a rejected push.
+  Phrase it as a **terse pattern, not an instance**: one line,
+  `<pattern>: <reason>`, ideally ≤100 chars. State the rule and stop — no
+  preamble, no narration, no instance line numbers, no restating the finding.
+  Only a final ACCEPT (accept-by-design) writes memory. A "won't-fix because transient / out-of-scope" is not a
   reusable rule — do not record it.
 - **CLARIFY**: do not fix, do not write memory, do not resolve. Reply with a
   specific question (handled below with `RESOLVE=0`).
@@ -89,7 +91,8 @@ different verdict (any of FIX / ACCEPT / CLARIFY).
    ```
 
    Then, for each ACCEPTED thread whose learning is genuinely new, write the
-   staged memory pattern (only now, after the push succeeded):
+   staged memory pattern (only now, after the push succeeded). Keep `LEARNING`
+   terse — one line, `<pattern>: <reason>`, ideally ≤100 chars, no filler:
 
    ```bash
    LEARNING="<general pattern>: <why it is accepted / what not to re-flag>" \

--- a/skills/woostack-review/prompts/address.md
+++ b/skills/woostack-review/prompts/address.md
@@ -66,8 +66,8 @@ different verdict (any of FIX / ACCEPT / CLARIFY).
   Phrase it as a **terse pattern, not an instance**: one line,
   `<pattern>: <reason>`, ideally ≤100 chars. State the rule and stop — no
   preamble, no narration, no instance line numbers, no restating the finding.
-  Only a final ACCEPT (accept-by-design) writes memory. A "won't-fix because transient / out-of-scope" is not a
-  reusable rule — do not record it.
+  Only a final ACCEPT (accept-by-design) writes memory. A "won't-fix because
+  transient / out-of-scope" is not a reusable rule — do not record it.
 - **CLARIFY**: do not fix, do not write memory, do not resolve. Reply with a
   specific question (handled below with `RESOLVE=0`).
 


### PR DESCRIPTION
## What

Add an explicit one-line phrasing rule at every `.woostack/memory.md` write site so accept-by-design learnings stay terse instead of growing into prose.

**Format enforced:** `<pattern>: <reason>`, one line, ideally ≤100 chars, no preamble / narration / instance detail.

## Why

Cross-PR memory is read back as review context on every run and as advisory rubric by every angle worker + both validators. Verbose entries cost tokens on each read and bury the signal. The prior guidance said "pattern, not instance" but set no length/style bar, so entries could drift into paragraphs.

## Where

| Site | Change |
|---|---|
| `prompts/address.md` | Phase 3 ACCEPT phrasing + `LEARNING` write comment — the `address` verb (woostack-address-comments path) |
| `SKILL.md` | Stage 6 step 3 + the "phrase as patterns" line — the live local-run dismissal path |

Both write the same file; the rule is now stated identically at both so the convention is single.

`memory-append.sh` is unchanged — it already whitespace-normalizes and dedups; phrasing is the LLM's job, now constrained.

## Scope

Skill-asset (Markdown) edits only. No filenames or cross-links touched. No application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)