### PR TITLE
feat: add woostack-visualize skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ pnpm-debug.log*
 
 # woostack: local-only review metrics (config.json and memory.md stay tracked)
 .woostack/metrics.json
+# woostack: disposable HTML renders (regenerated from source)
+.woostack/visuals/
 # Claude Code scheduling runtime lock (generated, not source)
 .claude/scheduled_tasks.lock
 .woostack/memory/

--- a/.woostack/plans/2026-06-03-woostack-visualize-skill.md
+++ b/.woostack/plans/2026-06-03-woostack-visualize-skill.md
@@ -1,0 +1,321 @@
+# woostack-visualize Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `woostack-visualize` skill that reads any source and writes a self-contained, audience-tailored HTML visualization, and wire the existing docs to it.
+
+**Architecture:** A new self-contained skill bundle (`skills/woostack-visualize/`) holding `SKILL.md` (command + four-step procedure + hard constraints) and `references/audiences.md` (three audience presets + free-form rubric). Five existing docs are edited to register and delegate to it. No code, no app build, no CI for this repo — the deliverable is Markdown + agent behavior. Source: [.woostack/specs/2026-06-03-woostack-visualize-skill.md](../specs/2026-06-03-woostack-visualize-skill.md).
+
+**Tech Stack:** Markdown skill files; generated output is self-contained HTML (inline CSS/SVG, offline-viewable). No new dependencies.
+
+**Out of scope (explicit):** Do NOT migrate or touch the two orphan HTML specs in `.woostack/specs/`. Do NOT move or rename any existing `SKILL.md`. Do NOT add app code, lockfiles, or CI workflows.
+
+---
+
+## File Structure
+
+- **Create** `skills/woostack-visualize/SKILL.md` — discovery frontmatter, `/woostack-visualize` command, four-step procedure, hard constraints.
+- **Create** `skills/woostack-visualize/references/audiences.md` — `engineer` / `non-technical` / `investor` profiles + the shared dimension rubric for free-form audiences.
+- **Modify** `.gitignore` — gitignore `.woostack/visuals/` (disposable renders).
+- **Modify** `skills/woostack-build/SKILL.md` — step 2 "visualize on demand" delegates to woostack-visualize.
+- **Modify** `skills/using-woostack/SKILL.md` — add `/woostack-visualize` routing row.
+- **Modify** `AGENTS.md` — "seven" → "eight" shipped skills; add list entry + file-map entry.
+- **Modify** `README.md` — add to install collection list + a "How it works" subsection.
+
+---
+
+## Task 1: Skill bundle (SKILL.md + audiences.md + gitignore)
+
+**Files:**
+- Create: `skills/woostack-visualize/SKILL.md`
+- Create: `skills/woostack-visualize/references/audiences.md`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Write `skills/woostack-visualize/SKILL.md`**
+
+```markdown
+---
+name: woostack-visualize
+description: Use when you want an HTML visualization of any source — a spec, plan, file, directory, or concept — tailored to a target audience (engineer, non-technical, investor, or any free-form reader). Reads the real source and writes one self-contained, offline-viewable HTML file; never the source of truth.
+---
+
+# woostack-visualize
+
+Turn any source into one self-contained HTML visualization, tailored to who will read it.
+The Markdown/code source stays the source of truth; the HTML is a disposable render.
+
+## Command
+
+- `/woostack-visualize <source> [for <audience>]`
+  - `<source>` — a spec/plan path, a file, a glob, a directory, or a free-form subject.
+  - `<audience>` — a preset (`engineer` | `non-technical` | `investor`) or any free-form
+    string ("a security auditor", "a designer"). Defaults to `engineer`.
+  - Examples:
+    - `/woostack-visualize .woostack/specs/2026-06-03-auth.md for an investor`
+    - `/woostack-visualize packages/api for a non-technical PM`
+    - `/woostack-visualize the review swarm architecture`
+
+## Procedure
+
+1. **Resolve input.** Read the actual source. For a file/glob, read the files. For a
+   directory, read enough structure (entry points, key modules, READMEs) to characterize it
+   honestly; state in the visual what you sampled versus read in full. For a free-form
+   subject with no path, build only from what the repo and conversation actually contain.
+   Never invent content. If the source cannot be read, stop and say so — do not render guesses.
+2. **Resolve audience.** A preset loads its profile from
+   [references/audiences.md](references/audiences.md). A free-form audience is interpreted
+   against the same dimension rubric in that file. Default `engineer`.
+3. **Compose bespoke HTML.** Design the layout, section set, and diagrams to fit *this*
+   content and *this* audience, guided by the audience profile — not a fixed template. Emit a
+   single self-contained `.html` file: inline `<style>` always; diagrams as inline SVG or
+   pure CSS; JavaScript only when it adds real value and can be inlined. The file MUST render
+   its core content offline, with no network fetch (no CDN-loaded library). For the
+   engineer-audience spec case, [woostack-build's spec-template.html](../woostack-build/references/spec-template.html)
+   is an available starting point.
+4. **Write and report.** Write to `.woostack/visuals/YYYY-MM-DD-<slug>-<audience>.html`
+   (derive `<slug>` from the source name/subject; kebab-case a free-form audience to a short
+   form). Honor an explicit user-supplied path instead. Print the path and offer to open it
+   — do not open a browser unprompted. If `.woostack/` does not exist, write next to the
+   source or to a user-supplied path and note that `visuals/` is the default once initialized;
+   do not require `/woostack-init`.
+
+## Hard constraints
+
+- **Source of truth is the source.** Generated HTML is a disposable render. Re-render anytime.
+- **Never write into `.woostack/specs/`.** That holds Markdown source only. Renders go to
+  `.woostack/visuals/` (gitignored) or a user path.
+- **Self-contained and offline.** No CDN, no external fetch to render core content. Inline
+  everything. Prefer inline SVG over a network-loaded diagram runtime.
+- **No fabrication.** Visualize only what the source contains. When a metric, timeline, or
+  benchmark is absent, omit it or mark it unknown — never invent one. This binds hardest for
+  the investor audience.
+- **Audience is open.** The three presets are shortcuts, not an allow-list; any free-form
+  audience is valid, interpreted against the rubric.
+- **No browser without consent.** Report the path; open only if the user agrees.
+```
+
+- [ ] **Step 2: Write `skills/woostack-visualize/references/audiences.md`**
+
+```markdown
+# Audience profiles
+
+Each visualization targets one reader. A preset below is a shortcut; any free-form audience
+("a designer", "a security auditor") is valid and is interpreted against the **dimension
+rubric** at the end. Default audience is `engineer`.
+
+## Dimensions
+
+Every profile answers these five questions. Free-form audiences answer them by inference.
+
+- **Surface** — what to show and what to hide.
+- **Depth** — how far down to go (mechanism vs. outcome).
+- **Vocabulary** — technical, plain, or business language.
+- **Visual density** — dense reference vs. spacious headline-driven.
+- **Cares about** — what this reader is actually trying to learn.
+
+## engineer
+
+- **Surface:** data flow, interfaces, components, key decisions, tradeoffs, edge cases,
+  failure modes. Hide marketing framing.
+- **Depth:** full technical depth, down to mechanism and contracts.
+- **Vocabulary:** precise technical terms; name the real types, files, and functions.
+- **Visual density:** dense — diagrams, tables, code/identifier callouts welcome.
+- **Cares about:** how it works, how to build it, how to maintain and extend it safely.
+
+## non-technical
+
+- **Surface:** what it does and why it matters; the user-facing shape. Hide implementation.
+- **Depth:** shallow on mechanism; concrete on outcomes and examples.
+- **Vocabulary:** plain language and analogies; expand or avoid jargon.
+- **Visual density:** moderate, with generous whitespace and clear signposting.
+- **Cares about:** what changes for people, the benefit, the "so what".
+
+## investor
+
+- **Surface:** the problem, the opportunity, scope, milestones, and risk. No code.
+- **Depth:** outcome-level; tie everything to value and feasibility.
+- **Vocabulary:** business language; crisp and confident, never hand-wavy.
+- **Visual density:** low — high-signal, headline-driven, a few strong visuals.
+- **Cares about:** what this is worth, what it costs, what could go wrong.
+- **Guard:** never fabricate numbers, timelines, or traction. Absent data is omitted or
+  labelled unknown — not invented.
+
+## Free-form audiences
+
+When the audience is not a preset, infer the five dimensions from who they are. A "security
+auditor" wants threat surface, trust boundaries, and failure modes at high depth in technical
+vocabulary; a "designer" wants flows, states, and UI surface at moderate depth. State the
+inferred framing briefly at the top of the visual so the reader knows the lens.
+```
+
+- [ ] **Step 3: Add the visuals gitignore line**
+
+Modify `.gitignore`. Under the existing `# woostack:` block (after the `.woostack/metrics.json` line, near the `.woostack/memory/` line), add:
+
+```
+# woostack: disposable HTML renders (regenerated from source)
+.woostack/visuals/
+```
+
+- [ ] **Step 4: Verify structure**
+
+Run:
+```bash
+test -f skills/woostack-visualize/SKILL.md && test -f skills/woostack-visualize/references/audiences.md && echo "files OK"
+head -4 skills/woostack-visualize/SKILL.md          # frontmatter: name + description present
+grep -n "woostack/visuals" .gitignore               # gitignore line present
+git ls-files skills/ | grep -c SKILL.md              # still 7 tracked SKILL.md (new one untracked yet)
+```
+Expected: `files OK`; frontmatter shows `name: woostack-visualize`; gitignore line printed; existing SKILL.md count unchanged (no renames).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/woostack-visualize/SKILL.md skills/woostack-visualize/references/audiences.md .gitignore
+git commit -m "feat: add woostack-visualize skill bundle"
+```
+
+---
+
+## Task 2: Wire existing docs to the new skill
+
+**Files:**
+- Modify: `skills/woostack-build/SKILL.md` (step 2 delegation)
+- Modify: `skills/using-woostack/SKILL.md` (routing row)
+- Modify: `AGENTS.md` (count + list + file map)
+- Modify: `README.md` (install list + How it works)
+
+- [ ] **Step 1: Delegate woostack-build's render-on-demand to the new skill**
+
+In `skills/woostack-build/SKILL.md`, in Procedure step 2 ("Write the spec as markdown"), the
+"Visualize on demand" sentence currently points directly at `references/spec-template.html`.
+Replace it so it delegates to woostack-visualize while keeping the template as the engineer
+starting point:
+
+Old (the trailing sentence of step 2):
+> **Visualize on demand** — if a rich view is wanted, render the markdown through [references/spec-template.html](references/spec-template.html); the HTML is a presentation target only, never the authored source.
+
+New:
+> **Visualize on demand** — if a rich view is wanted, hand the markdown to [`woostack-visualize`](../woostack-visualize/SKILL.md) (audience `engineer` for specs; it uses [references/spec-template.html](references/spec-template.html) as a starting point). The HTML is a presentation target only, never the authored source.
+
+- [ ] **Step 2: Add the routing row in using-woostack**
+
+In `skills/using-woostack/SKILL.md`, in the Command Routing table, add a row (keep table
+alignment with the existing rows):
+
+```
+| `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |
+```
+
+- [ ] **Step 3: Update AGENTS.md count, list, and file map**
+
+In `AGENTS.md`:
+- Change "The seven shipped skills are:" → "The eight shipped skills are:".
+- Add to that bulleted list, after the `woostack-review` entry:
+  ```
+  - [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
+  ```
+- In "Quick file map", add an entry after the Review engine line:
+  ```
+  - Visualization engine (audience-tailored HTML renders):
+    [`skills/woostack-visualize/`](skills/woostack-visualize/SKILL.md)
+  ```
+
+- [ ] **Step 4: Update README.md**
+
+In `README.md`:
+- In the Install section, the parenthetical skills list currently reads
+  `(skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-commit, woostack-review, woostack-address-comments)`.
+  Add `, woostack-visualize` to the end of that list.
+- In "How it works", add a subsection after the `/woostack-address-comments` one and before "Growing scope":
+  ```markdown
+  ### `/woostack-visualize <source> [for <audience>]`: audience-tailored HTML render
+
+  Reads any source — a markdown spec or plan, a file, a directory, or a described concept — and
+  writes one self-contained HTML visualization tailored to who will read it: an engineer, a
+  non-technical stakeholder, an investor, or any free-form audience you name. The markdown/code
+  source stays the source of truth; the HTML is a disposable render under `.woostack/visuals/`
+  (gitignored, regenerated on demand). It never fabricates data and renders offline with no
+  external dependencies. `woostack-build` delegates its spec render to this skill. → [SKILL.md](skills/woostack-visualize/SKILL.md)
+  ```
+
+- [ ] **Step 5: Verify cross-links and count**
+
+Run:
+```bash
+grep -n "eight shipped skills" AGENTS.md
+grep -n "woostack-visualize" AGENTS.md README.md skills/using-woostack/SKILL.md skills/woostack-build/SKILL.md
+grep -c "woostack-visualize" README.md          # >=2 (install list + how-it-works)
+```
+Expected: AGENTS.md says "eight"; each file references `woostack-visualize`; README hit count ≥ 2. Manually confirm no broken relative paths (each links to an existing file).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/woostack-build/SKILL.md skills/using-woostack/SKILL.md AGENTS.md README.md
+git commit -m "docs: register woostack-visualize and delegate spec render to it"
+```
+
+---
+
+## Task 3: End-to-end render exercise (proves the skill works)
+
+**Files:**
+- Output (gitignored, not committed): `.woostack/visuals/*.html`
+
+- [ ] **Step 1: Render this spec for all three presets**
+
+Following `skills/woostack-visualize/SKILL.md`, render
+`.woostack/specs/2026-06-03-woostack-visualize-skill.md` three times:
+- `for engineer` → `.woostack/visuals/2026-06-03-woostack-visualize-skill-engineer.html`
+- `for non-technical` → `...-non-technical.html`
+- `for investor` → `...-investor.html`
+
+- [ ] **Step 2: Verify self-contained + offline + differentiation**
+
+Run:
+```bash
+ls .woostack/visuals/
+# No external network refs in any render:
+grep -rliE "https?://[^\"']*(cdn|unpkg|jsdelivr|googleapis|mermaid)" .woostack/visuals/ && echo "FAIL: external dep found" || echo "offline OK"
+```
+Then inspect each file:
+- engineer view carries technical depth (data flow, file/identifier names, tradeoffs);
+- non-technical view carries no jargon (plain language, no code);
+- investor view carries no code and **no fabricated numbers/timelines** (the spec has none, so the render must not invent any);
+- each opens standalone in a browser with no network.
+
+Expected: `offline OK`; three differentiated files; investor file fabricates nothing.
+
+- [ ] **Step 3: Confirm renders are gitignored**
+
+Run:
+```bash
+git status --porcelain .woostack/visuals/   # expect NO output (ignored)
+git check-ignore .woostack/visuals/2026-06-03-woostack-visualize-skill-engineer.html  # prints the path => ignored
+```
+Expected: status shows nothing under `visuals/`; `check-ignore` prints the path.
+
+- [ ] **Step 4: No commit**
+
+Renders are disposable and gitignored — nothing to commit. Task 3 is verification only.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §4 step 1 (resolve input) → Task 1 SKILL.md Procedure 1. ✓
+- Spec §4 step 2 + audience presets/free-form → Task 1 SKILL.md Procedure 2 + audiences.md. ✓
+- Spec §4 step 3 (bespoke, self-contained, offline) → Task 1 SKILL.md Procedure 3 + hard constraints; verified Task 3 Step 2. ✓
+- Spec §4 step 4 + output location/slug/audience-in-name → Task 1 Procedure 4; verified Task 3. ✓
+- Spec §5 new files → Task 1. ✓
+- Spec §5 integration edits (build, using-woostack, AGENTS, README, gitignore) → Task 1 Step 3 (gitignore) + Task 2. ✓
+- Spec §6 error handling (unreadable source, dir sampling, no-fabrication, no `.woostack/`) → SKILL.md Procedure 1/4 + hard constraints. ✓
+- Spec §7 testing (frontmatter, cross-links, behavioral, no-fabrication, delegation) → Task 1 Step 4, Task 2 Step 5, Task 3. ✓
+- Spec §3 non-goals (don't move SKILL.md, no app/CI, don't replace template) → respected; Task 1 Step 4 asserts no SKILL.md renames. ✓
+- Orphan HTML specs → explicitly out of scope, untouched. ✓
+
+**Placeholder scan:** No TBD/TODO; both new files have full content; doc edits give exact old→new anchor text. ✓
+
+**Type consistency:** Filename scheme `YYYY-MM-DD-<slug>-<audience>.html` used consistently across SKILL.md, spec, and Task 3. Output dir `.woostack/visuals/` consistent everywhere. ✓

--- a/.woostack/specs/2026-06-03-woostack-visualize-skill.md
+++ b/.woostack/specs/2026-06-03-woostack-visualize-skill.md
@@ -1,0 +1,111 @@
+---
+name: woostack-visualize-skill
+type: spec
+status: draft
+date: 2026-06-03
+branch: feature/woostack-visualize
+links:
+---
+
+# woostack-visualize Skill — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+## 1. Problem
+
+woostack writes specs and plans as markdown (the source of truth) and offers a render-on-demand HTML view. But that render path is a single fixed asset — `skills/woostack-build/references/spec-template.html` — with eight hard-coded sections (Problem, Goal, Non-goals, …). It serves exactly one shape of content (a design spec) for exactly one reader (an engineer).
+
+There is no general way to turn *anything* — a spec, a plan, a module, a directory, a concept — into a visual, and no way to tailor that visual to *who is reading it*. A non-technical stakeholder, an investor, and an implementing engineer each need a different cut of the same source: different depth, different vocabulary, different things surfaced and hidden, different visual density. Today an agent would have to hand-build that HTML each time with no shared contract.
+
+## 2. Goal
+
+Ship a new woostack skill, `woostack-visualize`, that reads any source and writes one self-contained HTML file whose content, depth, vocabulary, and visual density are tailored to a stated **target audience**.
+
+The design must:
+
+- accept varied input: a spec/plan path, an arbitrary file or glob, a directory, or a free-form subject description;
+- accept a target audience as either a named preset (`engineer` | `non-technical` | `investor`) or a free-form audience string;
+- produce a **bespoke** single HTML file — layout, sections, and diagrams composed to fit the specific content and audience, not slotted into a fixed template;
+- produce HTML that is **viewable offline** by opening the file: inline CSS always, diagrams as inline SVG/CSS, no network fetch required to render core content;
+- never fabricate data — visualize only what the source contains;
+- let `woostack-build`'s "visualize on demand" step delegate to this skill instead of carrying its own render logic;
+- add no new runtime dependency (pure agent + filesystem; host-agnostic).
+
+## 3. Non-goals
+
+- Not a documentation generator. Markdown specs/plans remain the authored source of truth; generated HTML is disposable presentation.
+- Does not delete or replace `spec-template.html`. That file remains a built-in starting point for the engineer-audience spec case.
+- No build step, framework, bundler, or server. No new application code, app lockfile, or CI workflow for this repository.
+- Does not add a `requires.bins` dependency. Viewing needs only a browser.
+- Does not auto-open a browser without the user agreeing, and does not publish or upload the visual anywhere.
+- Does not invent metrics, numbers, timelines, or claims absent from the source (especially relevant for the investor audience).
+
+## 4. Approach
+
+Add a self-contained skill bundle `skills/woostack-visualize/` with a `SKILL.md` and one reference file, and wire four existing docs to it.
+
+The skill procedure is four steps:
+
+1. **Resolve input.** Accept a path (spec/plan/file/dir), a glob, or a free-form subject. The agent reads the actual source files; it never invents content. For a directory, the agent reads enough structure (entry points, key modules, READMEs) to characterize it honestly, and states in the visual what it sampled when it could not read everything.
+2. **Resolve audience.** Parse the audience from the invocation. A named preset (`engineer` | `non-technical` | `investor`) loads its profile from `references/audiences.md`. A free-form audience string (e.g. "a security auditor", "a designer") is interpreted by the agent against the same rubric dimensions. Default to `engineer` when no audience is given.
+3. **Compose bespoke HTML.** The agent designs the layout, section set, and diagrams to fit *this* content and *this* audience — guided by the audience profile, not a fixed template. Output is a single self-contained `.html` file: inline `<style>` always; diagrams as inline SVG or pure-CSS; JavaScript only when it adds real value and can be inlined; nothing that requires a network fetch to render the core content. For the engineer-audience spec case, `spec-template.html` is an available starting point.
+4. **Write and report.** Write to the resolved output path, print it, and offer to open it. Do not open a browser unprompted.
+
+The audience profiles live in `references/audiences.md`, one block per preset plus the shared dimension rubric that also governs free-form audiences. Each profile defines: **surface** (what to show / hide), **depth**, **vocabulary**, **visual density**, and **what this reader cares about**. Sketch:
+
+- **engineer** — surface data flow, interfaces, components, tradeoffs, edge cases; full technical depth; precise technical vocabulary; dense; cares about how it works and how to build/maintain it.
+- **non-technical** — surface what it does and why it matters; shallow on mechanism; plain language and analogies, no jargon; moderate density with generous whitespace; cares about outcomes and impact, not implementation.
+- **investor** — surface the problem, the opportunity, scope, milestones, and risk; outcome-level depth; business vocabulary; high-signal, low-density, headline-driven; cares about what this is worth and what could go wrong. No code. No fabricated numbers.
+
+## 5. Components & data flow
+
+New files:
+
+- `skills/woostack-visualize/SKILL.md` — frontmatter (`name`, `description`), the `/woostack-visualize` command, the four-step procedure, and hard constraints (self-contained/offline, no fabrication, HTML-is-disposable, no unprompted browser open).
+- `skills/woostack-visualize/references/audiences.md` — the three audience profiles and the shared dimension rubric used for free-form audiences.
+
+Command surface:
+
+- `/woostack-visualize <source> [for <audience>]` — e.g. `/woostack-visualize .woostack/specs/2026-06-03-woostack-visualize-skill.md for an investor`. Source defaults to the most recent spec/plan only when context makes it unambiguous; otherwise the skill asks. Audience defaults to `engineer`.
+
+Output location:
+
+- Default `.woostack/visuals/YYYY-MM-DD-<slug>-<audience>.html`. The audience is part of the filename so the three cuts of one source sit side by side instead of overwriting each other (free-form audiences are kebab-cased to a short form). The user may override the path. Generated HTML is treated as disposable (re-render anytime from source) and is gitignored, mirroring `.woostack/metrics.json`. A user may deliberately `git add -f` a visual to share it.
+- **Generated HTML never lands in `.woostack/specs/`.** That directory holds Markdown source only. Authoring a spec as HTML (or letting a render settle into `specs/`) is the exact anti-pattern this skill removes: the markdown is the source, the HTML is a disposable render under `visuals/`.
+
+Data flow: source files → agent reads → audience profile (preset file or free-form interpretation) → composed self-contained HTML → written to output path → path reported to user.
+
+Integration edits (cross-link, do not duplicate):
+
+- `skills/woostack-build/SKILL.md` step 2 — the "visualize on demand" sentence delegates to `woostack-visualize` (spec → `engineer` preset; `spec-template.html` as starting point) instead of describing its own render.
+- `skills/using-woostack/SKILL.md` — add a `/woostack-visualize` row to the Command Routing table.
+- `AGENTS.md` — update "seven shipped skills" → eight; add `woostack-visualize` to the skill list and the Quick file map.
+- `README.md` — add `woostack-visualize` to the install collection list and a short "How it works" subsection.
+- `.gitignore` — add `.woostack/visuals/` under the woostack section.
+
+## 6. Error handling
+
+- **Unreadable / missing source.** If the source path does not exist or cannot be read, stop and report it; do not emit a visual built on guesses.
+- **Directory too large to fully read.** Sample honestly (entry points, key modules, structure), and state in the visual what was sampled versus exhaustively read. Never present a partial read as complete.
+- **Unknown audience string.** Any free-form audience is valid — interpreted against the rubric. There is no error path for "unrecognized audience"; the presets are shortcuts, not an allow-list.
+- **No fabrication guard.** When a desired element (a metric, a timeline, a benchmark) is not in the source, the agent omits it or marks it explicitly as unknown — it never invents one. This is a hard constraint, called out for the investor audience where the temptation is highest.
+- **Output path collision.** If the target file exists, overwrite is fine (visuals are disposable, regenerated from source) — but confirm before overwriting a path the user supplied explicitly and that the skill did not create.
+- **`.woostack/` absent (consumer repo not initialized).** The skill still works — write next to the source or to a user-supplied path, and note that `.woostack/visuals/` is the default once initialized. Do not require `/woostack-init`.
+
+## 7. Testing
+
+This skill is Markdown + agent behavior; there is no script to unit-test and **no app build or CI workflow is added for this repository**. Verification is by inspection and exercise:
+
+- **Frontmatter / structure check.** `SKILL.md` has a valid `name`/`description` and does not move or rename any of the existing seven `SKILL.md` files.
+- **Cross-link integrity.** Every doc edit (build, using-woostack, AGENTS.md, README.md) links to the new skill; the AGENTS.md count reads "eight"; no dangling relative links.
+- **Behavioral exercise.** Render this very spec for each of the three audiences and confirm: each output is a single self-contained file that opens offline (no network), the engineer view carries technical depth, the investor view carries no code and no fabricated numbers, and the non-technical view carries no jargon.
+- **No-fabrication exercise.** Render a source that lacks metrics for the investor audience and confirm the output does not invent any.
+- **Delegation exercise.** Confirm `woostack-build` step 2 now points at `woostack-visualize` and that following it produces an engineer-audience spec render.
+
+## 8. Open questions
+
+No blocking open questions. Resolved defaults:
+
+- Generated visuals are gitignored and disposable (re-render from source); a user may force-add one to share. Mirrors `.woostack/metrics.json`.
+- HTML is fully self-contained and offline-viewable: inline SVG/CSS preferred over any CDN-loaded library (e.g. inline SVG over a network-loaded mermaid runtime).
+- `spec-template.html` stays in place as the engineer-spec starting point rather than moving into this skill, to avoid a disruptive cross-link churn; `woostack-build` and `woostack-visualize` both reference it by relative path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `npx skills add howarewoo/woostack`.
 
-The seven shipped skills are:
+The eight shipped skills are:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -22,6 +22,7 @@ The seven shipped skills are:
 - [`woostack-commit`](skills/woostack-commit/SKILL.md)
 - [`woostack-review`](skills/woostack-review/SKILL.md)
 - [`woostack-address-comments`](skills/woostack-address-comments/SKILL.md)
+- [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
 
 There is no application source code, app lockfile, build, or CI for this repo's own
 push/PR events. `skills-lock.json` is the dev-skill manifest and is currently empty.
@@ -40,8 +41,8 @@ docs, HTML templates, review scripts, prompts, or JSON config. Keep edits in ski
 do not add application code, app build configs, or app lockfiles.
 
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
-`/woostack-bootstrap`, `/woostack-build`, `/woostack-commit`, `/woostack-review`, or
-`/woostack-address-comments`, including intent-equivalent wording. Load the matching skill
+`/woostack-bootstrap`, `/woostack-build`, `/woostack-commit`, `/woostack-review`,
+`/woostack-address-comments`, or `/woostack-visualize`, including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
 directory, not in this repo.
 
@@ -63,7 +64,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the seven `SKILL.md` files.
+- Do not move or rename any of the eight `SKILL.md` files.
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
   updating every cross-link and the bootstrap skill table.
@@ -82,6 +83,8 @@ directory, not in this repo.
   [`skills/woostack-commit/SKILL.md`](skills/woostack-commit/SKILL.md)
 - Review engine:
   [`skills/woostack-review/`](skills/woostack-review/)
+- Visualization engine (audience-tailored HTML renders):
+  [`skills/woostack-visualize/SKILL.md`](skills/woostack-visualize/SKILL.md)
 - Address-comments delegator:
   [`skills/woostack-address-comments/SKILL.md`](skills/woostack-address-comments/SKILL.md)
 - Init workspace and memory contract:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Walks every unresolved review thread on a PR, recommends a verdict per thread (f
 
 ### `/woostack-visualize <source> [for <audience>]`: audience-tailored HTML render
 
-Reads any source — a markdown spec or plan, a file, a directory, or a described concept — and writes one self-contained HTML visualization tailored to who will read it: an engineer, a non-technical stakeholder, an investor, or any free-form audience you name. The markdown/code source stays the source of truth; the HTML is a disposable render under `.woostack/visuals/` (gitignored, regenerated on demand). It never fabricates data and renders offline with no external dependencies. `woostack-build` delegates its spec render to this skill. → [SKILL.md](skills/woostack-visualize/SKILL.md)
+A discovery command for rendering source material as an audience-tailored HTML view while keeping the source authoritative. → [SKILL.md](skills/woostack-visualize/SKILL.md)
 
 ### Growing scope
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** (skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-commit, woostack-review, woostack-address-comments) into your agent's skill directory and records it in `skills-lock.json`. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** (skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-commit, woostack-review, woostack-address-comments, woostack-visualize) into your agent's skill directory and records it in `skills-lock.json`. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 
@@ -72,6 +72,10 @@ Commits only the changes relevant to the current session, creates a `feature/*` 
 ### `/woostack-address-comments [PR#]`: work the review threads
 
 Walks every unresolved review thread on a PR, recommends a verdict per thread (fix / push back / clarify), then, once you approve the batch, applies fixes, replies, resolves, and pushes. Accept-by-design dismissals are recorded to `.woostack/memory.md` so future reviews don't re-raise them. Never merges. A thin delegator to the review skill's `address` verb. → [SKILL.md](skills/woostack-address-comments/SKILL.md)
+
+### `/woostack-visualize <source> [for <audience>]`: audience-tailored HTML render
+
+Reads any source — a markdown spec or plan, a file, a directory, or a described concept — and writes one self-contained HTML visualization tailored to who will read it: an engineer, a non-technical stakeholder, an investor, or any free-form audience you name. The markdown/code source stays the source of truth; the HTML is a disposable render under `.woostack/visuals/` (gitignored, regenerated on demand). It never fabricates data and renders offline with no external dependencies. `woostack-build` delegates its spec render to this skill. → [SKILL.md](skills/woostack-visualize/SKILL.md)
 
 ### Growing scope
 

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -62,6 +62,7 @@ of an approved workflow.
 | `/woostack-commit`, commit session-relevant changes and update PR fields | `woostack-commit` |
 | `/woostack-review [PR#]`, review a PR or local diff | `woostack-review` |
 | `/woostack-address-comments [PR#]`, address unresolved review threads | `woostack-address-comments` |
+| `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |
 
 If the user asks for the behavior without using the exact command name, route by intent.
 For example, "use woostack to review this PR" means load `woostack-review`.

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -37,9 +37,10 @@ continue. If the user declines, fall back to following the skill's principle man
    [references/spec-template.md](references/spec-template.md). Markdown specs are the source
    of truth: they carry `type: spec` frontmatter, are Obsidian vault nodes that can `[[link]]`
    memory notes, and are excluded from memory recall routing by type. **Visualize on demand** —
-   if a rich view is wanted, render the markdown through
-   [references/spec-template.html](references/spec-template.html); the HTML is a presentation
-   target only, never the authored source.
+   if a rich view is wanted, hand the markdown to
+   [`woostack-visualize`](../woostack-visualize/SKILL.md) (audience `engineer` for specs; it
+   uses [references/spec-template.html](references/spec-template.html) as a starting point).
+   The HTML is a presentation target only, never the authored source.
 3. **Harden it.** Invoke `grill-me` against the spec. Amend the spec in place until
    grilling stops producing new questions.
 4. **Plan.** Invoke `superpowers:writing-plans`, saving the plan as **markdown** to

--- a/skills/woostack-visualize/SKILL.md
+++ b/skills/woostack-visualize/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: woostack-visualize
+description: Use when you want an HTML visualization of any source — a spec, plan, file, directory, or concept — tailored to a target audience (engineer, non-technical, investor, or any free-form reader). Reads the real source and writes one self-contained, offline-viewable HTML file; never the source of truth.
+---
+
+# woostack-visualize
+
+Turn any source into one self-contained HTML visualization, tailored to who will read it.
+The Markdown/code source stays the source of truth; the HTML is a disposable render.
+
+## Command
+
+- `/woostack-visualize <source> [for <audience>]`
+  - `<source>` — a spec/plan path, a file, a glob, a directory, or a free-form subject.
+  - `<audience>` — a preset (`engineer` | `non-technical` | `investor`) or any free-form
+    string ("a security auditor", "a designer"). Defaults to `engineer`.
+  - Examples:
+    - `/woostack-visualize .woostack/specs/2026-06-03-auth.md for an investor`
+    - `/woostack-visualize packages/api for a non-technical PM`
+    - `/woostack-visualize the review swarm architecture`
+
+## Procedure
+
+1. **Resolve input.** Read the actual source. For a file/glob, read the files. For a
+   directory, read enough structure (entry points, key modules, READMEs) to characterize it
+   honestly; state in the visual what you sampled versus read in full. For a free-form
+   subject with no path, build only from what the repo and conversation actually contain.
+   Never invent content. If the source cannot be read, stop and say so — do not render guesses.
+2. **Resolve audience.** A preset loads its profile from
+   [references/audiences.md](references/audiences.md). A free-form audience is interpreted
+   against the same dimension rubric in that file. Default `engineer`.
+3. **Compose bespoke HTML.** Design the layout, section set, and diagrams to fit *this*
+   content and *this* audience, guided by the audience profile — not a fixed template. Emit a
+   single self-contained `.html` file: inline `<style>` always; diagrams as inline SVG or
+   pure CSS; JavaScript only when it adds real value and can be inlined. The file MUST render
+   its core content offline, with no network fetch (no CDN-loaded library). For the
+   engineer-audience spec case, [woostack-build's spec-template.html](../woostack-build/references/spec-template.html)
+   is an available starting point.
+4. **Write and report.** Write to `.woostack/visuals/YYYY-MM-DD-<slug>-<audience>.html`
+   (derive `<slug>` from the source name/subject; kebab-case a free-form audience to a short
+   form). Honor an explicit user-supplied path instead. Print the path and offer to open it
+   — do not open a browser unprompted. If `.woostack/` does not exist, write next to the
+   source or to a user-supplied path and note that `visuals/` is the default once initialized;
+   do not require `/woostack-init`.
+
+## Hard constraints
+
+- **Source of truth is the source.** Generated HTML is a disposable render. Re-render anytime.
+- **Never write into `.woostack/specs/`.** That holds Markdown source only. Renders go to
+  `.woostack/visuals/` (gitignored) or a user path.
+- **Self-contained and offline.** No CDN, no external fetch to render core content. Inline
+  everything. Prefer inline SVG over a network-loaded diagram runtime.
+- **No fabrication.** Visualize only what the source contains. When a metric, timeline, or
+  benchmark is absent, omit it or mark it unknown — never invent one. This binds hardest for
+  the investor audience.
+- **Audience is open.** The three presets are shortcuts, not an allow-list; any free-form
+  audience is valid, interpreted against the rubric.
+- **No browser without consent.** Report the path; open only if the user agrees.

--- a/skills/woostack-visualize/references/audiences.md
+++ b/skills/woostack-visualize/references/audiences.md
@@ -1,0 +1,49 @@
+# Audience profiles
+
+Each visualization targets one reader. A preset below is a shortcut; any free-form audience
+("a designer", "a security auditor") is valid and is interpreted against the **dimension
+rubric** at the end. Default audience is `engineer`.
+
+## Dimensions
+
+Every profile answers these five questions. Free-form audiences answer them by inference.
+
+- **Surface** — what to show and what to hide.
+- **Depth** — how far down to go (mechanism vs. outcome).
+- **Vocabulary** — technical, plain, or business language.
+- **Visual density** — dense reference vs. spacious headline-driven.
+- **Cares about** — what this reader is actually trying to learn.
+
+## engineer
+
+- **Surface:** data flow, interfaces, components, key decisions, tradeoffs, edge cases,
+  failure modes. Hide marketing framing.
+- **Depth:** full technical depth, down to mechanism and contracts.
+- **Vocabulary:** precise technical terms; name the real types, files, and functions.
+- **Visual density:** dense — diagrams, tables, code/identifier callouts welcome.
+- **Cares about:** how it works, how to build it, how to maintain and extend it safely.
+
+## non-technical
+
+- **Surface:** what it does and why it matters; the user-facing shape. Hide implementation.
+- **Depth:** shallow on mechanism; concrete on outcomes and examples.
+- **Vocabulary:** plain language and analogies; expand or avoid jargon.
+- **Visual density:** moderate, with generous whitespace and clear signposting.
+- **Cares about:** what changes for people, the benefit, the "so what".
+
+## investor
+
+- **Surface:** the problem, the opportunity, scope, milestones, and risk. No code.
+- **Depth:** outcome-level; tie everything to value and feasibility.
+- **Vocabulary:** business language; crisp and confident, never hand-wavy.
+- **Visual density:** low — high-signal, headline-driven, a few strong visuals.
+- **Cares about:** what this is worth, what it costs, what could go wrong.
+- **Guard:** never fabricate numbers, timelines, or traction. Absent data is omitted or
+  labelled unknown — not invented.
+
+## Free-form audiences
+
+When the audience is not a preset, infer the five dimensions from who they are. A "security
+auditor" wants threat surface, trust boundaries, and failure modes at high depth in technical
+vocabulary; a "designer" wants flows, states, and UI surface at moderate depth. State the
+inferred framing briefly at the top of the visual so the reader knows the lens.


### PR DESCRIPTION
## Summary

Adds an eighth woostack skill, `woostack-visualize`: reads any source (spec, plan, file, glob, directory, or free-form subject) and writes one self-contained, offline-viewable HTML visualization tailored to a target audience.

- **General engine.** `woostack-build`'s "visualize on demand" step now delegates here (audience `engineer` for specs); `spec-template.html` stays as the engineer-spec starting point.
- **Audience model.** Named presets (`engineer` | `non-technical` | `investor`) in `references/audiences.md` plus any free-form audience, interpreted against a shared 5-dimension rubric (surface / depth / vocabulary / density / cares-about).
- **Bespoke output.** Layout, sections, and diagrams are composed per request; single self-contained file (inline CSS/SVG), renders offline with no CDN/network. Output → `.woostack/visuals/YYYY-MM-DD-<slug>-<audience>.html` (gitignored, disposable; audience in filename so cuts don't overwrite).
- **Hard constraints.** Source stays source of truth; never writes into `.woostack/specs/`; no fabricated data (binds hardest for investor); no browser without consent.

### Files
- New: `skills/woostack-visualize/SKILL.md`, `skills/woostack-visualize/references/audiences.md`
- Wired: `woostack-build` delegation, `using-woostack` routing row, `AGENTS.md` (seven→eight), `README.md`, `.gitignore` (`.woostack/visuals/`)
- Artifacts: spec + plan under `.woostack/`

Out of scope: the two pre-existing orphan HTML specs are left untouched.

## Test plan

- [x] Structure: new `SKILL.md` has valid `name`/`description`; no existing `SKILL.md` moved/renamed (7 tracked unchanged).
- [x] Cross-links: `AGENTS.md` reads "eight"; build/using-woostack/README/AGENTS all reference the skill; link targets exist; no stale "seven".
- [x] End-to-end render: rendered this PR's own spec for all three audiences.
  - [x] Zero external/network refs in any render (offline OK).
  - [x] Differentiated: engineer = dense + SVG data-flow + real paths; non-technical = plain language, no code; investor = headline-driven, no code, **no fabricated numbers** (spec has none).
  - [x] Renders are gitignored (`git status` clean, `git check-ignore` confirms).

No app build / CI added for this repo (skill collection, per AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)