### PR TITLE
feat: delegate address analysis

### DIFF
--- a/skills/woostack-address-comments/SKILL.md
+++ b/skills/woostack-address-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-address-comments
-description: Use when addressing the unresolved review threads on a pull request — fix or push back on each finding, reply, resolve, and push. Delegates to the woostack-review address verb; never merges.
+description: Use when addressing the unresolved review threads on a pull request — fix or push back on each finding, reply, resolve, and push. Never merges.
 ---
 
 # woostack-address-comments
@@ -15,35 +15,56 @@ autonomously. After the approved verdicts are applied it replies without perform
 language, resolves, records accept-by-design learnings as scoped memory notes when
 available, pushes, and offers a re-review. **Never merges.**
 
-This is a thin entry point. The engine is the `address` verb of the `woostack-review` skill
-— there is no separate implementation here.
+## Workflow
 
-## Dependency preflight
+When the user invokes `/woostack-address-comments [PR#]`, address the unresolved review
+threads on that PR. If no PR number is given, use the current branch's open PR.
 
-This skill delegates to `woostack-review` (its sibling in the woostack collection). If it
-is not installed, name it and **offer to install the collection inline**
-(`pnpx skills add howarewoo/woostack`), then continue. There is no manual fallback — the
-address engine lives in that skill.
+This flow is **local only** — it commits, pushes, resolves GitHub threads, and may write
+memory. It never merges.
 
-## Procedure
+**Lifecycle (A0→A7):**
 
-1. **Preflight** `woostack-review` as above.
-2. **Invoke** `woostack-review address <PR#>` (or the current branch's open PR when no number
-   is given), passing `--auto` straight through when the user asked for an autonomous run. It
-   fetches unresolved threads into `/tmp/pr-review/address-threads.json`, reads the team's
-   cross-PR memory, and processes every thread per its own rubric — the interactive verdict
-   gate by default, or autonomously under `--auto`. When the repo has a `.woostack/memory/`
-   store, that memory is **scope-routed** to the PR's changed files (composed by the review
-   engine's `recall.sh`), so address applies the same matched conventions and accepted-issue
-   dismissals as review — not the whole dump. Final **ACCEPT** verdicts write back
-   through the same memory system: an individual scoped note under `.woostack/memory/`
-   when that store exists, or a flat `.woostack/memory.md` bullet as the legacy fallback.
-3. **Offer re-review.** When all threads are handled and pushed, offer to run
-   `woostack-review` again. Stop there — do not merge.
+0. **Resolve skill path** — set `WOO_ADDRESS_ACTION_PATH` to the directory containing this
+   `SKILL.md`. All address-comments prompts and scripts live inside this skill directory.
+1. **Prefetch** — resolve the PR# (explicit arg, else the current branch's open PR), then
+   `bash "$WOO_ADDRESS_ACTION_PATH/scripts/prefetch.sh"` writes every unresolved thread
+   (any author) to `$OUTDIR/address-threads.json`, writes changed paths to
+   `$OUTDIR/address-changed-paths.txt`, and composes `$OUTDIR/memory.md`. When the repo has
+   a `.woostack/memory/` store, memory is scope-routed to the PR's changed files via
+   `recall.sh`; otherwise flat `.woostack/memory.md` is used when present.
+2. **Precondition** — the working tree must be clean **and** the current branch must be the
+   PR head. Otherwise abort before any edit; tell the user to checkout the PR head on a
+   clean tree.
+3. **Reception loop (analysis only)** — per thread, follow `prompts/address.md`: read →
+   understand → verify → evaluate → **recommend** `FIX` / `ACCEPT` / `CLARIFY`. The loop
+   makes **no** working-tree edits, **no** replies, **no** resolves, and **no** memory writes;
+   it stages a recommended verdict + reasoning per thread. Hosts with subagent support may
+   fan out independent threads or file groups to fast workers, but workers only return
+   recommendation records and reply/fix drafts. The parent orchestrator validates worker
+   output, fills gaps itself or escalates complex threads, and remains the only actor that
+   owns the verdict gate, edits, commit, push, replies, resolution, and memory writes.
+4. **Verdict gate** — default: the user approves the batch or overrides specific threads
+   before anything is applied; `--auto` skips the gate; a non-interactive host with no
+   `--auto` aborts rather than acting unapproved. The **final** verdict per thread is the
+   override where given, else the recommendation. See `prompts/address.md` § Phase 2 for
+   the gate mechanics.
+5. **Commit + push** — apply all final `FIX` edits to the working tree → one commit
+   referencing the threads → push to the PR head → capture `<sha>` before any reply, so
+   "Fixed in `<sha>`" is real. Never force-push.
+6. **Reply + resolve + memory** — per handled thread, `scripts/resolve-thread.sh` posts the
+   reply then resolves. CLARIFY threads use `RESOLVE=0`: reply only, left open. Only a
+   **final** `ACCEPT` writes memory via `scripts/memory-record.sh`.
+7. **Report** — summary table: thread → recommended → final → action → memory-written?
+
+Only a **final ACCEPT** (accept-by-design — an ACCEPT the user kept in the default flow, or
+one the skill produced itself under `--auto`) writes memory, deduplicated and phrased as a
+reusable pattern — never a log of every fix. When `.woostack/memory/` exists, the write is a
+scoped note and `MEMORY.md` is rebuilt; otherwise the script appends to flat
+`.woostack/memory.md`. Memory is read back as context on the next review run, keeping
+re-reviews quiet.
 
 ## Hard constraints
 
 - **No merge.** Branch protection and the merge decision stay with the user.
