### PR TITLE
feat: add woostack-harden skill to replace grill-me dependency

### DIFF
--- a/.woostack/plans/2026-06-04-woostack-harden-skill.md
+++ b/.woostack/plans/2026-06-04-woostack-harden-skill.md
@@ -1,0 +1,167 @@
+# woostack-harden Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a woostack-native `woostack-harden` skill that grills a plan/spec/design until no new questions remain and hands back, then rewire `woostack-build` step 3 + preflight to use it instead of the external `grill-me`.
+
+**Architecture:** One new self-contained skill file (`skills/woostack-harden/SKILL.md`) — no references dir needed. It keeps `grill-me`'s load-bearing core (relentless interview, walk the decision tree resolving dependencies, one question at a time, a recommended answer per question, explore-the-codebase-instead-of-asking) and adds the loop behavior `grill-me` lacks: amend-the-artifact-in-place, a terminal "no new questions → hand back" state, and an explicit gate boundary (owns no approval gate). Six existing docs are edited to rewire it and document it as an internal building block (the 10th skill, second internal sub-skill — not a `/woostack-*` command). Source: [.woostack/specs/2026-06-04-woostack-harden-skill.md](../specs/2026-06-04-woostack-harden-skill.md).
+
+**Tech Stack:** Markdown skill files only. No code, no app build, no CI for this repo.
+
+**Out of scope (explicit):** Do NOT touch `superpowers:writing-plans` / `superpowers:executing-plans` wiring. Do NOT add a `using-woostack` routing row or grow the eight-skill public command/adoption surface. Do NOT edit `using-woostack/SKILL.md` (grep-verified: no internal-sub-skill mention to update). Do NOT rewrite historical `.woostack/specs|plans/*` grill-me references. Do NOT move/rename any existing `SKILL.md`. Do NOT add app code, lockfiles, or CI.
+
+---
+
+## File Structure
+
+- **Create** `skills/woostack-harden/SKILL.md` — scoped discovery frontmatter, core grill loop, amend-in-place, terminal/hand-back state, gate boundary, hard constraints.
+- **Modify** `skills/woostack-build/SKILL.md` — frontmatter `description`, Overview chain diagram, dependency preflight, step 3.
+- **Modify** `.claude/CLAUDE.md` (= `AGENTS.md`, symlinked) — second internal-sub-skill note; "nine → ten" `SKILL.md` constraint; Quick file map entry; protect from deletion (action.yml/ideate-style).
+- **Modify** `README.md` — build-loop prose + diagram (`grill` → `harden`); credit `woostack-harden` (in-collection), grill-me removed. Install command surface stays eight.
+- **Modify** `CONTRIBUTING.md` — build-loop summary row (`grill` → `harden`) + new "Change the harden phase" pointer row.
+- **Modify** `skills/woostack-bootstrap/references/development.md` — loop-summary table row (`grill` → `harden`).
+
+---
+
+## Task 1: Create `skills/woostack-harden/SKILL.md`
+
+**Files:** Create `skills/woostack-harden/SKILL.md`
+
+- [ ] **Step 1: Write the full skill file.** Author the file with exactly this content:
+
+```markdown
+---
+name: woostack-harden
+description: Use to harden a plan, spec, or design by relentless interview — walk every branch of the decision tree, resolve each open question one at a time with a recommended answer, and amend the artifact in place until no new questions remain. This is the harden phase of the woostack build loop (woostack-build step 3); also usable standalone to stress-test or "grill me" on a design before committing to it.
+---
+
+# woostack-harden
+
+Harden a plan, spec, or design by interviewing the user relentlessly until you reach shared
+understanding and the artifact stops producing new questions. This is woostack's own hardening
+phase — [`woostack-build`](../woostack-build/SKILL.md) step 3. It keeps the discipline that
+makes grilling worth doing, **amends the target artifact in place** as answers land, and
+**stops when no new questions remain**, handing back to its caller. It owns no approval gate.
+
+## The grill loop
+
+Interview relentlessly about every aspect of the plan or design until you reach a shared
+understanding. Walk down each branch of the decision tree, resolving dependencies between
+decisions one by one.
+
+- **One question per message.** Never stack questions; never overwhelm.
+- **Recommend an answer.** For every question, give your recommended answer and say why.
+- **Explore, don't ask.** If a question can be answered by exploring the codebase, explore
+  the codebase instead of asking the user.
+- **Resolve dependencies in order.** When one decision gates another, settle the upstream one
+  first so downstream questions are well-posed.
+
+## Amend the artifact in place
+
+When the thing being hardened is a written artifact — a `.woostack/` spec, or any plan/design
+file the caller names — **edit that file in place as each question resolves**, so it
+strengthens with every answer. Fold the resolution into the relevant section; record settled
+decisions (e.g. under the spec's "Open questions") so the artifact, not the chat log, is the
+record. When there is no file (pure standalone grilling), converge conversationally and write
+nothing.
+
+## Terminal state: hardened, handed back
+
+Stop when a full pass over the decision tree produces **no new questions** — the artifact is
+hardened. Then hand back to the caller and name the next step:
+
+- Inside `woostack-build`: hand back to its **step 3**, which owns the spec-approval HARD GATE
+  (present the written spec, wait for explicit user approval before planning). Do not run that
+  gate yourself.
+- Standalone: tell the user the artifact is hardened and ready to take to approval, and stop.
+
+## Gate boundary
+
+This skill owns **no approval gate**. It does not present-the-artifact-for-approval, does not
+merge, and does not chain the next phase. It hardens, then hands back. Keeping the gate with
+the caller is what preserves woostack-build's "inherit gates, add none."
+
+## Hard constraints
+
+- **One question at a time.** Multiple choice when the options are clear.
+- **Always recommend an answer** for every question you ask.
+- **Explore the codebase** to answer a question before asking the user.
+- **Amend in place; write nothing new.** Strengthen the named artifact; do not create a new
+  file, a spec, or a plan.
+- **Own no gate.** Hand back at "no new questions"; never solicit final approval or merge.
+```
+
+- [ ] **Step 2: Verify frontmatter parses.** Run: `head -4 skills/woostack-harden/SKILL.md` — expect a `---` / `name: woostack-harden` / `description: ...` / `---` block.
+- [ ] **Step 3: Commit.**
+
+```bash
+git add skills/woostack-harden/SKILL.md
+git commit -m "feat: add woostack-harden skill"
+```
+
+## Task 2: Rewire `skills/woostack-build/SKILL.md`
+
+**Files:** Modify `skills/woostack-build/SKILL.md`
+
+- [ ] **Step 1: Frontmatter `description`.** Change `Chains woostack-ideate, superpowers writing-plans/executing-plans, and grill-me in a fixed, gated order;` to `Chains woostack-ideate, woostack-harden, and superpowers writing-plans/executing-plans in a fixed, gated order;`.
+- [ ] **Step 2: Overview chain diagram.** In the chain on line ~15, change `grill-me` to `harden`:
+  `ideate → write spec (markdown) → harden → approve spec → writing-plans → executing-plans → distill memory → ask: open PR?`
+- [ ] **Step 3: Dependency preflight.** In the "Dependency preflight" section: (a) drop `- `grill-me`` from the bullet list of chained external skills, leaving `superpowers:writing-plans`, `superpowers:executing-plans`; (b) remove `grill-me` from the prose that names the hardening phase as an external chain — state that the harden phase uses the in-collection `woostack-harden` (no install needed), mirroring the existing `woostack-ideate` note; (c) in the "offer to install" line, remove `pnpx skills add mattpocock/skills for grill-me`, keeping `pnpx skills add obra/superpowers`.
+- [ ] **Step 4: Procedure step 3 ("Harden it…").** Change `Invoke `grill-me` against the spec.` to `Invoke [`woostack-harden`](../woostack-harden/SKILL.md) against the spec.` and `until grilling stops producing new questions` to `until hardening stops producing new questions`. Leave the spec-approval HARD GATE that follows ("always present the written spec to the user and get explicit approval before planning") unchanged.
+- [ ] **Step 5: Verify the gate text survives.** Run: `grep -n "explicit approval before planning\|hard gate" skills/woostack-build/SKILL.md` — expect the spec-approval gate language still present.
+- [ ] **Step 6: Commit.**
+
+```bash
+git add skills/woostack-build/SKILL.md
+git commit -m "feat: rewire woostack-build harden phase to woostack-harden"
+```
+
+## Task 3: Document the second internal sub-skill in `AGENTS.md`
+
+**Files:** Modify `.claude/CLAUDE.md` (canonical; `.claude/CLAUDE.md` is the symlinked source-of-truth per the file's own note — edit the real file `AGENTS.md` content)
+
+- [ ] **Step 1: Sub-skill note.** Update the paragraph that begins "The collection also installs a ninth, internal sub-skill: `woostack-ideate`." to describe **two** internal sub-skills: `woostack-ideate` (build's ideate phase) and `woostack-harden` (build's harden phase). Keep the framing: building blocks, not `/woostack-*` commands; no routing row; absent from the eight-skill command surface; shipped assets like `action.yml`, not strays to delete.
+- [ ] **Step 2: Hard-constraint count.** Update the constraint "Do not move or rename any of the nine `SKILL.md` files (the eight public command/adoption skills plus the internal `woostack-ideate`)." to **ten** files — "the eight public command/adoption skills plus the internal `woostack-ideate` and `woostack-harden`".
+- [ ] **Step 3: Quick file map.** Add an entry under "Quick file map", parallel to the ideate entry:
+  `- Hardening engine for the build loop (internal sub-skill): [`skills/woostack-harden/SKILL.md`](skills/woostack-harden/SKILL.md)`.
+- [ ] **Step 4: Verify.** Run: `grep -n "woostack-harden\|ten\|nine" .claude/CLAUDE.md` — expect the new sub-skill named, count updated to ten, no stray "nine".
+- [ ] **Step 5: Commit.**
+
+```bash
+git add .claude/CLAUDE.md AGENTS.md
+git commit -m "docs: document woostack-harden as second internal sub-skill"
+```
+
+## Task 4: Update `README.md`, `CONTRIBUTING.md`, `development.md`
+
+**Files:** Modify `README.md`, `CONTRIBUTING.md`, `skills/woostack-bootstrap/references/development.md`
+
+- [ ] **Step 1: README chain diagram.** Change the build-loop code block `ideate → markdown spec → grill → approve spec → plan → execute (TDD) → offer PR` to `ideate → markdown spec → harden → approve spec → plan → execute (TDD) → offer PR`.
+- [ ] **Step 2: README prose.** Change `with proven sub-skills (superpowers writing-plans/executing-plans + grill-me)` to credit the in-collection harden phase, e.g. `with woostack's own harden phase (`woostack-harden`) and proven superpowers sub-skills (writing-plans/executing-plans)`. Keep the Install/command surface at eight; `woostack-harden` is internal, not advertised as a command.
+- [ ] **Step 3: CONTRIBUTING build-loop row.** Change the row `Change the build loop (ideate→spec→grill→approve spec→plan→execute)` to `(ideate→spec→harden→approve spec→plan→execute)`.
+- [ ] **Step 4: CONTRIBUTING harden pointer row.** Add a row immediately after the "Change the ideate phase" row: `| Change the harden phase (the build loop's stress-test step) | `skills/woostack-harden/SKILL.md` |`.
+- [ ] **Step 5: development.md loop row.** Change the table row `| Ideate → markdown spec → grill → approve spec → plan → execute | `woostack-build` |` to `| Ideate → markdown spec → harden → approve spec → plan → execute | `woostack-build` |`.
+- [ ] **Step 6: Commit.**
+
+```bash
+git add README.md CONTRIBUTING.md skills/woostack-bootstrap/references/development.md
+git commit -m "docs: update build-loop summaries for woostack-harden"
+```
+
+## Task 5: Verify
+
+- [ ] **Step 1: Grep for live grill-me.** Run: `grep -rn "grill-me\|grill me\|grilling" --include='*.md' --include='*.yml' --include='*.json' . | grep -v '.woostack/specs/' | grep -v '.woostack/plans/'` — expect **no** results outside historical `.woostack/specs|plans/` artifacts (the new harden spec/plan may reference grill-me descriptively; that is allowed).
+- [ ] **Step 2: Frontmatter + sections.** Run: `head -4 skills/woostack-harden/SKILL.md` (valid `name`/`description`) and `grep -n "Gate boundary\|Terminal state\|no new questions" skills/woostack-harden/SKILL.md` (terminal-state + gate-boundary statements present).
+- [ ] **Step 3: Cross-links.** Confirm `skills/woostack-build/SKILL.md` links `../woostack-harden/SKILL.md` and `.claude/CLAUDE.md` file-map links `skills/woostack-harden/SKILL.md`; both target files exist.
+- [ ] **Step 4: Counts.** Run: `ls skills/*/SKILL.md | wc -l` — expect 10. Confirm `AGENTS.md`/`README.md` still present an eight-skill public command/adoption surface and document two internal sub-skills.
+- [ ] **Step 5: Build-flow summaries.** Run: `grep -rn "harden" README.md CONTRIBUTING.md skills/woostack-bootstrap/references/development.md skills/woostack-build/SKILL.md` — expect every shipped loop summary now shows `harden` (and still `approve spec` before planning).
+
+---
+
+## Self-Review
+
+**Spec coverage:** §4 approach (core loop, amend-in-place, terminal/hand-back, gate boundary) → Task 1. §4 wiring + §5 edit table → Tasks 2–4. §7 testing → Task 5. All spec sections map to a task.
+
+**Placeholder scan:** Task 1 contains the complete SKILL.md content; doc edits give exact before/after strings. No TBD/TODO.
+
+**Type consistency:** Skill name `woostack-harden`, phase label `harden`, link path `../woostack-harden/SKILL.md` used consistently across all tasks.

--- a/.woostack/specs/2026-06-04-woostack-harden-skill.md
+++ b/.woostack/specs/2026-06-04-woostack-harden-skill.md
@@ -1,0 +1,169 @@
+---
+name: woostack-harden-skill
+type: spec
+status: ready
+date: 2026-06-04
+branch: worktree-tender-exploring-swing
+links:
+  - "[[2026-06-03-woostack-ideate-skill]]"
+---
+
+# woostack-harden: a woostack-native hardening skill — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+## 1. Problem
+
+`woostack-build` step 3 invokes the external `grill-me` skill to harden a written spec —
+interview the user until grilling stops producing new questions. That dependency is a poor
+fit for the woostack loop in the same ways `superpowers:brainstorming` was before
+[`woostack-ideate`](../../skills/woostack-ideate/SKILL.md) replaced it:
+
+1. **External dependency for a core loop step.** The harden phase of the flagship build loop
+   is delegated to a third-party skill (`mattpocock/skills`) the consumer must install
+   separately. The preflight has to detect it, offer to install it, and degrade gracefully
+   when absent — friction for what should be a first-party phase.
+2. **Off-the-shelf, not woostack-shaped.** `grill-me` is 9 lines with no awareness of the
+   build loop: it does not know about the written markdown spec under `.woostack/`, does not
+   amend an artifact in place, and has no defined terminal state or hand-back contract. The
+   loop-specific behavior (amend-in-place, stop at "no new questions," hand back to the
+   spec-approval gate) lives in `woostack-build`'s prose rather than the skill.
+3. **Asymmetry with the rest of the loop.** ideate, spec-writing, planning, and execution are
+   all woostack-owned or woostack-conventioned; only the harden phase reaches outside the
+   collection. Owning it makes the loop self-contained and consistent.
+
+We want to own the hardening behavior so the build loop's harden phase fits woostack
+conventions and carries no external dependency. This is the same move `woostack-ideate` made
+one rung up the loop.
+
+## 2. Goal
+
+Ship `skills/woostack-harden/SKILL.md`: a woostack-native hardening skill that grills a plan,
+spec, or design until no new questions remain, **amends the artifact in place** when one
+exists, and **hands back** to its caller. Rewire `woostack-build` step 3 (and its dependency
+preflight) to use it instead of `grill-me`. Keep the parts of `grill-me` that earn their
+place — relentless interview, walk the decision tree resolving dependencies, one question at
+a time, a recommended answer per question, explore-the-codebase-instead-of-asking — and add
+the woostack-loop behavior `grill-me` lacks.
+
+## 3. Non-goals
+
+- **Not a new command.** `woostack-harden` is an internal building block bundled in the
+  collection, like [`woostack-ideate`](../../skills/woostack-ideate/SKILL.md) and
+  [`action.yml`](../../action.yml) — not a `/woostack-*` command. No `using-woostack` routing
+  row; the shipped command surface stays at eight.
+- **Owns no approval gate.** The skill hardens, then hands back. It does not present-for-
+  approval, does not merge, and does not chain the next phase. `woostack-build` step 3 keeps
+  the spec-approval HARD GATE. "Inherit gates, add none" still holds.
+- **No replacement of `writing-plans` / `executing-plans`.** This change touches only the
+  harden phase. Those superpowers skills remain `woostack-build` dependencies.
+- **No behavior change to the other skills** beyond the small doc edits listed in §5.
+- **No rewrite of history.** Historical `.woostack/specs/` and `.woostack/plans/` references
+  to `grill-me` are records of past work and are left as-is.
+
+## 4. Approach
+
+Author one self-contained `SKILL.md`. It mirrors `grill-me`'s proven core and adds the
+loop-specific behavior, parallel to how `woostack-ideate` mirrored superpowers brainstorming
+but truncated at "approved design":
+
+- **Frontmatter `description`** scoped so it is recognized as `woostack-build`'s harden phase
+  and as a standalone "stress-test / grill / harden my plan" trigger — broad enough to be
+  invocable by name and usable standalone, narrow enough not to shadow unrelated skills.
+- **Core grill loop** (kept from `grill-me`): interview relentlessly; walk every branch of
+  the decision tree, resolving dependencies between decisions; one question per message;
+  recommend an answer for each question; if a question is answerable by exploring the
+  codebase, explore instead of asking.
+- **Amend-in-place** (new): when hardening a written artifact — a `.woostack/` spec or any
+  plan/design file the caller names — edit the artifact in place as questions resolve, so it
+  strengthens with each answer. When there is no file (pure standalone grilling), converge
+  conversationally and write nothing.
+- **Terminal state = hardened, handed back** (new): stop when a full pass produces no new
+  questions. Then hand back to the caller and name the next step — inside `woostack-build`,
+  step 3's spec-approval gate; standalone, tell the user the artifact is hardened.
+- **Gate boundary** (new): an explicit statement that the skill owns no approval gate, does
+  not present-for-approval, and does not merge — preserving "inherit gates, add none."
+
+### Wiring `woostack-build`
+
+- **Dependency preflight**: drop `grill-me` (and its `pnpx skills add mattpocock/skills`
+  install line) from the external-skill list. `woostack-harden` ships in the same collection,
+  so it is a bundled internal sub-skill, not an external install. Keep
+  `superpowers:writing-plans` and `superpowers:executing-plans` in the preflight.
+- **Step 3**: invoke `woostack-harden` instead of `grill-me`. The step is otherwise
+  unchanged — harden the spec until no new questions, then the existing spec-approval HARD
+  GATE (present the written spec, wait for explicit yes) still fires. The skill hands back;
+  the gate stays in `woostack-build`.
+- **Overview diagram + `description`**: replace `grill-me` with `harden`; the harden phase is
+  now woostack's own (writing-plans/executing-plans still superpowers).
+
+## 5. Components & data flow
+
+Edit set (one PR-sized increment):
+
+| File | Change |
+|---|---|
+| `skills/woostack-harden/SKILL.md` | **NEW** — the skill (≈80–120 lines): scoped `description`, core grill loop, amend-in-place, terminal/hand-back, gate boundary. |
+| `skills/woostack-build/SKILL.md` | Preflight: drop `grill-me` bullet + its install line. Overview diagram: `grill-me` → `harden`. Step 3: invoke `woostack-harden`. `description` frontmatter: harden is now woostack's own (writing-plans/executing-plans still superpowers). |
+| `.claude/CLAUDE.md` (= `AGENTS.md`) | "The collection also installs a ninth, internal sub-skill" → two internal sub-skills (`woostack-ideate` + `woostack-harden`); update the "nine `SKILL.md` files" hard constraint to ten; add `woostack-harden` to the Quick file map; protect it from deletion the way `action.yml`/`woostack-ideate` are. |
+| `README.md` | Build-loop prose + diagram: `grill` → `harden`; credit `woostack-harden` (in-collection) for the harden phase, superpowers for writing-plans/executing-plans, grill-me removed. Install list (command surface) stays eight. |
+| `CONTRIBUTING.md` | Build-loop table row: `grill` → `harden` (the `ideate→spec→grill→…` summary on the "Change the build loop" row). Add a "Change the harden phase" pointer row → `skills/woostack-harden/SKILL.md`, parallel to the existing "Change the ideate phase" row. |
+| `skills/woostack-bootstrap/references/development.md` | Update the shipped development-loop summary (table row) to `Ideate → markdown spec → harden → approve spec → plan → execute`. |
+
+Verified during the harden pass — **no edit needed**: `skills/using-woostack/SKILL.md` makes no
+mention of internal sub-skills, `woostack-ideate`, or `action.yml` (grep clean), so there is no
+"lone internal sub-skill" claim to update there.
+
+Data flow at runtime: `woostack-build` step 3 → loads `woostack-harden` → interactive grill
+loop with the user, amending the markdown spec in place → "no new questions" → hand back to
+`woostack-build` → step 3's spec-approval gate fires. The skill produces no file of its own;
+it only amends the artifact the caller names.
+
+## 6. Error handling
+
+- **Skill missing at runtime.** Because it ships in the collection, absence means a broken
+  install. `woostack-build`'s preflight no longer lists it as installable; if the file is
+  genuinely missing, `woostack-build` falls back to following the hardening principle
+  manually and says so (same degraded-run contract the preflight already states).
+- **Description over-trigger.** Risk: a hardening `description` broad enough to hijack
+  unrelated requests. Mitigation: scope it to "stress-test / grill / harden a plan, spec, or
+  design" plus the build harden phase — not a generic trigger.
+- **Gate creep.** Risk: the skill drifts into owning the spec-approval gate (presenting the
+  spec for a yes), duplicating `woostack-build` step 3's gate. Mitigation: an explicit gate-
+  boundary statement that the skill hands back and owns no gate.
+- **Runaway grilling.** Risk: never reaching a terminal state. Mitigation: the terminal-state
+  rule — stop when a full pass yields no new questions — is stated explicitly.
+
+## 7. Testing
+
+No app/test harness in this repo (it is a skills collection). Verification is by inspection:
+
+- `woostack-build` no longer references `grill-me`; preflight + step 3 name `woostack-harden`.
+- Repo-wide grep: no remaining `grill-me` / `grill me` reference in shipped docs (`AGENTS.md`,
+  `README.md`, `CONTRIBUTING.md`, skill files, references); `.woostack/plans/` and
+  `.woostack/specs/` history entries are left as-is (only this new spec and historical ones
+  may mention it).
+- New `SKILL.md` has valid frontmatter (`name`, `description`) and the gate-boundary +
+  terminal-state statements.
+- Cross-links resolve (`woostack-build` ↔ `woostack-harden`).
+- Skill count is consistent everywhere: `AGENTS.md` reflects ten `SKILL.md` files / two
+  internal sub-skills; README command surface stays eight.
+
+## 8. Open questions
+
+Resolved during ideate (and to be re-confirmed during the harden pass):
+
+- **Naming** → `woostack-harden` (verb-family, matches build/commit/review/init/visualize/
+  ideate; the build loop already calls this phase "harden it").
+- **Depth** → richer, woostack-native (not a faithful 9-line port): core grill loop +
+  amend-in-place + terminal/hand-back + gate boundary.
+- **Scope** → general (any plan/spec/design) and usable standalone, mirroring `woostack-ideate`
+  and `grill-me`'s broad trigger; `woostack-build` step 3 points it at the markdown spec.
+- **Internal sub-skill description** → scoped so it is invocable by name and usable standalone
+  but does not auto-trigger on unrelated work or shadow other skills. Deliberately absent from
+  the `using-woostack` routing table and the README command list.
+- **`using-woostack` edit?** → resolved: **none needed**. Grep shows `using-woostack/SKILL.md`
+  never names `woostack-ideate` or any internal sub-skill, so there is no parallel mention to
+  add. The earlier "verify" item is closed.
+- **woostack-build `description` frontmatter** → "Chains woostack-ideate, **woostack-harden**,
+  superpowers writing-plans/executing-plans, in a fixed, gated order" (drop `grill-me`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,13 @@ The public command/adoption surface has eight skills:
 - [`woostack-address-comments`](skills/woostack-address-comments/SKILL.md)
 - [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
 
-The collection also installs a ninth, internal sub-skill:
-[`woostack-ideate`](skills/woostack-ideate/SKILL.md). `woostack-build` delegates its ideate
-phase to it. It is a bundled building block, not a `/woostack-*` command: it has no routing row
-and is absent from the eight-skill command surface above. Like [`action.yml`](action.yml), it is
-a shipped asset — do not delete it as a stray.
+The collection also installs two internal sub-skills:
+[`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
+[`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
+phase to the former and its harden phase to the latter. Both are bundled building blocks, not
+`/woostack-*` commands: they have no routing row and are absent from the eight-skill command
+surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+strays.
 
 There is no application source code, app lockfile, build, or CI for this repo's own
 push/PR events. `skills-lock.json` is the dev-skill manifest and is currently empty.
@@ -70,8 +72,8 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the nine `SKILL.md` files (the eight public command/adoption
-  skills plus the internal `woostack-ideate`).
+- Do not move or rename any of the ten `SKILL.md` files (the eight public command/adoption
+  skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
   updating every cross-link and the bootstrap skill table.
@@ -88,6 +90,8 @@ directory, not in this repo.
   [`skills/woostack-build/SKILL.md`](skills/woostack-build/SKILL.md)
 - Ideate phase engine for the build loop (internal sub-skill):
   [`skills/woostack-ideate/SKILL.md`](skills/woostack-ideate/SKILL.md)
+- Harden phase engine for the build loop (internal sub-skill):
+  [`skills/woostack-harden/SKILL.md`](skills/woostack-harden/SKILL.md)
 - Commit and PR update flow:
   [`skills/woostack-commit/SKILL.md`](skills/woostack-commit/SKILL.md)
 - Review engine:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,9 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Update the branching model | `skills/woostack-bootstrap/references/development.md` |
 | Refine the bootstrap procedure | `skills/woostack-bootstrap/references/bootstrap.md` |
 | Change the bootstrap skill entry / discovery description | `skills/woostack-bootstrap/SKILL.md` |
-| Change the build loop (ideate→spec→grill→approve spec→plan→execute) | `skills/woostack-build/SKILL.md` |
+| Change the build loop (ideate→spec→harden→approve spec→plan→execute) | `skills/woostack-build/SKILL.md` |
 | Change the ideate phase (the build loop's first step) | `skills/woostack-ideate/SKILL.md` |
+| Change the harden phase (the build loop's stress-test step) | `skills/woostack-harden/SKILL.md` |
 | Change the commit / PR update workflow | `skills/woostack-commit/SKILL.md` |
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |
 | Change the address-comments delegator | `skills/woostack-address-comments/SKILL.md` |

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Walks you through the [decision catalog](skills/woostack-bootstrap/references/de
 A fixed, gated chain that drives one feature from idea to implementation:
 
 ```
-ideate → markdown spec → grill → approve spec → plan → execute (TDD) → offer PR
+ideate → markdown spec → harden → approve spec → plan → execute (TDD) → offer PR
 ```
 
-It sequences woostack's own ideate phase (`woostack-ideate`) with proven sub-skills (superpowers writing-plans/executing-plans + grill-me), inheriting the ideate design gate and hosting the relocated spec-approval gate before planning. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work is steered toward reviewable PRs (soft target ≤500 LOC), one increment per cycle. It ends by *offering* a PR. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+It sequences woostack's own ideate and harden phases (`woostack-ideate`, `woostack-harden`) with proven superpowers sub-skills (writing-plans/executing-plans), inheriting the ideate design gate and hosting the relocated spec-approval gate before planning. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work is steered toward reviewable PRs (soft target ≤500 LOC), one increment per cycle. It ends by *offering* a PR. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
 
 ### `/woostack-review [PR#]`: parallel review swarm
 

--- a/skills/woostack-bootstrap/references/development.md
+++ b/skills/woostack-bootstrap/references/development.md
@@ -9,7 +9,7 @@ for each phase:
 
 | Phase | Skill |
 |---|---|
-| Ideate → markdown spec → grill → approve spec → plan → execute | `woostack-build` |
+| Ideate → markdown spec → harden → approve spec → plan → execute | `woostack-build` |
 | Review | `woostack-review` |
 | Address review feedback | `woostack-address-comments` |
 

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-build
-description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, and implement it. Chains woostack-ideate, superpowers writing-plans/executing-plans, and grill-me in a fixed, gated order; writes markdown specs and plans under .woostack/.
+description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, and implement it. Chains woostack-ideate, woostack-harden, and superpowers writing-plans/executing-plans in a fixed, gated order; writes markdown specs and plans under .woostack/.
 ---
 
 # woostack-build
@@ -12,7 +12,7 @@ glue: it sequences proven sub-skills and **inherits their gates** — it adds no
 its own. The value is the order and the handoffs.
 
 ```
-ideate → write spec (markdown) → grill-me → approve spec → writing-plans → executing-plans → distill memory → ask: open PR?
+ideate → write spec (markdown) → harden → approve spec → writing-plans → executing-plans → distill memory → ask: open PR?
 ```
 
 Two of those gates are hard stops where the user must say yes before the chain advances:
@@ -23,17 +23,17 @@ its own step 2, the gate lives here now. Relocating an inherited gate is not add
 
 ## Dependency preflight
 
-The ideate phase uses [`woostack-ideate`](../woostack-ideate/SKILL.md), which
-ships in this collection — no install needed. The plan, execution, and hardening phases chain
-external skills. At the start, check that each is installed:
+The ideate and hardening phases use [`woostack-ideate`](../woostack-ideate/SKILL.md) and
+[`woostack-harden`](../woostack-harden/SKILL.md), which ship in this collection — no install
+needed. The plan and execution phases chain external skills. At the start, check that each is
+installed:
 
 - `superpowers:writing-plans`, `superpowers:executing-plans`
-- `grill-me`
 
 For any that are missing: name exactly what's missing and **offer to install it inline**
-(`pnpx skills add obra/superpowers`, `pnpx skills add mattpocock/skills` for grill-me) and
-continue. If the user declines, fall back to following the skill's principle manually and
-**say so explicitly** — the run is degraded, not equivalent.
+(`pnpx skills add obra/superpowers`) and continue. If the user declines, fall back to
+following the skill's principle manually and **say so explicitly** — the run is degraded, not
+equivalent.
 
 ## Procedure
 
@@ -51,8 +51,9 @@ continue. If the user declines, fall back to following the skill's principle man
    [`woostack-visualize`](../woostack-visualize/SKILL.md) (audience `engineer` for specs; it
    uses [references/spec-template.html](references/spec-template.html) as a starting point).
    The HTML is a presentation target only, never the authored source.
-3. **Harden it, then get spec approval.** Invoke `grill-me` against the spec. Amend the spec
-   in place until grilling stops producing new questions. Then **always present the written
+3. **Harden it, then get spec approval.** Invoke [`woostack-harden`](../woostack-harden/SKILL.md)
+   against the spec. Amend the spec
+   in place until hardening stops producing new questions. Then **always present the written
    spec to the user and get explicit approval before planning** — this is a hard gate. Point
    the user at the file path (offer a `woostack-visualize` render if it helps), wait for a
    clear yes, and make any requested changes before advancing. Do **not** proceed to step 4

--- a/skills/woostack-harden/SKILL.md
+++ b/skills/woostack-harden/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: woostack-harden
+description: Use to harden a plan, spec, or design by relentless interview — walk every branch of the decision tree, resolve each open question one at a time with a recommended answer, and amend the artifact in place until no new questions remain. This is the harden phase of the woostack build loop (woostack-build step 3); also usable standalone to stress-test or "grill me" on a design before committing to it.
+---
+
+# woostack-harden
+
+Harden a plan, spec, or design by interviewing the user relentlessly until you reach shared
+understanding and the artifact stops producing new questions. This is woostack's own hardening
+phase — [`woostack-build`](../woostack-build/SKILL.md) step 3. It keeps the discipline that
+makes grilling worth doing, **amends the target artifact in place** as answers land, and
+**stops when no new questions remain**, handing back to its caller. It owns no approval gate.
+
+## The grill loop
+
+Interview relentlessly about every aspect of the plan or design until you reach a shared
+understanding. Walk down each branch of the decision tree, resolving dependencies between
+decisions one by one.
+
+- **One question per message.** Never stack questions; never overwhelm.
+- **Recommend an answer.** For every question, give your recommended answer and say why.
+- **Explore, don't ask.** If a question can be answered by exploring the codebase, explore
+  the codebase instead of asking the user.
+- **Resolve dependencies in order.** When one decision gates another, settle the upstream one
+  first so downstream questions are well-posed.
+
+## Amend the artifact in place
+
+When the thing being hardened is a written artifact — a `.woostack/` spec, or any plan/design
+file the caller names — **edit that file in place as each question resolves**, so it
+strengthens with every answer. Fold the resolution into the relevant section; record settled
+decisions (e.g. under the spec's "Open questions") so the artifact, not the chat log, is the
+record. When there is no file (pure standalone grilling), converge conversationally and write
+nothing.
+
+## Terminal state: hardened, handed back
+
+Stop when a full pass over the decision tree produces **no new questions** — the artifact is
+hardened. Then hand back to the caller and name the next step:
+
+- Inside `woostack-build`: hand back to its **step 3**, which owns the spec-approval HARD GATE
+  (present the written spec, wait for explicit user approval before planning). Do not run that
+  gate yourself.
+- Standalone: tell the user the artifact is hardened and ready to take to approval, and stop.
+
+## Gate boundary
+
+This skill owns **no approval gate**. It does not present-the-artifact-for-approval, does not
+merge, and does not chain the next phase. It hardens, then hands back. Keeping the gate with
+the caller is what preserves woostack-build's "inherit gates, add none."
+
+## Hard constraints
+
+- **One question at a time.** Multiple choice when the options are clear.
+- **Always recommend an answer** for every question you ask.
+- **Explore the codebase** to answer a question before asking the user.
+- **Amend in place; write nothing new.** Strengthen the named artifact; do not create a new
+  file, a spec, or a plan.
+- **Own no gate.** Hand back at "no new questions"; never solicit final approval or merge.


### PR DESCRIPTION
## Summary

Replaces the external `grill-me` dependency in the woostack build loop with a new in-collection internal sub-skill, **`woostack-harden`** — the same move `woostack-ideate` made for `superpowers:brainstorming`, one rung down the loop.

- **New** `skills/woostack-harden/SKILL.md` — the 10th skill, second internal sub-skill, owns no approval gate. Keeps grill-me's core (relentless interview, walk the decision tree, one question at a time, recommend an answer per question, explore-instead-of-ask) and adds woostack loop behavior: amend-the-artifact-in-place, a terminal "no new questions → hand back" state, and an explicit gate boundary.
- **Rewire** `woostack-build` step 3 + dependency preflight → `woostack-harden`; drop `grill-me` and its `pnpx skills add mattpocock/skills` install line.
- **Docs** — `README`, `CONTRIBUTING`, `skills/woostack-bootstrap/references/development.md`, `AGENTS.md` updated (build-loop summaries; nine → ten `SKILL.md` files / two internal sub-skills; file map).

Spec: `.woostack/specs/2026-06-04-woostack-harden-skill.md` · Plan: `.woostack/plans/2026-06-04-woostack-harden-skill.md`

## Test plan

No app/test harness in this repo (it is a skills collection); verified by inspection:

- [x] `grep` shows zero live `grill-me` dependency refs in shipped docs (only the new harden skill's own descriptive "grill me"/"grilling" text remains)
- [x] `ls skills/*/SKILL.md | wc -l` → 10
- [x] harden `SKILL.md` frontmatter valid; gate-boundary + terminal-state sections present
- [x] cross-links resolve (`woostack-build` ↔ `woostack-harden`; AGENTS file map)
- [x] `approve spec` hard gate preserved in `woostack-build` step 3
- [x] public command/adoption surface unchanged at eight skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
