### PR TITLE
Add memory stale provenance guard

### DIFF
--- a/.woostack/plans/2026-06-02-memory-staleness-guard.md
+++ b/.woostack/plans/2026-06-02-memory-staleness-guard.md
@@ -1,0 +1,172 @@
+# Memory Staleness Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Warn when scoped memory notes point `source:` at missing `.woostack/specs/` or `.woostack/plans/` provenance files.
+
+**Architecture:** Extend `doctor.sh` with one warning-only source check inside the existing per-note lint loop. Keep source validation constrained to authored woostack spec/plan paths so symbolic provenance such as `pr-165` remains valid.
+
+**Tech Stack:** Bash, existing woostack-init shell test harness, Markdown memory contract.
+
+---
+
+### Task 1: Add Failing Stale-Provenance Tests
+
+**Files:**
+- Modify: `skills/woostack-init/scripts/tests/test-doctor.sh`
+
+- [x] **Step 1: Add provenance fixtures to the clean repo setup**
+
+In `skills/woostack-init/scripts/tests/test-doctor.sh`, after the stale scope test and before the unresolved wikilink test, add:
+
+```bash
+# missing .woostack source → warn, exit 0
+mk_note "$md" stale-source-spec.md $'name: stale-source-spec\ntype: pattern\nscope: packages/api/**\nsource: .woostack/specs/missing.md' 'body'
+pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+assert_contains "$OUT" "source '.woostack/specs/missing.md' is missing" "missing spec source warned"
+assert_exit 0 "$CODE" "missing spec source is a warning"
+
+mk_note "$md" stale-source-plan.md $'name: stale-source-plan\ntype: pattern\nscope: packages/api/**\nsource: .woostack/plans/missing.md' 'body'
+pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+assert_contains "$OUT" "source '.woostack/plans/missing.md' is missing" "missing plan source warned"
+assert_exit 0 "$CODE" "missing plan source is a warning"
+
+mkdir -p "$repo/.woostack/specs" "$repo/.woostack/plans"
+touch "$repo/.woostack/specs/existing.md" "$repo/.woostack/plans/existing.md"
+mk_note "$md" live-source-spec.md $'name: live-source-spec\ntype: pattern\nscope: packages/api/**\nsource: .woostack/specs/existing.md' 'body'
+mk_note "$md" live-source-plan.md $'name: live-source-plan\ntype: pattern\nscope: packages/api/**\nsource: .woostack/plans/existing.md' 'body'
+mk_note "$md" pr-source.md $'name: pr-source\ntype: convention\nscope: packages/api/**\nsource: pr-165' 'body'
+pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+assert_not_contains "$OUT" "live-source-spec" "existing spec source is not warned"
+assert_not_contains "$OUT" "live-source-plan" "existing plan source is not warned"
+assert_not_contains "$OUT" "pr-source" "PR source is not treated as a filesystem path"
+```
+
+- [x] **Step 2: Run the doctor tests and verify the new expectations fail**
+
+Run:
+
+```bash
+bash skills/woostack-init/scripts/tests/test-doctor.sh
+```
+
+Expected: the test exits non-zero because the output does not contain the missing-source warnings yet.
+
+### Task 2: Implement Source Provenance Warning
+
+**Files:**
+- Modify: `skills/woostack-init/scripts/doctor.sh`
+- Test: `skills/woostack-init/scripts/tests/test-doctor.sh`
+
+- [x] **Step 1: Add the source check to `doctor.sh`**
+
+In `skills/woostack-init/scripts/doctor.sh`, after the existing stale-scope check and before wikilink validation, add:
+
+```bash
+  source_path="$(field "$f" source)"
+  case "$source_path" in
+    .woostack/specs/*|.woostack/plans/*)
+      [ -f "$source_path" ] || warn "$base: source '$source_path' is missing (stale provenance)"
+      ;;
+  esac
+```
+
+- [x] **Step 2: Run the doctor tests and verify they pass**
+
+Run:
+
+```bash
+bash skills/woostack-init/scripts/tests/test-doctor.sh
+```
+
+Expected: all assertions pass, including stale provenance warnings.
+
+- [x] **Step 3: Run the full woostack-init script test suite**
+
+Run:
+
+```bash
+bash skills/woostack-init/scripts/tests/run-tests.sh
+```
+
+Expected: every woostack-init script test passes.
+
+### Task 3: Document Doctor Staleness Checks
+
+**Files:**
+- Modify: `skills/woostack-init/references/memory.md`
+
+- [x] **Step 1: Update the doctor script summary**
+
+In `skills/woostack-init/references/memory.md` §8, change the `doctor.sh` row from:
+
+```markdown
+| `doctor.sh` | `bash doctor.sh [<memdir>]` — lints the memory directory; warnings exit 0, errors exit 1. Also emits the dead-note warning described below. |
+```
+
+to:
+
+```markdown
+| `doctor.sh` | `bash doctor.sh [<memdir>]` — lints the memory directory; warnings exit 0, errors exit 1. Also emits the staleness warnings described below. |
+```
+
+- [x] **Step 2: Replace the prose heading with complete warning coverage**
+
+Replace the paragraph headed `**Recall telemetry & the dead-note check.**` with:
+
+```markdown
+**Staleness warnings.** `doctor.sh` emits warning-only findings for cheap structural staleness signals:
+
+- **Orphaned scope:** a note with a non-global `scope:` whose globs match no tracked files in `git ls-files` is flagged as stale. This catches notes scoped to paths that were deleted or moved.
+- **Stale provenance:** a note whose `source:` starts with `.woostack/specs/` or `.woostack/plans/` is expected to point at an authored spec or plan in the current repo. If that file is missing, the note is flagged for review. Other provenance forms, such as `source: pr-165`, are not treated as filesystem paths.
+- **Dead note:** `recall.sh` stamps `recall_count`/`last_recalled` (§3) on every selected note — matched + one-hop linked + global — as a best-effort side effect: a write failure (e.g. a read-only checkout) logs `recall: stamp failed <note>` to stderr but never changes recall's output or exit status. Ephemeral CI clones therefore simply do not accrue telemetry; persistent checkouts do. `doctor.sh` turns that signal into a warning when a note's `updated:` date is older than `WOOSTACK_DEAD_DAYS` (default 90) days and its `recall_count` is absent or 0. Notes without an `updated:` field have no age basis and are skipped. `WOOSTACK_NOW` (default `date +%F`) overrides "today" for deterministic runs and tests.
+
+`doctor.sh` also warns on unresolved body `[[wikilinks]]`; those are graph integrity warnings rather than staleness signals.
+```
+
+- [x] **Step 3: Check docs wording and cross-references**
+
+Run:
+
+```bash
+rg -n "doctor.sh|stale provenance|orphaned scope|dead note|unresolved" skills/woostack-init/references/memory.md
+```
+
+Expected: §8 documents orphaned scope, stale provenance, dead notes, and unresolved wikilinks without duplicating details elsewhere.
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify: `skills/woostack-init/scripts/doctor.sh`
+- Verify: `skills/woostack-init/scripts/tests/test-doctor.sh`
+- Verify: `skills/woostack-init/references/memory.md`
+
+- [x] **Step 1: Run full tests**
+
+Run:
+
+```bash
+bash skills/woostack-init/scripts/tests/run-tests.sh
+```
+
+Expected: all tests pass.
+
+- [x] **Step 2: Inspect the diff**
+
+Run:
+
+```bash
+git diff -- skills/woostack-init/scripts/doctor.sh skills/woostack-init/scripts/tests/test-doctor.sh skills/woostack-init/references/memory.md .woostack/specs/2026-06-02-memory-staleness-guard.md .woostack/plans/2026-06-02-memory-staleness-guard.md
+```
+
+Expected: the diff is limited to the stale-provenance check, its tests, the memory contract update, and the woostack spec/plan artifacts.
+
+- [x] **Step 3: Commit the increment**
+
+Run:
+
+```bash
+gt modify -a -m "Add memory stale provenance guard"
+```
+
+Expected: Graphite records the branch changes without touching `main`.