-- **No duplicate engine.** All thread-handling logic lives in `woostack-review`; this skill
-  only routes to it.
 - **No performative replies.** Reply with the technical reasoning or the fix itself.

--- a/skills/woostack-address-comments/prompts/address.md
+++ b/skills/woostack-address-comments/prompts/address.md
@@ -16,6 +16,25 @@ autonomous flow).
 For **every** thread, decide a recommended verdict. Make **no** working-tree
 edits, **no** replies, **no** resolves, and **no** memory writes in this phase.
 
+**Optional worker fan-out.** On hosts with subagent support, the parent
+orchestrator may delegate this phase to fast workers, grouped by independent
+thread or by file when several threads touch the same code. Workers are
+recommendation drafters only. They receive the thread data plus relevant code,
+rules, memory, and `$OUTDIR` context; they return structured records to the
+parent and exit.
+
+Each worker returns one record per assigned thread:
+`{ threadId, file, line, finding, recommended, reasoning, learning, memory_scope, reply, fix_plan }`.
+`reply` is the technical reply draft for an ACCEPT or CLARIFY verdict, or an
+empty string for FIX. `fix_plan` is a short description of the needed code edit
+for FIX, or an empty string otherwise. A worker must not edit files, must not commit, must not push, must not reply, must not resolve, must not write memory, and must not spawn more agents.
+
+After workers finish, the parent orchestrator validates that every unresolved
+thread has exactly one recommendation. If a worker fails, returns malformed
+output, or marks a thread as too complex, the parent analyzes that thread itself
+or escalates it to a standard/deep model before the verdict gate. Worker output
+never skips Phase 2 unless the whole run was invoked with `--auto`.
+
 1. **READ** the whole thread — the original finding and every reply.
 2. **UNDERSTAND** — restate the ask in one sentence.
 3. **VERIFY** against the actual codebase — open `file` near `line`; confirm the
@@ -86,13 +105,13 @@ different verdict (any of FIX / ACCEPT / CLARIFY).
    ```bash
    # FIXED thread:
    THREAD_ID="<id>" REPLY_BODY="Fixed in <sha>." \
-     bash "$WOO_REVIEW_ACTION_PATH/scripts/resolve-thread.sh"
+     bash "$WOO_ADDRESS_ACTION_PATH/scripts/resolve-thread.sh"
    # ACCEPTED thread:
    THREAD_ID="<id>" REPLY_BODY="<technical reasoning for accepting as-is>" \
-     bash "$WOO_REVIEW_ACTION_PATH/scripts/resolve-thread.sh"
+     bash "$WOO_ADDRESS_ACTION_PATH/scripts/resolve-thread.sh"
    # CLARIFY thread (reply only, leave open):
    THREAD_ID="<id>" REPLY_BODY="<your specific question>" RESOLVE=0 \
-     bash "$WOO_REVIEW_ACTION_PATH/scripts/resolve-thread.sh"
+     bash "$WOO_ADDRESS_ACTION_PATH/scripts/resolve-thread.sh"
    ```
 
    Then, for each ACCEPTED thread whose learning is genuinely new, write the
