### PR TITLE
chore: add woostack gitignore

### DIFF
--- a/.woostack/.gitignore
+++ b/.woostack/.gitignore
@@ -1,0 +1,7 @@
+# Transient, per-clone — not shared knowledge.
+metrics.json
+*.local.*
+
+# Obsidian per-user UI state (the shared .obsidian/*.json config IS tracked).
+.obsidian/workspace*
+.obsidian/cache


### PR DESCRIPTION
## Summary

- Add the canonical `.woostack/.gitignore` scaffold for transient workspace files.
- Keep local metrics, local overrides, and Obsidian UI state out of shared repo history.

## Test plan

- [ ] Ran `bash skills/woostack-init/scripts/build-index.sh .woostack/memory` and it completed successfully.
- [ ] Ran `bash skills/woostack-init/scripts/doctor.sh .woostack/memory` and saw `doctor: 0 error(s), 0 warning(s)`.
- [ ] No `commit.pre_commit` command was configured in `.woostack/config.json`.