--- a/.woostack/specs/2026-06-02-memory-staleness-guard.md
+++ b/.woostack/specs/2026-06-02-memory-staleness-guard.md
@@ -1,0 +1,61 @@
+---
+name: memory-staleness-guard
+type: spec
+status: approved
+date: 2026-06-02
+branch: memory-staleness-guard
+links:
+---
+
+# Memory Staleness Guard — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+## 1. Problem
+
+`doctor.sh` already checks memory note structure and warns when a note's `scope:` globs match no tracked files. It does not check whether a distilled note's `.woostack` provenance still exists. A note derived from a deleted spec or plan can remain in the memory store and keep influencing future work without any prompt for review.
+
+## 2. Goal
+
+Add a cheap stale-provenance warning to `doctor.sh` for memory notes whose `source:` points at a missing `.woostack/specs/` or `.woostack/plans/` file, and document the warning in the memory contract.
+
+## 3. Non-goals
+
+- Do not add an expensive semantic validation pass.
+- Do not fail `doctor.sh` for stale provenance; warnings still exit 0.
+- Do not validate non-file provenance such as `source: pr-165`.
+- Do not change memory note schema or distillation behavior.
+- Do not rework the existing orphaned-scope check.
+
+## 4. Approach
+
+Keep the check in `skills/woostack-init/scripts/doctor.sh`, alongside the existing per-note warning checks. For each non-index note, read `source:` with the existing `field` helper. If `source:` starts with `.woostack/specs/` or `.woostack/plans/`, test it as a repo-root-relative file path. When the file is missing, emit a warning naming the note and source path, then continue.
+
+Sources outside those two `.woostack` authored-document roots are intentionally ignored. Review memory currently writes values like `source: pr-165`, and future provenance may be URLs or other symbolic references. Treating only `.woostack/specs/` and `.woostack/plans/` as filesystem paths keeps the check precise.
+
+## 5. Components & data flow
+
+- `doctor.sh` iterates each memory note under the supplied memory directory.
+- `field "$f" source` extracts provenance from frontmatter.
+- A shell `case` detects `.woostack/specs/*` and `.woostack/plans/*`.
+- `[ -f "$source" ]` checks existence from the current working directory, matching the existing expectation that `doctor.sh` is run from the consumer repo root.
+- Missing files call `warn`, incrementing the warning count without affecting the exit code.
+
+## 6. Error handling
+
+Malformed notes, missing required fields, bad types, duplicate names, and empty bodies remain errors. Stale provenance is a warning only. Blank `source:`, absent `source:`, PR provenance, URLs, and paths outside `.woostack/specs/` or `.woostack/plans/` produce no warning.
+
+## 7. Testing
+
+Extend `skills/woostack-init/scripts/tests/test-doctor.sh` with fixtures in the existing throwaway git repo:
+
+- A note with `source: .woostack/specs/missing.md` warns and exits 0.
+- A note with `source: .woostack/plans/missing.md` warns and exits 0.
+- Notes whose `.woostack/specs/existing.md` or `.woostack/plans/existing.md` files exist do not warn.
+- A note with `source: pr-165` does not warn.
+
+Run `bash skills/woostack-init/scripts/tests/run-tests.sh` to verify the full init-script test suite.
+
+## 8. Open questions
+
+None. The approved scope is the cheap structural stale-provenance proxy from issue 160.

