### PR TITLE
feat(commit): lead PR body with Goal and automated/manual test plan

### DIFF
--- a/.woostack/plans/2026-06-04-commit-pr-goal-test-plan.md
+++ b/.woostack/plans/2026-06-04-commit-pr-goal-test-plan.md
@@ -1,0 +1,159 @@
+# woostack-commit PR body: Goal + structured test plan — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update `woostack-commit` so PR bodies open with a `## Goal` section and split the test plan into `### Automated` and `### Manual` (with **Before merge** / **After merge** groups).
+
+**Architecture:** Documentation-only change to a single skill file. Edit four spots in `skills/woostack-commit/SKILL.md` — the PR-body template, the step-7 filling rules, the fast-subagent draftable-field list, and the description frontmatter + step-8 report — keeping them mutually consistent.
+
+**Tech Stack:** Markdown. No code, no build, no test harness in this repo for its own skill markdown.
+
+**Spec:** `.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md`
+
+**Verification note:** This repo has no automated tests/CI for its skill markdown, so there is no failing-test-first loop. Each task's verification is a structured read confirming the edited text matches the spec and stays internally consistent. State `Not run` honestly for automated coverage.
+
+---
+
+### Task 1: Replace the PR-body template
+
+**Files:**
+- Modify: `skills/woostack-commit/SKILL.md` — the template block under step 7 (currently the fenced markdown at lines ~190–200, the `## Summary` + `## Test plan` block)
+
+- [ ] **Step 1: Replace the template block**
+
+Replace the existing fenced block:
+
+````markdown
+```markdown
+## Summary
+
+- <concise bullet describing a user-visible or reviewer-relevant change>
+- <concise bullet describing another relevant change>
+
+## Test plan
+
+- [ ] <command run and result, or "Not run (reason)">
+- [ ] <manual verification step, when a meaningful one exists>
+```
+````
+
+with:
+
+````markdown
+```markdown
+## Goal
+
+<1-2 sentences: why this PR exists / the problem it solves>
+
+## Summary
+
+- <concise bullet describing a user-visible or reviewer-relevant change>
+- <concise bullet describing another relevant change>
+
+## Test plan
+
+### Automated
+
+- [ ] <command run and result, or "Not run (reason)">
+
+### Manual
+
+**Before merge**
+
+- [ ] <step a reviewer can inspect or exercise on the branch or preview>
+
+**After merge**
+
+- [ ] <step only verifiable post-merge — deploy / migration / env-gated>
+```
+````
+
+- [ ] **Step 2: Verify**
+
+Read the block back. Confirm `## Goal` precedes `## Summary`, and `## Test plan` contains `### Automated` then `### Manual` with bold `**Before merge**` / `**After merge**` groups. No stray old bullets remain.
+
+---
+
+### Task 2: Rewrite the step-7 filling rules
+
+**Files:**
+- Modify: `skills/woostack-commit/SKILL.md` — the `Rules:` bullet list under step 7 (currently lines ~202–211)
+
+- [ ] **Step 1: Replace the rules list**
+
+Replace the current bullet list (from `- Keep bullets concise and specific.` through `- If tests were not run, say `Not run`...`) with a list that:
+
+1. Keeps: bullets concise/specific; include only committed-diff changes; preserve still-accurate existing context; replace stale generated content; checkbox format for test-plan items.
+2. Adds a **Goal** rule: state intent or the problem solved in 1–2 sentences — not a change list; distinct from Summary, which lists *what* changed. Always present.
+3. Adds an **Automated** rule: list commands/tests actually run, plus the configured `commit.pre_commit` command and result when it ran. Show this group whenever an automated check (test, lint, typecheck, `pre_commit`) could have run for the change — list results, or `Not run` with the reason when one was expected but skipped. Omit `### Automated` entirely when no automated check is applicable (e.g. a doc-only edit in a repo with no test harness); do not emit a `Not run` placeholder then.
+4. Adds a **Manual** rule with two groups:
+   - **Before merge** — what a reviewer can inspect or exercise now: read the diff, run the command locally, exercise the change on the branch or a preview. Keep a concrete example (e.g. `Run /woostack-commit on a dirty feature branch and confirm the PR body shows Goal, Summary, and the Automated/Manual test plan`).
+   - **After merge** — verification that cannot happen until the PR lands (staging/prod deploy behavior, migrations, env-specific config). Omit this group when nothing applies — this is the "if applicable".
+5. Adds the uniform **omit-when-empty** rule: omit any empty group (`### Automated`, `### Manual`, or either before/after block) rather than leaving placeholder bullets.
+
+Concretely, the replacement list:
+
+```markdown
+Rules:
+
+- State the **Goal** as intent or the problem solved in one or two sentences — not a change list. It is distinct from Summary, which lists *what* changed. Always present.
+- Keep Summary bullets concise and specific. Include only changes in the committed diff.
+- Under **Automated**, list the commands/tests actually run, plus the configured `commit.pre_commit` command and result when it ran. Show this group whenever an automated check (test, lint, typecheck, `pre_commit`) could have run for the change: list results, or `Not run` with the reason when one was expected but skipped. Omit `### Automated` entirely when no automated check applies to the change (for example a doc-only edit in a repo with no test harness) rather than emitting a `Not run` placeholder.
+- Under **Manual**, group human verification into **Before merge** (steps a reviewer can inspect or exercise now — read the diff, run the command locally, exercise the change on the branch or a preview, for example `Run /woostack-commit on a dirty feature branch and confirm the PR body shows Goal, Summary, and the Automated/Manual test plan`) and **After merge** (verification only possible once the PR lands — staging/prod deploy behavior, migrations, env-specific config). Include the After-merge group only when such steps exist; this is the "if applicable".
+- Omit any empty group — `### Automated`, `### Manual`, or either before/after block — rather than leaving placeholder bullets.
+- Preserve important existing PR context when it is still accurate. Replace stale generated summaries/test plans with the current ones.
+- Format test-plan items as unchecked Markdown checkboxes (`- [ ] ...`) so reviewers can mark verification complete.
+```
+
+- [ ] **Step 2: Verify**
+
+Read the rules list back. Confirm every section of the new template (Goal, Summary, Automated, Manual/before, Manual/after) has a governing rule, the omit-when-empty rule is uniform, and no rule still references a single flat test-plan list.
+
+---
+
+### Task 3: Update the fast-subagent draftable-field list
+
+**Files:**
+- Modify: `skills/woostack-commit/SKILL.md` — the "Fast-subagent drafting" bullet listing draftable text (currently lines ~48–50: "PR title candidate, Summary bullets, and Test plan bullets.")
+
+- [ ] **Step 1: Add Goal to the list**
+
+Change the delegated-text bullet so the draftable fields read: commit subject/body candidate, PR title candidate, **Goal line**, Summary bullets, and Test plan bullets (Automated and Manual).
+
+- [ ] **Step 2: Verify**
+
+Confirm the draftable list now names the Goal and reflects the Automated/Manual test-plan shape, and the "subagent returns only proposed text / main agent validates" boundary is unchanged.
+
+---
+
+### Task 4: Update description frontmatter and step-8 report
+
+**Files:**
+- Modify: `skills/woostack-commit/SKILL.md` — `description:` frontmatter (line 3) and the step-8 "Report" return list (lines ~219–227)
+
+- [ ] **Step 1: Update the description**
+
+Reword the trailing clause of the `description:` so it reflects the new body shape, e.g. "...update the current PR title/body with a goal, concise summary, and structured (automated + manual) test plan." Keep the trigger phrases intact.
+
+- [ ] **Step 2: Update the step-8 report list**
+
+Add `Goal used` to the returned fields alongside Summary bullets and Test plan bullets, so the report mirrors the body sections.
+
+- [ ] **Step 3: Verify**
+
+Confirm description still fits on sensible length, trigger phrases preserved, and the report list mentions Goal + the test-plan sections.
+
+---
+
+### Task 5: Whole-file consistency pass and commit
+
+**Files:**
+- Read: `skills/woostack-commit/SKILL.md` (entire file)
+
+- [ ] **Step 1: Full read-through**
+
+Read the whole file. Confirm: no remaining reference to a flat single-section test plan; the template, rules, fast-subagent list, description, and report all agree; the omit-when-empty and after-merge "if applicable" semantics are stated once and consistent; no placeholder text introduced.
+
+- [ ] **Step 2: Commit**
+
+Hand off to `woostack-commit` (build step 8 offers the PR). Until then, the change sits staged on the branch. Automated tests: `Not run` — this repo has no test harness for its own skill markdown (doc-only change).

--- a/.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
+++ b/.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
@@ -1,0 +1,162 @@
+---
+name: commit-pr-goal-test-plan
+type: spec
+status: ready
+date: 2026-06-04
+branch: worktree-delightful-pondering-thimble
+links:
+---
+
+# woostack-commit: PR body with Goal and structured test plan — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+## 1. Problem
+
+`woostack-commit` writes the PR body with a fixed two-section shape (SKILL.md:188–200):
+
+```markdown
+## Summary
+- <change>
+
+## Test plan
+- [ ] <command or manual step>
+```
+
+Two gaps:
+
+1. **No stated intent.** The body opens with a change list (`## Summary`) but never says
+   *why* the PR exists. A reviewer reconstructs the goal from the bullets. Intent up front is
+   what lets a reviewer judge whether the change actually serves its purpose.
+2. **Flat, undifferentiated test plan.** Automated runs (commands, `commit.pre_commit`) and
+   human verification are mixed in one checklist. There is no signal about which steps a
+   reviewer must perform by hand, and no place for verification that can only happen *after*
+   the PR lands (deploy behavior, migrations, env-gated config). The skill already pushes for
+   manual steps when automated coverage is thin (SKILL.md:210–211) but gives them no
+   structure.
+
+## 2. Goal
+
+Update the `woostack-commit` PR body template and its surrounding rules so every PR body:
+
+- Opens with a `## Goal` section (1–2 sentences of intent) above the kept `## Summary`.
+- Splits `## Test plan` into `### Automated` and `### Manual`.
+- Groups manual steps into **Before merge** and **After merge**, including the after-merge
+  group only when post-merge-only verification applies.
+
+Scope is the prose and template of one file: `skills/woostack-commit/SKILL.md`. No code, no
+other skills, no behavior outside what the skill documents.
+
+## 3. Non-goals
+
+- No change to git/Graphite/GitHub mechanics (branch shaping, staging, push, `gh pr edit`).
+- No change to the fast-subagent delegation boundary — only the list of draftable fields.
+- No new config keys. `commit.pre_commit` behavior is unchanged; it keeps surfacing in the
+  test plan, now under `### Automated`.
+- Not retrofitting existing open PRs. The template governs new/updated bodies going forward.
+
+## 4. Approach
+
+Edit four spots in `skills/woostack-commit/SKILL.md`:
+
+1. **Template block (SKILL.md:188–200)** — replace with the Goal + structured-test-plan
+   shape (see §5).
+2. **Step-7 rules (SKILL.md:202–211)** — add rules for filling Goal, Automated, and the
+   Manual before/after groups; fold the existing command-bullet and `Not run` guidance under
+   Automated; relocate the manual-step guidance under Manual with the before/after split and
+   the omit-when-empty rule.
+3. **Fast-subagent drafting (SKILL.md:48–50)** — add "Goal line" to the draftable text list
+   alongside Summary and Test plan bullets.
+4. **Description frontmatter (SKILL.md:3)** and **Step-8 Report (SKILL.md:219–227)** — minor
+   wording so both reflect goal + structured test plan.
+
+Markdown-only change; the skill is documentation that an agent executes.
+
+## 5. Components & data flow
+
+New PR body template:
+
+```markdown
+## Goal
+
+<1-2 sentences: why this PR exists / the problem it solves>
+
+## Summary
+
+- <concise bullet describing a relevant change>
+- <another relevant change>
+
+## Test plan
+
+### Automated
+
+- [ ] <command run and result, or "Not run (reason)">
+
+### Manual
+
+**Before merge**
+
+- [ ] <step a reviewer can inspect or exercise on the branch or preview>
+
+**After merge**
+
+- [ ] <step only verifiable post-merge — deploy / migration / env-gated>
+```
+
+Filling rules:
+
+- **Goal** states intent or the problem solved, not a change list — distinct from Summary,
+  which lists *what* changed. One or two sentences.
+- **Automated** lists commands/tests actually run, plus the configured `commit.pre_commit`
+  command and result when it ran. Show this group whenever an automated check (test, lint,
+  typecheck, `pre_commit`) *could* have run for this change: list results, or `Not run` with
+  the reason when one was expected but skipped. **Omit `### Automated` entirely when no
+  automated check is applicable to the change** (e.g. a doc-only edit in a repo with no test
+  harness) — do not emit a `Not run` placeholder in that case.
+- **Manual → Before merge** is what a reviewer can inspect or exercise now: read the diff,
+  run the command locally, exercise the change on the branch or a preview.
+- **Manual → After merge** is verification that *cannot* be done until the PR lands —
+  staging/prod deploy behavior, migrations, environment-specific config. This is the "if
+  applicable": **omit the After-merge group entirely when nothing applies.** Most
+  skill/doc-only changes have none.
+- Omit any empty group — `### Automated`, `### Manual`, or either before/after block —
+  rather than leaving placeholder bullets. The omit rule is uniform across all groups: an
+  inapplicable automated check drops `### Automated` just as a change with no manual steps
+  drops `### Manual`.
+- All test-plan items stay unchecked Markdown checkboxes (`- [ ] …`).
+
+## 6. Error handling
+
+No new failure modes — the change is template prose. Existing stop conditions
+(`pre_commit` non-zero, ambiguous relevance, no PR) are unchanged. Degenerate cases resolve
+by the omit-when-empty rule: a change with only automated coverage renders just
+`### Automated`; a doc change with one before-merge check renders `### Manual` with a single
+**Before merge** item and no **After merge** block.
+
+## 7. Testing
+
+Automated: none meaningful — this repo has no app build/CI for its own skill markdown, and
+the change is documentation. State that explicitly rather than inventing a test.
+
+Manual (before merge):
+- Read the updated `skills/woostack-commit/SKILL.md` and confirm the template shows `## Goal`
+  above `## Summary` and the `### Automated` / `### Manual` (with **Before merge** / **After
+  merge**) split, and that the rules describe each section including omit-when-empty and the
+  after-merge "if applicable" condition.
+- Confirm the four edit spots (template, step-7 rules, fast-subagent list, description +
+  step-8 report) are mutually consistent — no leftover reference to the old flat test plan.
+
+Manual (after merge): none — the skill takes effect for consumers on install; there is no
+deploy or runtime surface to verify post-merge for this repo.
+
+## 8. Open questions
+
+None. All decisions are resolved:
+
+- Goal sits above a kept Summary (`## Goal` heading, 1–2 sentences).
+- Manual steps use labeled **Before merge** / **After merge** subsections; the after-merge
+  group is omitted when no post-merge-only verification applies ("if applicable").
+- The omit-when-empty rule is uniform across every group. `### Automated` is shown with
+  results or a `Not run (reason)` line whenever an automated check could have run, and
+  omitted entirely when none is applicable to the change (rather than emitting a `Not run`
+  placeholder).

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-commit
-description: Commit the current session-relevant changes, create a feature branch first when needed, push with Graphite, and update the current PR title/body with a concise summary and test plan. Use for /woostack-commit, "commit this", "commit the current changes", "update the PR", or when finishing a woostack change before review.
+description: Commit the current session-relevant changes, create a feature branch first when needed, push with Graphite, and update the current PR title/body with a goal, concise summary, and structured (automated + manual) test plan. Use for /woostack-commit, "commit this", "commit the current changes", "update the PR", or when finishing a woostack change before review.
 ---
 
 # woostack-commit
