### PR TITLE
feat: add woostack-ideate skill

### DIFF
--- a/.woostack/plans/2026-06-03-woostack-ideate-skill.md
+++ b/.woostack/plans/2026-06-03-woostack-ideate-skill.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Markdown skill files only. No code, no app build, no CI for this repo.
 
-**Out of scope (explicit):** Do NOT touch `superpowers:writing-plans` / `superpowers:executing-plans` wiring. Do NOT add a `using-woostack` routing row or grow the "eight shipped skills" command surface. Do NOT port the superpowers browser companion. Do NOT move/rename any existing `SKILL.md`. Do NOT add app code, lockfiles, or CI.
+**Out of scope (explicit):** Do NOT touch `superpowers:writing-plans` / `superpowers:executing-plans` wiring. Do NOT add a `using-woostack` routing row or grow the eight-skill public command/adoption surface. Do NOT port the superpowers browser companion. Do NOT move/rename any existing `SKILL.md`. Do NOT add app code, lockfiles, or CI.
 
 ---
 
@@ -16,7 +16,7 @@
 
 - **Create** `skills/woostack-ideate/SKILL.md` — scoped discovery frontmatter, HARD GATE, process (explore → visualize-on-demand → clarify → approaches → present design), pure-design terminal state, hard constraints.
 - **Modify** `skills/woostack-build/SKILL.md` — frontmatter `description`, Overview, dependency preflight, step 1.
-- **Modify** `AGENTS.md` — internal-sub-skill note after the skills list; Quick file map entry; protect it from deletion (action.yml-style); keep "eight shipped skills".
+- **Modify** `AGENTS.md` — internal-sub-skill note after the public skill list; Quick file map entry; protect it from deletion (action.yml-style); keep the public command/adoption surface at eight skills.
 - **Modify** `README.md` — build-loop prose names `woostack-ideate` for the ideate phase (superpowers for plans/execution). Install command list stays eight.
 - **Modify** `CONTRIBUTING.md` — add a "where to edit the ideate phase" row.
 
@@ -46,7 +46,7 @@
 
 **Files:** Modify `AGENTS.md`
 
-- [ ] **Step 1: Sub-skill note.** After the eight-skill list, add a sentence: woostack-build delegates its ideate phase to the bundled internal `woostack-ideate` sub-skill — a building block, not a ninth `/woostack-*` command. Keep "eight shipped skills" as the command surface.
+- [ ] **Step 1: Sub-skill note.** After the eight-skill public surface list, add a sentence: woostack-build delegates its ideate phase to the bundled internal `woostack-ideate` sub-skill — a building block, not a ninth `/woostack-*` command. Keep the public command/adoption surface at eight skills.
 - [ ] **Step 2: Protect from deletion.** In the constraints/notes, treat `skills/woostack-ideate/SKILL.md` like `action.yml`: a shipped internal asset, not a stray to be deleted.
 - [ ] **Step 3: Quick file map.** Add an entry pointing to `skills/woostack-ideate/SKILL.md` (ideate phase engine for the build loop).
 
@@ -54,7 +54,7 @@
 
 **Files:** Modify `README.md`, `CONTRIBUTING.md`
 
-- [ ] **Step 1: README build-loop prose.** Change "sequences proven sub-skills (superpowers brainstorming/writing-plans/executing-plans + grill-me)" to credit `woostack-ideate` for the ideate phase and superpowers for writing-plans/executing-plans. Include `approve spec` between `grill` and `plan`. Leave the Install command list at eight.
+- [ ] **Step 1: README build-loop prose.** Change "sequences proven sub-skills (superpowers brainstorming/writing-plans/executing-plans + grill-me)" to credit `woostack-ideate` for the ideate phase and superpowers for writing-plans/executing-plans. Include `approve spec` between `grill` and `plan`. Make the Install section distinguish the eight public command/adoption skills from the installed internal sub-skill.
 - [ ] **Step 2: CONTRIBUTING row.** Add a table row: "Change the ideate phase → `skills/woostack-ideate/SKILL.md`" near the existing build-loop row.
 - [ ] **Step 3: Bootstrap development reference.** Update `skills/woostack-bootstrap/references/development.md` so the shipped loop summary says `ideate → markdown spec → grill → approve spec → plan → execute`.
 
@@ -63,5 +63,5 @@
 - [ ] **Step 1: Grep.** No `superpowers:brainstorming` / "superpowers brainstorming" reference remains in shipped docs (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `skills/**/SKILL.md`). `.woostack/` history files left as-is.
 - [ ] **Step 2: Frontmatter + gate.** New `SKILL.md` has valid `name`/`description` and the HARD GATE block.
 - [ ] **Step 3: Cross-links.** woostack-build ↔ woostack-ideate links resolve; woostack-visualize pointer resolves; AGENTS file-map link resolves.
-- [ ] **Step 4: Count.** `AGENTS.md` still says "eight shipped skills" and the list has eight entries.
+- [ ] **Step 4: Count.** `AGENTS.md` still presents an eight-skill public command/adoption surface, and documents `woostack-ideate` as an installed internal sub-skill.
 - [ ] **Step 5: Build-flow summaries.** Shipped summaries (`README.md`, `CONTRIBUTING.md`, `skills/woostack-bootstrap/references/development.md`, and `skills/woostack-build/SKILL.md`) all include the required `approve spec` gate before planning.

