### PR TITLE
feat(review): per-angle cross-angle overlap metric (tokens deferred)

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -1,0 +1,5 @@
+{
+  "review": {
+    "metrics": true
+  }
+}

--- a/.woostack/plans/2026-06-02-review-metrics-overlap.md
+++ b/.woostack/plans/2026-06-02-review-metrics-overlap.md
@@ -1,0 +1,409 @@
+# Cross-Angle Overlap Metric — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-angle cross-angle overlap signal to woostack-review's opt-in metrics so redundant review angles (those whose findings other angles also raise) are visible per run and in the rolling aggregate.
+
+**Architecture:** Extend the existing per-run assembler `emit_angle_metrics` (embedded Python in `intersect-findings.sh`) to cluster raw findings by `(file, line, title_stem)` — excluding unanchored findings — and emit `overlap_total` + `overlap_with` per angle. Extend `metrics-fold.sh` to accumulate those into the rolling `.woostack/metrics.json` and bump its schema version 1→2 (existing version-mismatch path reseeds the old aggregate). Document in `SKILL.md`. Tokens are a separate, deferred increment (spec §8).
+
+**Tech Stack:** Bash + embedded Python 3 + `jq`; bash test harness under `skills/woostack-review/scripts/tests/` sourcing `skills/woostack-init/scripts/tests/assert.sh`.
+
+**Spec:** `.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md` (Increment 1).
+
+---
+
+## File Structure
+
+- **Modify** `skills/woostack-review/scripts/intersect-findings.sh` — inside `emit_angle_metrics`'s Python heredoc: add overlap clustering + two per-angle keys; bump the per-run doc's `schema_version` to 2.
+- **Modify** `skills/woostack-review/scripts/metrics-fold.sh` — `SCHEMA_VERSION=2`; per-angle slot init + accumulation of `overlap_total` / `overlap_with`.
+- **Modify** `skills/woostack-review/SKILL.md` — artifact-table row for `findings.metrics.json` (add keys); `metrics` config note (mention overlap + schema v2).
+- **Create** `skills/woostack-review/scripts/tests/test-intersect-overlap.sh` — drives `intersect-findings.sh` over fixtures, asserts overlap shape.
+- **Create** `skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh` — drives `metrics-fold.sh`, asserts accumulation + v1→v2 reseed.
+
+---
+
+## Task 1: Overlap computation in `emit_angle_metrics`
+
+**Files:**
+- Test: `skills/woostack-review/scripts/tests/test-intersect-overlap.sh` (create)
+- Modify: `skills/woostack-review/scripts/intersect-findings.sh` (the `emit_angle_metrics` Python heredoc)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `skills/woostack-review/scripts/tests/test-intersect-overlap.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/intersect-findings.sh"
+
+work="$(mktemp -d)"
+export OUTDIR="$work"
+
+# Metrics on; defender-only (no prosecutor) keeps the fixture minimal — overlap
+# is computed from raw_findings.json regardless of validator mode.
+printf '%s\n' '{"metrics": true, "disable_adversarial": true}' > "$work/config.json"
+
+# Raw set: one 3-angle cluster (bugs+security+types at foo.ts:42, same title),
+# one solo finding (bugs at bar.ts:7), one UNANCHORED finding (no line) that
+# must be excluded from overlap.
+cat > "$work/raw_findings.json" <<'JSON'
+[
+  {"angle":"bugs","file":"foo.ts","line":42,"title":"Null deref on user","severity":"HIGH"},
+  {"angle":"security","file":"foo.ts","line":42,"title":"Null deref on user","severity":"HIGH"},
+  {"angle":"types","file":"foo.ts","line":42,"title":"Null deref on user","severity":"MEDIUM"},
+  {"angle":"bugs","file":"bar.ts","line":7,"title":"Off by one","severity":"LOW"},
+  {"angle":"security","file":"baz.ts","title":"Unanchored secret","severity":"HIGH"}
+]
+JSON
+
+# Defender output is mandatory and becomes findings.json in defender-only mode.
+cp "$work/raw_findings.json" "$work/findings.defender.json"
+
+bash "$SCRIPT" >/tmp/intersect-overlap.out 2>&1
+
+M="$work/findings.metrics.json"
+assert_eq "$(test -f "$M" && echo yes || echo no)" "yes" "findings.metrics.json emitted"
+
+# bugs co-occurs with security and types once each at foo.ts:42 → total 2.
+assert_eq "$(jq -r '.angles.bugs.overlap_total' "$M")" "2" "bugs overlap_total == 2"
+assert_eq "$(jq -r '.angles.bugs.overlap_with.security' "$M")" "1" "bugs overlaps security once"
+assert_eq "$(jq -r '.angles.bugs.overlap_with.types' "$M")" "1" "bugs overlaps types once"
+
+# security overlaps bugs + types; the unanchored baz.ts finding is excluded.
+assert_eq "$(jq -r '.angles.security.overlap_total' "$M")" "2" "security overlap_total == 2"
+assert_eq "$(jq -r '.angles.security.overlap_with | has(\"baz\")' "$M")" "false" "no phantom angle key"
+
+# types overlaps bugs + security.
+assert_eq "$(jq -r '.angles.types.overlap_total' "$M")" "2" "types overlap_total == 2"
+
+# The solo bugs finding at bar.ts adds no self-overlap; bugs map has exactly
+# two keys (security, types).
+assert_eq "$(jq -r '.angles.bugs.overlap_with | keys | length' "$M")" "2" "bugs overlap_with has 2 keys, no self"
+assert_eq "$(jq -r '.angles.bugs.overlap_with | has(\"bugs\")' "$M")" "false" "bugs never overlaps itself"
+
+# schema_version of the per-run doc bumped to 2.
+assert_eq "$(jq -r '.schema_version' "$M")" "2" "per-run metrics schema_version == 2"
+
+rm -rf "$work"
+finish
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash skills/woostack-review/scripts/tests/test-intersect-overlap.sh`
+Expected: FAIL — `overlap_total` is `null` (jq prints `null`, not `2`), and `schema_version` is `1`. (The script still produces `findings.metrics.json`, so the first assert passes; the overlap asserts fail.)
+
+- [ ] **Step 3: Implement overlap in the `emit_angle_metrics` heredoc**
+
+In `skills/woostack-review/scripts/intersect-findings.sh`, find the Python heredoc inside `emit_angle_metrics()`. Make three edits.
+
+(a) Change the import line at the top of that heredoc from:
+
+```python
+import json, sys
+```
+to:
+```python
+import json, re, sys
+```
+
+(b) Immediately **before** the line `out = {"schema_version": 1, "mode": mode, "degraded": degraded == "true", "angles": {}}`, insert the clustering block:
+
+```python
+# Cross-angle overlap (redundancy signal). Cluster RAW findings by identity
+# key (file, line, title_stem) — the merge-findings dedup key minus `angle` —
+# so the same logical issue raised by multiple angles lands in one cluster.
+# Unanchored findings (no file or no positive integer line) are EXCLUDED:
+# without a stable anchor they cannot credibly be "the same issue" as another,
+# and would otherwise form phantom clusters under a degenerate key.
+def _title_stem(s):
+    return re.sub(r"[^a-z0-9]+", "", (s or "").lower())[:40]
+
+clusters = {}
+for f in raw:
+    file = f.get("file")
+    try:
+        line = int(f.get("line"))
+    except (TypeError, ValueError):
+        continue
+    if not file or line <= 0:
+        continue
+    key = (file, line, _title_stem(f.get("title")))
+    clusters.setdefault(key, set()).add(angle_of(f))
+
+overlap_with = {a: {} for a in angles}
+for angle_set in clusters.values():
+    if len(angle_set) < 2:
+        continue
+    for a in angle_set:
+        bucket = overlap_with.setdefault(a, {})
+        for b in angle_set:
+            if a != b:
+                bucket[b] = bucket.get(b, 0) + 1
+```
+
+(c) Change the per-run doc version and add the two keys to each angle's `rec`. Change:
+
+```python
+out = {"schema_version": 1, "mode": mode, "degraded": degraded == "true", "angles": {}}
+```
+to:
+```python
+out = {"schema_version": 2, "mode": mode, "degraded": degraded == "true", "angles": {}}
+```
+
+Then, inside the `for a in angles:` loop, **after** the `rec = { ... }` literal is assigned and before `if has_pros:`, add:
+
+```python
+    ow = overlap_with.get(a, {})
+    rec["overlap_with"] = ow
+    rec["overlap_total"] = sum(ow.values())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash skills/woostack-review/scripts/tests/test-intersect-overlap.sh`
+Expected: PASS — `0 failed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/woostack-review/scripts/intersect-findings.sh skills/woostack-review/scripts/tests/test-intersect-overlap.sh
+git commit -m "feat(review): per-angle cross-angle overlap in findings.metrics.json"
+```
+
+---
+
+## Task 2: Accumulate overlap in the rolling fold + schema bump
+
+**Files:**
+- Test: `skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh` (create)
+- Modify: `skills/woostack-review/scripts/metrics-fold.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/metrics-fold.sh"
+
+work="$(mktemp -d)"
+export OUTDIR="$work/out"
+export GITHUB_WORKSPACE="$work/repo"
+mkdir -p "$OUTDIR" "$GITHUB_WORKSPACE"
+
+printf '%s\n' '{"metrics": true}' > "$OUTDIR/config.json"
+
+# A per-run metrics doc with overlap fields (shape emitted by Task 1).
+write_run() {
+  cat > "$OUTDIR/findings.metrics.json" <<JSON
+{
+  "schema_version": 2,
+  "mode": "defender-only",
+  "degraded": false,
+  "angles": {
+    "bugs":     {"raw_count": 1, "kept": 1, "overlap_total": 2, "overlap_with": {"security": 1, "types": 1}},
+    "security": {"raw_count": 1, "kept": 1, "overlap_total": 1, "overlap_with": {"bugs": 1}}
+  }
+}
+JSON
+}
+
+ROLLING="$GITHUB_WORKSPACE/.woostack/metrics.json"
+
+# --- v1 reseed: a stale v1 aggregate must be backed up and replaced at v2. ---
+mkdir -p "$GITHUB_WORKSPACE/.woostack"
+printf '%s\n' '{"schema_version": 1, "runs": 9, "angles": {}}' > "$ROLLING"
+
+write_run
+bash "$SCRIPT" >/tmp/fold-overlap-1.out 2>&1
+
+assert_eq "$(test -f "$ROLLING.bak" && echo yes || echo no)" "yes" "stale v1 aggregate backed up to .bak"
+assert_eq "$(jq -r '.schema_version' "$ROLLING")" "2" "aggregate reseeded at schema_version 2"
+assert_eq "$(jq -r '.runs' "$ROLLING")" "1" "reseeded aggregate counts this run as run 1"
+assert_eq "$(jq -r '.angles.bugs.overlap_total' "$ROLLING")" "2" "bugs overlap_total folded"
+assert_eq "$(jq -r '.angles.bugs.overlap_with.security' "$ROLLING")" "1" "bugs->security folded"
+
+# --- accumulation: a second identical run doubles the sums + map values. ---
+write_run
+bash "$SCRIPT" >/tmp/fold-overlap-2.out 2>&1
+
+assert_eq "$(jq -r '.runs' "$ROLLING")" "2" "second fold increments runs"
+assert_eq "$(jq -r '.angles.bugs.overlap_total' "$ROLLING")" "4" "bugs overlap_total summed across runs"
+assert_eq "$(jq -r '.angles.bugs.overlap_with.types' "$ROLLING")" "2" "bugs->types summed across runs"
+assert_eq "$(jq -r '.angles.security.overlap_with.bugs' "$ROLLING")" "2" "security->bugs summed across runs"
+
+rm -rf "$work"
+finish
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh`
+Expected: FAIL — with `SCHEMA_VERSION=1` the stale v1 file is treated as current (no `.bak`, `schema_version` stays 1), and `overlap_total` folds to `null`.
+
+- [ ] **Step 3: Bump the schema version**
+
+In `skills/woostack-review/scripts/metrics-fold.sh`, change:
+
+```bash
+SCHEMA_VERSION=1
+```
+to:
+```bash
+SCHEMA_VERSION=2
+```
+
+- [ ] **Step 4: Add overlap to the slot template and accumulation**
+
+In the Python heredoc of `metrics-fold.sh`, the per-angle slot is created with `agg["angles"].setdefault(angle, { ... })`. Add the two overlap keys to that template dict (alongside `"severity_total"`):
+
+```python
+        "overlap_total": 0,
+        "overlap_with": {},
+```
+
+Then, in the accumulation block that currently ends with the `severity_total` loop:
+
+```python
+    sev = rec.get("severity") or {}
+    for s in SEVS:
+        slot["severity_total"][s] += num(sev.get(s))
+```
+add immediately after it:
+
+```python
+    # Guard for aggregates seeded before overlap existed (defensive; reseed on
+    # the version bump normally makes every slot use the new template).
+    slot.setdefault("overlap_total", 0)
+    slot.setdefault("overlap_with", {})
+    slot["overlap_total"] += num(rec.get("overlap_total"))
+    for b, n in (rec.get("overlap_with") or {}).items():
+        slot["overlap_with"][b] = num(slot["overlap_with"].get(b)) + num(n)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh`
+Expected: PASS — `0 failed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/woostack-review/scripts/metrics-fold.sh skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh
+git commit -m "feat(review): fold cross-angle overlap into rolling metrics, schema v2"
+```
+
+---
+
+## Task 3: Document overlap in SKILL.md
+
+**Files:**
+- Modify: `skills/woostack-review/SKILL.md`
+
+- [ ] **Step 1: Update the `findings.metrics.json` artifact-table row**
+
+Find the table row (around line 222) beginning:
+
+```
+| `findings.metrics.json` | `intersect-findings.sh` | metrics fold, telemetry | Per-angle signal/noise breakdown. Emitted **only when `review.metrics: true`** in config. Keyed by angle: `raw_count`, `prosecutor_kept`, `defender_kept`, `kept`, `dropped_by_defender`, `dropped_by_prosecutor`, `blocking_count`, `nonblocking_count`, `severity` |
+```
+
+Append the two new keys to its key list so it ends:
+
+```
+… `blocking_count`, `nonblocking_count`, `severity`, `overlap_total`, `overlap_with` (per-other-angle co-occurrence counts on the raw set; schema v2) |
+```
+
+- [ ] **Step 2: Update the `metrics` config note**
+
+Find the bullet (around line 165):
+
+```
+- **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). See Stage 6.5.
+```
+
+Replace it with:
+
+```
+- **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). Each angle also carries `overlap_total` + `overlap_with` (how often another angle raised the same issue, on the raw pre-validation set — a redundancy signal). Aggregate schema is v2; an older v1 aggregate is reseeded on first fold. See Stage 6.5.
+```
+
+- [ ] **Step 3: Verify no cross-links broke**
+
+Run: `grep -n "findings.metrics.json\|review.metrics\|overlap" skills/woostack-review/SKILL.md`
+Expected: the updated row + bullet appear; no other reference contradicts the new keys.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/woostack-review/SKILL.md
+git commit -m "docs(review): document overlap metric + schema v2 in SKILL.md"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run both new tests**
+
+Run:
+```bash
+bash skills/woostack-review/scripts/tests/test-intersect-overlap.sh
+bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh
+```
+Expected: each prints `0 failed`.
+
+- [ ] **Step 2: Run the rest of the review/init test suite to catch regressions**
+
+Run:
+```bash
+for t in skills/woostack-review/scripts/tests/*.sh skills/woostack-init/scripts/tests/*.sh; do
+  echo "== $t =="; bash "$t" || { echo "FAILED: $t"; exit 1; }
+done
+```
+Expected: every test reports `0 failed`; no `FAILED:` line.
+
+- [ ] **Step 3: Lint the touched shell scripts**
+
+Run: `shellcheck skills/woostack-review/scripts/intersect-findings.sh skills/woostack-review/scripts/metrics-fold.sh`
+Expected: no new warnings introduced by these edits. (If `shellcheck` is unavailable, note it and skip — the embedded Python is not shellcheck-covered anyway.)
+
+- [ ] **Step 4: Sanity-check JSON shape end-to-end**
+
+Run the Task 1 fixture once more and pretty-print:
+```bash
+OUTDIR="$(mktemp -d)"; export OUTDIR
+printf '%s\n' '{"metrics": true, "disable_adversarial": true}' > "$OUTDIR/config.json"
+cat > "$OUTDIR/raw_findings.json" <<'JSON'
+[{"angle":"bugs","file":"foo.ts","line":42,"title":"Null deref","severity":"HIGH"},
+ {"angle":"security","file":"foo.ts","line":42,"title":"Null deref","severity":"HIGH"}]
+JSON
+cp "$OUTDIR/raw_findings.json" "$OUTDIR/findings.defender.json"
+bash skills/woostack-review/scripts/intersect-findings.sh >/dev/null 2>&1
+jq '.angles | {bugs: .bugs.overlap_with, security: .security.overlap_with}' "$OUTDIR/findings.metrics.json"
+rm -rf "$OUTDIR"
+```
+Expected: `{"bugs":{"security":1},"security":{"bugs":1}}`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §4.1 overlap compute → Task 1. §4.2 schema (`overlap_total`/`overlap_with`) → Task 1. §4.3 fold + v1→v2 bump → Task 2. §4.4 docs → Task 3. §7 tests: overlap math, unanchored exclusion, within-angle non-self-count → Task 1 test; fold accumulation + v1→v2 reseed → Task 2 test; metrics-off no-op already covered by existing behavior (no code path changed for the off case — no new test needed). All covered.
+- **Placeholder scan:** none — every code/step is concrete.
+- **Type consistency:** key names `overlap_total` / `overlap_with` identical across Task 1 (emit), Task 2 (fold), Task 3 (docs), and both tests. Per-run doc `schema_version` and fold `SCHEMA_VERSION` both → 2.
+```

--- a/.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
+++ b/.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
@@ -1,0 +1,196 @@
+---
+name: review-metrics-tokens-overlap
+type: spec
+status: draft
+date: 2026-06-02
+branch: feature/review-metrics-overlap
+links:
+---
+
+# Review metrics: cross-angle overlap (+ deferred token cost) — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+## 1. Problem
+
+`woostack-review`'s opt-in per-angle metrics (`findings.metrics.json` per run,
+folded into a rolling `.woostack/metrics.json`) record signal/noise per angle
+(raw vs kept, dropped-by-validator, severity). They cannot answer two
+operationally important questions:
+
+1. **Which angles are redundant?** When several angles independently raise the
+   same issue, that duplicated effort is invisible. An angle whose findings are
+   nearly always also found by another angle is a candidate to drop.
+2. **Which angles are expensive but low-value?** There is no token-cost signal,
+   so an angle that burns many tokens to surface few kept findings is invisible.
+
+## 2. Goal & scope split
+
+Two signals were requested; they have very different feasibility, so they ship
+as **two increments**:
+
+- **Increment 1 (this spec / this cycle) — cross-angle overlap.** Fully
+  deterministic, host-independent, no capture dependency.
+- **Increment 2 (next cycle) — per-angle tokens.** Deferred because token usage
+  is **not capturable on a bare chat host** (see §8). Designed here so the schema
+  evolves coherently, but **not implemented in this increment**.
+
+Both stay behind the existing opt-in (`review.metrics: true`, default off). No
+new gate.
+
+### Increment 1 goal
+
+For each angle, record a `overlap_with` map counting, per *other* angle, how many
+of this angle's findings that other angle also raised (total pairwise hits), plus
+an `overlap_total`. Measured on the **raw** (pre-validation) finding set. Folded
+into the rolling aggregate so redundancy is visible across runs.
+
+## 3. Non-goals
+
+- **No new gate / no default-on.** Behind `review.metrics: true` exactly as today.
+- **No fuzzy overlap matching.** Overlap clustering uses the exact identity key
+  already used by dedup. The fuzzy line/title matcher in `intersect-findings.sh`
+  is prosecutor-vs-defender and is **not** reused here.
+- **No token implementation this cycle.** §7 records the deferred design only.
+- **`validator-metrics.json` unchanged.** Only `findings.metrics.json` and the
+  rolling aggregate gain fields.
+
+## 4. Approach (Increment 1 — overlap)
+
+### 4.1 Overlap computation (`intersect-findings.sh` → `emit_angle_metrics`)
+
+`emit_angle_metrics` already loads `raw_findings.json` and is the per-run
+assembler for `findings.metrics.json`. Extend its embedded Python:
+
+- **Anchor filter.** Skip any raw finding missing `file` **or** a usable `line`
+  (`safe_line` returns 0 / non-int). Unanchored findings are not credibly "the
+  same issue" as another and must not form phantom clusters. They still count
+  toward existing per-angle counts (`raw_count` etc.) — only overlap excludes
+  them.
+- **Cluster** the surviving findings by identity key
+  `(file, safe_line(line), title_stem(title))`, where `title_stem` is the
+  existing lowercase-alphanumeric-truncated-to-40 helper used in
+  `merge-findings.sh` / `intersect-findings.sh`. This is the merge-findings dedup
+  key **minus `angle`**, so identity is consistent across stages.
+- merge-findings already collapsed within-angle duplicates in
+  `raw_findings.json`, so within one cluster (fixed `title_stem`) an angle appears
+  **at most once** → each cluster is a set of distinct angles `S`.
+- For a cluster with angle set `S`: for each `a ∈ S`, and each `b ∈ S, b ≠ a`,
+  `overlap_with[a][b] += 1`. Solo clusters (`|S| == 1`) contribute nothing. No
+  angle ever counts itself (it appears once per cluster).
+- `overlap_total[a] = sum(overlap_with[a].values())`.
+
+Angle attribution uses the finding's `.angle` field (schema-required; missing →
+existing `_unknown` bucket, unchanged).
+
+### 4.2 `findings.metrics.json` schema (per-angle rec gains)
+
+```json
+"overlap_total": 3,
+"overlap_with": { "security": 2, "types": 1 }
+```
+
+`overlap_with` is empty `{}` and `overlap_total` is `0` for an angle whose
+findings never co-occur. No top-level change in this increment.
+
+### 4.3 Rolling fold (`metrics-fold.sh`) + schema bump
+
+- Bump `SCHEMA_VERSION 1 → 2`. An existing v1 `.woostack/metrics.json` hits the
+  already-implemented version-mismatch path: backed up to `.bak`, reseeded.
+  Acceptable — per-clone, gitignored, cheaply rebuilt.
+- Per-angle slot init gains `overlap_total: 0` and `overlap_with: {}`.
+- Fold per angle present in the run:
+  - `slot.overlap_total += run overlap_total`
+  - for each `(b, n)` in run `overlap_with[a]`: `slot.overlap_with[b] += n`
+    (missing key initialized to 0).
+- Reseed on the bump means no half-populated legacy slots to migrate.
+
+### 4.4 Docs (`skills/woostack-review/SKILL.md`)
+
+- **Artifact table**: update the `findings.metrics.json` row's key list with
+  `overlap_total`, `overlap_with`.
+- **`metrics` config note** (line ~165 / ~222): mention the new per-angle overlap
+  fields and the rolling aggregate's new totals. Note schema is now v2.
+
+## 5. Components & data flow (Increment 1)
+
+```
+Stage 4 merge-findings.sh
+  └─ raw_findings.json   (unchanged; within-angle dedup already applied)
+
+Stage 4 intersect-findings.sh → emit_angle_metrics  (EXTENDED)
+  reads:  raw_findings.json (+ existing inputs)
+  writes: findings.metrics.json
+          per angle: …existing… + overlap_total, overlap_with
+
+Stage 6.5 metrics-fold.sh  (EXTENDED, schema v2)
+  reads:  findings.metrics.json + existing .woostack/metrics.json
+  writes: .woostack/metrics.json
+          per angle: …existing totals… + overlap_total, overlap_with
+```
+
+Boundaries unchanged: `emit_angle_metrics` owns per-run assembly,
+`metrics-fold.sh` owns aggregation. Each independently testable from on-disk
+fixtures.
+
+## 6. Error handling (Increment 1)
+
+- **Unanchored findings** — excluded from overlap (cannot crash clustering;
+  `safe_line` / `title_stem` normalize inputs).
+- **`emit_angle_metrics` failure** — already non-fatal (`|| echo "::warning::…"`).
+  New code stays inside the guarded block; a bug here never sinks a review.
+- **Schema bump on stale aggregate** — existing reseed-with-`.bak` path; the v1
+  version check already rejects the old file.
+- **Metrics off** — unchanged no-op: no `findings.metrics.json`, fold no-op.
+
+## 7. Testing (Increment 1)
+
+`skills/woostack-review/scripts/tests/` (follow existing harness conventions):
+
+- **Overlap math** — 3-angle cluster → each angle `overlap_total == 2` with
+  correct `overlap_with`; solo finding → `overlap_total == 0`,
+  `overlap_with == {}`; two separate clusters sum per angle.
+- **Unanchored exclusion** — findings missing `file`/`line` do not appear in any
+  `overlap_with` and don't inflate another angle's totals.
+- **Within-angle non-self-count** — same angle across chunks (already collapsed
+  by merge) never counts overlap with itself.
+- **Fold accumulation** — two folded runs sum `overlap_total` and merge-add
+  `overlap_with`.
+- **Fold v1→v2 reseed** — pre-existing v1 aggregate backed up to `.bak` and
+  reseeded at v2 without crashing.
+- **Metrics-off no-op** — unchanged.
+
+## 8. Deferred: per-angle tokens (Increment 2, next cycle)
+
+**Why deferred — capture gap.** On a bare Claude Code chat host the orchestrator
+model only receives a sub-agent's final message via the `Task` result; it
+**cannot observe the sub-agent's token usage**. The `skills` CLI install
+(`npx skills add …`) writes skill files + symlinks only — it never wires a
+consumer `SubagentStop` hook, and `woostack-init` scaffolds `.woostack/`, not
+`.claude/settings.json`. So a naive "orchestrator writes `usage.<angle>.json`"
+contract yields `null` for essentially every chat-host install.
+
+**Planned next-cycle design (not built here):**
+
+- Per-angle `usage.<angle>[.chunk-<id>].json` = `{input_tokens, output_tokens}`,
+  summed per angle; `tokens: {input, output, total} | null` per angle in
+  `findings.metrics.json`; top-level `tokens_degraded: bool`.
+- Concrete producers: **CI `action.yml`** (claude-code-action reports usage; the
+  metrics artifact is already uploaded) and an **optional shipped
+  `scripts/capture-usage.sh` + documented `SubagentStop` hook** the chat-host
+  consumer pastes into their own `settings.json`.
+- Rolling fold: `tokens_input_total`, `tokens_output_total`, `tokens_total`,
+  `token_runs_present` (honest averaging), top-level `tokens_degraded_runs`.
+  Schema bump `2 → 3`.
+- Degraded-by-default and stated plainly: no proxy/estimate, no pretending the
+  chat host captures tokens for free.
+
+## 9. Open questions
+
+- **Exact vs fuzzy overlap key (resolved: exact).** Independent angles may anchor
+  the same issue at slightly different lines or word the title past the 40-char
+  stem, so exact keying can undercount. We accept undercount for determinism and
+  zero false merges. Revisit only if real runs show material undercount.
+- **Schema bump reseeds rolling history (resolved: accept).** v1→v2 discards the
+  accumulated local aggregate (backed up to `.bak`). Acceptable: per-clone,
+  gitignored, cheaply rebuilt.

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -162,7 +162,7 @@ Key reference (JSON has no comments, so the per-key semantics live here):
 - **`models`** — per-tier slug overrides; the action input `inputs.model` still wins.
 - **`fix_commands`** — reserved for `--loop` mode (issue #15).
 - **`disable_adversarial`** — cost-sensitive opt-out for the prosecutor+defender validator (issue #13). When `true`, only the defender pass runs and its output becomes `findings.json` directly.
-- **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). See Stage 6.5.
+- **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). Each angle also carries `overlap_total` + `overlap_with` (how often another angle raised the same issue, on the raw pre-validation set — a redundancy signal). Aggregate schema is v2; an older v1 aggregate is reseeded on first fold. See Stage 6.5.
 - **`chunking.max_loc`** — diff-chunking threshold (issue #14). When the post-ignore diff exceeds this many changed lines, prefetch splits it into chunks honoring workspace package roots > top-level dirs > file-LOC-balanced groups; each angle fans out as angles × chunks parallel sub-agents. `0` disables chunking; missing => 4000.
 
 **Precedence**: for the angle set, `angles.force` beats `angles.skip` when the same angle is listed in both. For model resolution, the action input `inputs.model` beats `models.<tier>` which beats the table default in `prompts/_header.md`. `ignore` is applied to both file paths and the per-file diff sections before angle gates evaluate.
@@ -219,7 +219,7 @@ When prefetch resolves a PR number AND finds an open PR, it produces the full ar
 | `raw_findings.json` | `merge-findings.sh` | validator passes | Merged, chunk-collapsed findings |
 | `findings.json` | `intersect-findings.sh` | Stage 5 posting | Final validated set |
 | `validator-metrics.json` | `intersect-findings.sh` | observability | `prosecutor_count`, `defender_count`, `kept_count`, `disagreement_count`, `mode`, `degraded` |
-| `findings.metrics.json` | `intersect-findings.sh` | metrics fold, telemetry | Per-angle signal/noise breakdown. Emitted **only when `review.metrics: true`** in config. Keyed by angle: `raw_count`, `prosecutor_kept`, `defender_kept`, `kept`, `dropped_by_defender`, `dropped_by_prosecutor`, `blocking_count`, `nonblocking_count`, `severity` |
+| `findings.metrics.json` | `intersect-findings.sh` | metrics fold, telemetry | Per-angle signal/noise breakdown. Emitted **only when `review.metrics: true`** in config. Keyed by angle: `raw_count`, `prosecutor_kept`, `defender_kept`, `kept`, `dropped_by_defender`, `dropped_by_prosecutor`, `blocking_count`, `nonblocking_count`, `severity`, `overlap_total`, `overlap_with` (per-other-angle co-occurrence counts on the raw set; schema v2) |
 
 **If no PR number resolved (local mode):**
 

--- a/skills/woostack-review/scripts/intersect-findings.sh
+++ b/skills/woostack-review/scripts/intersect-findings.sh
@@ -127,7 +127,7 @@ write_metrics() {
 emit_angle_metrics() {
   [ "$metrics_enabled" = "true" ] || return 0
   python3 - "$RAW" "$PROSECUTOR" "$DEFENDER" "$FINAL" "$ANGLE_METRICS" "$1" "$2" <<'PY'
-import json, sys
+import json, re, sys
 
 raw_p, pros_p, def_p, final_p, out_p, mode, degraded = sys.argv[1:8]
 
@@ -180,7 +180,38 @@ def sev_hist(items, a):
 def blocking_count(items, a):
     return sum(1 for f in items if angle_of(f) == a and bool(f.get("blocking", False)))
 
-out = {"schema_version": 1, "mode": mode, "degraded": degraded == "true", "angles": {}}
+# Cross-angle overlap (redundancy signal). Cluster RAW findings by identity
+# key (file, line, title_stem) — the merge-findings dedup key minus `angle` —
+# so the same logical issue raised by multiple angles lands in one cluster.
+# Unanchored findings (no file or no positive integer line) are EXCLUDED:
+# without a stable anchor they cannot credibly be "the same issue" as another,
+# and would otherwise form phantom clusters under a degenerate key.
+def _title_stem(s):
+    return re.sub(r"[^a-z0-9]+", "", (s or "").lower())[:40]
+
+clusters = {}
+for f in raw:
+    file = f.get("file")
+    try:
+        line = int(f.get("line"))
+    except (TypeError, ValueError):
+        continue
+    if not file or line <= 0:
+        continue
+    key = (file, line, _title_stem(f.get("title")))
+    clusters.setdefault(key, set()).add(angle_of(f))
+
+overlap_with = {a: {} for a in angles}
+for angle_set in clusters.values():
+    if len(angle_set) < 2:
+        continue
+    for a in angle_set:
+        bucket = overlap_with.setdefault(a, {})
+        for b in angle_set:
+            if a != b:
+                bucket[b] = bucket.get(b, 0) + 1
+
+out = {"schema_version": 2, "mode": mode, "degraded": degraded == "true", "angles": {}}
 
 for a in angles:
     kept = final_c.get(a, 0)
@@ -196,6 +227,9 @@ for a in angles:
         "nonblocking_count": kept - blk,
         "severity": sev_hist(final, a),
     }
+    ow = overlap_with.get(a, {})
+    rec["overlap_with"] = ow
+    rec["overlap_total"] = sum(ow.values())
     if has_pros:
         prok = pros_c.get(a, 0)
         rec["prosecutor_kept"] = prok

--- a/skills/woostack-review/scripts/metrics-fold.sh
+++ b/skills/woostack-review/scripts/metrics-fold.sh
@@ -20,7 +20,7 @@ PER_RUN="$OUTDIR/findings.metrics.json"
 ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
 ROLLING="$ROOT/.woostack/metrics.json"
 GITIGNORE="$ROOT/.gitignore"
-SCHEMA_VERSION=1
+SCHEMA_VERSION=2
 
 # Gate: metrics opt-in (default off).
 metrics_enabled="false"
@@ -99,6 +99,8 @@ for angle, rec in (run.get("angles") or {}).items():
         "dropped_by_prosecutor_total": 0,
         "blocking_total": 0,
         "severity_total": {s: 0 for s in SEVS},
+        "overlap_total": 0,
+        "overlap_with": {},
     })
     slot["runs_present"] += 1
     slot["raw_total"]  += num(rec.get("raw_count"))
@@ -109,6 +111,13 @@ for angle, rec in (run.get("angles") or {}).items():
     sev = rec.get("severity") or {}
     for s in SEVS:
         slot["severity_total"][s] += num(sev.get(s))
+    # Guard for aggregates seeded before overlap existed (defensive; reseed on
+    # the version bump normally makes every slot use the new template).
+    slot.setdefault("overlap_total", 0)
+    slot.setdefault("overlap_with", {})
+    slot["overlap_total"] += num(rec.get("overlap_total"))
+    for b, n in (rec.get("overlap_with") or {}).items():
+        slot["overlap_with"][b] = num(slot["overlap_with"].get(b)) + num(n)
 
 # Atomic write: a mid-write crash leaves the prior aggregate intact rather
 # than a truncated file (the reseed path would recover either way, but this

--- a/skills/woostack-review/scripts/tests/test-intersect-overlap.sh
+++ b/skills/woostack-review/scripts/tests/test-intersect-overlap.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/intersect-findings.sh"
+
+work="$(mktemp -d)"
+export OUTDIR="$work"
+
+# Metrics on; defender-only (no prosecutor) keeps the fixture minimal — overlap
+# is computed from raw_findings.json regardless of validator mode.
+printf '%s\n' '{"metrics": true, "disable_adversarial": true}' > "$work/config.json"
+
+# Raw set: one 3-angle cluster (bugs+security+types at foo.ts:42, same title),
+# one solo finding (bugs at bar.ts:7), one UNANCHORED finding (no line) that
+# must be excluded from overlap.
+cat > "$work/raw_findings.json" <<'JSON'
+[
+  {"angle":"bugs","file":"foo.ts","line":42,"title":"Null deref on user","severity":"HIGH"},
+  {"angle":"security","file":"foo.ts","line":42,"title":"Null deref on user","severity":"HIGH"},
+  {"angle":"types","file":"foo.ts","line":42,"title":"Null deref on user","severity":"MEDIUM"},
+  {"angle":"bugs","file":"bar.ts","line":7,"title":"Off by one","severity":"LOW"},
+  {"angle":"security","file":"baz.ts","title":"Unanchored secret","severity":"HIGH"}
+]
+JSON
+
+# Defender output is mandatory and becomes findings.json in defender-only mode.
+cp "$work/raw_findings.json" "$work/findings.defender.json"
+
+bash "$SCRIPT" >/tmp/intersect-overlap.out 2>&1
+
+M="$work/findings.metrics.json"
+assert_eq "$(test -f "$M" && echo yes || echo no)" "yes" "findings.metrics.json emitted"
+
+# bugs co-occurs with security and types once each at foo.ts:42 → total 2.
+assert_eq "$(jq -r '.angles.bugs.overlap_total' "$M")" "2" "bugs overlap_total == 2"
+assert_eq "$(jq -r '.angles.bugs.overlap_with.security' "$M")" "1" "bugs overlaps security once"
+assert_eq "$(jq -r '.angles.bugs.overlap_with.types' "$M")" "1" "bugs overlaps types once"
+
+# security overlaps bugs + types; the unanchored baz.ts finding is excluded.
+assert_eq "$(jq -r '.angles.security.overlap_total' "$M")" "2" "security overlap_total == 2"
+assert_eq "$(jq -r '.angles.security.overlap_with | has("baz")' "$M")" "false" "no phantom angle key"
+
+# types overlaps bugs + security.
+assert_eq "$(jq -r '.angles.types.overlap_total' "$M")" "2" "types overlap_total == 2"
+
+# The solo bugs finding at bar.ts adds no self-overlap; bugs map has exactly
+# two keys (security, types).
+assert_eq "$(jq -r '.angles.bugs.overlap_with | keys | length' "$M")" "2" "bugs overlap_with has 2 keys, no self"
+assert_eq "$(jq -r '.angles.bugs.overlap_with | has("bugs")' "$M")" "false" "bugs never overlaps itself"
+
+# schema_version of the per-run doc bumped to 2.
+assert_eq "$(jq -r '.schema_version' "$M")" "2" "per-run metrics schema_version == 2"
+
+rm -rf "$work"
+finish

--- a/skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh
+++ b/skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/metrics-fold.sh"
+
+work="$(mktemp -d)"
+export OUTDIR="$work/out"
+export GITHUB_WORKSPACE="$work/repo"
+mkdir -p "$OUTDIR" "$GITHUB_WORKSPACE"
+
+printf '%s\n' '{"metrics": true}' > "$OUTDIR/config.json"
+
+# A per-run metrics doc with overlap fields (shape emitted by Task 1).
+write_run() {
+  cat > "$OUTDIR/findings.metrics.json" <<JSON
+{
+  "schema_version": 2,
+  "mode": "defender-only",
+  "degraded": false,
+  "angles": {
+    "bugs":     {"raw_count": 1, "kept": 1, "overlap_total": 2, "overlap_with": {"security": 1, "types": 1}},
+    "security": {"raw_count": 1, "kept": 1, "overlap_total": 1, "overlap_with": {"bugs": 1}}
+  }
+}
+JSON
+}
+
+ROLLING="$GITHUB_WORKSPACE/.woostack/metrics.json"
+
+# --- v1 reseed: a stale v1 aggregate must be backed up and replaced at v2. ---
+mkdir -p "$GITHUB_WORKSPACE/.woostack"
+printf '%s\n' '{"schema_version": 1, "runs": 9, "angles": {}}' > "$ROLLING"
+
+write_run
+bash "$SCRIPT" >/tmp/fold-overlap-1.out 2>&1
+
+assert_eq "$(test -f "$ROLLING.bak" && echo yes || echo no)" "yes" "stale v1 aggregate backed up to .bak"
+assert_eq "$(jq -r '.schema_version' "$ROLLING")" "2" "aggregate reseeded at schema_version 2"
+assert_eq "$(jq -r '.runs' "$ROLLING")" "1" "reseeded aggregate counts this run as run 1"
+assert_eq "$(jq -r '.angles.bugs.overlap_total' "$ROLLING")" "2" "bugs overlap_total folded"
+assert_eq "$(jq -r '.angles.bugs.overlap_with.security' "$ROLLING")" "1" "bugs->security folded"
+
+# --- accumulation: a second identical run doubles the sums + map values. ---
+write_run
+bash "$SCRIPT" >/tmp/fold-overlap-2.out 2>&1
+
+assert_eq "$(jq -r '.runs' "$ROLLING")" "2" "second fold increments runs"
+assert_eq "$(jq -r '.angles.bugs.overlap_total' "$ROLLING")" "4" "bugs overlap_total summed across runs"
+assert_eq "$(jq -r '.angles.bugs.overlap_with.types' "$ROLLING")" "2" "bugs->types summed across runs"
+assert_eq "$(jq -r '.angles.security.overlap_with.bugs' "$ROLLING")" "2" "security->bugs summed across runs"
+
+rm -rf "$work"
+finish


### PR DESCRIPTION
## What

Adds a per-angle **cross-angle overlap** signal to `woostack-review`'s opt-in metrics, so redundant review angles (those whose findings other angles also raise) are visible per run and across runs.

This is **increment 1 of 2**. The second requested signal — per-angle **token cost** — is deferred to a follow-up (see Deferred below).

## Why

The existing opt-in metrics (`findings.metrics.json` + rolling `.woostack/metrics.json`) record signal/noise per angle but cannot show **redundancy**: when several angles independently raise the same issue, that duplicated effort is invisible. An angle whose findings are nearly always also found by another angle is a candidate to drop.

## How

- **`intersect-findings.sh` → `emit_angle_metrics`**: cluster raw findings by `(file, line, title_stem)` — the merge-findings dedup key minus `angle` — and emit per angle:
  - `overlap_with`: `{other_angle: count}` (total pairwise co-occurrence on the **raw** pre-validation set)
  - `overlap_total`: sum of that map
  - **Unanchored findings** (no `file`/positive-int `line`) are excluded — no phantom clusters.
  - An angle never counts overlap with itself (within-angle dupes already collapsed by `merge-findings.sh`).
  - Per-run doc `schema_version` → 2.
- **`metrics-fold.sh`**: `SCHEMA_VERSION` → 2; accumulate `overlap_total` (sum) and `overlap_with` (merge-add) into the rolling aggregate. A stale v1 aggregate is backed up to `.bak` and reseeded via the existing version-mismatch path (per-clone, gitignored data — acceptable).
- **`SKILL.md`**: artifact-table row + `metrics` config note document the new fields and schema v2.

Everything stays behind the existing opt-in (`review.metrics: true`, default off). No new gate. `validator-metrics.json` unchanged.

## Design decisions

- **Exact identity key (not fuzzy).** Independent angles may anchor the same issue at slightly different lines / reword past the 40-char stem, so exact keying can undercount. Accepted for determinism + zero false merges; the fuzzy matcher in `intersect-findings.sh` is prosecutor-vs-defender and not reused here.
- **Schema bump reseeds rolling history.** v1→v2 discards the accumulated local aggregate (backed up to `.bak`). Acceptable: per-clone, gitignored, cheaply rebuilt.

## Deferred — per-angle tokens (increment 2)

Token usage is **not capturable on a bare chat host**: the orchestrator model only receives a sub-agent's final message via the `Task` result, not its token usage; the `skills` CLI install never wires a `SubagentStop` hook, and `woostack-init` doesn't touch `.claude/settings.json`. Next cycle will wire CI `action.yml` as the concrete producer plus an optional shipped `capture-usage.sh` + documented hook, degraded-by-default on chat hosts. Full design in the spec §8.

## Tests

- `test-intersect-overlap.sh` (10 assertions): 3-angle cluster math, unanchored exclusion, no self-count, schema v2.
- `test-metrics-fold-overlap.sh` (9 assertions): fold accumulation across runs, v1→v2 reseed.
- Full `woostack-review` + `woostack-init` suites pass; shellcheck clean (only pre-existing SC1091 info).

Spec: `.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md`
Plan: `.woostack/plans/2026-06-02-review-metrics-overlap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