@@ -45,8 +45,8 @@ verification decisions.
 
 Rules:
 
-- Delegate only text drafting: commit subject/body candidate, PR title candidate, Summary
-  bullets, and Test plan bullets.
+- Delegate only text drafting: commit subject/body candidate, PR title candidate, Goal line,
+  Summary bullets, and Test plan bullets (Automated and Manual).
 - Pass a bounded prompt containing the staged diff, changed-file list, commands run and
   results, relevant user intent, and any existing PR title/body that should be preserved.
 - Use the host's fast model when it can be selected explicitly. Follow the `fast` tier in
@@ -171,7 +171,7 @@ Update the PR after the commit/push so the PR reflects the latest branch state.
 
 Use a validated fast-subagent draft for the PR title/body when available. The main agent
 must still preserve accurate existing context, remove stale generated content, and ensure
-the Summary and Test plan mention only committed changes and real verification.
+the Goal, Summary, and Test plan mention only committed changes and real verification.
 
 Resolve the PR:
 
@@ -188,6 +188,10 @@ gh pr create --base staging --head "$(git branch --show-current)" --title "<conc
 Set or update the body with this structure:
 
 ```markdown
+## Goal
+
+<1-2 sentences: why this PR exists / the problem it solves>
+
 ## Summary
 
 - <concise bullet describing a user-visible or reviewer-relevant change>
@@ -195,20 +199,30 @@ Set or update the body with this structure:
 
 ## Test plan
 
+### Automated
+
 - [ ] <command run and result, or "Not run (reason)">
-- [ ] <manual verification step, when a meaningful one exists>
+
+### Manual
+
+**Before merge**
+
+- [ ] <step a reviewer can inspect or exercise on the branch or preview>
+
+**After merge**
+
+- [ ] <step only verifiable post-merge — deploy / migration / env-gated>
 ```
 
 Rules:
 
