### PR TITLE
feat(build): add execution-handoff gate before execute

### DIFF
--- a/.woostack/plans/2026-06-04-build-execution-handoff-gate.md
+++ b/.woostack/plans/2026-06-04-build-execution-handoff-gate.md
@@ -19,7 +19,7 @@
 **Files:**
 - Modify: `skills/woostack-build/SKILL.md` (Overview section, lines ~10–29)
 
-- [ ] **Step 1: Reword the "thin glue" intro — build now adds one gate**
+- [x] **Step 1: Reword the "thin glue" intro — build now adds one gate**
 
 Replace:
 
@@ -38,7 +38,7 @@ adds exactly one of its own** — the execution handoff — because the plan→e
 belongs to no sub-skill. The value is the order and the handoffs.
 ```
 
-- [ ] **Step 2: Insert the handoff stop into the ASCII chain**
+- [x] **Step 2: Insert the handoff stop into the ASCII chain**
 
 Replace:
 
@@ -56,7 +56,7 @@ ideate → write spec (markdown) → harden spec → approve spec → writing-pl
   → execute (per increment: implement → commit → review → distill) → reviewed PR stack
 ```
 
-- [ ] **Step 3: Update the "two gates" paragraph to three**
+- [x] **Step 3: Update the "two gates" paragraph to three**
 
 Replace:
 
@@ -80,7 +80,7 @@ one. The execution-handoff gate is build's own: no sub-skill owns the plan→exe
 build adds it to let you stop after planning and execute later or elsewhere.
 ```
 
-- [ ] **Step 4: Update the hardening paragraph (gate count → three)**
+- [x] **Step 4: Update the hardening paragraph (gate count → three)**
 
 Replace:
 
@@ -101,7 +101,7 @@ an approval stop. The execution-handoff gate (step 8) is build-owned, not harden
 sits after that PR. So the chain has exactly the three hard gates above.
 ```
 
-- [ ] **Step 5: Verify the Overview reads coherently**
+- [x] **Step 5: Verify the Overview reads coherently**
 
 Run: `sed -n '8,35p' skills/woostack-build/SKILL.md`
 Expected: intro says "adds exactly one"; chain shows "stop before execute (handoff gate)"; gate paragraph lists three gates; hardening paragraph says "three hard gates". No remaining "adds none of its own" or "exactly the two hard gates".
@@ -113,7 +113,7 @@ Expected: intro says "adds exactly one"; chain shows "stop before execute (hando
 **Files:**
 - Modify: `skills/woostack-build/SKILL.md` (step 6, lines ~80–85)
 
-- [ ] **Step 1: Replace the step 6 tail**
+- [x] **Step 1: Replace the step 6 tail**
 
 Replace:
 
@@ -132,7 +132,7 @@ With:
    harden into a plan-approval gate.
 ```
 
-- [ ] **Step 2: Verify step 6**
+- [x] **Step 2: Verify step 6**
 
 Run: `sed -n '80,86p' skills/woostack-build/SKILL.md`
 Expected: still says "adds **no approval gate**"; now points to step 8 as the last hard stop; no "spec-approval gate (step 3) remains the chain's last hard stop".
@@ -144,7 +144,7 @@ Expected: still says "adds **no approval gate**"; now points to step 8 as the la
 **Files:**
 - Modify: `skills/woostack-build/SKILL.md` (steps 8–9, lines ~86–100)
 
-- [ ] **Step 1: Insert the new step 8 immediately after step 7**
+- [x] **Step 1: Insert the new step 8 immediately after step 7**
 
 Find the end of step 7 (the line ending `merged** by build. This is a work step, not an approval stop.`) and the start of the current step 8. Replace the current step 8 header line:
 
@@ -171,7 +171,7 @@ With the new step 8, then the renumbered step 9 header:
 (The body of the old step 8 — "work the plan as PR-sized stacked increments …" through "… separate
 'distill memory' and 'offer the PR' steps here." — is unchanged; only its number becomes 9.)
 
-- [ ] **Step 2: Renumber and rewrite the terminal step (old 9 → 10, two terminal shapes)**
+- [x] **Step 2: Renumber and rewrite the terminal step (old 9 → 10, two terminal shapes)**
 
 Replace:
 
@@ -193,7 +193,7 @@ With:
     steps) and **never merges**.
 ```
 
-- [ ] **Step 3: Fix the in-prose step-number reference inside step 7**
+- [x] **Step 3: Fix the in-prose step-number reference inside step 7**
 
 Step 7's body points at the execute step by number ("execution increments (step 8)"); execute is now step 9, so this reference must follow. Replace:
 