@@ -106,7 +125,7 @@ different verdict (any of FIX / ACCEPT / CLARIFY).
    ```bash
    LEARNING="<general pattern>: <why it is accepted / what not to re-flag>" \
    MEMORY_SCOPE="<narrow glob or comma-separated globs>" \
-     bash "$WOO_REVIEW_ACTION_PATH/scripts/memory-record.sh"
+     bash "$WOO_ADDRESS_ACTION_PATH/scripts/memory-record.sh"
    ```
 
 3. Print a summary table: thread → recommended → final → action → memory-written?

--- a/skills/woostack-address-comments/prompts/address.md
+++ b/skills/woostack-address-comments/prompts/address.md
@@ -1,9 +1,9 @@
 # Addressing review threads (the `address` verb)
 
 You are addressing the unresolved review threads on a pull request. The threads
-are in `/tmp/pr-review/address-threads.json` (written by `fetch-threads.sh`),
+are in `$OUTDIR/address-threads.json` (written by `fetch-threads.sh`),
 each: `{ threadId, file, line, diffHunk, comments: [ { author, body } ] }`. The
-team's accepted-design memory is in `/tmp/pr-review/memory.md` (may be absent).
+team's accepted-design memory is in `$OUTDIR/memory.md` (may be absent).
 
 By **default** you run an interactive walk-through: analyze every thread, then
 present a single batched table of *recommended* verdicts for the user to approve
@@ -79,7 +79,7 @@ different verdict (any of FIX / ACCEPT / CLARIFY).
 ## Phase 3 — Act on final verdicts
 
 - **FIX**: edit the working tree. Accumulate all fixes; do NOT commit per thread.
-- **ACCEPT**: this is the issue-#53 step. First check `/tmp/pr-review/memory.md`,
+- **ACCEPT**: this is the issue-#53 step. First check `$OUTDIR/memory.md`,
   the live `.woostack/memory.md`, and `.woostack/memory/MEMORY.md` when present:
   if an existing entry already covers this learning — even phrased differently
   or more broadly — do NOT add a duplicate; widen the existing scoped note or

--- a/skills/woostack-address-comments/scripts/fetch-threads.sh
+++ b/skills/woostack-address-comments/scripts/fetch-threads.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Fetches every UNRESOLVED review thread on a PR (any author) with full comment
 # bodies, the thread GraphQL node-id (for reply + resolve), and the diff hunk.
-# Used by the `woostack-review address <PR#>` verb (local hosts only).
+# Used by `woostack-address-comments` (local hosts only).
 #
 # Inputs (env): GITHUB_REPOSITORY, PR_NUMBER, OUTDIR (default /tmp/pr-review).
 # Output: $OUTDIR/address-threads.json — an array of:
@@ -14,7 +14,7 @@
 # truncation is logged below, never silent.
 set -euo pipefail
 
-# shellcheck source=skills/woostack-review/scripts/resolve-outdir.sh
+# shellcheck source=skills/woostack-address-comments/scripts/resolve-outdir.sh
 source "$(dirname "${BASH_SOURCE[0]}")/resolve-outdir.sh"
 mkdir -p "$OUTDIR"
 PR_NUMBER="${PR_NUMBER:?PR_NUMBER env var required}"

--- a/skills/woostack-address-comments/scripts/memory-append.sh
+++ b/skills/woostack-address-comments/scripts/memory-append.sh
@@ -2,7 +2,7 @@
 # Appends one accept-by-design learning to ./.woostack/memory.md as a bullet,
 # unless a whitespace-normalized identical bullet is already present. Creates
 # the file (and dir) on first write. This is the deterministic safety net under
-# the caller's semantic dedup prompt.
+# the LLM's semantic dedup in the address-comments prompt.
 #
 # Inputs (env):
 #   LEARNING   the pattern-phrased rule (required, non-empty)