-- Keep bullets concise and specific.
-- Include only changes in the committed diff.
-- Preserve important existing PR context when it is still accurate.
-- Replace stale generated summaries/test plans with the current ones.
+- State the **Goal** as intent or the problem solved in one or two sentences — not a change list. It is distinct from Summary, which lists *what* changed. Always present it.
+- Keep Summary bullets concise and specific. Include only changes in the committed diff.
+- Under **Automated**, list the commands/tests actually run, plus the configured `commit.pre_commit` command and result when it ran. Show this group whenever an automated check (test, lint, typecheck, `pre_commit`) could have run for the change: list results, or `Not run` with the reason when one was expected but skipped. Omit `### Automated` entirely when no automated check applies to the change (for example a doc-only edit in a repo with no test harness) rather than emitting a `Not run` placeholder.
+- Under **Manual**, group human verification into **Before merge** and **After merge**. Before-merge steps are what a reviewer can inspect or exercise now — read the diff, run the command locally, exercise the change on the branch or a preview, for example `Run /woostack-commit on a dirty feature branch and confirm the PR body shows Goal, Summary, and the Automated/Manual test plan`. After-merge steps are verification only possible once the PR lands — staging/prod deploy behavior, migrations, env-specific config. Include the After-merge group only when such steps exist; this is the "if applicable".
+- Omit any empty group — `### Automated`, `### Manual`, or either before/after block — rather than leaving placeholder bullets.
+- Preserve important existing PR context when it is still accurate. Replace stale generated summaries/test plans with the current ones.
 - Format test-plan items as unchecked Markdown checkboxes (`- [ ] ...`) so reviewers can mark verification complete.
