### PR TITLE
Memory: recall usage telemetry (close the feedback loop) (#159)

### DIFF
--- a/.woostack/memory.md
+++ b/.woostack/memory.md
@@ -1,0 +1,1 @@
+- .woostack/specs and .woostack/plans are tracked skill artifacts; do not flag them as stray.

--- a/.woostack/plans/2026-06-02-memory-recall-telemetry.md
+++ b/.woostack/plans/2026-06-02-memory-recall-telemetry.md
@@ -1,0 +1,420 @@
+# Memory Recall Telemetry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist recall usage (`recall_count` + `last_recalled`) onto each memory note when `recall.sh` loads it, and add a `doctor.sh` dead-note warning, converting the store from write-only to self-correcting.
+
+**Architecture:** Add three shared helpers to `lib.sh` (`set_field` for atomic frontmatter mutation, `_woo_now` + `_woo_epoch` for deterministic dates). `recall.sh` stamps every selected note (matched + one-hop linked + global) best-effort. `doctor.sh` derives a dead-note warning from `updated:` age vs `recall_count`. Document the new fields + knobs in the memory contract. No app code — these are skill assets.
+
+**Tech Stack:** POSIX-ish bash (3.2 / macOS BSD compatible), awk, the existing `tests/assert.sh` harness. No new dependencies.
+
+Spec: [.woostack/specs/2026-06-02-memory-recall-telemetry.html](../specs/2026-06-02-memory-recall-telemetry.html) · Issue #159.
+
+**Conventions to respect:**
+- All scripts live in `skills/woostack-init/scripts/`. `lib.sh` is sourced by `recall.sh`, `doctor.sh`, `build-index.sh`.
+- bash 3.2: no `mapfile`, no GNU-only flags. macOS `date` is BSD (no `-d`); macOS `mktemp` needs an `XXXXXX` template.
+- Tests: each `test-*.sh` sources `tests/assert.sh` (which provides `assert_eq`, `assert_contains`, `assert_not_contains`, `assert_exit`, `mk_note`, `finish`). Run all via `tests/run-tests.sh`.
+- Frontmatter is line-oriented between two `---` fences. `field()` reads the first match; `note_body()` is everything after the second fence.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `skills/woostack-init/scripts/lib.sh` | Shared frontmatter + date helpers | Add `set_field`, `_woo_now`, `_woo_epoch` |
+| `skills/woostack-init/scripts/recall.sh` | Compose per-PR memory; now also stamps telemetry | Add stamping block |
+| `skills/woostack-init/scripts/doctor.sh` | Lint memory dir; now warns on dead notes | Add dead-note check |
+| `skills/woostack-init/references/memory.md` | Memory contract | Document new fields + doctor behavior + knobs |
+| `skills/woostack-init/scripts/tests/test-lib.sh` | Unit tests for lib helpers | Add `set_field` + date-helper tests |
+| `skills/woostack-init/scripts/tests/test-recall.sh` | recall behavior tests | Add stamping tests |
+| `skills/woostack-init/scripts/tests/test-doctor.sh` | doctor behavior tests | Add dead-note tests |
+
+---
+
+## Task 1: Date helpers in lib.sh (`_woo_now`, `_woo_epoch`)
+
+**Files:**
+- Modify: `skills/woostack-init/scripts/lib.sh`
+- Test: `skills/woostack-init/scripts/tests/test-lib.sh`
+
+- [ ] **Step 1: Read the current test file to find the source line + append point**
+
+Run: `cat skills/woostack-init/scripts/tests/test-lib.sh`
+Confirm it sources `lib.sh` (via `$DIR/lib.sh` or similar) and ends with `finish`. You will append new assertions *before* the final `finish` call.
+
+- [ ] **Step 2: Write the failing tests** (append before `finish` in `test-lib.sh`)
+
+```bash
+# --- _woo_now / _woo_epoch ---
+assert_eq "$(WOOSTACK_NOW=2026-01-02 _woo_now)" "2026-01-02" "_woo_now honors WOOSTACK_NOW"
+e1="$(_woo_epoch 2026-01-01)"; e2="$(_woo_epoch 2026-01-02)"
+assert_eq "$(( e2 - e1 ))" "86400" "_woo_epoch: one day apart = 86400s (time-of-day zeroed)"
+set +e; _woo_epoch "not-a-date" >/dev/null 2>&1; rc=$?; set -e
+assert_exit 1 "$rc" "_woo_epoch returns non-zero on unparseable input"
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `bash skills/woostack-init/scripts/tests/test-lib.sh`
+Expected: FAIL — `_woo_now`/`_woo_epoch` not defined (`command not found`) or assertion failures.
+
+- [ ] **Step 4: Implement the helpers** (append to `skills/woostack-init/scripts/lib.sh`)
+
+```bash
+# _woo_now → today's ISO date (YYYY-MM-DD). Override with WOOSTACK_NOW for tests.
+_woo_now() { printf '%s\n' "${WOOSTACK_NOW:-$(date +%F)}"; }
+
+# _woo_epoch <YYYY-MM-DD> → Unix epoch seconds at 00:00:00 of that date.
+# Time-of-day is zeroed so age math and tests are deterministic. Tries GNU
+# `date -d` first, falls back to BSD `date -j -f`. Non-zero on unparseable input.
+_woo_epoch() {
+  local d="$1" e
+  e="$(date -d "$d 00:00:00" +%s 2>/dev/null)" \
+    || e="$(date -j -f '%Y-%m-%d %H:%M:%S' "$d 00:00:00" +%s 2>/dev/null)" \
+    || return 1
+  printf '%s\n' "$e"
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bash skills/woostack-init/scripts/tests/test-lib.sh`
+Expected: PASS (the three new assertions; existing ones still pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/woostack-init/scripts/lib.sh skills/woostack-init/scripts/tests/test-lib.sh
+git commit -m "feat(memory): add _woo_now/_woo_epoch date helpers to lib.sh"
+```
+
+---
+
+## Task 2: `set_field` frontmatter mutator in lib.sh
+
+**Files:**
+- Modify: `skills/woostack-init/scripts/lib.sh`
+- Test: `skills/woostack-init/scripts/tests/test-lib.sh`
+
+- [ ] **Step 1: Write the failing tests** (append before `finish` in `test-lib.sh`)
+
+```bash
+# --- set_field ---
+sfd="$(mktemp -d)"
+mk_note "$sfd" n.md $'name: x\ntype: pattern\nscope: a/**' 'body [[link]] here'
+# update existing key
+set_field "$sfd/n.md" type "gotcha"
+assert_eq "$(field "$sfd/n.md" type)" "gotcha" "set_field updates an existing key"
+assert_eq "$(field "$sfd/n.md" name)" "x" "set_field: other fields preserved on update"
+assert_contains "$(note_body "$sfd/n.md")" "body [[link]] here" "set_field: body preserved on update"
+# insert absent key
+set_field "$sfd/n.md" recall_count "1"
+assert_eq "$(field "$sfd/n.md" recall_count)" "1" "set_field inserts an absent key"
+assert_eq "$(field "$sfd/n.md" name)" "x" "set_field: fields intact after insert"
+assert_contains "$(note_body "$sfd/n.md")" "body [[link]] here" "set_field: body intact after insert"
+# date value round-trips
+set_field "$sfd/n.md" last_recalled "2026-06-02"
+assert_eq "$(field "$sfd/n.md" last_recalled)" "2026-06-02" "set_field: date value round-trips"
+# malformed note (no frontmatter) → non-zero, file unchanged
+printf 'no frontmatter\n' > "$sfd/bad.md"
+set +e; set_field "$sfd/bad.md" recall_count 1; rc=$?; set -e
+assert_exit 1 "$rc" "set_field fails on a note without frontmatter"
+assert_eq "$(cat "$sfd/bad.md")" "no frontmatter" "set_field leaves a malformed note unchanged"
+rm -rf "$sfd"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bash skills/woostack-init/scripts/tests/test-lib.sh`
+Expected: FAIL — `set_field: command not found`.
+
+- [ ] **Step 3: Implement `set_field`** (append to `skills/woostack-init/scripts/lib.sh`)
+
+```bash
+# set_field <file> <key> <value> — set a frontmatter key (update if present, else
+# insert before the closing fence). Rewrites ONLY the first frontmatter block;
+# body and all other fields are preserved verbatim. Atomic: writes a temp file in
+# the note's own directory, then mv's it over the original. Returns non-zero
+# WITHOUT modifying the file if it lacks two '---' fences or the write fails.
+set_field() {
+  local file="$1" key="$2" val="$3" tmp dir
+  [ "$(grep -c '^---$' "$file" 2>/dev/null)" -ge 2 ] || return 1
+  dir="$(dirname "$file")"
+  tmp="$(mktemp "$dir/.woomem.XXXXXX")" || return 1
+  awk -v key="$key" -v val="$val" '
+    { 
+      if ($0 == "---") {
+        fence++
+        if (fence == 1) { infm=1; print; next }
+        if (fence == 2) { if (infm && !seen) print key ": " val; infm=0; print; next }
+      }
+      if (infm && !seen && index($0, key ":") == 1) { print key ": " val; seen=1; next }
+      print
+    }
+  ' "$file" > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+}
+```
+
+Note: `index($0, key ":") == 1` matches a line that *starts with* `key:` without treating `key` as a regex (robust + matches how `field()` greps `^key:`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash skills/woostack-init/scripts/tests/test-lib.sh`
+Expected: PASS (all new assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/woostack-init/scripts/lib.sh skills/woostack-init/scripts/tests/test-lib.sh
+git commit -m "feat(memory): add atomic set_field frontmatter mutator to lib.sh"
+```
+
+---
+
+## Task 3: Stamp telemetry in recall.sh
+
+**Files:**
+- Modify: `skills/woostack-init/scripts/recall.sh` (insert after `linked_files` array is built, ~line 62, before the `global_out` block)
+- Test: `skills/woostack-init/scripts/tests/test-recall.sh`
+
+- [ ] **Step 1: Write the failing tests** (append before `finish` in `test-recall.sh`)
+
+```bash
+# --- telemetry stamping ---
+woo5="$(mktemp -d)"; md5="$woo5/memory"; mkdir -p "$md5"
+mk_note "$md5" a.md $'name: a\ntype: pattern\nscope: pkg/**'      'A body [[b]]'
+mk_note "$md5" b.md $'name: b\ntype: pattern\nscope: zzz/**'      'B linked body'
+mk_note "$md5" g.md $'name: g\ntype: convention\nscope: *'        'G global body'
+p5="$(mktemp)"; printf 'pkg/x.ts\n' > "$p5"
+
+WOOSTACK_NOW=2026-06-02 bash "$RECALL" "$woo5" "$p5" >/dev/null
+assert_eq "$(field "$md5/a.md" recall_count)"  "1"          "matched note stamped count=1"
+assert_eq "$(field "$md5/a.md" last_recalled)" "2026-06-02" "matched note last_recalled stamped"
+assert_eq "$(field "$md5/b.md" recall_count)"  "1"          "one-hop linked note stamped"
+assert_eq "$(field "$md5/g.md" recall_count)"  "1"          "global (scope:*) note stamped"
+
+# second run bumps the cumulative count and refreshes the date
+WOOSTACK_NOW=2026-06-03 bash "$RECALL" "$woo5" "$p5" >/dev/null
+assert_eq "$(field "$md5/a.md" recall_count)"  "2"          "second run bumps count to 2"
+assert_eq "$(field "$md5/a.md" last_recalled)" "2026-06-03" "second run refreshes last_recalled"
+
+# best-effort: a read-only memory dir makes stamping fail, but recall still
+# produces output and exits 0, logging the failure to stderr.
+chmod -R a-w "$md5" 2>/dev/null || true
+set +e
+out="$(WOOSTACK_NOW=2026-06-04 bash "$RECALL" "$woo5" "$p5" 2>/dev/null)"; code=$?
+err="$(WOOSTACK_NOW=2026-06-04 bash "$RECALL" "$woo5" "$p5" 2>&1 >/dev/null)"
+set -e
+chmod -R u+w "$md5" 2>/dev/null || true
+assert_exit 0 "$code"            "recall exits 0 even when stamping fails"
+assert_contains "$out" "A body"  "recall output intact when stamping fails"
+assert_contains "$err" "stamp failed" "stamp failure logged to stderr"
+rm -rf "$woo5" "$p5"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bash skills/woostack-init/scripts/tests/test-recall.sh`
+Expected: FAIL — `recall_count` is empty (no stamping yet), so the count assertions fail.
+
+- [ ] **Step 3: Implement stamping** — insert this block in `recall.sh` immediately after the `linked_files=()` building loop (the `done < "$linked"` around line 62) and before `global_out=""`:
+
+```bash
+# --- Stamp recall telemetry on every selected note (best-effort). ---
+# Cumulative recall_count + last_recalled. Failures never break recall: they
+# log to stderr and recall still exits 0. Stamps matched + one-hop linked +
+# global notes (each appears in exactly one set, so no double-counting).
+_now="$(_woo_now)"
+stamp_note() {
+  local f="$1" cur next
+  cur="$(field "$f" recall_count)"; cur="${cur:-0}"
+  case "$cur" in (*[!0-9]*) cur=0 ;; esac
+  next=$(( cur + 1 ))
+  { set_field "$f" recall_count "$next" && set_field "$f" last_recalled "$_now"; } \
+    || echo "recall: stamp failed $(basename "$f")" >&2
+}
+for f in "${matched_files[@]:-}"; do [ -n "${f:-}" ] && stamp_note "$f"; done
+for f in "${linked_files[@]:-}"; do [ -n "${f:-}" ] && stamp_note "$f"; done
+while IFS= read -r f; do [ -n "$f" ] && stamp_note "$f"; done < "$globals"
+```
+
+(`$globals` is the tmpfile of global note paths written during the initial scan; it still exists — the EXIT trap removes it.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash skills/woostack-init/scripts/tests/test-recall.sh`
+Expected: PASS — new stamping assertions AND all pre-existing recall assertions (stdout is unchanged by stamping).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/woostack-init/scripts/recall.sh skills/woostack-init/scripts/tests/test-recall.sh
+git commit -m "feat(memory): stamp recall_count/last_recalled on recalled notes"
+```
+
+---
+
+## Task 4: Dead-note warning in doctor.sh
+
+**Files:**
+- Modify: `skills/woostack-init/scripts/doctor.sh` (insert at the end of the per-note `for` loop body, after the wikilink check, before the `done` ~line 54)
+- Test: `skills/woostack-init/scripts/tests/test-doctor.sh`
+
+- [ ] **Step 1: Write the failing tests** (append before `finish` in `test-doctor.sh`)
+
+```bash
+# --- dead-note check ---
+# old + never recalled → dead warning, exit 0
+dd1="$(mktemp -d)/m"; mkdir -p "$dd1"
+mk_note "$dd1" old.md $'name: old\ntype: pattern\nscope: *\nupdated: 2026-01-01' 'stale body'
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd1" 2>&1)"; CODE=$?
+assert_contains "$OUT" "dead note" "old + zero recalls flagged as dead"
+assert_exit 0 "$CODE" "dead note is a warning (exit 0)"
+
+# old but recalled → not flagged
+dd2="$(mktemp -d)/m"; mkdir -p "$dd2"
+mk_note "$dd2" old.md $'name: old\ntype: pattern\nscope: *\nupdated: 2026-01-01\nrecall_count: 3' 'body'
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd2" 2>&1)"
+assert_not_contains "$OUT" "dead note" "a recalled note is never flagged dead"
+
+# fresh updated → not flagged
+dd3="$(mktemp -d)/m"; mkdir -p "$dd3"
+mk_note "$dd3" fresh.md $'name: fresh\ntype: pattern\nscope: *\nupdated: 2026-05-30' 'body'
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd3" 2>&1)"
+assert_not_contains "$OUT" "dead note" "a fresh note is not flagged"
+
+# no updated: → not aged, not flagged
+dd4="$(mktemp -d)/m"; mkdir -p "$dd4"
+mk_note "$dd4" noupd.md $'name: noupd\ntype: pattern\nscope: *' 'body'
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd4" 2>&1)"
+assert_not_contains "$OUT" "dead note" "a note without updated: is not flagged"
+
+# WOOSTACK_DEAD_DAYS tightens the window
+dd5="$(mktemp -d)/m"; mkdir -p "$dd5"
+mk_note "$dd5" recent.md $'name: recent\ntype: pattern\nscope: *\nupdated: 2026-05-30' 'body'
+OUT="$(WOOSTACK_NOW=2026-06-02 WOOSTACK_DEAD_DAYS=1 bash "$DOC" "$dd5" 2>&1)"
+assert_contains "$OUT" "dead note" "DEAD_DAYS=1 flags a 3-day-old never-recalled note"
+rm -rf "$dd1" "$dd2" "$dd3" "$dd4" "$dd5"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
+Expected: FAIL — no "dead note" warning emitted (and the DEAD_DAYS case fails).
+
+- [ ] **Step 3: Implement the check** — insert at the end of the `for f in "$MEM_DIR"/*.md` loop body in `doctor.sh`, after the wikilink `while` loop and before `done`:
+
+```bash
+  # Dead-note signal: old (by updated:) AND never recalled → prune candidate.
+  # Requires updated: (no age basis otherwise). Warning only.
+  upd="$(field "$f" updated)"
+  if [ -n "$upd" ]; then
+    upd_e="$(_woo_epoch "$upd" || true)"
+    if [ -n "$upd_e" ]; then
+      now_e="$(_woo_epoch "$(_woo_now)")"
+      rc="$(field "$f" recall_count)"; rc="${rc:-0}"
+      case "$rc" in (*[!0-9]*) rc=0 ;; esac
+      age=$(( ( now_e - upd_e ) / 86400 ))
+      if [ "$age" -gt "${WOOSTACK_DEAD_DAYS:-90}" ] && [ "$rc" -eq 0 ]; then
+        warn "$base: dead note — written ${age}d ago, never recalled (prune candidate)"
+      fi
+    fi
+  fi
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
+Expected: PASS (new dead-note assertions + all pre-existing doctor assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/woostack-init/scripts/doctor.sh skills/woostack-init/scripts/tests/test-doctor.sh
+git commit -m "feat(memory): doctor warns on dead notes (old + never recalled)"
+```
+
+---
+
+## Task 5: Document the contract in memory.md
+
+**Files:**
+- Modify: `skills/woostack-init/references/memory.md`
+
+- [ ] **Step 1: Add the new fields to the §3 fields table**
+
+In the fields table (after the `source` row), add:
+
+```markdown
+| `recall_count` | no | **Tool-managed.** Cumulative count of recall runs that loaded this note, written by `recall.sh`. Never hand-edit. Absent ⇒ never recalled. |
+| `last_recalled` | no | **Tool-managed.** ISO date of the most recent recall load, written by `recall.sh`. Never hand-edit. |
+```
+
+Then add a sentence under the table:
+
+```markdown
+`recall_count` and `last_recalled` are **written by tooling, not by hand** — `recall.sh` stamps them (best-effort) on every note it loads. They are the recall-telemetry signal feeding `doctor.sh`'s dead-note check (see §8).
+```
+
+- [ ] **Step 2: Document the dead-note warning + knobs in §8 (Scripts)**
+
+Update the `doctor.sh` row in the §8 scripts table to mention the dead-note check, and add a paragraph after the table:
+
+```markdown
+`doctor.sh` also emits a **dead-note warning** (exit 0): a note whose `updated:` date is older than `WOOSTACK_DEAD_DAYS` (default 90) days **and** whose `recall_count` is absent or 0 is flagged as a prune candidate. Notes without an `updated:` field have no age basis and are skipped. `WOOSTACK_NOW` (default `date +%F`) overrides "today" for deterministic runs and tests.
+
+`recall.sh` stamps `recall_count`/`last_recalled` on every selected note (matched + one-hop linked + global) as a best-effort side effect: a write failure (e.g. read-only checkout) logs `recall: stamp failed <note>` to stderr but never changes recall's output or exit status. Ephemeral CI clones therefore simply do not accrue telemetry; persistent checkouts do.
+```
+
+- [ ] **Step 3: Update the §8 lib.sh helper list**
+
+Find the sentence listing lib.sh helpers (`field()`, `note_body()`, `first_body_line()`) and extend it to include `set_field()` (atomic frontmatter mutation) and the date helpers `_woo_now()`/`_woo_epoch()`.
+
+- [ ] **Step 4: Verify cross-links + render**
+
+Run: `grep -n "recall_count\|last_recalled\|WOOSTACK_DEAD_DAYS\|set_field" skills/woostack-init/references/memory.md`
+Expected: matches in §3 and §8. Confirm no broken section references were introduced.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/woostack-init/references/memory.md
+git commit -m "docs(memory): document recall telemetry fields + doctor dead-note check"
+```
+
+---
+
+## Task 6: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the whole test suite**
+
+Run: `bash skills/woostack-init/scripts/tests/run-tests.sh`
+Expected: every `test-*.sh` reports `N passed, 0 failed`; overall exit 0.
+
+- [ ] **Step 2: Smoke-test doctor on the repo's own example notes (if any) and a hand-built fixture**
+
+Run:
+```bash
+tmp="$(mktemp -d)/m"; mkdir -p "$tmp"
+printf -- '---\nname: z\ntype: pattern\nscope: *\nupdated: 2025-01-01\n---\nbody\n' > "$tmp/z.md"
+WOOSTACK_NOW=2026-06-02 bash skills/woostack-init/scripts/doctor.sh "$tmp"
+```
+Expected: stderr shows `::warning:: z.md: dead note — written ...d ago, never recalled (prune candidate)` and exit 0.
+
+- [ ] **Step 3: Confirm clean tree + branch state**
+
+Run: `git status --short && git log --oneline -6`
+Expected: clean tree; commits for tasks 1–5 present on `feat/memory-recall-telemetry`.
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** §4 decisions → Tasks 1–4; `_woo_epoch` determinism → Task 1; `set_field` malformed-note safety → Task 2; stamp-all-selected + best-effort → Task 3; dead-note rule + 90d knob + updated-only → Task 4; §3/§5/§8 docs → Task 5. All covered.
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code.
+- **Type/name consistency:** `set_field`, `_woo_now`, `_woo_epoch`, `stamp_note`, `WOOSTACK_NOW`, `WOOSTACK_DEAD_DAYS` used identically across tasks. recall stamps via the same helpers doctor reads.
+- **Deferred (follow-up issues at PR time, per spec §8):** churn-guard for unrelated-branch reviews; distillation stamping `updated:`; the recalled-but-never-acted-on signal.

--- a/.woostack/specs/2026-06-02-memory-recall-telemetry.html
+++ b/.woostack/specs/2026-06-02-memory-recall-telemetry.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Memory recall telemetry — Design Spec</title>
+<style>
+  :root { --bg:#0f1115; --panel:#171a21; --ink:#e6e9ef; --muted:#9aa4b2; --accent:#6ea8fe; --line:#2a2f3a;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55}
+  .wrap{max-width:920px;margin:0 auto;padding:48px 24px 96px}
+  h1{font-size:30px;letter-spacing:-.02em;margin:0 0 6px}
+  h2{font-size:21px;border-left:3px solid var(--accent);padding-left:10px;margin:40px 0 12px}
+  h3{font-size:16px;margin:20px 0 6px;color:var(--accent)}
+  .meta{color:var(--muted);font-size:13px;border-bottom:1px solid var(--line);padding-bottom:20px;margin-bottom:28px}
+  code{font-family:var(--mono);background:#20242d;padding:1px 6px;border-radius:5px;font-size:13px}
+  pre{font-family:var(--mono);background:#20242d;padding:14px 16px;border-radius:8px;font-size:13px;overflow-x:auto;border:1px solid var(--line)}
+  pre code{background:none;padding:0}
+  table{border-collapse:collapse;width:100%;margin:12px 0;font-size:14px}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--muted);text-transform:uppercase;font-size:12px;letter-spacing:.04em}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px;margin:14px 0}
+  ul,ol{margin:8px 0;padding-left:22px} li{margin:4px 0}
+  .tag{display:inline-block;background:#20242d;border:1px solid var(--line);border-radius:5px;padding:1px 8px;font-size:12px;color:var(--muted);margin-right:4px}
+</style>
+</head>
+<body><div class="wrap">
+  <h1>Memory recall telemetry — close the feedback loop</h1>
+  <div class="meta">Status: Approved · Date: 2026-06-02 · Branch: feat/memory-recall-telemetry · Issue: <a href="https://github.com/howarewoo/woostack/issues/159" style="color:var(--accent)">#159</a></div>
+
+  <h2>1. Problem</h2>
+  <div class="panel">
+    The <code>.woostack/memory/</code> store writes confidently but never measures. There is no signal on whether a note ever <em>helped</em>: distillation writes blind and never learns which notes earn their keep. This is the root cause of <strong>curation rot</strong> — the store cannot tell live notes from dead weight, so it grows monotonically and recall quality decays.
+    <p><code>recall.sh</code> already computes, every run, exactly the signal that would fix this: a per-note scope-match count (the <code>matched</code> tmpfile, sorted <code>-k1,1nr</code>). Today that signal is used to order output and then discarded. Nothing is persisted, so the store stays write-only.</p>
+  </div>
+
+  <h2>2. Goal</h2>
+  <div class="panel">
+    Convert the memory store from write-only to <strong>self-correcting</strong> by persisting recall usage back onto each note, then surfacing a prune signal.
+    <ul>
+      <li>Stamp two tool-managed frontmatter fields on every note the recall algorithm loads: <code>recall_count</code> (cumulative count of recall runs that loaded it) and <code>last_recalled</code> (ISO date of the most recent load).</li>
+      <li>Teach <code>doctor.sh</code> to derive a <strong>dead-note</strong> warning from those fields: old + never recalled = prune candidate.</li>
+      <li>Document the new fields and the doctor behavior in the memory contract.</li>
+    </ul>
+    Nearly free: the data is already in hand. This is the foundation later staleness/ranking work builds on.
+  </div>
+
+  <h2>3. Non-goals</h2>
+  <div class="panel">
+    <ul>
+      <li><strong>No "recalled-but-never-acted-on" detection.</strong> The issue floats it but flags it as needing a downstream <em>act</em> signal that does not exist yet. Out of scope; <code>recall_count</code> alone ships here.</li>
+      <li><strong>No automatic pruning.</strong> doctor <em>warns</em>; a human prunes. No note is ever deleted by tooling.</li>
+      <li><strong>No ranking / cap-eviction changes.</strong> Recall ordering and the <code>RECALL_CAP</code> budget logic are untouched. Telemetry is a side channel.</li>
+      <li><strong>No change to the flat <code>memory.md</code> shard.</strong> It remains free-form and untracked by this tooling.</li>
+      <li><strong>No config schema.</strong> Thresholds are env knobs, not <code>config.json</code> keys.</li>
+    </ul>
+  </div>
+
+  <h2>4. Approach</h2>
+  <div class="panel">
+    <p>Three decisions, locked during brainstorming:</p>
+    <table>
+      <tr><th>Decision</th><th>Choice</th><th>Why</th></tr>
+      <tr><td><code>recall_count</code> semantics</td><td>Cumulative recall <em>events</em> (+1 per run that loads the note)</td><td>The "zero recalls → dead" signal only works if the count measures times-loaded. Stamps matched, linked, and global notes uniformly — linked/global have no match-count of their own.</td></tr>
+      <tr><td>Write-back behavior</td><td>Unconditional, best-effort</td><td>Always stamp in place; never fail recall if the write fails. Ephemeral CI clones simply don't contribute; local/persistent checkouts accrue the signal.</td></tr>
+      <tr><td>Stamp on selection vs emission</td><td>All <em>selected</em> notes</td><td>Selection = relevance. The <code>RECALL_CAP</code> drop is a display budget, not a relevance verdict, so a cap-dropped note still counts as recalled.</td></tr>
+      <tr><td>Dead threshold</td><td>90 days (<code>WOOSTACK_DEAD_DAYS</code>)</td><td>A full quarter written but never loaded = strong prune signal; tolerant of rarely-touched subsystems.</td></tr>
+    </table>
+
+    <h3>In-place frontmatter mutation</h3>
+    <p>The risky primitive. Chosen mechanism: an <strong>awk rewrite of the frontmatter block</strong>, written to a temp file and <code>mv</code>'d over the original (atomic). It replaces the key's line if present, else inserts before the closing <code>---</code> fence, preserving the body and all other fields verbatim.</p>
+    <p>Rejected: <code>sed -i</code> per key (cannot cleanly insert-when-absent; <code>-i</code> syntax differs BSD vs GNU); full reserialize via <code>field()</code>/<code>note_body()</code> (lossy — normalizes/reorders frontmatter).</p>
+  </div>
+
+  <h2>5. Components &amp; data flow</h2>
+  <div class="panel">
+    <h3>lib.sh — new shared helpers</h3>
+    <table>
+      <tr><th>Helper</th><th>Contract</th></tr>
+      <tr><td><code>set_field &lt;file&gt; &lt;key&gt; &lt;value&gt;</code></td><td>awk-rewrite the frontmatter block: update <code>key:</code> line if present, else insert before the closing fence. Atomic temp+<code>mv</code>. Preserves body and other fields. Returns non-zero on write failure without clobbering the original.</td></tr>
+      <tr><td><code>_woo_now</code></td><td>Echo <code>${WOOSTACK_NOW:-$(date +%F)}</code> — today's ISO date, overridable for deterministic tests.</td></tr>
+      <tr><td><code>_woo_epoch &lt;YYYY-MM-DD&gt;</code></td><td>ISO date → Unix epoch seconds, <strong>time-of-day zeroed</strong> for determinism. Tries GNU <code>date -d "$d 00:00:00"</code>, falls back to BSD <code>date -j -f "%Y-%m-%d %H:%M:%S" "$d 00:00:00"</code>. Empty/non-zero on unparseable input. <em>Zeroing is mandatory:</em> BSD <code>date -j -f "%Y-%m-%d"</code> on a bare date injects the current time-of-day (verified: differs run-to-run), which would make age math and tests nondeterministic.</td></tr>
+    </table>
+    <p><strong><code>set_field</code> on malformed notes:</strong> recall selects a note with no/empty frontmatter as "global" (empty scope ⇒ <code>is_global</code>) and will attempt to stamp it. If <code>set_field</code> cannot find two <code>---</code> fences it returns non-zero <strong>without writing</strong> — recall then logs <code>stamp failed</code> and moves on. The temp file is created in the <em>note's own directory</em> so the <code>mv</code> is same-filesystem and atomic, and a read-only note dir makes <code>set_field</code> fail cleanly (this is what the best-effort test exercises).</p>
+
+    <h3>recall.sh — stamping</h3>
+    <p>After the selection phase produces the three note sets (matched scoped, one-hop linked, global) and before/independent of CAP rendering, stamp each <strong>unique selected note exactly once</strong> (the existing <code>inc_set</code> dedup already enumerates them):</p>
+    <pre><code>cur="$(field "$f" recall_count)"; cur="${cur:-0}"
+case "$cur" in (*[!0-9]*) cur=0 ;; esac      # tolerate garbage
+next=$(( cur + 1 ))
+{ set_field "$f" recall_count "$next" \
+    && set_field "$f" last_recalled "$(_woo_now)" ; } \
+  || echo "recall: stamp failed $(basename "$f")" >&2</code></pre>
+    <p>Stamping never changes stdout and never affects exit status — recall still exits 0. Output sections (Scoped / Linked / Global) are unchanged.</p>
+    <p><span class="tag">concurrency</span> <code>prefetch.sh:707</code> calls <code>recall.sh</code> exactly once per review, before any angle fan-out — so there is no parallel-stamp race within a review. Sequential reviews on the same checkout simply accumulate counts.</p>
+
+    <h3>doctor.sh — dead-note check</h3>
+    <p>Per note, after the existing field/scope/link checks:</p>
+    <pre><code>upd="$(field "$f" updated)"
+[ -z "$upd" ] && continue                    # no age basis → skip, no flag
+rc="$(field "$f" recall_count)"; rc="${rc:-0}"
+case "$rc" in (*[!0-9]*) rc=0 ;; esac
+upd_e="$(_woo_epoch "$upd")" || continue     # unparseable date → skip
+now_e="$(_woo_epoch "$(_woo_now)")"
+age_days=$(( (now_e - upd_e) / 86400 ))
+if [ "$age_days" -gt "${WOOSTACK_DEAD_DAYS:-90}" ] && [ "$rc" -eq 0 ]; then
+  warn "$base: dead note — written ${age_days}d ago, never recalled (prune candidate)"
+fi</code></pre>
+    <p>Warning only (exit 0). A note with no <code>updated:</code>, or any <code>recall_count &gt; 0</code>, or age within threshold is not flagged.</p>
+    <p><strong>Known coverage limit (documented, not fixed here):</strong> the dead check requires <code>updated:</code>, which is optional. Notes without it are silently uncovered. The clean fix is for distillation (§7) to stamp <code>updated:</code> on every note it writes — tracked as a follow-up, not in this increment. doctor takes on no git/<code>stat</code> dependency. Also out of scope: flagging notes recalled long-ago-but-now-quiet (<code>recall_count &gt; 0</code>, stale <code>last_recalled</code>) — that staleness/ranking work is seeded by <code>last_recalled</code> and deferred.</p>
+
+    <h3>Resulting note shape</h3>
+    <pre><code>---
+name: orpc-error-mapping
+type: pattern
+scope: packages/api/**
+updated: 2026-03-01
+recall_count: 7          &lt;- tool-managed, never hand-edited
+last_recalled: 2026-06-02 &lt;- tool-managed
+---
+oRPC ORPCError maps to TanStack retry policy ...</code></pre>
+
+    <h3>memory.md (contract)</h3>
+    <ul>
+      <li>§3 fields table: add <code>recall_count</code> and <code>last_recalled</code> as optional, <strong>tool-managed</strong> fields (written by <code>recall.sh</code>; never hand-edited).</li>
+      <li>§5 / §8: document the dead-note warning and the <code>WOOSTACK_DEAD_DAYS</code> (default 90) and <code>WOOSTACK_NOW</code> knobs.</li>
+    </ul>
+  </div>
+
+  <h2>6. Error handling</h2>
+  <div class="panel">
+    <ul>
+      <li><strong>Stamp write fails</strong> (read-only FS, permission): <code>set_field</code> returns non-zero without overwriting the original; recall logs <code>recall: stamp failed &lt;note&gt;</code> to stderr and continues. Telemetry is best-effort; recall output and exit 0 are never compromised.</li>
+      <li><strong>Garbage <code>recall_count</code></strong> (hand-edited to non-numeric): treated as 0 in both recall (resets to 1) and doctor (treated as never-recalled). No crash under <code>set -e</code>.</li>
+      <li><strong>Unparseable <code>updated:</code> date</strong> in doctor: <code>_woo_epoch</code> fails → that note is skipped for the dead check (no false flag, no error).</li>
+      <li><strong>Missing <code>updated:</code></strong>: skipped — there is no age basis, so no dead verdict.</li>
+      <li><strong>Atomicity</strong>: temp+<code>mv</code> means a note is never left half-written even if the process dies mid-stamp.</li>
+    </ul>
+  </div>
+
+  <h2>7. Testing</h2>
+  <div class="panel">
+    All tests use the existing bash harness (<code>assert.sh</code>, <code>mk_note</code>) and inject <code>WOOSTACK_NOW</code> for determinism.
+    <h3>test-lib.sh — set_field</h3>
+    <ul>
+      <li>Update existing key leaves value changed, body + other fields intact.</li>
+      <li>Insert absent key adds it before the closing fence, body intact.</li>
+      <li>Value with spaces / a date round-trips through <code>field()</code>.</li>
+      <li><code>_woo_now</code> honors <code>WOOSTACK_NOW</code>; <code>_woo_epoch</code> parses an ISO date and is monotonic (later date → larger epoch).</li>
+    </ul>
+    <h3>test-recall.sh — stamping</h3>
+    <ul>
+      <li>After one run, a matched note has <code>recall_count: 1</code> and <code>last_recalled</code> = injected date.</li>
+      <li>A second run bumps to <code>recall_count: 2</code>.</li>
+      <li>Linked (one-hop) and global (<code>scope:*</code>) notes are stamped too.</li>
+      <li>Existing recall output assertions (scoped/linked/global/cap/ordering) still pass — stamping does not alter stdout.</li>
+      <li>Best-effort: a read-only note dir makes recall log <code>stamp failed</code> to stderr yet still exit 0 with full output.</li>
+    </ul>
+    <h3>test-doctor.sh — dead note</h3>
+    <ul>
+      <li>Note with old <code>updated:</code> + no recall_count → warns "dead note", exit 0.</li>
+      <li>Same note with <code>recall_count: 1</code> → not flagged.</li>
+      <li>Fresh <code>updated:</code> (within 90d) + recall_count 0 → not flagged.</li>
+      <li>No <code>updated:</code> field → not flagged.</li>
+      <li><code>WOOSTACK_DEAD_DAYS</code> override changes the boundary.</li>
+    </ul>
+  </div>
+
+  <h2>8. Open questions</h2>
+  <div class="panel">
+    None blocking. Resolved during brainstorming + grilling: count semantics (cumulative events), write-back (unconditional best-effort), stamp scope (all selected), dead threshold (90d, env-overridable), <code>_woo_epoch</code> determinism (zero time-of-day), <code>set_field</code> safety on malformed notes, no concurrency race (single recall call per review).
+    <p>Deferred by design, to be filed as follow-up issues at PR time:</p>
+    <ul>
+      <li>Optional churn-guard for stamping during local reviews of unrelated branches — revisit only if real-world churn proves painful.</li>
+      <li>Distillation stamping <code>updated:</code> on every written note, so dead-note coverage is complete.</li>
+      <li>The "recalled-but-never-acted-on" signal (needs a downstream <em>act</em> signal that does not exist yet).</li>
+    </ul>
+  </div>
+</div></body>
+</html>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Apply in both modes:
 - **No fabricated versions.** When the skill or a generated project needs a version, run `npm view <pkg> version` (or equivalent). Do not invent numbers.
 - **No hidden tools.** This repo has no CI that runs on its own events and no app test runner. Don't pretend they exist; don't add them without justification. (`action.yml` + `.github/workflows/reusable-review.yml` are consumer-facing shipped assets, not self-CI — see [What this repo is](#what-this-repo-is).)
 - **Respect branch protection.** `main` is protected and requires PRs. Push changes to a feature branch and open a PR; never force-push to `main`.
+- **Use Graphite for source control.** Prefer `gt` for branch, stack, commit-amend, sync, submit, and PR operations (`gt create`, `gt modify`, `gt sync`, `gt submit`, `gt track`, `gt log`). Use raw `git` for read-only inspection and low-level operations only when Graphite does not cover the task, and do not bypass the Graphite stack state casually.
 - **Cross-link, don't duplicate.** If a fact lives in `architecture.md`, link to it from `patterns.md`; don't restate.
 - **Reference frameworks by name, not version**, except in [references/frameworks.md](skills/woostack-bootstrap/references/frameworks.md), which may pin exact versions when an incompatibility forces it.
 - **Caveman mode is a personal hook**, not a repo convention — do not propagate compressed prose into the skill. Skill content is written in normal English.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** (skills: woostack-bootstrap, woostack-build, woostack-review, woostack-address-comments) into your agent's skill directory and records it in `skills-lock.json`. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** (skills: woostack-init, woostack-bootstrap, woostack-build, woostack-review, woostack-address-comments) into your agent's skill directory and records it in `skills-lock.json`. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 
 ## How it works
 
-Each command is a skill with its own gated procedure. Together they cover the life of a change: scaffold, build, review, iterate. Run a command by name in your agent (e.g. `/woostack-build add password reset`); the agent loads that skill's `SKILL.md` and follows it. Only `bootstrap` is greenfield-specific. `build`, `review`, and `address-comments` operate on any repo, whether woostack scaffolded it or not.
+Each command is a skill with its own gated procedure. Together they cover the life of a change: scaffold, build, review, iterate. Run a command by name in your agent (e.g. `/woostack-build add password reset`); the agent loads that skill's `SKILL.md` and follows it. **Codex syntax differs:** use `$woostack-build add password reset` or open `/skills` and select the skill. Only `bootstrap` is greenfield-specific. `build`, `review`, and `address-comments` operate on any repo, whether woostack scaffolded it or not.
 
 ### `/woostack-bootstrap <goal>`: scaffold a new monorepo
 
@@ -70,7 +70,7 @@ pnpx skills add howarewoo/woostack          # install the collection into your a
 
 /woostack-bootstrap a habit-tracker with web + mobile + API   # scaffolds a fresh repo; walks you through decisions first
 /woostack-build add streak tracking with a weekly reset       # build a feature in the new repo
-/woostack-review 42                                            # review the PR build opened
+/woostack-review 42                                           # review the PR build opened
 /woostack-address-comments 42                                 # iterate on the review's findings
 ```
 
@@ -80,8 +80,8 @@ pnpx skills add howarewoo/woostack          # install the collection into your a
 pnpx skills add howarewoo/woostack          # install once
 
 /woostack-build add CSV export to the reports page   # feature loop in your current repo
-/woostack-review 1337                                 # review the PR
-/woostack-address-comments 1337                       # iterate
+/woostack-review 1337                                # review the PR
+/woostack-address-comments 1337                      # iterate
 ```
 
 Review and address-comments need the GitHub CLI (`gh`) authenticated for any step that touches a PR.

--- a/skills/woostack-init/references/memory.md
+++ b/skills/woostack-init/references/memory.md
@@ -62,8 +62,12 @@ let [[tanstack-query-retries]] decide. Terse body.
 | `scope` | no | Comma-separated glob list; omitted or `*` means global (see §5). |
 | `hook` | no | One-line index summary. If absent, the index falls back to the first non-empty body line, truncated to ~80 characters. |
 | `tags` | no | Comma list; informational only in increment A. |
-| `updated` | no | ISO date; informational. |
+| `updated` | no | ISO date the note's content was last written. Informational, **and** the age basis for `doctor.sh`'s dead-note check (see §8) — a note without it cannot be aged. |
 | `source` | no | Provenance path (used by the increment-C distill step; empty in A). |
+| `recall_count` | no | **Tool-managed.** Cumulative count of recall runs that loaded this note, written by `recall.sh`. Never hand-edit. Absent ⇒ never recalled. |
+| `last_recalled` | no | **Tool-managed.** ISO date of the most recent recall load, written by `recall.sh`. Never hand-edit. |
+
+`recall_count` and `last_recalled` are **written by tooling, not by hand** — `recall.sh` stamps them (best-effort) on every note it loads. They are the recall-telemetry signal feeding `doctor.sh`'s dead-note check (see §8).
 
 **Caution:** hook or body text containing a backtick can render as ambiguous Markdown in the derived index line; keep hooks plain text.
 
@@ -155,10 +159,13 @@ The scripts live under `skills/woostack-init/scripts/` relative to the woostack 
 |---|---|
 | `scope-match.sh` | `printf '%s\n' <paths> \| bash scope-match.sh '<glob-spec>'` — prints matching paths from stdin; exits 0 if any matched, 1 if none. |
 | `build-index.sh` | `bash build-index.sh [<memdir>]` — regenerates `<memdir>/MEMORY.md` from note frontmatter; defaults to `.woostack/memory`. |
-| `doctor.sh` | `bash doctor.sh [<memdir>]` — lints the memory directory; warnings exit 0, errors exit 1. |
+| `doctor.sh` | `bash doctor.sh [<memdir>]` — lints the memory directory; warnings exit 0, errors exit 1. Also emits the dead-note warning described below. |
+| `recall.sh` | `bash recall.sh <woostack_dir> <paths_file>` — composes the per-PR memory context (see §6) and **stamps recall telemetry** on every selected note. |
 | `graph.sh` | `bash graph.sh <memdir> <note> [--links\|--backlinks]` — lists a note's outbound wikilinks (`--links`, default) or the notes that link to it (`--backlinks`). Grep-based by default; see §9 for the opt-in Obsidian path. |
 
-`build-index.sh` and `doctor.sh` source `lib.sh` (frontmatter helpers `field()`, `note_body()`, `first_body_line()`) from the same directory. `doctor.sh` additionally invokes `scope-match.sh` as a subprocess for its stale-scope check. `scope-match.sh` and `graph.sh` are self-contained — they source nothing.
+`build-index.sh`, `doctor.sh`, and `recall.sh` source `lib.sh` (frontmatter helpers `field()`, `note_body()`, `first_body_line()`; the atomic frontmatter mutator `set_field()`; and the date helpers `_woo_now()`/`_woo_epoch()`) from the same directory. `doctor.sh` additionally invokes `scope-match.sh` as a subprocess for its stale-scope check. `scope-match.sh` and `graph.sh` are self-contained — they source nothing.
+
+**Recall telemetry & the dead-note check.** `recall.sh` stamps `recall_count`/`last_recalled` (§3) on every selected note — matched + one-hop linked + global — as a best-effort side effect: a write failure (e.g. a read-only checkout) logs `recall: stamp failed <note>` to stderr but never changes recall's output or exit status. Ephemeral CI clones therefore simply do not accrue telemetry; persistent checkouts do. `doctor.sh` turns that signal into a **dead-note warning** (exit 0): a note whose `updated:` date is older than `WOOSTACK_DEAD_DAYS` (default 90) days **and** whose `recall_count` is absent or 0 is flagged as a prune candidate. Notes without an `updated:` field have no age basis and are skipped. `WOOSTACK_NOW` (default `date +%F`) overrides "today" for deterministic runs and tests.
 
 ---
 

--- a/skills/woostack-init/scripts/doctor.sh
+++ b/skills/woostack-init/scripts/doctor.sh
@@ -51,6 +51,22 @@ for f in "$MEM_DIR"/*.md; do
     [ -z "$link" ] && continue
     [ -f "$MEM_DIR/$link.md" ] || warn "$base: unresolved [[$link]]"
   done < <(grep -oE '\[\[[^]]+\]\]' "$f" 2>/dev/null | sed 's/\[\[//; s/\]\]//' | sort -u)
+
+  # Dead-note signal: old (by updated:) AND never recalled → prune candidate.
+  # Requires updated: (no age basis otherwise). Warning only.
+  upd="$(field "$f" updated)"
+  if [ -n "$upd" ]; then
+    upd_e="$(_woo_epoch "$upd" || true)"
+    if [ -n "$upd_e" ]; then
+      now_e="$(_woo_epoch "$(_woo_now)")"
+      rc="$(field "$f" recall_count)"; rc="${rc:-0}"
+      case "$rc" in (*[!0-9]*) rc=0 ;; esac
+      age=$(( ( now_e - upd_e ) / 86400 ))
+      if [ "$age" -gt "${WOOSTACK_DEAD_DAYS:-90}" ] && [ "$rc" -eq 0 ]; then
+        warn "$base: dead note — written ${age}d ago, never recalled (prune candidate)"
+      fi
+    fi
+  fi
 done
 rm -f "$seen"
 

--- a/skills/woostack-init/scripts/lib.sh
+++ b/skills/woostack-init/scripts/lib.sh
@@ -18,3 +18,17 @@ note_body() {
 first_body_line() {
   note_body "$1" | sed '/^[[:space:]]*$/d' | head -1 | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
 }
+
+# _woo_now → today's ISO date (YYYY-MM-DD). Override with WOOSTACK_NOW for tests.
+_woo_now() { printf '%s\n' "${WOOSTACK_NOW:-$(date +%F)}"; }
+
+# _woo_epoch <YYYY-MM-DD> → Unix epoch seconds at 00:00:00 of that date.
+# Time-of-day is zeroed so age math and tests are deterministic. Tries GNU
+# `date -d` first, falls back to BSD `date -j -f`. Non-zero on unparseable input.
+_woo_epoch() {
+  local d="$1" e
+  e="$(date -d "$d 00:00:00" +%s 2>/dev/null)" \
+    || e="$(date -j -f '%Y-%m-%d %H:%M:%S' "$d 00:00:00" +%s 2>/dev/null)" \
+    || return 1
+  printf '%s\n' "$e"
+}

--- a/skills/woostack-init/scripts/lib.sh
+++ b/skills/woostack-init/scripts/lib.sh
@@ -32,3 +32,27 @@ _woo_epoch() {
     || return 1
   printf '%s\n' "$e"
 }
+
+# set_field <file> <key> <value> — set a frontmatter key (update if present, else
+# insert before the closing fence). Rewrites ONLY the first frontmatter block;
+# body and all other fields are preserved verbatim. Atomic: writes a temp file in
+# the note's own directory, then mv's it over the original. Returns non-zero
+# WITHOUT modifying the file if it lacks two '---' fences or the write fails.
+set_field() {
+  local file="$1" key="$2" val="$3" tmp dir
+  [ "$(grep -c '^---$' "$file" 2>/dev/null)" -ge 2 ] || return 1
+  dir="$(dirname "$file")"
+  tmp="$(mktemp "$dir/.woomem.XXXXXX")" || return 1
+  awk -v key="$key" -v val="$val" '
+    {
+      if ($0 == "---") {
+        fence++
+        if (fence == 1) { infm=1; print; next }
+        if (fence == 2) { if (infm && !seen) print key ": " val; infm=0; print; next }
+      }
+      if (infm && !seen && index($0, key ":") == 1) { print key ": " val; seen=1; next }
+      print
+    }
+  ' "$file" > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+}

--- a/skills/woostack-init/scripts/recall.sh
+++ b/skills/woostack-init/scripts/recall.sh
@@ -61,6 +61,23 @@ while IFS= read -r line; do
   [ -n "$line" ] && linked_files+=("$line")
 done < "$linked"
 
+# --- Stamp recall telemetry on every selected note (best-effort). ---
+# Cumulative recall_count + last_recalled. Failures never break recall: they
+# log to stderr and recall still exits 0. Stamps matched + one-hop linked +
+# global notes (each appears in exactly one set, so no double-counting).
+_now="$(_woo_now)"
+stamp_note() {
+  local f="$1" cur next
+  cur="$(field "$f" recall_count || true)"; cur="${cur:-0}"
+  case "$cur" in (*[!0-9]*) cur=0 ;; esac
+  next=$(( cur + 1 ))
+  { set_field "$f" recall_count "$next" && set_field "$f" last_recalled "$_now"; } \
+    || echo "recall: stamp failed $(basename "$f")" >&2
+}
+for f in "${matched_files[@]:-}"; do [ -n "${f:-}" ] && stamp_note "$f"; done
+for f in "${linked_files[@]:-}"; do [ -n "${f:-}" ] && stamp_note "$f"; done
+while IFS= read -r f; do [ -n "$f" ] && stamp_note "$f"; done < "$globals"
+
 global_out=""
 [ -f "$FLAT" ] && global_out="$(cat "$FLAT")"
 while IFS= read -r f; do

--- a/skills/woostack-init/scripts/tests/test-doctor.sh
+++ b/skills/woostack-init/scripts/tests/test-doctor.sh
@@ -53,5 +53,38 @@ err6="$(mktemp -d)/m"; mkdir -p "$err6"
 mk_note "$err6" nobody.md $'name: x\ntype: pattern' ''
 run_doctor "$err6"; assert_exit 1 "$CODE" "empty body errors"
 
+# --- dead-note check ---
+# old + never recalled → dead warning, exit 0
+dd1="$(mktemp -d)/m"; mkdir -p "$dd1"
+mk_note "$dd1" old.md $'name: old\ntype: pattern\nscope: *\nupdated: 2026-01-01' 'stale body'
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd1" 2>&1)"; CODE=$?
+assert_contains "$OUT" "dead note" "old + zero recalls flagged as dead"
+assert_exit 0 "$CODE" "dead note is a warning (exit 0)"
+
+# old but recalled → not flagged
+dd2="$(mktemp -d)/m"; mkdir -p "$dd2"
+mk_note "$dd2" old.md $'name: old\ntype: pattern\nscope: *\nupdated: 2026-01-01\nrecall_count: 3' 'body'
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd2" 2>&1)"
+assert_not_contains "$OUT" "dead note" "a recalled note is never flagged dead"
+
+# fresh updated → not flagged
+dd3="$(mktemp -d)/m"; mkdir -p "$dd3"
+mk_note "$dd3" fresh.md $'name: fresh\ntype: pattern\nscope: *\nupdated: 2026-05-30' 'body'
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd3" 2>&1)"
+assert_not_contains "$OUT" "dead note" "a fresh note is not flagged"
+
+# no updated: → not aged, not flagged
+dd4="$(mktemp -d)/m"; mkdir -p "$dd4"
+mk_note "$dd4" noupd.md $'name: noupd\ntype: pattern\nscope: *' 'body'
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd4" 2>&1)"
+assert_not_contains "$OUT" "dead note" "a note without updated: is not flagged"
+
+# WOOSTACK_DEAD_DAYS tightens the window
+dd5="$(mktemp -d)/m"; mkdir -p "$dd5"
+mk_note "$dd5" recent.md $'name: recent\ntype: pattern\nscope: *\nupdated: 2026-05-30' 'body'
+OUT="$(WOOSTACK_NOW=2026-06-02 WOOSTACK_DEAD_DAYS=1 bash "$DOC" "$dd5" 2>&1)"
+assert_contains "$OUT" "dead note" "DEAD_DAYS=1 flags a 3-day-old never-recalled note"
+rm -rf "$dd1" "$dd2" "$dd3" "$dd4" "$dd5"
+
 rm -rf "$repo"
 finish

--- a/skills/woostack-init/scripts/tests/test-lib.sh
+++ b/skills/woostack-init/scripts/tests/test-lib.sh
@@ -14,4 +14,12 @@ assert_eq "$(field "$d/a.md" hook)" "short hook" "field hook"
 assert_eq "$(first_body_line "$d/a.md")" "First body line." "first body line"
 assert_contains "$(note_body "$d/a.md")" "[[beta]]" "body contains wikilink"
 rm -rf "$d"
+
+# --- _woo_now / _woo_epoch ---
+assert_eq "$(WOOSTACK_NOW=2026-01-02 _woo_now)" "2026-01-02" "_woo_now honors WOOSTACK_NOW"
+e1="$(_woo_epoch 2026-01-01)"; e2="$(_woo_epoch 2026-01-02)"
+assert_eq "$(( e2 - e1 ))" "86400" "_woo_epoch: one day apart = 86400s (time-of-day zeroed)"
+set +e; _woo_epoch "not-a-date" >/dev/null 2>&1; rc=$?; set -e
+assert_exit 1 "$rc" "_woo_epoch returns non-zero on unparseable input"
+
 finish

--- a/skills/woostack-init/scripts/tests/test-lib.sh
+++ b/skills/woostack-init/scripts/tests/test-lib.sh
@@ -22,4 +22,27 @@ assert_eq "$(( e2 - e1 ))" "86400" "_woo_epoch: one day apart = 86400s (time-of-
 set +e; _woo_epoch "not-a-date" >/dev/null 2>&1; rc=$?; set -e
 assert_exit 1 "$rc" "_woo_epoch returns non-zero on unparseable input"
 
+# --- set_field ---
+sfd="$(mktemp -d)"
+mk_note "$sfd" n.md $'name: x\ntype: pattern\nscope: a/**' 'body [[link]] here'
+# update existing key
+set_field "$sfd/n.md" type "gotcha"
+assert_eq "$(field "$sfd/n.md" type)" "gotcha" "set_field updates an existing key"
+assert_eq "$(field "$sfd/n.md" name)" "x" "set_field: other fields preserved on update"
+assert_contains "$(note_body "$sfd/n.md")" "body [[link]] here" "set_field: body preserved on update"
+# insert absent key
+set_field "$sfd/n.md" recall_count "1"
+assert_eq "$(field "$sfd/n.md" recall_count)" "1" "set_field inserts an absent key"
+assert_eq "$(field "$sfd/n.md" name)" "x" "set_field: fields intact after insert"
+assert_contains "$(note_body "$sfd/n.md")" "body [[link]] here" "set_field: body intact after insert"
+# date value round-trips
+set_field "$sfd/n.md" last_recalled "2026-06-02"
+assert_eq "$(field "$sfd/n.md" last_recalled)" "2026-06-02" "set_field: date value round-trips"
+# malformed note (no frontmatter) → non-zero, file unchanged
+printf 'no frontmatter\n' > "$sfd/bad.md"
+set +e; set_field "$sfd/bad.md" recall_count 1; rc=$?; set -e
+assert_exit 1 "$rc" "set_field fails on a note without frontmatter"
+assert_eq "$(cat "$sfd/bad.md")" "no frontmatter" "set_field leaves a malformed note unchanged"
+rm -rf "$sfd"
+
 finish

--- a/skills/woostack-init/scripts/tests/test-recall.sh
+++ b/skills/woostack-init/scripts/tests/test-recall.sh
@@ -2,6 +2,7 @@
 set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$DIR/tests/assert.sh"
+source "$DIR/lib.sh"
 RECALL="$DIR/recall.sh"
 
 # Build a fixture .woostack with flat file + scoped notes.
@@ -64,4 +65,36 @@ narrow_line="$(printf '%s\n' "$out" | grep -n 'NARROW note' | cut -d: -f1)"
   || { FAIL=$((FAIL+1)); echo "  FAIL: ordering — wide(line $wide_line) should precede narrow(line $narrow_line)"; }
 
 rm -rf "$woo" "$woo2" "$woo3" "$woo4" "$paths2"
+
+# --- telemetry stamping ---
+woo5="$(mktemp -d)"; md5="$woo5/memory"; mkdir -p "$md5"
+mk_note "$md5" a.md $'name: a\ntype: pattern\nscope: pkg/**'      'A body [[b]]'
+mk_note "$md5" b.md $'name: b\ntype: pattern\nscope: zzz/**'      'B linked body'
+mk_note "$md5" g.md $'name: g\ntype: convention\nscope: *'        'G global body'
+p5="$(mktemp)"; printf 'pkg/x.ts\n' > "$p5"
+
+WOOSTACK_NOW=2026-06-02 bash "$RECALL" "$woo5" "$p5" >/dev/null
+assert_eq "$(field "$md5/a.md" recall_count)"  "1"          "matched note stamped count=1"
+assert_eq "$(field "$md5/a.md" last_recalled)" "2026-06-02" "matched note last_recalled stamped"
+assert_eq "$(field "$md5/b.md" recall_count)"  "1"          "one-hop linked note stamped"
+assert_eq "$(field "$md5/g.md" recall_count)"  "1"          "global (scope:*) note stamped"
+
+# second run bumps the cumulative count and refreshes the date
+WOOSTACK_NOW=2026-06-03 bash "$RECALL" "$woo5" "$p5" >/dev/null
+assert_eq "$(field "$md5/a.md" recall_count)"  "2"          "second run bumps count to 2"
+assert_eq "$(field "$md5/a.md" last_recalled)" "2026-06-03" "second run refreshes last_recalled"
+
+# best-effort: a read-only memory dir makes stamping fail, but recall still
+# produces output and exits 0, logging the failure to stderr.
+chmod -R a-w "$md5" 2>/dev/null || true
+set +e
+out="$(WOOSTACK_NOW=2026-06-04 bash "$RECALL" "$woo5" "$p5" 2>/dev/null)"; code=$?
+err="$(WOOSTACK_NOW=2026-06-04 bash "$RECALL" "$woo5" "$p5" 2>&1 >/dev/null)"
+set -e
+chmod -R u+w "$md5" 2>/dev/null || true
+assert_exit 0 "$code"            "recall exits 0 even when stamping fails"
+assert_contains "$out" "A body"  "recall output intact when stamping fails"
+assert_contains "$err" "stamp failed" "stamp failure logged to stderr"
+rm -rf "$woo5" "$p5"
+
 finish


### PR DESCRIPTION
Closes #159.

Converts the `.woostack/memory/` store from write-only to self-correcting by persisting recall usage onto each note, then surfacing a prune signal.

## What changed

- **`lib.sh`** — three shared helpers:
  - `_woo_now` / `_woo_epoch` — deterministic dates (`WOOSTACK_NOW`-overridable; epoch zeros time-of-day so BSD/GNU agree and tests don't flake).
  - `set_field <file> <key> <value>` — atomic frontmatter mutate (awk rewrite → temp in same dir → `mv`). Updates the key if present, inserts before the closing fence if absent, preserves body + other fields. Returns non-zero **without writing** on a malformed note (no two `---` fences) or write failure.
- **`recall.sh`** — stamps `recall_count` (cumulative recall events) + `last_recalled` on every *selected* note (matched + one-hop linked + global), **best-effort**: a write failure logs `recall: stamp failed <note>` to stderr and recall still exits 0 with unchanged output. (Guards the `recall_count` read with `|| true` — `field()`'s `grep -m1` exits 1 when the key is absent and recall runs under `set -e`.)
- **`doctor.sh`** — dead-note warning (exit 0): `updated:` older than `WOOSTACK_DEAD_DAYS` (default 90) days **and** `recall_count` absent/0 → prune candidate. No `updated:` → skipped (no age basis).
- **`memory.md`** — §3 documents the two tool-managed fields; §8 documents the dead-note check, the best-effort stamping, and the `WOOSTACK_DEAD_DAYS` / `WOOSTACK_NOW` knobs.

## Decisions (brainstormed + grilled)

- `recall_count` = cumulative recall **events**, not last-run match count (the "zero recalls → dead" signal needs times-loaded).
- Write-back is **unconditional, best-effort** — ephemeral CI clones simply don't accrue telemetry; persistent checkouts do.
- Stamp **all selected** notes regardless of `RECALL_CAP` truncation (selection = relevance; the cap is a display budget).
- No concurrency race: `prefetch.sh` calls `recall.sh` exactly once per review, before fan-out.

## Tests

+24 assertions across `test-lib.sh`, `test-recall.sh`, `test-doctor.sh` (set_field update/insert/malformed; count increments + linked/global stamping + best-effort read-only; dead-note positives/negatives + `WOOSTACK_DEAD_DAYS`). Full suite: **95/95** passing.

## Follow-ups (filed separately, deferred by design)

- Optional churn-guard for stamping during local reviews of unrelated branches.
- Distillation stamping `updated:` on every written note so dead-note coverage is complete.
- The "recalled-but-never-acted-on" signal (needs a downstream *act* signal).

Spec: `.woostack/specs/2026-06-02-memory-recall-telemetry.html` · Plan: `.woostack/plans/2026-06-02-memory-recall-telemetry.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)