### PR TITLE
Add using-woostack skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for AI coding agents working in this repository. Compatible with Cl
 
 ## What this repo is
 
-A **published collection of skills**, not a codebase. It packages the decisions for building new web + mobile + API projects so any agent can install it (`npx skills add howarewoo/woostack`) and bootstrap fresh projects at the latest framework versions. The five skills are: `woostack-init` (sets up the `.woostack/` workspace and memory store the other skills rely on), `woostack-bootstrap`, `woostack-build`, `woostack-review`, and `woostack-address-comments`.
+A **published collection of skills**, not a codebase. It packages the decisions for building new web + mobile + API projects so any agent can install it (`npx skills add howarewoo/woostack`) and bootstrap fresh projects at the latest framework versions. The six skills are: `using-woostack` (teaches agents to load project woostack rules and route commands), `woostack-init` (sets up the `.woostack/` workspace and memory store the other skills rely on), `woostack-bootstrap`, `woostack-build`, `woostack-review`, and `woostack-address-comments`.
 
 There is no application source code, no app lockfile, no build, and no CI that runs on this repo's own events, by design. (`skills-lock.json` is the manifest for any *dev* skills this repo bundles for its own use — see [Skills](#skills) — it is not an app lockfile. It is currently empty: the repo bundles no external dev skills and relies on the agent's global install.)
 
@@ -19,6 +19,8 @@ woostack/
 ├── CONTRIBUTING.md    How to evolve the skill collection
 ├── LICENSE
 ├── skills/
+│   ├── using-woostack/
+│   │   └── SKILL.md           Project adoption + command routing entry point
 │   ├── woostack-init/
 │   │   ├── SKILL.md           Init skill entry point
 │   │   ├── references/
@@ -85,6 +87,8 @@ The agent has the collection installed (or is pointed at this repo) and is asked
 | `/woostack-review [PR#]` | Parallel review swarm + skeptical validation; posts a batched GitHub review. |
 | `/woostack-address-comments [PR#]` | Address unresolved review threads autonomously. No merge. |
 
+If a consumer project's root `AGENTS.md` references `using-woostack`, load [using-woostack](skills/using-woostack/SKILL.md) first so the agent follows project-local woostack rules before routing to one of the command skills.
+
 Bootstrap procedure (for `/woostack-bootstrap`):
 1. Read [SKILL.md](skills/woostack-bootstrap/SKILL.md), then the files in [`references/`](skills/woostack-bootstrap/references/) — they are inputs.
 2. Walk the user through [references/decisions.md](skills/woostack-bootstrap/references/decisions.md) and get explicit sign-off on every relevant decision before scaffolding anything.