-- Include the configured `commit.pre_commit` command and result when it ran.
-- Prefer concrete manual verification steps when automated tests are unavailable, not run, or insufficient. Manual steps should describe what a reviewer can inspect or exercise, for example `Review the updated skill routing table in README.md` or `Run /woostack-commit on a dirty feature branch and confirm the PR body includes Summary and Test plan sections`.
-- If tests were not run, say `Not run` and give the reason, then include manual verification steps when possible.
 
 Update with:
 
@@ -223,7 +237,8 @@ Return:
 - Branch name.
 - Commit subject/SHA if available.
 - PR URL.
+- Goal used.
 - Summary bullets used.
-- Test plan bullets used.
+- Test plan bullets used (Automated and Manual).
 
 Do not claim tests passed unless you ran them and saw passing output.


### PR DESCRIPTION
## Goal

Make `woostack-commit` PR descriptions lead with intent and give reviewers a clearer test plan: a Goal section up top, and the test plan split into automated runs and manual checks, with manual checks grouped into before- and after-merge.

## Summary

- PR body template now opens with `## Goal` (1–2 sentences of intent) above the kept `## Summary`.
- `## Test plan` splits into `### Automated` and `### Manual`; Manual is grouped into **Before merge** and **After merge**, with the after-merge group included only when post-merge-only verification applies.
- Uniform omit-when-empty rule: `### Automated` shows results or `Not run (reason)` when a check could have run, and is omitted entirely when none applies; empty groups are dropped rather than left as placeholder bullets.
- Updated the four supporting spots in the skill for consistency — body template, step-7 rules, fast-subagent draftable list, and the description + step-8 report.
- Adds the design spec and implementation plan under `.woostack/`.

## Test plan

### Manual

**Before merge**

- [x] Read `skills/woostack-commit/SKILL.md`: the body template shows `## Goal` above `## Summary`, and `## Test plan` → `### Automated` / `### Manual` with **Before merge** / **After merge** groups.
- [x] Step-7 rules, fast-subagent draftable list, description, and step-8 report all reference the new shape; no leftover flat-test-plan wording remains.
- [x] Dogfood: this PR's own body was produced in the new shape — Goal on top, and because this is a doc-only change in a repo with no test harness, both `### Automated` and the **After merge** group are correctly omitted per the new "if applicable" / omit-when-empty rules.