--- a/skills/woostack-address-comments/scripts/memory-record.sh
+++ b/skills/woostack-address-comments/scripts/memory-record.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Records one accept-by-design learning.
+# If .woostack/memory/ exists, writes a scoped memory note and rebuilds MEMORY.md.
+# Otherwise falls back to the flat .woostack/memory.md append path.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INIT_SCRIPTS="$(cd "$HERE/../../woostack-init/scripts" 2>/dev/null && pwd || true)"
+
+LEARNING="${LEARNING:?LEARNING env var required}"
+MEMORY_DIR="${MEMORY_DIR:-.woostack/memory}"
+MEMORY_FILE="${MEMORY_FILE:-.woostack/memory.md}"
+MEMORY_SCOPE="${MEMORY_SCOPE:-*}"
+MEMORY_TYPE="${MEMORY_TYPE:-convention}"
+MEMORY_SOURCE="${MEMORY_SOURCE:-${PR_NUMBER:+pr-$PR_NUMBER}}"
+MEMORY_SOURCE="${MEMORY_SOURCE:-address-comments}"
+
+norm() { printf '%s' "$1" | tr -s '[:space:]' ' ' | sed 's/^ *//; s/ *$//'; }
+NEW_NORM="$(norm "$LEARNING")"
+
+if [ -z "$NEW_NORM" ]; then
+  echo "memory-record: empty learning, nothing to write" >&2
+  exit 0
+fi
+
+if [ ! -d "$MEMORY_DIR" ]; then
+  MEMORY_FILE="$MEMORY_FILE" LEARNING="$NEW_NORM" bash "$HERE/memory-append.sh"
+  exit 0
+fi
+
+note_body_of() {
+  awk 'done2{print} /^---$/{c++; if(c==2){done2=1}}' "$1"
+}
+
+shopt -s nullglob
+for f in "$MEMORY_DIR"/*.md; do
+  [ "$(basename "$f")" = "MEMORY.md" ] && continue
+  if [ "$(norm "$(note_body_of "$f")")" = "$NEW_NORM" ]; then
+    echo "memory-record: already present, skipping"
+    exit 0
+  fi
+done
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9][^a-z0-9]*/-/g; s/^-//; s/-$//' \
+    | cut -c1-60 \
+    | sed 's/-$//'
+}
+
+name="${MEMORY_NAME:-$(slugify "$NEW_NORM")}"
+[ -n "$name" ] || name="accepted-review-finding"
+file="$MEMORY_DIR/$name.md"
+if [ -e "$file" ]; then
+  base_name="$name"
+  i=2
+  while [ -e "$MEMORY_DIR/$base_name-$i.md" ]; do i=$((i + 1)); done
+  name="$base_name-$i"
+  file="$MEMORY_DIR/$name.md"
+fi
+
+updated="${WOOSTACK_NOW:-$(date +%F)}"
+cat > "$file" <<EOF
+---
+name: $name
+type: $MEMORY_TYPE
+scope: $MEMORY_SCOPE
+updated: $updated
+source: $MEMORY_SOURCE
+---
+$NEW_NORM
+EOF
+
+if [ -n "$INIT_SCRIPTS" ] && [ -x "$INIT_SCRIPTS/build-index.sh" ]; then
+  bash "$INIT_SCRIPTS/build-index.sh" "$MEMORY_DIR"
+else
+  echo "memory-record: build-index.sh unavailable; wrote note without rebuilding index" >&2
+fi
+
+echo "memory-record: wrote scoped learning to $file"

--- a/skills/woostack-address-comments/scripts/prefetch.sh
+++ b/skills/woostack-address-comments/scripts/prefetch.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Address-comments prefetch: unresolved threads + changed paths + memory context.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+
+# shellcheck source=skills/woostack-address-comments/scripts/resolve-outdir.sh
+source "$HERE/resolve-outdir.sh"
+mkdir -p "$OUTDIR"
+
+PR_NUMBER="${PR_NUMBER:-$(gh pr view --json number --jq .number 2>/dev/null || echo)}"
+PR_NUMBER="${PR_NUMBER:?PR_NUMBER env var required, or run from a branch with an open PR}"
+export PR_NUMBER
+
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo)}"
+export GITHUB_REPOSITORY
+
+bash "$HERE/fetch-threads.sh"
+
+PATHS_FILE="$OUTDIR/address-changed-paths.txt"
+if [ "${WOO_REVIEW_TEST_MODE:-}" = "1" ] && [ -n "${WOO_ADDRESS_FAKE_CHANGED_PATHS:-}" ]; then
+  printf '%s\n' "$WOO_ADDRESS_FAKE_CHANGED_PATHS" > "$PATHS_FILE"
+else
+  gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > "$PATHS_FILE" 2>/dev/null || : > "$PATHS_FILE"
+fi
+
+MEMORY_OUT="$OUTDIR/memory.md"
+rm -f "$MEMORY_OUT"
+if [ -d ".woostack/memory" ] && [ -x "$ROOT/skills/woostack-init/scripts/recall.sh" ]; then
+  bash "$ROOT/skills/woostack-init/scripts/recall.sh" ".woostack" "$PATHS_FILE" > "$MEMORY_OUT" 2>"$OUTDIR/recall.log" || : > "$MEMORY_OUT"
+elif [ -f ".woostack/memory.md" ]; then
+  head -c 102400 ".woostack/memory.md" > "$MEMORY_OUT"
+fi
+
+if [ -f "$MEMORY_OUT" ]; then
+  bytes="$(wc -c < "$MEMORY_OUT" | tr -d ' ')"
+  echo "Composed address memory: ${bytes}B"
+else
+  echo "Composed address memory: none"
+fi
+
+echo "Address prefetch complete: $OUTDIR"