--- a/.woostack/plans/2026-06-03-woostack-ideate-skill.md
+++ b/.woostack/plans/2026-06-03-woostack-ideate-skill.md
@@ -1,0 +1,67 @@
+# woostack-ideate Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a woostack-native `woostack-ideate` skill that drives idea → approved design and stops there, then rewire `woostack-build` step 1 + preflight to use it instead of `superpowers:brainstorming`.
+
+**Architecture:** One new self-contained skill file (`skills/woostack-ideate/SKILL.md`) — no references dir needed. It keeps superpowers' load-bearing parts (HARD GATE, one-question-at-a-time, 2-3 approaches, design-for-isolation, scope decomposition) and truncates the tail: no spec write, no `writing-plans` chain. Visual treatment defers to `woostack-visualize` instead of a bespoke browser companion. Four existing docs are edited to rewire and document it as an internal building block (not a ninth command). Source: [.woostack/specs/2026-06-03-woostack-ideate-skill.md](../specs/2026-06-03-woostack-ideate-skill.md).
+
+**Tech Stack:** Markdown skill files only. No code, no app build, no CI for this repo.
+
+**Out of scope (explicit):** Do NOT touch `superpowers:writing-plans` / `superpowers:executing-plans` wiring. Do NOT add a `using-woostack` routing row or grow the "eight shipped skills" command surface. Do NOT port the superpowers browser companion. Do NOT move/rename any existing `SKILL.md`. Do NOT add app code, lockfiles, or CI.
+
+---
+
+## File Structure
+
+- **Create** `skills/woostack-ideate/SKILL.md` — scoped discovery frontmatter, HARD GATE, process (explore → visualize-on-demand → clarify → approaches → present design), pure-design terminal state, hard constraints.
+- **Modify** `skills/woostack-build/SKILL.md` — frontmatter `description`, Overview, dependency preflight, step 1.
+- **Modify** `AGENTS.md` — internal-sub-skill note after the skills list; Quick file map entry; protect it from deletion (action.yml-style); keep "eight shipped skills".
+- **Modify** `README.md` — build-loop prose names `woostack-ideate` for the ideate phase (superpowers for plans/execution). Install command list stays eight.
+- **Modify** `CONTRIBUTING.md` — add a "where to edit the ideate phase" row.
+
+---
+
+## Task 1: Create `skills/woostack-ideate/SKILL.md`
+
+**Files:** Create `skills/woostack-ideate/SKILL.md`
+
+- [ ] **Step 1: Frontmatter.** `name: woostack-ideate`. `description` scoped to the woostack build loop's design phase — recognizable as woostack-build's ideate step and usable standalone, but NOT a generic "before any creative work" trigger that would shadow other skills. Mention it stops at an approved design and writes nothing.
+- [ ] **Step 2: HARD GATE block.** State as an explicit block element: no implementation action — no code, no scaffold, no downstream skill, no spec write — until a design is presented and the user approves. Include the "too simple to need a design" anti-pattern note.
+- [ ] **Step 3: Process section.** Explore project context → offer `woostack-visualize` only for genuinely visual questions (one-line pointer, not a consent server) → clarifying questions one at a time, multiple-choice preferred → propose 2-3 approaches with a recommendation → present design in sections scaled to complexity, approval per section. Include scope-decomposition guidance (flag multi-subsystem asks; decompose before refining) and design-for-isolation guidance (small units, clear interfaces).
+- [ ] **Step 4: Terminal state.** Explicit: the skill ends at an approved design and hands it back to the caller. It does NOT write a spec file and does NOT invoke `writing-plans`. Name the caller's next step (woostack-build step 2 writes the markdown spec); when run standalone, tell the user the design is ready to capture as a spec.
+- [ ] **Step 5: Hard constraints + key principles.** YAGNI, one-question-at-a-time, 2-3 approaches, incremental validation; the "writes no files / chains no skill" rule; visual treatment via woostack-visualize.
+
+## Task 2: Rewire `skills/woostack-build/SKILL.md`
+
+**Files:** Modify `skills/woostack-build/SKILL.md`
+
+- [ ] **Step 1: Frontmatter `description`.** Change "Chains superpowers (brainstorming, writing-plans, executing-plans) and grill-me" so brainstorming is no longer attributed to superpowers (e.g. "Chains woostack-ideate, superpowers writing-plans/executing-plans, and grill-me").
+- [ ] **Step 2: Overview chain + prose.** Rename the chain diagram's first node to `ideate` (the phase label is now "ideate"); ensure no prose claims the ideate phase is superpowers'.
+- [ ] **Step 3: Dependency preflight.** Remove `superpowers:brainstorming` from the external-skill bullet. Keep `superpowers:writing-plans`, `superpowers:executing-plans`, `grill-me`. Optionally note `woostack-ideate` ships in the collection (internal, no install).
+- [ ] **Step 4: Procedure step 1.** "Invoke `superpowers:brainstorming`" → "Invoke `woostack-ideate`", linking `../woostack-ideate/SKILL.md`. Preserve "let it run its own approval gate"; note it hands back an approved design (no spec write, no plan chain).
+- [ ] **Step 5: Spec-approval gate.** Preserve the required gate after hardening: present the written spec, get explicit user approval, then proceed to planning. Reflect `approve spec` in the overview chain and hard constraints.
+
+## Task 3: Document the internal sub-skill in `AGENTS.md`
+
+**Files:** Modify `AGENTS.md`
+
+- [ ] **Step 1: Sub-skill note.** After the eight-skill list, add a sentence: woostack-build delegates its ideate phase to the bundled internal `woostack-ideate` sub-skill — a building block, not a ninth `/woostack-*` command. Keep "eight shipped skills" as the command surface.
+- [ ] **Step 2: Protect from deletion.** In the constraints/notes, treat `skills/woostack-ideate/SKILL.md` like `action.yml`: a shipped internal asset, not a stray to be deleted.
+- [ ] **Step 3: Quick file map.** Add an entry pointing to `skills/woostack-ideate/SKILL.md` (ideate phase engine for the build loop).
+
+## Task 4: Update `README.md` + `CONTRIBUTING.md`
+
+**Files:** Modify `README.md`, `CONTRIBUTING.md`
+
+- [ ] **Step 1: README build-loop prose.** Change "sequences proven sub-skills (superpowers brainstorming/writing-plans/executing-plans + grill-me)" to credit `woostack-ideate` for the ideate phase and superpowers for writing-plans/executing-plans. Include `approve spec` between `grill` and `plan`. Leave the Install command list at eight.
+- [ ] **Step 2: CONTRIBUTING row.** Add a table row: "Change the ideate phase → `skills/woostack-ideate/SKILL.md`" near the existing build-loop row.
+- [ ] **Step 3: Bootstrap development reference.** Update `skills/woostack-bootstrap/references/development.md` so the shipped loop summary says `ideate → markdown spec → grill → approve spec → plan → execute`.
+
+## Task 5: Verify
+
+- [ ] **Step 1: Grep.** No `superpowers:brainstorming` / "superpowers brainstorming" reference remains in shipped docs (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `skills/**/SKILL.md`). `.woostack/` history files left as-is.
+- [ ] **Step 2: Frontmatter + gate.** New `SKILL.md` has valid `name`/`description` and the HARD GATE block.
+- [ ] **Step 3: Cross-links.** woostack-build ↔ woostack-ideate links resolve; woostack-visualize pointer resolves; AGENTS file-map link resolves.
+- [ ] **Step 4: Count.** `AGENTS.md` still says "eight shipped skills" and the list has eight entries.
+- [ ] **Step 5: Build-flow summaries.** Shipped summaries (`README.md`, `CONTRIBUTING.md`, `skills/woostack-bootstrap/references/development.md`, and `skills/woostack-build/SKILL.md`) all include the required `approve spec` gate before planning.