--- a/skills/woostack-init/references/memory.md
+++ b/skills/woostack-init/references/memory.md
@@ -164,13 +164,19 @@ The scripts live under `skills/woostack-init/scripts/` relative to the woostack 
 |---|---|
 | `scope-match.sh` | `printf '%s\n' <paths> \| bash scope-match.sh '<glob-spec>'` — prints matching paths from stdin; exits 0 if any matched, 1 if none. |
 | `build-index.sh` | `bash build-index.sh [<memdir>]` — regenerates `<memdir>/MEMORY.md` from note frontmatter; defaults to `.woostack/memory`. |
-| `doctor.sh` | `bash doctor.sh [<memdir>]` — lints the memory directory; warnings exit 0, errors exit 1. Also emits the dead-note warning described below. |
+| `doctor.sh` | `bash doctor.sh [<memdir>]` — lints the memory directory; warnings exit 0, errors exit 1. Also emits the staleness warnings described below. |
 | `recall.sh` | `bash recall.sh <woostack_dir> <paths_file>` — composes the per-PR memory context (see §6) and **stamps recall telemetry** on every selected note. |
 | `graph.sh` | `bash graph.sh <memdir> <note> [--links\|--backlinks]` — lists a note's outbound wikilinks (`--links`, default) or the notes that link to it (`--backlinks`). Grep-based by default; see §9 for the opt-in Obsidian path. |
 
 `build-index.sh`, `doctor.sh`, and `recall.sh` source `lib.sh` (frontmatter helpers `field()`, `note_body()`, `first_body_line()`; the atomic frontmatter mutator `set_field()`; and the date helpers `_woo_now()`/`_woo_epoch()`) from the same directory. `doctor.sh` additionally invokes `scope-match.sh` as a subprocess for its stale-scope check. `scope-match.sh` and `graph.sh` are self-contained — they source nothing.
 