--- a/skills/woostack-address-comments/scripts/resolve-outdir.sh
+++ b/skills/woostack-address-comments/scripts/resolve-outdir.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Single source of truth for the default OUTDIR.
+#
+# Sourced (not executed) by every woostack-review script. Respect an explicit
+# OUTDIR override (host sandbox dirs, the GitHub Action's pin, tests); otherwise
+# derive a per-project path so concurrent reviews of different repos on one
+# machine do not share — and clobber — the same /tmp/pr-review tree.
+#
+# Derivation: hash the git toplevel (stable across subdirs of one repo); fall
+# back to the current directory when not in a git repo. Two distinct repo roots
+# hash to two distinct dirs; the same repo always resolves to the same dir.
+#
+# NOTE: per-project granularity only. Two concurrent runs of the SAME repo still
+# share one dir (rare; accepted). For full per-run isolation, set OUTDIR yourself.
+if [ -z "${OUTDIR:-}" ]; then
+  _wr_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  _wr_hash="$(printf '%s' "$_wr_root" | { sha1sum 2>/dev/null || shasum; } | cut -c1-12)"
+  OUTDIR="/tmp/pr-review-${_wr_hash}"
+  unset _wr_root _wr_hash
+fi
+export OUTDIR

--- a/skills/woostack-address-comments/scripts/resolve-thread.sh
+++ b/skills/woostack-address-comments/scripts/resolve-thread.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Posts a reply to a PR review thread, then (unless RESOLVE=0) resolves it.
-# Used by `woostack-review address` after a thread is FIXED or ACCEPTed. CLARIFY
+# Used by `woostack-address-comments` after a thread is FIXED or ACCEPTed. CLARIFY
 # threads call with RESOLVE=0 (reply only, leave open).
 #
 # Inputs (env):
@@ -22,7 +22,7 @@ RESOLVE="${RESOLVE:-1}"
 TEST_MODE="${WOO_REVIEW_TEST_MODE:-}"
 
 # Refuse fake/dry-run hooks inside GitHub Actions — same guard as the sibling
-# scripts. The address verb is local-only; never let CI silently no-op.
+# scripts. Address-comments is local-only; never let CI silently no-op.
 if [ "$TEST_MODE" = "1" ] && [ "${GITHUB_ACTIONS:-}" = "true" ]; then
   echo "::error::WOO_REVIEW_TEST_MODE refused in GitHub Actions" >&2
   exit 1

--- a/skills/woostack-address-comments/scripts/tests/test-address-comments-ownership.sh
+++ b/skills/woostack-address-comments/scripts/tests/test-address-comments-ownership.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+ADDRESS_SKILL="$ROOT/skills/woostack-address-comments/SKILL.md"
+REVIEW_SKILL="$ROOT/skills/woostack-review/SKILL.md"
+ADDRESS_PROMPT="$ROOT/skills/woostack-address-comments/prompts/address.md"
+ADDRESS_SCRIPTS="$ROOT/skills/woostack-address-comments/scripts"
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! rg -q "$pattern" "$file"; then
+    echo "missing pattern in ${file#$ROOT/}: $pattern" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  if rg -q "$pattern" "$file"; then
+    echo "unexpected pattern in ${file#$ROOT/}: $pattern" >&2
+    exit 1
+  fi
+}
+
+assert_contains "$ADDRESS_SKILL" "## Workflow"
+assert_contains "$ADDRESS_SKILL" "Lifecycle"
+assert_contains "$ADDRESS_SKILL" "WOO_ADDRESS_ACTION_PATH"
+assert_contains "$ADDRESS_PROMPT" "Optional worker fan-out"
+assert_contains "$ADDRESS_PROMPT" "fix_plan"
+
+for script in prefetch.sh fetch-threads.sh resolve-thread.sh memory-record.sh memory-append.sh resolve-outdir.sh; do
+  if [ ! -f "$ADDRESS_SCRIPTS/$script" ]; then
+    echo "missing address-comments script: $script" >&2
+    exit 1
+  fi
+done
+
+assert_not_contains "$ADDRESS_SKILL" "Delegates to the woostack-review address verb"
+assert_not_contains "$ADDRESS_SKILL" "woostack-review address"
+assert_not_contains "$ADDRESS_SKILL" "No duplicate engine"
+assert_not_contains "$ADDRESS_SKILL" "review prefetch"
+assert_not_contains "$REVIEW_SKILL" "woostack-review address"
+assert_not_contains "$REVIEW_SKILL" "Addressing Reviews"