--- a/.woostack/specs/2026-06-03-woostack-ideate-skill.md
+++ b/.woostack/specs/2026-06-03-woostack-ideate-skill.md
@@ -1,0 +1,149 @@
+---
+name: woostack-ideate-skill
+type: spec
+status: ready
+date: 2026-06-03
+branch: feature/woostack-ideate
+links:
+---
+
+# woostack-ideate: a woostack-native ideation skill — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+## 1. Problem
+
+`woostack-build` step 1 invokes `superpowers:brainstorming` to converge on a design.
+That dependency is a poor fit for the woostack loop in three concrete ways:
+
+1. **Wrong terminal state.** superpowers brainstorming does not stop at an approved
+   design — it *also* writes the spec doc to its own default `docs/superpowers/specs/`
+   and then chains `writing-plans`. woostack-build already owns spec-writing (its step 2,
+   to `.woostack/specs/`) and plan-writing (its step 4). The superpowers brainstorming
+   skill's tail fights woostack-build for ownership: wrong path, premature plan, double-write.
+2. **Wrong visual companion.** superpowers ships a bespoke browser companion server for
+   visual brainstorming. woostack already has a first-class visualization skill,
+   `woostack-visualize`, that produces self-contained offline HTML. Carrying a second,
+   redundant visual mechanism is waste.
+3. **External dependency for a core loop step.** The first phase of the flagship build
+   loop is delegated to a third-party skill the consumer must install separately. The
+   preflight has to detect it, offer to install it, and degrade gracefully when absent.
+
+We want to own the ideation behavior so the build loop's first phase fits woostack
+conventions and carries no external dependency.
+
+## 2. Goal
+
+Ship `skills/woostack-ideate/SKILL.md`: a woostack-native ideation skill that
+drives idea → approved design and **stops there**, handing the approved design back to its
+caller. Rewire `woostack-build` step 1 (and its dependency preflight) to use it instead of
+`superpowers:brainstorming`. Keep the superpowers parts that earn their place — the HARD
+GATE, one-question-at-a-time, propose-2-3-approaches, design-for-isolation, scope
+decomposition — and drop the parts that conflict with woostack-build's ownership.
+
+## 3. Non-goals
+
+- **Not a new command.** `woostack-ideate` is an internal building block bundled in the
+  collection, like [`action.yml`](../../action.yml) — not a ninth `/woostack-*` command. No
+  `using-woostack` routing row; the shipped command surface stays at eight.
+- **No spec writing, no plan chaining.** The skill writes no files and invokes no downstream
+  skill. woostack-build keeps owning the `.woostack/specs/` write (step 2) and the
+  `writing-plans` chain (step 4).
+- **No replacement of `writing-plans` / `executing-plans`.** This change touches only the
+  ideate phase. Those superpowers skills remain woostack-build dependencies.
+- **No bespoke browser companion.** Visual treatment defers to `woostack-visualize`. We do
+  not port or reinvent the superpowers companion server.
+- **No behavior change to the other seven skills** beyond the small doc edits listed in §5.
+
+## 4. Approach
+
+Author one self-contained `SKILL.md`. It mirrors the proven superpowers structure but
+truncates the tail at "approved design":
+
+- **Frontmatter `description`** scoped so it is recognized as woostack-build's ideate
+  phase, not a general-purpose creative-work trigger that would shadow other skills.
+- **HARD GATE** preserved verbatim in spirit: no implementation action — no code, no
+  scaffold, no downstream skill — until a design is presented and the user approves.
+- **Process**: explore project context → (optional) offer `woostack-visualize` for
+  genuinely visual questions → clarifying questions one at a time → propose 2-3 approaches
+  with a recommendation → present design in sections scaled to complexity, approval per
+  section → scope-decomposition guidance for oversized requests → design-for-isolation
+  guidance.
+- **Terminal state = approved design, handed back.** Explicitly: the skill does NOT write a
+  spec file and does NOT invoke `writing-plans`. It names its caller's next step
+  (woostack-build step 2) so the handoff is legible, and when run standalone it tells the
+  user the design is ready to capture as a spec.
+- **Visual companion** section replaced by a short pointer to `woostack-visualize` (audience
+  chosen to fit the question), replacing the superpowers browser-server consent flow.
+
+### Wiring `woostack-build`
+
+- **Dependency preflight**: drop `superpowers:brainstorming` from the external-skill list.
+  `woostack-ideate` ships in the same collection, so it is a bundled internal sub-skill,
+  not an external install. Keep `superpowers:writing-plans`, `superpowers:executing-plans`,
+  and `grill-me` in the preflight.
+- **Step 1**: invoke `woostack-ideate` instead of `superpowers:brainstorming`. The step
+  still "lets it run its own approval gate"; the difference is the skill now hands back an
+  approved design rather than writing a spec and chaining a plan.
+- **Restore the spec-approval gate (step 3).** `superpowers:brainstorming` owned a "user
+  reviews the written spec" gate. Pulling spec-writing into woostack-build step 2 — and making
+  `woostack-ideate` stop at *design* approval — orphans that gate. woostack-build must host
+  it: after hardening (step 3), **always present the written spec and get explicit user
+  approval before planning**. Two distinct hard gates now exist: design approval
+  (`woostack-ideate`) and spec approval (woostack-build). Relocating an inherited gate is
+  not adding one, so "inherit gates, add none" still holds.
+
+## 5. Components & data flow
+
+Edit set (one PR-sized increment):
+
+| File | Change |
+|---|---|
+| `skills/woostack-ideate/SKILL.md` | **NEW** — the skill (≈120-160 lines). |
+| `skills/woostack-build/SKILL.md` | Preflight: drop `superpowers:brainstorming`. Step 1: invoke `woostack-ideate`. Overview line + `description` frontmatter: ideation is now woostack's own (writing-plans/executing-plans still superpowers). **Step 3: restore the spec-approval hard gate** (present spec, get explicit approval before planning); reflect both gates in the Overview + Hard constraints. |
+| `AGENTS.md` | Note that woostack-build delegates its ideate phase to the bundled internal `woostack-ideate` sub-skill (not a ninth command); add to the Quick file map; protect it from deletion the way `action.yml` is protected ("shipped asset, not a stray"). Keep "eight shipped skills". |
+| `README.md` | Build-loop prose: "sequences proven sub-skills (superpowers brainstorming/writing-plans/executing-plans + grill-me)" → name `woostack-ideate` for the ideate phase, superpowers for the other two, and show `approve spec` before planning. Install list (command surface) stays eight. |
+| `CONTRIBUTING.md` | Add a "where to edit the ideate phase" row → `skills/woostack-ideate/SKILL.md`; keep the build-loop summary's `approve spec` gate visible. |
+| `skills/woostack-bootstrap/references/development.md` | Update the shipped development-loop summary to `ideate → markdown spec → grill → approve spec → plan → execute`. |
+
+Data flow at runtime: woostack-build → loads `woostack-ideate` → interactive
+design loop with the user → approved design returned to woostack-build → woostack-build
+step 2 writes the markdown spec. No file is produced by the ideate skill itself.
+
+## 6. Error handling
+
+- **Skill missing at runtime.** Because it ships in the collection, absence means a broken
+  install. woostack-build's preflight no longer lists it as installable; if the file is
+  genuinely missing, woostack-build falls back to following the ideation principle
+  manually and says so (same degraded-run contract the preflight already states for other
+  deps).
+- **Description over-trigger.** Risk: an ideation `description` broad enough to hijack
+  unrelated creative-work requests. Mitigation: scope the description to the woostack build
+  loop's design phase, not generic "before any creative work".
+- **Gate bypass.** The HARD GATE is the load-bearing safety property; it is stated as an
+  explicit block element so it is not lost to summarization.
+
+## 7. Testing
+
+No app/test harness in this repo (it is a skills collection). Verification is by inspection:
+
+- `woostack-build` no longer references `superpowers:brainstorming`; preflight + step 1 name
+  `woostack-ideate`.
+- Repo-wide grep: no remaining `superpowers:brainstorming` / "superpowers brainstorming"
+  reference in shipped docs (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, skill files);
+  `.woostack/plans/` and `.woostack/specs/` history entries are left as-is.
+- New `SKILL.md` has valid frontmatter (`name`, `description`) and the HARD GATE.
+- Cross-links resolve (woostack-build ↔ woostack-ideate, woostack-visualize pointer).
+- `eight shipped skills` count in `AGENTS.md` remains accurate (woostack-ideate is internal).
+
+## 8. Open questions
+
+Resolved during the grill pass:
+
+- **Naming** → `woostack-ideate` (verb-family, matches build/commit/review/init/visualize).
+- **Internal sub-skill description** → keep a *scoped* `description` so the skill is
+  invocable by name (woostack-build calls it directly) and usable standalone, but narrow
+  enough that it does not auto-trigger on generic creative work or shadow other skills. It is
+  deliberately absent from the `using-woostack` routing table and the README command list.
+- **README Install list** → stays at the eight command skills; woostack-ideate is
+  documented as an internal building block in `AGENTS.md`, not advertised as a command.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ The eight shipped skills are:
 - [`woostack-address-comments`](skills/woostack-address-comments/SKILL.md)
 - [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
 
+`woostack-build` delegates its ideate phase to a ninth, internal sub-skill,
+[`woostack-ideate`](skills/woostack-ideate/SKILL.md). It is a bundled building block,
+not a `/woostack-*` command: it has no routing row and is absent from the eight-skill command
+surface above. Like [`action.yml`](action.yml), it is a shipped asset — do not delete it as a
+stray.
+
 There is no application source code, app lockfile, build, or CI for this repo's own
 push/PR events. `skills-lock.json` is the dev-skill manifest and is currently empty.
 
@@ -64,7 +70,8 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the eight `SKILL.md` files.
+- Do not move or rename any of the nine `SKILL.md` files (the eight shipped skills plus the
+  internal `woostack-ideate`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
   updating every cross-link and the bootstrap skill table.
@@ -79,6 +86,8 @@ directory, not in this repo.
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/)
 - Build loop:
   [`skills/woostack-build/SKILL.md`](skills/woostack-build/SKILL.md)
+- Ideate phase engine for the build loop (internal sub-skill):
+  [`skills/woostack-ideate/SKILL.md`](skills/woostack-ideate/SKILL.md)
 - Commit and PR update flow:
   [`skills/woostack-commit/SKILL.md`](skills/woostack-commit/SKILL.md)
 - Review engine:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `npx skills add howarewoo/woostack`.
 
-The eight shipped skills are:
+The public command/adoption surface has eight skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -24,11 +24,11 @@ The eight shipped skills are:
 - [`woostack-address-comments`](skills/woostack-address-comments/SKILL.md)
 - [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
 
-`woostack-build` delegates its ideate phase to a ninth, internal sub-skill,
-[`woostack-ideate`](skills/woostack-ideate/SKILL.md). It is a bundled building block,
-not a `/woostack-*` command: it has no routing row and is absent from the eight-skill command
-surface above. Like [`action.yml`](action.yml), it is a shipped asset — do not delete it as a
-stray.
+The collection also installs a ninth, internal sub-skill:
+[`woostack-ideate`](skills/woostack-ideate/SKILL.md). `woostack-build` delegates its ideate
+phase to it. It is a bundled building block, not a `/woostack-*` command: it has no routing row
+and is absent from the eight-skill command surface above. Like [`action.yml`](action.yml), it is
+a shipped asset — do not delete it as a stray.
 
 There is no application source code, app lockfile, build, or CI for this repo's own
 push/PR events. `skills-lock.json` is the dev-skill manifest and is currently empty.
@@ -70,8 +70,8 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the nine `SKILL.md` files (the eight shipped skills plus the
-  internal `woostack-ideate`).
+- Do not move or rename any of the nine `SKILL.md` files (the eight public command/adoption
+  skills plus the internal `woostack-ideate`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
   updating every cross-link and the bootstrap skill table.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The seven skills are `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-commit`, `woostack-review`, and `woostack-address-comments`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, and `woostack-visualize`. The collection also ships `woostack-ideate` as an internal sub-skill used by `woostack-build`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Update the branching model | `skills/woostack-bootstrap/references/development.md` |
 | Refine the bootstrap procedure | `skills/woostack-bootstrap/references/bootstrap.md` |
 | Change the bootstrap skill entry / discovery description | `skills/woostack-bootstrap/SKILL.md` |
-| Change the build loop (brainstorm→spec→grill→plan→execute) | `skills/woostack-build/SKILL.md` |
+| Change the build loop (ideate→spec→grill→approve spec→plan→execute) | `skills/woostack-build/SKILL.md` |
+| Change the ideate phase (the build loop's first step) | `skills/woostack-ideate/SKILL.md` |
 | Change the commit / PR update workflow | `skills/woostack-commit/SKILL.md` |
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |
 | Change the address-comments delegator | `skills/woostack-address-comments/SKILL.md` |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A fixed, gated chain that drives one feature from idea to implementation:
 ideate → markdown spec → grill → approve spec → plan → execute (TDD) → offer PR
 ```
 
-It sequences woostack's own ideate phase (`woostack-ideate`) with proven sub-skills (superpowers writing-plans/executing-plans + grill-me) and inherits their approval gates rather than adding its own. The written spec must be explicitly approved after grilling and before planning. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work is steered toward reviewable PRs (soft target ≤500 LOC), one increment per cycle. It ends by *offering* a PR. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+It sequences woostack's own ideate phase (`woostack-ideate`) with proven sub-skills (superpowers writing-plans/executing-plans + grill-me), inheriting the ideate design gate and hosting the relocated spec-approval gate before planning. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work is steered toward reviewable PRs (soft target ≤500 LOC), one increment per cycle. It ends by *offering* a PR. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
 
 ### `/woostack-review [PR#]`: parallel review swarm
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Walks you through the [decision catalog](skills/woostack-bootstrap/references/de
 A fixed, gated chain that drives one feature from idea to implementation:
 
 ```
-brainstorm → markdown spec → grill → plan → execute (TDD) → offer PR
+ideate → markdown spec → grill → approve spec → plan → execute (TDD) → offer PR
 ```
 
-It sequences proven sub-skills (superpowers brainstorming/writing-plans/executing-plans + grill-me) and inherits their approval gates rather than adding its own. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work is steered toward reviewable PRs (soft target ≤500 LOC), one increment per cycle. It ends by *offering* a PR. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+It sequences woostack's own ideate phase (`woostack-ideate`) with proven sub-skills (superpowers writing-plans/executing-plans + grill-me) and inherits their approval gates rather than adding its own. The written spec must be explicitly approved after grilling and before planning. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work is steered toward reviewable PRs (soft target ≤500 LOC), one increment per cycle. It ends by *offering* a PR. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
 
 ### `/woostack-review [PR#]`: parallel review swarm
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** (skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-commit, woostack-review, woostack-address-comments, woostack-visualize) into your agent's skill directory and records it in `skills-lock.json`. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is eight skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-commit, woostack-review, woostack-address-comments, and woostack-visualize. The collection also installs `woostack-ideate`, an internal sub-skill used by `woostack-build`; it is not a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 

--- a/skills/woostack-bootstrap/SKILL.md
+++ b/skills/woostack-bootstrap/SKILL.md
@@ -64,7 +64,7 @@ Defaults are overridable per project — record any deviation in the project's o
 | [references/frameworks.md](references/frameworks.md) | Recommended frameworks per layer, catalog protocol, **known gotchas** |
 | [references/infrastructure.md](references/infrastructure.md) | Hosting, CI/CD, env, observability, auth, data layer |
 | [references/patterns.md](references/patterns.md) | oRPC contracts, TanStack Query, RSC, navigation, TDD, feature exposure |
-| [references/development.md](references/development.md) | Dev loop (brainstorm → merge) and branching model |
+| [references/development.md](references/development.md) | Dev loop (ideate → approve spec → merge) and branching model |
 
 ## Hard constraints
 

--- a/skills/woostack-bootstrap/references/development.md
+++ b/skills/woostack-bootstrap/references/development.md
@@ -9,13 +9,13 @@ for each phase:
 
 | Phase | Skill |
 |---|---|
-| Brainstorm → spec (HTML) → grill → plan → execute | `woostack-build` |
+| Ideate → markdown spec → grill → approve spec → plan → execute | `woostack-build` |
 | Review | `woostack-review` |
 | Address review feedback | `woostack-address-comments` |
 
 Each command is discrete and ends by offering the next step. Merge stays with the human.
 
-Artifacts live under `.woostack/` in the project: HTML specs in `.woostack/specs/`,
+Artifacts live under `.woostack/` in the project: markdown specs in `.woostack/specs/`,
 markdown plans in `.woostack/plans/`, review config/memory in `.woostack/config.json`
 and `.woostack/memory.md` (`.woostack/metrics.json` is gitignored).
 

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-build
-description: Use when building a feature with the full woostack development loop — brainstorm a design, harden it, plan it, and implement it. Chains superpowers (brainstorming, writing-plans, executing-plans) and grill-me in a fixed, gated order; writes markdown specs and plans under .woostack/.
+description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, and implement it. Chains woostack-ideate, superpowers writing-plans/executing-plans, and grill-me in a fixed, gated order; writes markdown specs and plans under .woostack/.
 ---
 
 # woostack-build
@@ -12,14 +12,22 @@ glue: it sequences proven sub-skills and **inherits their gates** — it adds no
 its own. The value is the order and the handoffs.
 
 ```
-brainstorming → write spec (markdown) → grill-me → writing-plans → executing-plans → distill memory → ask: open PR?
+ideate → write spec (markdown) → grill-me → approve spec → writing-plans → executing-plans → distill memory → ask: open PR?
 ```
+
+Two of those gates are hard stops where the user must say yes before the chain advances:
+**design approval** (owned by `woostack-ideate`, step 1) and **spec approval** (step 3).
+The spec-approval gate is the "user reviews the written spec" step that
+`superpowers:brainstorming` used to own; because woostack-build relocated the spec write into
+its own step 2, the gate lives here now. Relocating an inherited gate is not adding one.
 
 ## Dependency preflight
 
-This skill chains external skills. At the start, check that each is installed:
+The ideate phase uses [`woostack-ideate`](../woostack-ideate/SKILL.md), which
+ships in this collection — no install needed. The plan, execution, and hardening phases chain
+external skills. At the start, check that each is installed:
 
-- `superpowers:brainstorming`, `superpowers:writing-plans`, `superpowers:executing-plans`
+- `superpowers:writing-plans`, `superpowers:executing-plans`
 - `grill-me`
 
 For any that are missing: name exactly what's missing and **offer to install it inline**
@@ -29,8 +37,10 @@ continue. If the user declines, fall back to following the skill's principle man
 
 ## Procedure
 
-1. **Brainstorm.** Invoke `superpowers:brainstorming` to explore the problem and converge
-   on a design. Let it run its own approval gate.
+1. **Ideate.** Invoke [`woostack-ideate`](../woostack-ideate/SKILL.md) to explore
+   the problem and converge on a design. Let it run its own approval gate. It hands back an
+   approved design and stops there — it writes no spec and chains no plan, so the next steps
+   are yours to drive.
 2. **Write the spec as markdown.** When the design is approved, do **not** write to the
    superpowers default `docs/superpowers/specs/`. Instead author a markdown spec to
    `.woostack/specs/YYYY-MM-DD-<slug>.md`, populating
@@ -41,9 +51,14 @@ continue. If the user declines, fall back to following the skill's principle man
    [`woostack-visualize`](../woostack-visualize/SKILL.md) (audience `engineer` for specs; it
    uses [references/spec-template.html](references/spec-template.html) as a starting point).
    The HTML is a presentation target only, never the authored source.
-3. **Harden it.** Invoke `grill-me` against the spec. Amend the spec in place until
-   grilling stops producing new questions.
-4. **Plan.** Invoke `superpowers:writing-plans`, saving the plan as **markdown** to
+3. **Harden it, then get spec approval.** Invoke `grill-me` against the spec. Amend the spec
+   in place until grilling stops producing new questions. Then **always present the written
+   spec to the user and get explicit approval before planning** — this is a hard gate. Point
+   the user at the file path (offer a `woostack-visualize` render if it helps), wait for a
+   clear yes, and make any requested changes before advancing. Do **not** proceed to step 4
+   on inferred or assumed approval; silence is not a yes.
+4. **Plan.** Once the spec is approved, invoke `superpowers:writing-plans`, saving the plan as
+   **markdown** to
    `.woostack/plans/YYYY-MM-DD-<slug>.md` (plans are working checklists, not visualization
    artifacts).
 5. **Decompose to PR-sized increments.** Steer work toward well-scoped PRs of **preferably
@@ -72,7 +87,12 @@ continue. If the user declines, fall back to following the skill's principle man
 
 ## Hard constraints
 
-- **Inherit gates, add none.** Do not insert extra approval stops between phases.
+- **Inherit gates, add none.** Do not insert *extra* approval stops between phases. The two
+  inherited hard gates are non-negotiable: **design approval** (step 1) and **spec approval**
+  (step 3).
+- **Always get explicit spec approval before planning.** After hardening, present the written
+  spec and wait for the user's clear yes. Never advance to `writing-plans` on assumed or
+  inferred approval.
 - **Markdown specs and plans, under `.woostack/`.** Never write specs to the superpowers
   default location. HTML is a render-on-demand target only, not the authored format.
 - **Never merge.** build ends by offering a PR, nothing further.

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -36,8 +36,8 @@ The skill ends the moment the user approves the design. At that point:
 - **Hand back.** State that the design is approved and name the next step:
   - Inside `woostack-build`: its **step 2** captures this design as a markdown spec under
     `.woostack/specs/`. Return control there.
-  - Standalone: tell the user the design is ready to capture as a spec (offer
-    `/woostack-build` or writing one), and stop.
+  - Standalone: tell the user the design is ready to capture as a spec; offer to write the
+    spec directly or hand off to `woostack-build` starting at **step 2**, and stop.
 
 This boundary is the whole point of owning the phase: the caller owns the spec write and the
 plan, so this skill must not.

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: woostack-ideate
+description: Use as the ideate phase of the woostack build loop — turn a feature idea into an approved design through collaborative dialogue, then stop. Explores intent, constraints, and approaches; presents a design and gets explicit approval. Writes no files and chains no skill; the caller (woostack-build) owns the spec and plan. Usable standalone to design before implementation.
+---
+
+# woostack-ideate
+
+Turn a feature idea into a fully formed, approved design through natural collaborative
+dialogue. This is woostack's own ideation phase — the first step of
+[`woostack-build`](../woostack-build/SKILL.md). It keeps the discipline that makes
+ideation worth doing and **stops at an approved design**: it writes no spec file and
+invokes no downstream skill. The caller decides what to do with the design.
+
+<HARD-GATE>
+Do NOT take any implementation action — write code, scaffold, run an implementation skill,
+or write a spec/plan file — until you have presented a design and the user has approved it.
+This applies to EVERY request regardless of perceived simplicity. The design can be short,
+but you MUST present it and get approval.
+</HARD-GATE>
+
+## Anti-pattern: "this is too simple to need a design"
+
+Every change goes through this. A config tweak, a one-function utility, a copy change — all
+of them. "Simple" work is where unexamined assumptions waste the most effort. Scale the
+design to the work (a few sentences for a truly small change), but present it and get
+approval before moving on.
+
+## Terminal state: approved design, handed back
+
+The skill ends the moment the user approves the design. At that point:
+
+- **Write nothing.** Do not create a spec file, a plan, or any artifact. The approved design
+  lives in the conversation.
+- **Chain nothing.** Do not invoke `writing-plans`, `executing-plans`, or any implementation
+  skill yourself.
+- **Hand back.** State that the design is approved and name the next step:
+  - Inside `woostack-build`: its **step 2** captures this design as a markdown spec under
+    `.woostack/specs/`. Return control there.
+  - Standalone: tell the user the design is ready to capture as a spec (offer
+    `/woostack-build` or writing one), and stop.
+
+This boundary is the whole point of owning the phase: the caller owns the spec write and the
+plan, so this skill must not.
+
+## Process
+
+Work the steps in order. Ask **one question per message** so you never overwhelm.
+
+1. **Explore project context.** Read the relevant files, docs, and recent commits before
+   asking anything. In an existing codebase, learn the current structure and follow its
+   patterns rather than proposing greenfield shapes.
+2. **Check scope first.** If the request bundles multiple independent subsystems ("a platform
+   with chat, billing, and analytics"), flag it immediately. Don't refine details of
+   something that needs decomposing first — help split it into independent pieces, note how
+   they relate and in what order to build them, then ideate on the first piece through the
+   normal flow. Each piece gets its own design → spec → plan → implementation cycle.
+3. **Ask clarifying questions.** One at a time. Multiple-choice when you can; open-ended is
+   fine. Aim at purpose, constraints, and success criteria — not implementation trivia.
+4. **Propose 2-3 approaches.** Present them conversationally with trade-offs. Lead with your
+   recommendation and say why.
+5. **Present the design in sections.** Scale each section to its complexity — a sentence or
+   two when straightforward, up to a few hundred words when nuanced. Cover architecture,
+   components, data flow, error handling, and testing as the work warrants. Ask after each
+   section whether it looks right; go back and clarify when something doesn't fit.
+6. **Get explicit approval.** The HARD GATE clears only on a clear yes. Then hand back per
+   the terminal-state rules above.
+
+## Design for isolation and clarity
+
+- Break the system into small units that each have one clear purpose, communicate through
+  well-defined interfaces, and can be understood and tested on their own.
+- For each unit, be able to answer: what does it do, how do you use it, what does it depend
+  on? If a consumer can't understand a unit without reading its internals, or you can't
+  change the internals without breaking consumers, the boundaries need work.
+- Smaller, well-bounded units are also easier to implement reliably. A file that's growing
+  large is usually a signal it's doing too much.
+
+## Working in existing codebases
+
+- Explore the current structure before proposing changes; follow existing patterns.
+- Where existing code in the path of the work has real problems (a too-large file, tangled
+  responsibilities, unclear boundaries), fold targeted improvements into the design — the way
+  a good developer improves code they're already touching.
+- Don't propose unrelated refactoring. Stay focused on what serves this goal.
+
+## Visual treatment, on demand
+
+This skill does not run a browser companion. When a question is genuinely visual — a layout,
+wireframe, side-by-side comparison, or architecture diagram the user would grasp faster by
+seeing than reading — offer to render it with
+[`woostack-visualize`](../woostack-visualize/SKILL.md) (pick the audience that fits) and
+continue. Keep conceptual and requirements questions in the terminal; a UI topic is not
+automatically a visual question.
+
+## Key principles
+
+- **One question at a time.** Don't stack questions in a single message.
+- **Multiple choice preferred.** Easier to answer than open-ended when the options are clear.
+- **YAGNI ruthlessly.** Cut unnecessary features from every design.
+- **Explore alternatives.** Always weigh 2-3 approaches before settling.
+- **Incremental validation.** Present, get approval, then move on.
+- **Be flexible.** Go back and clarify whenever something stops making sense.
+
+## Hard constraints
+
+- **Stop at an approved design.** Never write a spec/plan file or chain a downstream skill —
+  the caller owns those. Handing back is the terminal state.
+- **Respect the gate.** No implementation action of any kind before the user approves.
+- **No bespoke visual server.** Defer visual treatment to `woostack-visualize`.

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -36,8 +36,8 @@ The skill ends the moment the user approves the design. At that point:
 - **Hand back.** State that the design is approved and name the next step:
   - Inside `woostack-build`: its **step 2** captures this design as a markdown spec under
     `.woostack/specs/`. Return control there.
-  - Standalone: tell the user the design is ready to capture as a spec; offer to write the
-    spec directly or hand off to `woostack-build` starting at **step 2**, and stop.
+  - Standalone: tell the user the design is ready to capture as a spec; offer
+    to hand off to `woostack-build` starting at **step 2**, and stop.
 
 This boundary is the whole point of owning the phase: the caller owns the spec write and the
 plan, so this skill must not.


### PR DESCRIPTION
## Summary

- Add `woostack-ideate`, a woostack-native ideate phase skill that converges on an approved design, writes no files, and chains no downstream skill.
- Rewire `woostack-build` to use `woostack-ideate` for step 1 while keeping `superpowers:writing-plans`, `superpowers:executing-plans`, and `grill-me` for the later phases.
- Restore and document the required spec-approval gate after grilling and before planning across `woostack-build`, README, contributing guidance, and bootstrap development references.
- Add the woostack ideate spec/plan artifacts and document the new internal sub-skill in AGENTS/README/CONTRIBUTING.

## Test plan

- [ ] `git diff origin/main...HEAD --check` passed.
- [ ] `rg -n "grill.?→.?plan|grill → plan|spec \(HTML\)|HTML specs|Dev loop \(brainstorm|Brainstorm →" README.md CONTRIBUTING.md AGENTS.md skills .woostack/plans/2026-06-03-woostack-ideate-skill.md .woostack/specs/2026-06-03-woostack-ideate-skill.md --glob '!skills/woostack-review/**' || true` returned no stale build-flow matches.
- [ ] `test -f skills/woostack-ideate/SKILL.md && rg -n "^name: woostack-ideate|^description:|<HARD-GATE>|approve spec" ...` found the new skill frontmatter/HARD-GATE and the expected `approve spec` summaries.
- [ ] Not run: no app test harness exists for this skills collection.