@@ -141,7 +145,7 @@ Feature branches are cut from `staging`, never `main`. PRs target `staging`. `st
 - Do not regenerate `apps/`, `packages/`, `pnpm-workspace.yaml`, or root build configs in this repo. They were removed deliberately.
 - Do not add a CI workflow that runs on this repo's own push/PR events — woostack has nothing to test. (The shipped `reusable-review.yml` is `workflow_call`-only and `action.yml` is a composite action consumers reference; neither triggers on this repo. Leave them in place.)
 - Do not rename files under `skills/woostack-bootstrap/references/` without updating every cross-link and the SKILL.md table.
-- Do not move or rename any of the five SKILL.md files (`skills/woostack-init/SKILL.md`, `skills/woostack-bootstrap/SKILL.md`, `skills/woostack-build/SKILL.md`, `skills/woostack-review/SKILL.md`, `skills/woostack-address-comments/SKILL.md`) — `npx skills add` resolves skills by those paths.
+- Do not move or rename any of the six SKILL.md files (`skills/using-woostack/SKILL.md`, `skills/woostack-init/SKILL.md`, `skills/woostack-bootstrap/SKILL.md`, `skills/woostack-build/SKILL.md`, `skills/woostack-review/SKILL.md`, `skills/woostack-address-comments/SKILL.md`) — `npx skills add` resolves skills by those paths.
 - Do not commit `.env*`, secrets, or generated files.
 
 ### Skills
@@ -156,6 +160,7 @@ To bundle a dev skill again, use the `skills` CLI (`pnpx skills add <source>`) r
 
 | Task | File to edit |
 |---|---|
+| Change project adoption / command routing guidance | [SKILL.md](skills/using-woostack/SKILL.md) |
 | Add/revise a bootstrap decision or its default | [references/decisions.md](skills/woostack-bootstrap/references/decisions.md) |
 | Swap a default framework | [references/frameworks.md](skills/woostack-bootstrap/references/frameworks.md) |
 | Document a gotcha | [references/frameworks.md](skills/woostack-bootstrap/references/frameworks.md#known-gotchas-to-respect-at-bootstrap) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The four skills are `woostack-bootstrap`, `woostack-build`, `woostack-review`, and `woostack-address-comments`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The six skills are `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-review`, and `woostack-address-comments`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 
@@ -8,6 +8,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 
 | You want to... | Edit |
 |---|---|
+| Change project adoption / command routing guidance | `skills/using-woostack/SKILL.md` |
 | Add/revise a bootstrap decision or its default | `skills/woostack-bootstrap/references/decisions.md` |
 | Swap a default framework | `skills/woostack-bootstrap/references/frameworks.md` |
 | Document a new gotcha | `skills/woostack-bootstrap/references/frameworks.md` (Known gotchas section) |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **An installable collection of opinionated skills that encode my software-development process (bootstrap, build, review, iterate) for both new and existing codebases.**
 
-This is a public representation of how I build software, packaged so any AI coding agent can follow the same loop. It covers the life of a change end to end: scaffold a project (greenfield), drive a feature, review it, and address the feedback (brownfield, since those work in any existing repo, not just one woostack created). The scope grows over time toward the rest of the loop. A commit utility for good messages and other day-to-day tools are on the way.
+This is a public representation of how I build software, packaged so any AI coding agent can follow the same loop. It covers the life of a change end to end: load project rules, scaffold a project (greenfield), drive a feature, review it, and address the feedback (brownfield, since those work in any existing repo, not just one woostack created). The scope grows over time toward the rest of the loop. A commit utility for good messages and other day-to-day tools are on the way.
 
 Not a template. It's the decisions and workflow an agent follows. For greenfield, that's the frameworks, architecture, infrastructure, and patterns to scaffold, resolved at the latest versions every time. For brownfield, it's the gated build → review → iterate loop applied to whatever repo you're in.
 
@@ -26,13 +26,17 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** (skills: woostack-init, woostack-bootstrap, woostack-build, woostack-review, woostack-address-comments) into your agent's skill directory and records it in `skills-lock.json`. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** (skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-review, woostack-address-comments) into your agent's skill directory and records it in `skills-lock.json`. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 
 ## How it works
 
-Each command is a skill with its own gated procedure. Together they cover the life of a change: scaffold, build, review, iterate. Run a command by name in your agent (e.g. `/woostack-build add password reset`); the agent loads that skill's `SKILL.md` and follows it. **Codex syntax differs:** use `$woostack-build add password reset` or open `/skills` and select the skill. Only `bootstrap` is greenfield-specific. `build`, `review`, and `address-comments` operate on any repo, whether woostack scaffolded it or not.
+Each command is a skill with its own gated procedure. Together they cover the life of a change: load project rules, scaffold, build, review, iterate. Run a command by name in your agent (e.g. `/woostack-build add password reset`); the agent loads that skill's `SKILL.md` and follows it. **Codex syntax differs:** use `$woostack-build add password reset` or open `/skills` and select the skill. Only `bootstrap` is greenfield-specific. `build`, `review`, and `address-comments` operate on any repo, whether woostack scaffolded it or not.
+
+### `using-woostack`: project adoption and command routing
+
+An adoption skill for consumer repositories. Reference it from a project's root `AGENTS.md` when you want agents to load project-local woostack rules before acting, then route `/woostack-*` requests to the matching command skill. It does not initialize `.woostack/`, scaffold code, or mutate the project by itself. → [SKILL.md](skills/using-woostack/SKILL.md)
 
 ### `/woostack-bootstrap <goal>`: scaffold a new monorepo
 

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: using-woostack
+description: Use when starting work in a project that references woostack from its root AGENTS.md, or when deciding whether a woostack skill or command applies before answering, editing, scaffolding, reviewing, or addressing PR feedback.
+---
+
+# using-woostack
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent for a narrow task, follow the dispatch prompt first.
+Use this skill only when the prompt asks you to apply project-level woostack rules.
+</SUBAGENT-STOP>
+
+<EXTREMELY-IMPORTANT>
+When a project root `AGENTS.md` references woostack, treat that file as the project
+authority. Load and follow its woostack rules before taking action.
+
+This skill teaches rule loading and command routing only. It does not initialize,
+scaffold, edit, review, or push anything by itself.
+</EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+Follow instructions in this order:
+
+1. The user's explicit request and the project's root `AGENTS.md`.
+2. The specific woostack skill that applies to the task.
+3. Other installed process or implementation skills.
+4. Default agent behavior.
+
+If `AGENTS.md` and a woostack skill disagree, prefer `AGENTS.md` and state the conflict
+briefly when it matters to the work.
+
+## The Rule
+
+Before answering or acting in a woostack project, check whether a woostack rule or command
+applies. If it does, load the specific woostack skill before proceeding.
+
+Do not summarize the intended workflow from memory when the skill is available. The current
+`SKILL.md` is the source of truth.
+
+## Project Entry Check
+
+At the start of work in a repository:
+
+1. Read the root `AGENTS.md` if it exists.
+2. If it references woostack, follow its woostack section as binding project policy.
+3. Check whether the user's request maps to one of the woostack skills below.
+4. Load the mapped skill before asking clarifying questions, making edits, opening PRs, or
+   posting review feedback.
+
+Do not run `/woostack-init`, create `.woostack/`, scaffold code, or add config unless the
+user explicitly asks for that behavior or the loaded task-specific skill requires it as part
+of an approved workflow.
+
+## Command Routing
+
+| Request | Load |
+|---|---|
+| `/woostack-init [path]`, initialize or repair the `.woostack/` workspace | `woostack-init` |
+| `/woostack-bootstrap <goal>`, scaffold a new web/mobile/API project | `woostack-bootstrap` |
+| `/woostack-build <goal>`, build a feature through the woostack loop | `woostack-build` |
+| `/woostack-review [PR#]`, review a PR or local diff | `woostack-review` |
+| `/woostack-address-comments [PR#]`, address unresolved review threads | `woostack-address-comments` |
+
+If the user asks for the behavior without using the exact command name, route by intent.
+For example, "use woostack to review this PR" means load `woostack-review`.
+
+## Red Flags
+
+These thoughts mean stop and load the relevant rules:
+
+| Thought | Reality |
+|---|---|
+| "I can just make the edit." | In a woostack project, the root `AGENTS.md` may define the required loop. |
+| "The command name is just shorthand." | Woostack commands are skills with gates and constraints. |
+| "I remember the workflow." | The installed skill may have changed. Load it. |
+| "I'll initialize `.woostack/` to be helpful." | This skill is adoption-only; mutate project state only when requested or required by the task skill. |
+| "This is only a review comment." | Review and address flows have posting, validation, and memory rules. |
+
+## AGENTS.md Usage
+
+When a project wants woostack behavior, its root `AGENTS.md` should reference this skill and
+state the local rules the agent must obey. Keep project-specific policy in `AGENTS.md`; keep
+the reusable workflow in the woostack skills.
+
+Minimal pattern:
+
+```markdown
+# AGENTS.md
+
+This project follows woostack. At the start of work, use `using-woostack` to load the
+project rules and route `/woostack-*` requests to the matching woostack skill.
+
+Follow this file first when it conflicts with generic agent defaults.
+```
+
+## Missing Skills
+
+If a mapped woostack skill is not installed, say exactly which skill is missing and ask the
+user whether to install the woostack collection. Do not silently approximate a gated
+workflow unless the user asks you to proceed without the skill.


### PR DESCRIPTION
## Summary
- Add `using-woostack`, an adoption-only skill for loading root `AGENTS.md` woostack rules and routing `/woostack-*` intent to the matching command skill.
- Document that the skill does not initialize `.woostack/`, scaffold code, or mutate project state by itself.
- Update README, AGENTS, and CONTRIBUTING to list the six-skill collection and point contributors to the new file.

## Testing
- `ruby -e 'require "psych"; Dir["skills/*/SKILL.md"].each { |f| s=File.read(f); y=s[/\\A---\\n(.*?)\\n---/m,1] or abort("missing frontmatter: #{f}"); h=Psych.safe_load(y); abort("missing name: #{f}") unless h["name"]; abort("missing description: #{f}") unless h["description"] }; puts "skill frontmatter ok"'`
- Modified Markdown link check for `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, and `skills/using-woostack/SKILL.md`
