### PR TITLE
feat(woostack-build): markdown specs, HTML as on-demand render

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ woostack/
 │   ├── woostack-build/
 │   │   ├── SKILL.md           Feature-loop skill (brainstorm → spec → grill → plan → execute)
 │   │   └── references/
-│   │       └── spec-template.html  HTML spec scaffold
+│   │       ├── spec-template.md    Markdown spec scaffold (authored source)
+│   │       └── spec-template.html  HTML render target (on-demand visualization)
 │   ├── woostack-review/
 │   │   ├── SKILL.md           Review skill (review + address verbs)
 │   │   ├── scripts/           Review engine scripts
@@ -70,7 +71,7 @@ The agent has the collection installed (or is pointed at this repo) and is asked
 | Command | What it does |
 |---|---|
 | `/woostack-bootstrap <goal>` | Scaffold a new web/mobile/API monorepo at latest versions. |
-| `/woostack-build <goal>` | Feature loop: brainstorm → HTML spec → grill → plan → execute. |
+| `/woostack-build <goal>` | Feature loop: brainstorm → markdown spec → grill → plan → execute. |
 | `/woostack-review [PR#]` | Parallel review swarm + skeptical validation; posts a batched GitHub review. |
 | `/woostack-address-comments [PR#]` | Address unresolved review threads autonomously. No merge. |
 

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-build
-description: Use when building a feature with the full woostack development loop — brainstorm a design, harden it, plan it, and implement it. Chains superpowers (brainstorming, writing-plans, executing-plans) and grill-me in a fixed, gated order; writes HTML specs and markdown plans under .woostack/.
+description: Use when building a feature with the full woostack development loop — brainstorm a design, harden it, plan it, and implement it. Chains superpowers (brainstorming, writing-plans, executing-plans) and grill-me in a fixed, gated order; writes markdown specs and plans under .woostack/.
 ---
 
 # woostack-build
@@ -12,7 +12,7 @@ glue: it sequences proven sub-skills and **inherits their gates** — it adds no
 its own. The value is the order and the handoffs.
 
 ```
-brainstorming → write spec (HTML) → grill-me → writing-plans → executing-plans → ask: open PR?
+brainstorming → write spec (markdown) → grill-me → writing-plans → executing-plans → ask: open PR?
 ```
 
 ## Dependency preflight
@@ -31,12 +31,16 @@ continue. If the user declines, fall back to following the skill's principle man
 
 1. **Brainstorm.** Invoke `superpowers:brainstorming` to explore the problem and converge
    on a design. Let it run its own approval gate.
-2. **Write the spec as HTML.** When the design is approved, do **not** write the default
-   markdown to `docs/superpowers/specs/`. Instead author a self-contained HTML spec to
-   `.woostack/specs/YYYY-MM-DD-<slug>.html`, populating
-   [references/spec-template.html](references/spec-template.html). HTML is for
-   visualization — richer than markdown.
-3. **Harden it.** Invoke `grill-me` against the HTML spec. Amend the spec in place until
+2. **Write the spec as markdown.** When the design is approved, do **not** write to the
+   superpowers default `docs/superpowers/specs/`. Instead author a markdown spec to
+   `.woostack/specs/YYYY-MM-DD-<slug>.md`, populating
+   [references/spec-template.md](references/spec-template.md). Markdown specs are the source
+   of truth: they carry `type: spec` frontmatter, are Obsidian vault nodes that can `[[link]]`
+   memory notes, and are excluded from memory recall routing by type. **Visualize on demand** —
+   if a rich view is wanted, render the markdown through
+   [references/spec-template.html](references/spec-template.html); the HTML is a presentation
+   target only, never the authored source.
+3. **Harden it.** Invoke `grill-me` against the spec. Amend the spec in place until
    grilling stops producing new questions.
 4. **Plan.** Invoke `superpowers:writing-plans`, saving the plan as **markdown** to
    `.woostack/plans/YYYY-MM-DD-<slug>.md` (plans are working checklists, not visualization
@@ -55,7 +59,7 @@ continue. If the user declines, fall back to following the skill's principle man
 ## Hard constraints
 
 - **Inherit gates, add none.** Do not insert extra approval stops between phases.
-- **HTML specs, markdown plans, under `.woostack/`.** Never write specs to the superpowers
-  default location or format.
+- **Markdown specs and plans, under `.woostack/`.** Never write specs to the superpowers
+  default location. HTML is a render-on-demand target only, not the authored format.
 - **Never merge.** build ends by offering a PR, nothing further.
 - **One increment per cycle.** Do not let a single build cycle balloon past a reviewable PR.

--- a/skills/woostack-build/references/spec-template.md
+++ b/skills/woostack-build/references/spec-template.md
@@ -1,0 +1,44 @@
+---
+name: {{SLUG}}
+type: spec
+status: {{STATUS}}
+date: {{DATE}}
+branch: {{BRANCH}}
+links:
+---
+
+# {{TITLE}} — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+## 1. Problem
+
+{{PROBLEM}}
+
+## 2. Goal
+
+{{GOAL}}
+
+## 3. Non-goals
+
+{{NON_GOALS}}
+
+## 4. Approach
+
+{{APPROACH}}
+
+## 5. Components & data flow
+
+{{COMPONENTS}}
+
+## 6. Error handling
+
+{{ERRORS}}
+
+## 7. Testing
+
+{{TESTING}}
+
+## 8. Open questions
+
+{{OPEN_QUESTIONS}}


### PR DESCRIPTION
## What

Flip woostack-build to author specs as **markdown** instead of HTML. HTML becomes an on-demand render target only.

## Why

Part of the project-memory-vault work (increment **A0** of that effort). Markdown specs carry `type: spec` frontmatter, making them Obsidian vault nodes that can `[[link]]` to memory notes (and vice versa) while staying excluded from memory **recall routing** by type. HTML specs are dead nodes in Obsidian's markdown-only graph — this fixes that.

`spec-template.html` is retained purely as a presentation target a user can render on demand; markdown is the source of truth.

## Changes

- `skills/woostack-build/SKILL.md` — description, flow diagram, step 2 (author markdown), step 3 (grill the spec), hard constraint (markdown specs + plans; HTML render-on-demand).
- `skills/woostack-build/references/spec-template.md` — new authored scaffold (frontmatter + 8 sections, mirrors the HTML template).
- `AGENTS.md` — repo layout (both templates, roles noted) + command table.

## Scope

Single concern. No behavioral wiring into other skills. ~49 net lines. Prerequisite for the `woostack-init` increment (A), which assumes markdown specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)