@@ -209,7 +209,7 @@ increments (step 9) stack on top of it via `gt create`.
 
 (This is the **only** in-prose `step 8` reference in the file — verified by grep before planning; all other `step 8` mentions are introduced by Task 1/3/4 and correctly point at the new handoff gate.)
 
-- [ ] **Step 4: Verify the procedure numbering**
+- [x] **Step 4: Verify the procedure numbering**
 
 Run: `grep -nE '^[0-9]+\. \*\*' skills/woostack-build/SKILL.md`
 Expected: exactly ten numbered steps, 1–10, in order; step 8 is "Stop before execute (execution-handoff gate)", step 9 is "Execute", step 10 is "End on the chosen terminal state". No duplicate or skipped numbers.
@@ -224,7 +224,7 @@ Expected: every `step N` reference resolves to a real step 1–10; the lone `ste
 **Files:**
 - Modify: `skills/woostack-build/SKILL.md` (Hard constraints, lines ~104–117)
 
-- [ ] **Step 1: Replace the first two doctrine bullets**
+- [x] **Step 1: Replace the first two doctrine bullets**
 
 Replace:
 
@@ -249,7 +249,7 @@ With:
   plan-approval gate.
 ```
 
-- [ ] **Step 2: Add the "Stop before execute" bullet before the "Never merge" bullet**
+- [x] **Step 2: Add the "Stop before execute" bullet before the "Never merge" bullet**
 
 Replace:
 
@@ -267,7 +267,7 @@ With:
   further.
 ```
 
-- [ ] **Step 3: Verify the hard constraints**
+- [x] **Step 3: Verify the hard constraints**
 
 Run: `sed -n '/## Hard constraints/,$p' skills/woostack-build/SKILL.md`
 Expected: first bullet "Inherit two gates, add one"; second "Harden twice, neither harden gates"; a "Stop before execute" bullet present; "Never merge" mentions both terminal shapes. No "Inherit gates, add none" or "Harden twice, gate once".
@@ -279,17 +279,17 @@ Expected: first bullet "Inherit two gates, add one"; second "Harden twice, neith
 **Files:**
 - Read-only: `skills/woostack-build/SKILL.md`
 
-- [ ] **Step 1: Grep-sweep for stale doctrine**
+- [x] **Step 1: Grep-sweep for stale doctrine**
 
 Run: `grep -nE 'two hard gates|add none|adds none|gate once|exactly two' skills/woostack-build/SKILL.md`
 Expected: **no matches.** Any match is a stale assertion to fix.
 
-- [ ] **Step 2: Confirm surviving "plan-approval gate" / "three" usages are intentional**
+- [x] **Step 2: Confirm surviving "plan-approval gate" / "three" usages are intentional**
 
 Run: `grep -nE 'plan-approval gate|three hard gates|three of those gates|adds exactly one|add one' skills/woostack-build/SKILL.md`
 Expected: every "plan-approval gate" hit is in a *forbidding* sentence ("do not turn… into a plan-approval gate"); "three" hits describe the gate count; "adds exactly one / add one" hits are the doctrine reframe. No hit asserts a plan-approval gate exists.
 
-- [ ] **Step 3: Full read for coherence**
+- [x] **Step 3: Full read for coherence**
 
 Run: `cat skills/woostack-build/SKILL.md`
 Expected (manual check against spec §7 Testing):
@@ -300,7 +300,7 @@ Expected (manual check against spec §7 Testing):
 - Frontmatter `description:` unchanged and still true.
 - Step 4 untouched ("plans are working checklists, not visualization artifacts" still present).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 Executed by `woostack-execute` via [`woostack-commit`](../../skills/woostack-commit/SKILL.md) on this increment's Graphite branch (stacked on the spec+plan PR). Suggested message:
 

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -8,25 +8,29 @@ description: Use when building a feature with the full woostack development loop
 ## Overview
 
 Drives one feature from idea to implementation through a fixed, gated chain. Thin
-glue: it sequences proven sub-skills and **inherits their gates** — it adds none of
-its own. The value is the order and the handoffs.
+glue: it sequences proven sub-skills, **inherits their two gates** (design, spec) **and
+adds exactly one of its own** — the execution handoff — because the plan→execute boundary
+belongs to no sub-skill. The value is the order and the handoffs.
 
 ```
 ideate → write spec (markdown) → harden spec → approve spec → writing-plans → decompose