-**Recall telemetry & the dead-note check.** `recall.sh` stamps `recall_count`/`last_recalled` (§3) on every selected note — matched + one-hop linked + global — as a best-effort side effect: a write failure (e.g. a read-only checkout) logs `recall: stamp failed <note>` to stderr but never changes recall's output or exit status. Ephemeral CI clones therefore simply do not accrue telemetry; persistent checkouts do. `doctor.sh` turns that signal into a **dead-note warning** (exit 0): a note whose `updated:` date is older than `WOOSTACK_DEAD_DAYS` (default 90) days **and** whose `recall_count` is absent or 0 is flagged as a prune candidate. Notes without an `updated:` field have no age basis and are skipped. `WOOSTACK_NOW` (default `date +%F`) overrides "today" for deterministic runs and tests.
+**Staleness warnings.** `doctor.sh` emits warning-only findings for cheap structural staleness signals:
+
+- **Orphaned scope:** a note with a non-global `scope:` whose globs match no tracked files in `git ls-files` is flagged as stale. This catches notes scoped to paths that were deleted or moved.
+- **Stale provenance:** a note whose `source:` starts with `.woostack/specs/` or `.woostack/plans/` is expected to point at an authored spec or plan in the current repo. If that file is missing, the note is flagged for review. Other provenance forms, such as `source: pr-165`, are not treated as filesystem paths.
+- **Dead note:** `recall.sh` stamps `recall_count`/`last_recalled` (§3) on every selected note — matched + one-hop linked + global — as a best-effort side effect: a write failure (e.g. a read-only checkout) logs `recall: stamp failed <note>` to stderr but never changes recall's output or exit status. Ephemeral CI clones therefore simply do not accrue telemetry; persistent checkouts do. `doctor.sh` turns that signal into a warning when a note's `updated:` date is older than `WOOSTACK_DEAD_DAYS` (default 90) days and its `recall_count` is absent or 0. Notes without an `updated:` field have no age basis and are skipped. `WOOSTACK_NOW` (default `date +%F`) overrides "today" for deterministic runs and tests.
+
+`doctor.sh` also warns on unresolved body `[[wikilinks]]`; those are graph integrity warnings rather than staleness signals.
 
 ---
 

--- a/skills/woostack-init/scripts/doctor.sh
+++ b/skills/woostack-init/scripts/doctor.sh
@@ -47,6 +47,13 @@ for f in "$MEM_DIR"/*.md; do
     fi
   fi
 
+  source_path="$(field "$f" source)"
+  case "$source_path" in
+    .woostack/specs/*|.woostack/plans/*)
+      [ -f "$source_path" ] || warn "$base: source '$source_path' is missing (stale provenance)"
+      ;;
+  esac
+
   while IFS= read -r link; do
     [ -z "$link" ] && continue
     [ -f "$MEM_DIR/$link.md" ] || warn "$base: unresolved [[$link]]"

--- a/skills/woostack-init/scripts/tests/test-doctor.sh
+++ b/skills/woostack-init/scripts/tests/test-doctor.sh
@@ -22,6 +22,27 @@ pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
 assert_contains "$OUT" "stale" "stale scope warned"
 assert_exit 0 "$CODE" "warnings still exit 0"
 
+# missing .woostack source → warn, exit 0
+mk_note "$md" stale-source-spec.md $'name: stale-source-spec\ntype: pattern\nscope: packages/api/**\nsource: .woostack/specs/missing.md' 'body'
+pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+assert_contains "$OUT" "source '.woostack/specs/missing.md' is missing" "missing spec source warned"
+assert_exit 0 "$CODE" "missing spec source is a warning"
+
+mk_note "$md" stale-source-plan.md $'name: stale-source-plan\ntype: pattern\nscope: packages/api/**\nsource: .woostack/plans/missing.md' 'body'
+pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+assert_contains "$OUT" "source '.woostack/plans/missing.md' is missing" "missing plan source warned"
+assert_exit 0 "$CODE" "missing plan source is a warning"
+
+mkdir -p "$repo/.woostack/specs" "$repo/.woostack/plans"
+touch "$repo/.woostack/specs/existing.md" "$repo/.woostack/plans/existing.md"
+mk_note "$md" live-source-spec.md $'name: live-source-spec\ntype: pattern\nscope: packages/api/**\nsource: .woostack/specs/existing.md' 'body'
+mk_note "$md" live-source-plan.md $'name: live-source-plan\ntype: pattern\nscope: packages/api/**\nsource: .woostack/plans/existing.md' 'body'
+mk_note "$md" pr-source.md $'name: pr-source\ntype: convention\nscope: packages/api/**\nsource: pr-165' 'body'
+pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+assert_not_contains "$OUT" "live-source-spec" "existing spec source is not warned"
+assert_not_contains "$OUT" "live-source-plan" "existing plan source is not warned"
+assert_not_contains "$OUT" "pr-source" "PR source is not treated as a filesystem path"
+
 # unresolved wikilink → warn
 mk_note "$md" link.md $'name: link\ntype: pattern\nscope: packages/api/**' 'see [[ghost]] note'
 pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