--- a/skills/woostack-address-comments/scripts/tests/test-address-helper-scripts.sh
+++ b/skills/woostack-address-comments/scripts/tests/test-address-helper-scripts.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPTS="$ROOT/skills/woostack-address-comments/scripts"
+
+for script in prefetch.sh fetch-threads.sh resolve-thread.sh memory-record.sh memory-append.sh resolve-outdir.sh; do
+  bash -n "$SCRIPTS/$script"
+done
+
+work="$(mktemp -d)"
+OUTDIR="$work/out" \
+GITHUB_REPOSITORY="owner/repo" \
+PR_NUMBER=123 \
+WOO_REVIEW_TEST_MODE=1 \
+WOO_REVIEW_FAKE_THREADS_JSON='{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"path":"src/a.ts","line":7,"diffHunk":"@@ -1 +1 @@","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"fix this"}]}}]}}}}}' \
+  bash "$SCRIPTS/fetch-threads.sh" >/tmp/address-fetch-threads.out
+
+assert_contains "$(cat /tmp/address-fetch-threads.out)" "Unresolved threads to address: 1" "fetch reports unresolved thread count"
+assert_contains "$(jq -r '.[0].threadId' "$work/out/address-threads.json")" "thread-1" "fetch writes thread id"
+
+mkdir -p "$work/repo/.woostack/memory"
+cat > "$work/repo/.woostack/memory/address-rule.md" <<'NOTE'
+---
+name: address-rule
+type: convention
+scope: src/**
+updated: 2026-06-03
+source: address-comments
+---
+Address-comments scoped memory is loaded before analysis.
+NOTE
+
+pushd "$work/repo" >/dev/null
+OUTDIR="$work/prefetch-out" \
+GITHUB_REPOSITORY="owner/repo" \
+PR_NUMBER=123 \
+WOO_REVIEW_TEST_MODE=1 \
+WOO_ADDRESS_FAKE_CHANGED_PATHS="src/a.ts" \
+WOO_REVIEW_FAKE_THREADS_JSON='{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}' \
+  bash "$SCRIPTS/prefetch.sh" >/tmp/address-prefetch.out
+popd >/dev/null
+
+assert_contains "$(cat /tmp/address-prefetch.out)" "Address prefetch complete" "prefetch reports completion"
+assert_contains "$(cat "$work/prefetch-out/address-changed-paths.txt")" "src/a.ts" "prefetch writes changed paths"
+assert_contains "$(cat "$work/prefetch-out/memory.md")" "Address-comments scoped memory" "prefetch composes scoped memory"
+
+MEMORY_FILE="$work/memory.md" \
+LEARNING="Accepted address-comments pattern: do not re-flag." \
+  bash "$SCRIPTS/memory-append.sh" >/tmp/address-memory-append.out
+assert_contains "$(cat "$work/memory.md")" "Accepted address-comments pattern" "memory append writes learning"
+
+rm -rf "$work"
+finish

--- a/skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh
+++ b/skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+PROMPT="$ROOT/skills/woostack-address-comments/prompts/address.md"
+SKILL="$ROOT/skills/woostack-address-comments/SKILL.md"
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! rg -q "$pattern" "$file"; then
+    echo "missing pattern in ${file#$ROOT/}: $pattern" >&2
+    exit 1
+  fi
+}
+
+assert_contains "$PROMPT" "worker"
+assert_contains "$PROMPT" "reply"
+assert_contains "$PROMPT" "fix_plan"
+assert_contains "$PROMPT" "must not edit files"
+assert_contains "$PROMPT" "must not commit"
+assert_contains "$PROMPT" "must not push"
+assert_contains "$PROMPT" "must not reply"
+assert_contains "$PROMPT" "must not resolve"
+assert_contains "$PROMPT" "must not write memory"
+assert_contains "$SKILL" "fast workers"
+assert_contains "$SKILL" "parent orchestrator"

--- a/skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh
+++ b/skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh
@@ -8,7 +8,7 @@ SKILL="$ROOT/skills/woostack-address-comments/SKILL.md"
 assert_contains() {
   local file="$1"
   local pattern="$2"
-  if ! rg -q "$pattern" "$file"; then
+  if ! rg -F -q "$pattern" "$file"; then
     echo "missing pattern in ${file#$ROOT/}: $pattern" >&2
     exit 1
   fi
@@ -17,11 +17,17 @@ assert_contains() {
 assert_contains "$PROMPT" "worker"
 assert_contains "$PROMPT" "reply"
 assert_contains "$PROMPT" "fix_plan"
+assert_contains "$PROMPT" "\$OUTDIR/address-threads.json"
+assert_contains "$PROMPT" "\$OUTDIR/memory.md"
 assert_contains "$PROMPT" "must not edit files"
 assert_contains "$PROMPT" "must not commit"
 assert_contains "$PROMPT" "must not push"
 assert_contains "$PROMPT" "must not reply"
 assert_contains "$PROMPT" "must not resolve"
 assert_contains "$PROMPT" "must not write memory"
+if rg -q "/tmp/pr-review/(address-threads|memory)\\.md|/tmp/pr-review/address-threads\\.json" "$PROMPT"; then
+  echo "address prompt must use \$OUTDIR for prefetched address artifacts" >&2
+  exit 1
+fi
 assert_contains "$SKILL" "fast workers"
 assert_contains "$SKILL" "parent orchestrator"

--- a/skills/woostack-init/references/memory.md
+++ b/skills/woostack-init/references/memory.md
@@ -158,7 +158,8 @@ Distillation **dedupes against `MEMORY.md` first** (update an existing note rath
 a duplicate) and runs `build-index.sh` + `doctor.sh` afterward. Only cross-feature knowledge
 is distilled — not feature-specific trivia.
 
-The accept-by-design review path uses `woostack-review/scripts/memory-record.sh`: when
+The accept-by-design address-comments path uses
+`woostack-address-comments/scripts/memory-record.sh`: when
 `.woostack/memory/` exists it writes a scoped `convention` note with `source: pr-<n>`
 and rebuilds `MEMORY.md`; when the scoped store is absent it falls back to the flat
 `memory.md` bullet append path. Address-comments should pass the narrowest `scope`

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -21,8 +21,6 @@ This skill is **host-agnostic**: it works in any AI coding agent that supports s
 - `/woostack-review --full` (or `@review --full` in a PR comment) — Force a complete re-review even when a prior SHA marker exists. Skips the incremental path described below.
 - `woostack-review install` — Verify local deps (`gh`, `jq`, `node`) and pre-fetch `impeccable` + `react-doctor` (run once per repo).
 - `woostack-review status` — Show the current PR's review status.
-- `woostack-review address <PR#>` — Walk through the PR's unresolved review threads: the skill recommends a verdict per thread (fix / push back / clarify), then you approve the batch or override specific threads before anything is applied. Local hosts only. See *Addressing Reviews* below.
-- `woostack-review address <PR#> --auto` — Skip the confirmation gate and address autonomously (fix or push back, commit, reply, resolve, and record accept-by-design dismissals to scoped `.woostack/memory/` notes when available, falling back to `.woostack/memory.md`). This is the pre-walk-through behavior, for trusted/non-interactive runs.
 
 ### PR-comment triggers (issue #19)
 
@@ -417,36 +415,6 @@ MEMORY_SCOPE="<narrow glob or comma-separated globs>" \
 ```
 
 Phrase entries as terse patterns, not instances — prefer "Generated `*.pb.go` files are intentional; do not flag their style" over "dismissed line 42 in user.pb.go". One line per entry, no narration. The local skill writes this memory directly — no post-session hook, no permission-isolated job. Only record on an explicit dismissal or a stated gotcha — never auto-record every finding. Do NOT write memory in CI: the GitHub Action's validator job holds `contents: read` and posts the review only; memory is curated locally and by humans editing the files. Memory is read back as review context on the next run (Stage 1) and the validator drops findings it records.
-
-## Addressing Reviews (`woostack-review address <PR#>`, local hosts)
-
-Stage 6 only fires when a finding is dismissed *during a live local run*. For
-PR-targeted reviews the accept/dismiss decision happens **later**, on the PR
-(often in a separate comment-addressing session) — so Stage 6's memory write
-structurally never fires for the primary flow (issue #53). The `address` verb
-closes that gap by owning the comment-addressing flow itself, with the memory
-write at the moment a dismissal is **confirmed** — by the user in the default
-interactive flow, or by the skill itself under `--auto`.
-
-`address` is **local only** — it commits, pushes, and writes memory, none of
-which the GitHub Action's `contents: read` validator job can do.
-
-**Lifecycle (A1→A7):**
-
-1. **Fetch** — resolve the PR# (explicit arg, else the current branch's open PR), then `bash "$WOO_REVIEW_ACTION_PATH/scripts/fetch-threads.sh"` writes every unresolved thread (any author) to `$OUTDIR/address-threads.json`. Memory + config are loaded as in Stage 1.
-2. **Precondition** — the working tree must be clean **and** the current branch must be the PR head. Otherwise abort before any edit; tell the user to checkout the PR head on a clean tree.
-3. **Reception loop (analysis only)** — per thread, follow `prompts/address.md`: read → understand → verify → evaluate → **recommend** `FIX` / `ACCEPT` / `CLARIFY`. The loop makes **no** working-tree edits, **no** replies, **no** resolves, and **no** memory writes; it stages a recommended verdict + reasoning per thread.
-4. **Verdict gate** — default: the user approves the batch or overrides specific threads before anything is applied; `--auto` skips the gate; a non-interactive host with no `--auto` aborts rather than acting unapproved. The **final** verdict per thread is the override where given, else the recommendation. See `prompts/address.md` § Phase 2 for the gate mechanics (table shape, override syntax, host primitives).
-5. **Commit + push** — apply all final `FIX` edits to the working tree → one commit referencing the threads → push to the PR head → capture `<sha>` (before any reply, so "Fixed in `<sha>`" is real). Never force-push.
-6. **Reply + resolve + memory** — per handled thread, `scripts/resolve-thread.sh` posts the reply then resolves (CLARIFY threads use `RESOLVE=0`: reply only, left open). Only a **final** `ACCEPT` writes memory via `scripts/memory-record.sh`.
-7. **Report** — summary table: thread → recommended → final → action → memory-written?
-
-Only a **final ACCEPT** (accept-by-design — an ACCEPT the user kept in the
-default flow, or one the skill produced itself under `--auto`) writes memory,
-deduplicated and phrased as a reusable pattern — never a log of every fix. When
-`.woostack/memory/` exists, the write is a scoped note and `MEMORY.md` is
-rebuilt; otherwise the script appends to flat `.woostack/memory.md`. Memory is
-read back as context on the next review run (Stage 1), keeping re-reviews quiet.
 
 ### Stage 6.5 — Fold per-angle metrics (local hosts, opt-in)
 


### PR DESCRIPTION
## Summary

- Make `woostack-address-comments` the owner of the address-comments workflow, prompt, local prefetch, and helper scripts.
- Remove the public `woostack-review address` command surface and address workflow section from `woostack-review`.
- Add ownership, worker-contract, and helper smoke tests covering thread fetch, changed-path capture, and scoped memory composition.

## Test plan

- [ ] `bash skills/woostack-address-comments/scripts/tests/test-address-comments-ownership.sh && bash skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh && bash skills/woostack-address-comments/scripts/tests/test-address-helper-scripts.sh && bash skills/woostack-review/scripts/tests/test-memory-record.sh && bash skills/woostack-review/scripts/tests/test-intersect-overlap.sh && bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh` (passed: address helper smoke reported 6 passed/0 failed; related review tests reported 11, 10, and 9 passed/0 failed)
- [ ] Review `skills/woostack-address-comments/SKILL.md` and confirm it owns the address-comments lifecycle without cross-referencing `woostack-review address`.