-  → harden plan → commit spec+plan as their own PR → execute (per increment: implement →
-  commit → review → distill) → reviewed PR stack
+  → harden plan → commit spec+plan as their own PR → stop before execute (handoff gate)
+  → execute (per increment: implement → commit → review → distill) → reviewed PR stack
 ```
 
-Two of those gates are hard stops where the user must say yes before the chain advances:
-**design approval** (owned by `woostack-ideate`, step 1) and **spec approval** (step 3).
-The spec-approval gate is the "user reviews the written spec" step that
-`superpowers:brainstorming` used to own; because woostack-build relocated the spec write into
-its own step 2, the gate lives here now. Relocating an inherited gate is not adding one.
+Three of those gates are hard stops where the user must say yes before the chain advances:
+**design approval** (owned by `woostack-ideate`, step 1), **spec approval** (step 3), and the
+**execution handoff** (step 8). The spec-approval gate is the "user reviews the written spec"
+step that `superpowers:brainstorming` used to own; because woostack-build relocated the spec
+write into its own step 2, the gate lives here now — relocating an inherited gate is not adding
+one. The execution-handoff gate is build's own: no sub-skill owns the plan→execute boundary, so
+build adds it to let you stop after planning and execute later or elsewhere.
 
 Hardening runs **twice** — once on the spec (step 3) and once on the plan (step 6) — but only
-the spec harden feeds a gate. The plan harden amends the plan in place and hands straight back,
-and committing the spec+plan PR (step 7) is a work step, not an approval stop. Neither adds a
-gate: the chain still has exactly the two hard gates above.
+the spec harden feeds a gate (the spec-approval gate, step 3). The plan harden amends the plan
+in place and hands straight back, and committing the spec+plan PR (step 7) is a work step, not
+an approval stop. The execution-handoff gate (step 8) is build-owned, not harden-owned, and
+sits after that PR. So the chain has exactly the three hard gates above.
 
 ## Dependency preflight
 
@@ -81,14 +85,25 @@ equivalent.
    time against the plan and its increment breakdown — stress-test the sequencing, the
    increment boundaries, and the verifications until hardening stops producing new questions.
    Amend the plan markdown in place as answers land. This adds **no approval gate**: harden
-   owns none and hands straight back. The spec-approval gate (step 3) remains the chain's last
-   hard stop; do not invent a plan-approval gate here.
+   owns none and hands straight back. The chain's last hard stop is the **execution-handoff
+   gate (step 8)**, after the spec+plan PR — not a plan-*quality* gate here. Do not turn this
+   harden into a plan-approval gate.
 7. **Commit the spec and plan as their own PR.** Before any implementation, commit the
    `.woostack/` spec and plan via [`woostack-commit`](../woostack-commit/SKILL.md) on a fresh
    Graphite branch and open a PR. This docs-only PR is the **base of the stack** — execution
-   increments (step 8) stack on top of it via `gt create`. It carries no code and is **never
+   increments (step 9) stack on top of it via `gt create`. It carries no code and is **never
    merged** by build. This is a work step, not an approval stop.
-8. **Execute.** Invoke [`woostack-execute`](../woostack-execute/SKILL.md) with the plan path to
+8. **Stop before execute (execution-handoff gate).** After the spec+plan PR is open, **halt** —
+   this is a hard gate. Surface the handoff artifacts: the plan path (`.woostack/plans/…`), the
+   spec+plan PR URL, and — on request — a
+   [`woostack-visualize`](../woostack-visualize/SKILL.md) render of the plan (audience
+   `engineer`). Then ask the user to choose:
+   - **Go** → proceed to step 9 and run `woostack-execute` in this session.
+   - **Hand off** → stop here. The user takes the plan PR and executes later or elsewhere (e.g.
+     Codex, or a fresh session via `/woostack-execute <plan-path>`).
+   Ambiguous or no answer is **not** a "go": never auto-run execute without an explicit
+   go-ahead. This is the chain's last hard gate.
+9. **Execute.** Invoke [`woostack-execute`](../woostack-execute/SKILL.md) with the plan path to
    work the plan as PR-sized stacked increments on top of the spec+plan PR — each implemented
    with TDD, the plan's checkboxes ticked in place, committed via `woostack-commit`, reviewed per
    the execution mode `woostack-execute` selects (`woostack-review --fast` in inline mode, or the
@@ -97,17 +112,24 @@ equivalent.
    per-increment commit/review/distill cadence and the inline-vs-subagent mode choice (one plan
    per spec, multiple stacked PRs per plan), so it absorbs what used to be separate "distill
    memory" and "offer the PR" steps here.
-9. **End on the reviewed stack.** The terminal state is a Graphite stack with the spec+plan PR
-   at the base and a reviewed increment PR above each step. Build does not separately ask to
-   open a PR (step 7 and `woostack-execute` open them as work steps) and **never merges**.
+10. **End on the chosen terminal state.** Build ends in one of two shapes, never merging either:
+    - **Hand off** → only the spec+plan PR is open (no increment PRs), ready for external or
+      later execute.
+    - **Go** → a Graphite stack with the spec+plan PR at the base and a reviewed increment PR
+      above each step.
+    Build does not separately ask to open a PR (step 7 and `woostack-execute` open them as work
+    steps) and **never merges**.
 
 ## Hard constraints
 
-- **Inherit gates, add none.** Do not insert *extra* approval stops between phases. The two
-  inherited hard gates are non-negotiable: **design approval** (step 1) and **spec approval**
-  (step 3). The plan harden (step 6) and the spec+plan PR (step 7) are work steps, not gates.
-- **Harden twice, gate once.** Harden the spec (step 3, feeds the spec-approval gate) and the
-  plan (step 6, amends in place, no gate). Never add a plan-approval gate.
+- **Inherit two gates, add one.** Do not insert *extra* approval stops beyond the three hard
+  gates: **design approval** (step 1) and **spec approval** (step 3), both inherited, plus the
+  **execution handoff** (step 8), which build owns because the plan→execute boundary belongs to
+  no sub-skill. The plan harden (step 6) and the spec+plan PR (step 7) are work steps, not gates.
+- **Harden twice, neither harden gates.** Harden the spec (step 3, feeds the spec-approval gate)
+  and the plan (step 6, amends in place, no gate). The execution-handoff gate (step 8) is
+  separate and build-owned, not a plan-*quality* gate; never turn the plan harden into a
+  plan-approval gate.
 - **Always get explicit spec approval before planning.** After the spec harden, present the
   written spec and wait for the user's clear yes. Never advance to `writing-plans` on assumed
   or inferred approval.
@@ -115,7 +137,11 @@ equivalent.
   default location. HTML is a render-on-demand target only, not the authored format.
 - **Spec+plan ship as their own PR before execution.** Commit the spec and plan as a docs-only
   PR (step 7) — the base of the stack — before any implementation begins. Never merge it.
-- **Never merge.** build ends on the reviewed PR stack, nothing further.
+- **Stop before execute.** Never auto-run execute; always halt at the execution-handoff gate
+  (step 8) after the spec+plan PR. The plan PR is the artifact for executing here or in another
+  tool. Ambiguous or no answer is not a "go."
+- **Never merge.** build ends on the terminal state (handoff PR, or reviewed stack), nothing
+  further.
 - **One increment per cycle.** Do not let a single build cycle balloon past a reviewable PR.
 - **Distill durable knowledge only.** `woostack-execute` writes scoped, deduplicated memory
   notes per increment — never feature-specific trivia, never a duplicate of an existing note. A


### PR DESCRIPTION
## Goal

Let a feature be planned in Claude Code and then executed later or elsewhere (e.g. Codex) by adding a hard **execution-handoff gate** to `woostack-build` between the spec+plan PR and execute — so the loop no longer auto-flows from planning straight into implementation.

## Summary

- `skills/woostack-build/SKILL.md`: insert a new **step 8 — "Stop before execute (execution-handoff gate)"** after the spec+plan PR; build halts and surfaces plan path + PR URL + on-demand `woostack-visualize` render, then offers **Go** (execute here) or **Hand off** (stop). Ambiguous/no answer → stop.
- Renumber execute → **9** and terminal → **10**; step 10 now documents **two terminal shapes** (hand off = spec+plan PR only; go = reviewed stack). Fix the in-prose `step 8` → `step 9` reference inside step 7.
- Honest doctrine reframe **2 → 3 gates**: Overview now says "inherits two gates (design, spec) and adds exactly one of its own — the execution handoff"; ASCII chain shows the stop; hardening paragraph and step 6 updated.
- Hard constraints: rewrite "Inherit gates, add none" → "Inherit two gates, add one"; "Harden twice, gate once" → "Harden twice, neither harden gates"; add a **"Stop before execute"** bullet; "Never merge" notes both terminal shapes.
- Tick the plan checkboxes in `.woostack/plans/2026-06-04-build-execution-handoff-gate.md`.

## Test plan

### Manual

**Before merge**

- [ ] Read the `SKILL.md` diff — confirm the new step 8 gate, the 8→9→10 renumber, and three-gate framing throughout.
- [ ] `grep -nE 'two hard gates|add none|adds none|gate once|exactly two' skills/woostack-build/SKILL.md` → no matches (stale doctrine gone).
- [ ] `grep -nE '^[0-9]+\. \*\*' skills/woostack-build/SKILL.md` → steps 1–10, ordered; `grep -noE 'step [0-9]+'` → every `step 8` means the handoff gate, every `step 9` means execute.
