### PR TITLE
feat(status): add /woostack-status command and producer wiring (Increment 2)

### DIFF
--- a/.woostack/plans/2026-06-04-woostack-status.md
+++ b/.woostack/plans/2026-06-04-woostack-status.md
@@ -1033,7 +1033,7 @@ git commit -m "chore(status): migrate spec status vocabulary to the phase enum"
 
 **Files:** Modify `skills/woostack-build/SKILL.md`
 
-- [x] Annotate each step with the `status:` it authors: step 2 → `draft`; step 3 post-grill → `hardened`, gate cleared → `approved`; step 4 → `planning`; step 6 → `executing`; step 8 → `in-review`; post-merge → `done`. Add a one-line "the build loop owns `status:` transitions — see `woostack-status/references/conventions.md`."
+- [x] Annotate each step with the `status:` it authors: step 2 → `draft`; step 3 post-grill → `hardened`, gate cleared → `approved`; step 4 → `planning`; step 9 execute drives the `executing`/`in-review` band; post-merge → `done`. Add a one-line "the build loop owns `status:` transitions — see `woostack-status/references/conventions.md`."
 - [x] In step 4 (plan), require the plan to open with the `**Source:** .woostack/specs/<file>.md` line.
 - [x] In step 2/5, state the invariant explicitly: exactly one plan per spec; the plan owns the increments. Link `conventions.md`.
 - [x] Commit: `docs(build): author status: per step, require Source line, state 1:1 invariant`.
@@ -1059,9 +1059,9 @@ git commit -m "chore(status): migrate spec status vocabulary to the phase enum"
 
 **Files:** Modify `AGENTS.md` (and its symlink `.claude/CLAUDE.md` is the same file), `README.md`
 
-- [x] Update the public command surface from eight to nine: add the `woostack-status` bullet to the list, add it to the Quick file map, and update any "eight skills" wording (keep the internal `woostack-ideate` framing intact — it is not part of the count).
+- [x] Update the public command surface from nine to ten: add the `woostack-status` bullet to the list, add it to the Quick file map, and update any stale skill-count wording (keep the internal `woostack-ideate` framing intact — it is not part of the count).
 - [x] Update `README.md`'s skill list / how-it-works the same way; resolve any version/command counts.
-- [x] Commit: `docs: add woostack-status to the public command surface (8 → 9)`.
+- [x] Commit: `docs: add woostack-status to the public command surface (9 → 10)`.
 
 ### Increment 2 close-out
 

--- a/.woostack/plans/2026-06-04-woostack-status.md
+++ b/.woostack/plans/2026-06-04-woostack-status.md
@@ -66,7 +66,7 @@
 - Create: `skills/woostack-status/scripts/tests/run-tests.sh`
 - Create: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Copy the test harness verbatim.** Copy `skills/woostack-init/scripts/tests/assert.sh` and `skills/woostack-init/scripts/tests/run-tests.sh` to `skills/woostack-status/scripts/tests/`. (They are generic; reuse, do not re-invent.)
+- [x] **Step 1: Copy the test harness verbatim.** Copy `skills/woostack-init/scripts/tests/assert.sh` and `skills/woostack-init/scripts/tests/run-tests.sh` to `skills/woostack-status/scripts/tests/`. (They are generic; reuse, do not re-invent.)
 
 ```bash
 mkdir -p skills/woostack-status/scripts/tests skills/woostack-status/references
@@ -74,7 +74,7 @@ cp skills/woostack-init/scripts/tests/assert.sh skills/woostack-status/scripts/t
 cp skills/woostack-init/scripts/tests/run-tests.sh skills/woostack-status/scripts/tests/run-tests.sh
 ```
 
-- [ ] **Step 2: Create the bundled `lib.sh`** with only the helpers status.sh needs (copied from `woostack-init/scripts/lib.sh`, trimmed to four functions).
+- [x] **Step 2: Create the bundled `lib.sh`** with only the helpers status.sh needs (copied from `woostack-init/scripts/lib.sh`, trimmed to four functions).
 
 ```bash
 #!/usr/bin/env bash
@@ -107,7 +107,7 @@ _woo_epoch() {
 }
 ```
 
-- [ ] **Step 3: Write the failing test** for empty state.
+- [x] **Step 3: Write the failing test** for empty state.
 
 ```bash
 # skills/woostack-status/scripts/tests/test-status.sh
@@ -130,14 +130,14 @@ assert_contains "$OUT" "no specs found" "empty state prints guidance"
 assert_exit 0 "$CODE" "empty state exits 0"
 ```
 
-- [ ] **Step 4: Run it, verify it fails** (status.sh does not exist yet).
+- [x] **Step 4: Run it, verify it fails** (status.sh does not exist yet).
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — status.sh missing / OUT empty, assertion fails
 ```
 
-- [ ] **Step 5: Write the minimal `status.sh`** that handles empty state.
+- [x] **Step 5: Write the minimal `status.sh`** that handles empty state.
 
 ```bash
 #!/usr/bin/env bash
@@ -160,14 +160,14 @@ if [ "${#specs[@]}" -eq 0 ]; then
 fi
 ```
 
-- [ ] **Step 6: Run the test, verify it passes.**
+- [x] **Step 6: Run the test, verify it passes.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: "1 passed, 0 failed" for the empty-state assertions (others added later)
 ```
 
-- [ ] **Step 7: Commit.**
+- [x] **Step 7: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts
@@ -180,7 +180,7 @@ git commit -m "feat(status): scaffold status.sh skeleton + empty-state, bundle l
 - Modify: `skills/woostack-status/scripts/status.sh`
 - Test: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Write the failing test** — three specs in head states render with phase + next action; the `.html` is ignored.
+- [x] **Step 1: Write the failing test** — three specs in head states render with phase + next action; the `.html` is ignored.
 
 ```bash
 # append to test-status.sh
@@ -203,14 +203,14 @@ assert_contains "$OUT" "writing-plans" "approved next-action"
 assert_not_contains "$OUT" "orphan-design" "html spec is ignored"
 ```
 
-- [ ] **Step 2: Run it, verify it fails** (no row rendering yet).
+- [x] **Step 2: Run it, verify it fails** (no row rendering yet).
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — alpha/draft not found in OUT
 ```
 
-- [ ] **Step 3: Add the `next_action` lookup and a first render pass** to `status.sh` (after the empty-state guard).
+- [x] **Step 3: Add the `next_action` lookup and a first render pass** to `status.sh` (after the empty-state guard).
 
 ```bash
 next_action() { # phase done total mergedCount prCount
@@ -241,14 +241,14 @@ for f in "${specs[@]}"; do
 done
 ```
 
-- [ ] **Step 4: Run the test, verify it passes.**
+- [x] **Step 4: Run the test, verify it passes.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: head-state assertions pass; html ignored
 ```
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts
@@ -261,7 +261,7 @@ git commit -m "feat(status): render head-state rows with phase + next-action loo
 - Modify: `skills/woostack-status/scripts/status.sh`
 - Test: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Write the failing test** — a spec with one plan shows `N/M`; zero plans and two plans both FLAG.
+- [x] **Step 1: Write the failing test** — a spec with one plan shows `N/M`; zero plans and two plans both FLAG.
 
 ```bash
 mkplan() { # dir name specfile boxes_done boxes_todo
@@ -290,14 +290,14 @@ run_status "$p"
 assert_contains "$OUT" "2 plans" "duplicate-plan flagged"
 ```
 
-- [ ] **Step 2: Run it, verify it fails.**
+- [x] **Step 2: Run it, verify it fails.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — 3/10 not present
 ```
 
-- [ ] **Step 3: Add `plan_for`, `plan_progress`, a FLAGS buffer, and wire PLAN cell.**
+- [x] **Step 3: Add `plan_for`, `plan_progress`, a FLAGS buffer, and wire PLAN cell.**
 
 ```bash
 # near the top, after counters
@@ -351,14 +351,14 @@ if [ -n "$FLAGS" ]; then printf '\n⚠ FLAGS\n%s' "$FLAGS"; fi
 > plans=(); while IFS= read -r ln; do [ -n "$ln" ] && plans+=("$ln"); done < <(plan_for "$f")
 > ```
 
-- [ ] **Step 4: Run the test, verify it passes.**
+- [x] **Step 4: Run the test, verify it passes.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: 3/10 present; 0-plan and 2-plan flags present
 ```
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts
@@ -371,7 +371,7 @@ git commit -m "feat(status): join single plan via Source line, count boxes, flag
 - Modify: `skills/woostack-status/scripts/status.sh`
 - Test: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Write the failing test** using a fake `gh` on `PATH` to feed PR state.
+- [x] **Step 1: Write the failing test** using a fake `gh` on `PATH` to feed PR state.
 
 ```bash
 # A fake gh: prints fixture JSON based on a file the test controls.
@@ -398,14 +398,14 @@ assert_contains "$OUT" "in-review" "open PR ⇒ in-review via truth table"
 unset FAKE_GH_JSON
 ```
 
-- [ ] **Step 2: Run it, verify it fails.**
+- [x] **Step 2: Run it, verify it fails.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — phase still shows authored "executing"
 ```
 
-- [ ] **Step 3: Add `gh_json`, `prs_for_spec`, `resolve_phase`; apply the truth table.**
+- [x] **Step 3: Add `gh_json`, `prs_for_spec`, `resolve_phase`; apply the truth table.**
 
 ```bash
 GH_BIN="${WOOSTACK_GH:-gh}"
@@ -456,14 +456,14 @@ In the loop, after computing `done`/`total`, compute PR counts and the effective
 
 Render `$eff` (not the raw authored `$phase`) in the PHASE cell, and pass `$done $total $merged $prcount` into `next_action`.
 
-- [ ] **Step 4: Run the test, verify it passes.**
+- [x] **Step 4: Run the test, verify it passes.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: foxtrot shows in-review
 ```
 
-- [ ] **Step 5: Add band-coverage tests** (executing when partial + no open PR; done when 100% + merged) and re-run.
+- [x] **Step 5: Add band-coverage tests** (executing when partial + no open PR; done when 100% + merged) and re-run.
 
 ```bash
 # partial, no PRs ⇒ executing
@@ -475,7 +475,7 @@ assert_contains "$OUT" "golf" "golf present"
 assert_exit 0 "$CODE" "band compute exits 0"
 ```
 
-- [ ] **Step 6: Commit.**
+- [x] **Step 6: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts
@@ -488,7 +488,7 @@ git commit -m "feat(status): stubbable gh access + truth-table for exec/review/d
 - Modify: `skills/woostack-status/scripts/status.sh`
 - Test: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Write the failing test** — two PRs (one merged, one open) render as a rollup.
+- [x] **Step 1: Write the failing test** — two PRs (one merged, one open) render as a rollup.
 
 ```bash
 h="$(mktemp -d)/.woostack"
@@ -501,14 +501,14 @@ assert_contains "$OUT" "#190" "open increment listed"
 unset FAKE_GH_JSON
 ```
 
-- [ ] **Step 2: Run it, verify it fails.**
+- [x] **Step 2: Run it, verify it fails.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — INCREMENTS cell still "—"
 ```
 
-- [ ] **Step 3: Build the increments cell** while iterating PRs (extend the loop from Task 4).
+- [x] **Step 3: Build the increments cell** while iterating PRs (extend the loop from Task 4).
 
 ```bash
   inc_parts=""
@@ -522,7 +522,7 @@ bash skills/woostack-status/scripts/tests/test-status.sh
 
 (Merge this into the single PR loop from Task 4 — do not iterate twice. Keep counts and `inc_parts` in one pass.)
 
-- [ ] **Step 4: Add the missing-trailer fallback test + behavior.** When the trailer search returns nothing but `branch:` exists, query by head branch and mark "partial".
+- [x] **Step 4: Add the missing-trailer fallback test + behavior.** When the trailer search returns nothing but `branch:` exists, query by head branch and mark "partial".
 
 ```bash
 # behavior in status.sh: if prcount==0 and branch nonempty, try head query
@@ -547,14 +547,14 @@ mkplan "$i" india 2026-06-01-india.md 1 9
 assert_contains "$(next_action executing 1 10 0 0)" "first increment" "no-pr exec next-action"
 ```
 
-- [ ] **Step 5: Run the tests, verify they pass.**
+- [x] **Step 5: Run the tests, verify they pass.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: #181 / #190 present; rollup assertions pass
 ```
 
-- [ ] **Step 6: Commit.**
+- [x] **Step 6: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts
@@ -567,7 +567,7 @@ git commit -m "feat(status): increment-PR rollup cell + missing-trailer head fal
 - Modify: `skills/woostack-status/scripts/status.sh`
 - Test: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Write the failing test** — a pre-PR spec gets owner/age from the spec file's git log; deterministic via `WOOSTACK_NOW`.
+- [x] **Step 1: Write the failing test** — a pre-PR spec gets owner/age from the spec file's git log; deterministic via `WOOSTACK_NOW`.
 
 ```bash
 # real git repo so spec git-log works
@@ -581,14 +581,14 @@ assert_contains "$OUT" "Tess" "pre-PR owner from spec git log"
 assert_contains "$OUT" "15d" "pre-PR age from spec git log (2026-05-20 → 2026-06-04)"
 ```
 
-- [ ] **Step 2: Run it, verify it fails.**
+- [x] **Step 2: Run it, verify it fails.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — OWNER/AGE blank
 ```
 
-- [ ] **Step 3: Add owner/age resolution.** For PR phases use the latest PR's `author`/`updatedAt`; for pre-PR phases use `git log -1` on the spec file.
+- [x] **Step 3: Add owner/age resolution.** For PR phases use the latest PR's `author`/`updatedAt`; for pre-PR phases use `git log -1` on the spec file.
 
 ```bash
 GIT_BIN="${WOOSTACK_GIT:-git}"
@@ -620,7 +620,7 @@ In the loop, after the PR pass:
     last_author="$author"; last_upd_date="${upd:0:10}"
 ```
 
-- [ ] **Step 4: Add stale flag + collision check.**
+- [x] **Step 4: Add stale flag + collision check.**
 
 ```bash
   if [ -n "$agecell" ]; then
@@ -642,14 +642,14 @@ staleDays() { echo 14; }   # overridden in Task 9 to read config
 SEEN_BRANCHES=""
 ```
 
-- [ ] **Step 5: Run the tests, verify they pass.**
+- [x] **Step 5: Run the tests, verify they pass.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: Tess / 15d present
 ```
 
-- [ ] **Step 6: Commit.**
+- [x] **Step 6: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts
@@ -662,7 +662,7 @@ git commit -m "feat(status): owner/age/stale + branch-collision (gh vs spec git-
 - Modify: `skills/woostack-status/scripts/status.sh`
 - Test: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Write the failing tests** for the boundary rules.
+- [x] **Step 1: Write the failing tests** for the boundary rules.
 
 ```bash
 # unknown branch ⇒ flag
@@ -687,14 +687,14 @@ assert_contains "$OUT" "status lags" "PR-open-but-early-phase flagged"
 unset FAKE_GH_JSON
 ```
 
-- [ ] **Step 2: Run them, verify they fail.**
+- [x] **Step 2: Run them, verify they fail.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — no such flags yet
 ```
 
-- [ ] **Step 3: Add the boundary checks** in the loop (after `eff` and PR counts are known).
+- [x] **Step 3: Add the boundary checks** in the loop (after `eff` and PR counts are known).
 
 ```bash
   # phase enum sanity
@@ -714,14 +714,14 @@ bash skills/woostack-status/scripts/tests/test-status.sh
   esac
 ```
 
-- [ ] **Step 4: Run the tests, verify they pass.**
+- [x] **Step 4: Run the tests, verify they pass.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: all boundary flags present; sibling rows survive
 ```
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts
@@ -734,7 +734,7 @@ git commit -m "feat(status): reconcile boundary flags (branch sanity, enum, phas
 - Modify: `skills/woostack-status/scripts/status.sh`
 - Test: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Write the failing tests.**
+- [x] **Step 1: Write the failing tests.**
 
 ```bash
 # done hidden by default, shown with --all, counted in footer
@@ -762,14 +762,14 @@ assert_exit 0 "$qc" "gh-absent still exits 0"
 assert_contains "$(cat /tmp/q.out)" "quebec" "renders without gh"
 ```
 
-- [ ] **Step 2: Run them, verify they fail.**
+- [x] **Step 2: Run them, verify they fail.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — done not hidden, no footer counts, no notice
 ```
 
-- [ ] **Step 3: Add arg parsing, the hide/show partition, footer counters, gh-absent notice.**
+- [x] **Step 3: Add arg parsing, the hide/show partition, footer counters, gh-absent notice.**
 
 ```bash
 # arg parse (top, after WOO_DIR)
@@ -816,14 +816,14 @@ exit 0
 
 (Move the phase-enum sanity, flags, owner/age, and band computation so they all run before the row is built. The header `printf` from Task 2 inside the loop is removed — header now prints once after the loop.)
 
-- [ ] **Step 4: Run the tests, verify they pass.**
+- [x] **Step 4: Run the tests, verify they pass.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: done/abandoned hidden + counted; --all shows them; gh-absent renders + notice
 ```
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts
@@ -837,7 +837,7 @@ git commit -m "feat(status): default in-flight view, done/abandoned footer, --al
 - Modify: `skills/woostack-init/templates/config.json`
 - Test: `skills/woostack-status/scripts/tests/test-status.sh`
 
-- [ ] **Step 1: Write the failing test** — `staleDays: 3` makes a 5-day-old executing spec stale; default 14 does not.
+- [x] **Step 1: Write the failing test** — `staleDays: 3` makes a 5-day-old executing spec stale; default 14 does not.
 
 ```bash
 s="$(mktemp -d)/.woostack"; mkdir -p "$s"
@@ -852,14 +852,14 @@ printf '# r\n\n**Source:** .woostack/specs/2026-06-01-romeo.md\n\n- [x] a\n- [ ]
 assert_contains "$(cat /tmp/r.out)" "stale" "staleDays:3 makes 5d spec stale"
 ```
 
-- [ ] **Step 2: Run it, verify it fails** (default 14 ⇒ not stale).
+- [x] **Step 2: Run it, verify it fails** (default 14 ⇒ not stale).
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: FAIL — no stale flag at default 14
 ```
 
-- [ ] **Step 3: Replace the stub `staleDays()`** with a config reader (jq, with a no-jq fallback).
+- [x] **Step 3: Replace the stub `staleDays()`** with a config reader (jq, with a no-jq fallback).
 
 ```bash
 staleDays() {
@@ -875,27 +875,27 @@ staleDays() {
 }
 ```
 
-- [ ] **Step 4: Update the config template** so new workspaces ship the namespace. Edit `skills/woostack-init/templates/config.json`:
+- [x] **Step 4: Update the config template** so new workspaces ship the namespace. Edit `skills/woostack-init/templates/config.json`:
 
 ```json
 { "review": {}, "status": { "staleDays": 14 } }
 ```
 
-- [ ] **Step 5: Run the tests, verify they pass.**
+- [x] **Step 5: Run the tests, verify they pass.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/test-status.sh
 # Expected: stale flag appears under staleDays:3
 ```
 
-- [ ] **Step 6: Run the FULL suite to confirm nothing regressed.**
+- [x] **Step 6: Run the FULL suite to confirm nothing regressed.**
 
 ```bash
 bash skills/woostack-status/scripts/tests/run-tests.sh
 # Expected: "test-status.sh" … "<N> passed, 0 failed"
 ```
 
-- [ ] **Step 7: Commit.**
+- [x] **Step 7: Commit.**
 
 ```bash
 git add skills/woostack-status/scripts skills/woostack-init/templates/config.json
@@ -907,7 +907,7 @@ git commit -m "feat(status): read status.staleDays from config; ship namespace i
 **Files:**
 - Create: `skills/woostack-status/references/conventions.md`
 
-- [ ] **Step 1: Write `conventions.md`** — the single source of truth. No test (doc), but it must state each contract exactly so producers can link it.
+- [x] **Step 1: Write `conventions.md`** — the single source of truth. No test (doc), but it must state each contract exactly so producers can link it.
 
 ````markdown
 # woostack feature-state conventions
@@ -961,7 +961,7 @@ spec older than `status.staleDays` (config, default 14) · two in-flight specs o
 the same branch.
 ````
 
-- [ ] **Step 2: Commit.**
+- [x] **Step 2: Commit.**
 
 ```bash
 git add skills/woostack-status/references/conventions.md
@@ -973,30 +973,30 @@ git commit -m "docs(status): canonical feature-state conventions"
 **Files:**
 - Modify: `.woostack/specs/*.md` (only those needing it)
 
-- [ ] **Step 1: Find specs to migrate.**
+- [x] **Step 1: Find specs to migrate.**
 
 ```bash
 grep -l '^status: ready' .woostack/specs/*.md
 grep -l '^branch: unknown' .woostack/specs/*.md
 ```
 
-- [ ] **Step 2: Migrate `ready → approved`** on each matching file (verify each is genuinely past the approval gate before changing). Use the `set_field` helper from `woostack-init/scripts/lib.sh` or a manual edit.
+- [x] **Step 2: Migrate `ready → approved`** on each matching file (verify each is genuinely past the approval gate before changing). Use the `set_field` helper from `woostack-init/scripts/lib.sh` or a manual edit.
 
 ```bash
 # example, per file:
 sed -i '' 's/^status: ready$/status: approved/' .woostack/specs/<file>.md   # macOS sed
 ```
 
-- [ ] **Step 3: Fix `branch: unknown`** — set the real branch where known (e.g. `bounded-review-swarms`), else leave and let the board flag it. Do not invent a branch.
+- [x] **Step 3: Fix `branch: unknown`** — set the real branch where known (e.g. `bounded-review-swarms`), else leave and let the board flag it. Do not invent a branch.
 
-- [ ] **Step 4: Run the board against the real repo** to confirm it parses and flags honestly.
+- [x] **Step 4: Run the board against the real repo** to confirm it parses and flags honestly.
 
 ```bash
 bash skills/woostack-status/scripts/status.sh
 # Expected: a table for the live specs; flags for any genuine 1:1 / branch gaps
 ```
 
-- [ ] **Step 5: Commit.**
+- [x] **Step 5: Commit.**
 
 ```bash
 git add .woostack/specs
@@ -1005,8 +1005,8 @@ git commit -m "chore(status): migrate spec status vocabulary to the phase enum"
 
 ### Increment 1 close-out
 
-- [ ] **Distill memory** (build step 7): extract durable conventions (the `**Source:**` join, the `Spec:` trailer contract, the truth table) into `.woostack/memory/` notes with `source: .woostack/plans/2026-06-04-woostack-status.md`; dedupe; run `build-index.sh` + `doctor.sh`.
-- [ ] **Offer a PR** for Increment 1 (engine) before starting Increment 2.
+- [x] **Distill memory** (build step 7): extract durable conventions (the `**Source:**` join, the `Spec:` trailer contract, the truth table) into `.woostack/memory/` notes with `source: .woostack/plans/2026-06-04-woostack-status.md`; dedupe; run `build-index.sh` + `doctor.sh`.
+- [x] **Offer a PR** for Increment 1 (engine) before starting Increment 2.
 
 ---
 
@@ -1018,56 +1018,56 @@ git commit -m "chore(status): migrate spec status vocabulary to the phase enum"
 
 **Files:** Create `skills/woostack-status/SKILL.md`
 
-- [ ] Write the SKILL with: frontmatter `name: woostack-status`, description scoped to "show the derived feature board / what's in flight / what to do next"; an Overview; a Procedure that runs `bash <skill>/scripts/status.sh` against the project's `.woostack`, then narrates the board and the single next action per in-flight feature; a flags section documenting `--all` and `--fetch`; a Hard-constraints block ("read-only; never fetches/commits/pushes; source of truth is the artifacts"); and a link to `references/conventions.md`. Do not restate the enum — link it.
-- [ ] Commit: `feat(status): add /woostack-status command skill`.
+- [x] Write the SKILL with: frontmatter `name: woostack-status`, description scoped to "show the derived feature board / what's in flight / what to do next"; an Overview; a Procedure that runs `bash <skill>/scripts/status.sh` against the project's `.woostack`, then narrates the board and the single next action per in-flight feature; a flags section documenting `--all` and `--fetch`; a Hard-constraints block ("read-only; never fetches/commits/pushes; source of truth is the artifacts"); and a link to `references/conventions.md`. Do not restate the enum — link it.
+- [x] Commit: `feat(status): add /woostack-status command skill`.
 
 ### Task 13: woostack-commit — `Spec:` trailer + advisory invariant check
 
 **Files:** Modify `skills/woostack-commit/SKILL.md`
 
-- [ ] In the PR-body section (step 7), add the trailer to the body template, after Test plan: a line `Spec: .woostack/specs/<file>.md` resolved from the session's spec (the spec whose `branch:` matches the current branch, or the spec under active work). Document that the board relies on it (link `conventions.md`).
-- [ ] Add a step 4.5 "Invariant check (advisory)": when staged files include `.woostack/specs/*` or `.woostack/plans/*`, run the cheap checks — each touched spec resolves to exactly one plan, `branch:` present, `status:` ∈ enum — and print any violation as a single non-blocking line in the commit report. Never abort. Link `conventions.md`.
-- [ ] Commit: `feat(commit): write Spec: PR trailer + advisory invariant check`.
+- [x] In the PR-body section (step 7), add the trailer to the body template, after Test plan: a line `Spec: .woostack/specs/<file>.md` resolved from the session's spec (the spec whose `branch:` matches the current branch, or the spec under active work). Document that the board relies on it (link `conventions.md`).
+- [x] Add a step 4.5 "Invariant check (advisory)": when staged files include `.woostack/specs/*` or `.woostack/plans/*`, run the cheap checks — each touched spec resolves to exactly one plan, `branch:` present, `status:` ∈ enum — and print any violation as a single non-blocking line in the commit report. Never abort. Link `conventions.md`.
+- [x] Commit: `feat(commit): write Spec: PR trailer + advisory invariant check`.
 
 ### Task 14: woostack-build — author `status:`, write `**Source:**`, state 1:1
 
 **Files:** Modify `skills/woostack-build/SKILL.md`
 
-- [ ] Annotate each step with the `status:` it authors: step 2 → `draft`; step 3 post-grill → `hardened`, gate cleared → `approved`; step 4 → `planning`; step 6 → `executing`; step 8 → `in-review`; post-merge → `done`. Add a one-line "the build loop owns `status:` transitions — see `woostack-status/references/conventions.md`."
-- [ ] In step 4 (plan), require the plan to open with the `**Source:** .woostack/specs/<file>.md` line.
-- [ ] In step 2/5, state the invariant explicitly: exactly one plan per spec; the plan owns the increments. Link `conventions.md`.
-- [ ] Commit: `docs(build): author status: per step, require Source line, state 1:1 invariant`.
+- [x] Annotate each step with the `status:` it authors: step 2 → `draft`; step 3 post-grill → `hardened`, gate cleared → `approved`; step 4 → `planning`; step 6 → `executing`; step 8 → `in-review`; post-merge → `done`. Add a one-line "the build loop owns `status:` transitions — see `woostack-status/references/conventions.md`."
+- [x] In step 4 (plan), require the plan to open with the `**Source:** .woostack/specs/<file>.md` line.
+- [x] In step 2/5, state the invariant explicitly: exactly one plan per spec; the plan owns the increments. Link `conventions.md`.
+- [x] Commit: `docs(build): author status: per step, require Source line, state 1:1 invariant`.
 
 ### Task 15: spec-template enum + init reference note
 
 **Files:** Modify `skills/woostack-build/references/spec-template.md`, the init config reference
 
-- [ ] In `spec-template.md`, annotate the `status:` field with the enum values and link `conventions.md`.
-- [ ] In the woostack-init reference that documents `config.json` namespaces, add the `status` namespace (`staleDays`, default 14) alongside `review`.
-- [ ] Commit: `docs(build): document status enum in spec template + status config namespace`.
+- [x] In `spec-template.md`, annotate the `status:` field with the enum values and link `conventions.md`.
+- [x] In the woostack-init reference that documents `config.json` namespaces, add the `status` namespace (`staleDays`, default 14) alongside `review`.
+- [x] Commit: `docs(build): document status enum in spec template + status config namespace`.
 
 ### Task 16: using-woostack — routing, pointer, red-flags
 
 **Files:** Modify `skills/using-woostack/SKILL.md`
 
-- [ ] Add a Command Routing row: ``| `/woostack-status`, show the derived feature board | `woostack-status` |``.
-- [ ] Add a one-line invariant pointer under the Project Entry Check linking `woostack-status/references/conventions.md` ("specs↔plans are 1:1; `status:`/`branch:` are load-bearing for the board").
-- [ ] Add three Red-Flags rows: writing a second plan for a spec; hand-setting/blanking `status:`/`branch:`; renaming/moving a spec or plan.
-- [ ] Commit: `docs(using-woostack): route /woostack-status, add invariant pointer + red-flags`.
+- [x] Add a Command Routing row: ``| `/woostack-status`, show the derived feature board | `woostack-status` |``.
+- [x] Add a one-line invariant pointer under the Project Entry Check linking `woostack-status/references/conventions.md` ("specs↔plans are 1:1; `status:`/`branch:` are load-bearing for the board").
+- [x] Add three Red-Flags rows: writing a second plan for a spec; hand-setting/blanking `status:`/`branch:`; renaming/moving a spec or plan.
+- [x] Commit: `docs(using-woostack): route /woostack-status, add invariant pointer + red-flags`.
 
 ### Task 17: Surface — AGENTS.md / README
 
 **Files:** Modify `AGENTS.md` (and its symlink `.claude/CLAUDE.md` is the same file), `README.md`
 
-- [ ] Update the public command surface from eight to nine: add the `woostack-status` bullet to the list, add it to the Quick file map, and update any "eight skills" wording (keep the internal `woostack-ideate` framing intact — it is not part of the count).
-- [ ] Update `README.md`'s skill list / how-it-works the same way; resolve any version/command counts.
-- [ ] Commit: `docs: add woostack-status to the public command surface (8 → 9)`.
+- [x] Update the public command surface from eight to nine: add the `woostack-status` bullet to the list, add it to the Quick file map, and update any "eight skills" wording (keep the internal `woostack-ideate` framing intact — it is not part of the count).
+- [x] Update `README.md`'s skill list / how-it-works the same way; resolve any version/command counts.
+- [x] Commit: `docs: add woostack-status to the public command surface (8 → 9)`.
 
 ### Increment 2 close-out
 
-- [ ] Run `bash skills/woostack-status/scripts/tests/run-tests.sh` — confirm the engine still passes after producer edits.
-- [ ] Distill any new durable conventions; run `build-index.sh` + `doctor.sh`.
-- [ ] Offer a PR for Increment 2.
+- [x] Run `bash skills/woostack-status/scripts/tests/run-tests.sh` — confirm the engine still passes after producer edits.
+- [x] Distill any new durable conventions; run `build-index.sh` + `doctor.sh`.
+- [x] Offer a PR for Increment 2.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `npx skills add howarewoo/woostack`.
 
-The public command/adoption surface has nine skills:
+The public command/adoption surface has ten skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -23,13 +23,14 @@ The public command/adoption surface has nine skills:
 - [`woostack-commit`](skills/woostack-commit/SKILL.md)
 - [`woostack-review`](skills/woostack-review/SKILL.md)
 - [`woostack-address-comments`](skills/woostack-address-comments/SKILL.md)
+- [`woostack-status`](skills/woostack-status/SKILL.md)
 - [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
 
 The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the nine-skill command
+`/woostack-*` commands: they have no routing row and are absent from the ten-skill command
 surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
@@ -51,8 +52,8 @@ do not add application code, app build configs, or app lockfiles.
 
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
 `/woostack-bootstrap`, `/woostack-build`, `/woostack-execute`, `/woostack-commit`,
-`/woostack-review`, `/woostack-address-comments`, or `/woostack-visualize`, including
-intent-equivalent wording. Load the matching skill
+`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, or `/woostack-visualize`,
+including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
 directory, not in this repo.
 
@@ -74,7 +75,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the eleven `SKILL.md` files (the nine public command/adoption
+- Do not move or rename any of the twelve `SKILL.md` files (the ten public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -104,5 +105,8 @@ directory, not in this repo.
   [`skills/woostack-visualize/SKILL.md`](skills/woostack-visualize/SKILL.md)
 - Address-comments delegator:
   [`skills/woostack-address-comments/SKILL.md`](skills/woostack-address-comments/SKILL.md)
+- Derived feature board (status command) and its canonical feature-state conventions:
+  [`skills/woostack-status/SKILL.md`](skills/woostack-status/SKILL.md),
+  [`skills/woostack-status/references/conventions.md`](skills/woostack-status/references/conventions.md)
 - Init workspace and memory contract:
   [`skills/woostack-init/`](skills/woostack-init/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, and `woostack-visualize`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, and `woostack-visualize`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 
@@ -25,6 +25,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Change the commit / PR update workflow | `skills/woostack-commit/SKILL.md` |
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |
 | Change the address-comments delegator | `skills/woostack-address-comments/SKILL.md` |
+| Change the status board / feature-state conventions | `skills/woostack-status/SKILL.md`, `skills/woostack-status/references/conventions.md`, `skills/woostack-status/scripts/` |
 | Update agent instructions (Claude or any) | `AGENTS.md` (`.claude/CLAUDE.md` is a symlink to it) |
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is nine skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, and woostack-visualize. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is ten skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, and woostack-visualize. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 
@@ -76,6 +76,10 @@ Commits only the changes relevant to the current session, creates a `feature/*` 
 ### `/woostack-address-comments [PR#]`: work the review threads
 
 Walks every unresolved review thread on a PR, recommends a verdict per thread (fix / push back / clarify), then, once you approve the batch, applies fixes, replies, resolves, and pushes. Accept-by-design dismissals are recorded to `.woostack/memory.md` so future reviews don't re-raise them. Never merges. A thin delegator to the review skill's `address` verb. → [SKILL.md](skills/woostack-address-comments/SKILL.md)
+
+### `/woostack-status [--all] [--fetch]`: derived feature board
+
+A read-only, on-demand board derived fresh from your `.woostack/` artifacts: for every spec it shows the reconciled phase, plan progress, increment-PR rollup, owner, age, and the single next action, and flags any drift between the authored `status:` and what's on disk. It never fetches (except the opt-in `--fetch`), commits, or pushes, and writes no `STATUS.md`. Backed by the `spec : plan : PRs = 1 : 1 : N` invariant and the phase enum defined once in [conventions.md](skills/woostack-status/references/conventions.md). → [SKILL.md](skills/woostack-status/SKILL.md)
 
 ### `/woostack-visualize <source> [for <audience>]`: audience-tailored HTML render
 

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -52,6 +52,13 @@ Do not run `/woostack-init`, create `.woostack/`, scaffold code, or add config u
 user explicitly asks for that behavior or the loaded task-specific skill requires it as part
 of an approved workflow.
 
+**Feature-state invariant:** in a woostack project, every spec has exactly one plan
+(`spec : plan : PRs = 1 : 1 : N`), and the spec's `status:`/`branch:` frontmatter is
+load-bearing for the `/woostack-status` board. The phase enum and the join contracts are
+defined once in
+[`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md);
+link it, never restate it.
+
 ## Command Routing
 
 | Request | Load |
@@ -63,6 +70,7 @@ of an approved workflow.
 | `/woostack-commit`, commit session-relevant changes and update PR fields | `woostack-commit` |
 | `/woostack-review [PR#]`, review a PR or local diff | `woostack-review` |
 | `/woostack-address-comments [PR#]`, address unresolved review threads | `woostack-address-comments` |
+| `/woostack-status [--all] [--fetch]`, show the derived feature board (what's in flight, what to do next) | `woostack-status` |
 | `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |
 
 If the user asks for the behavior without using the exact command name, route by intent.
@@ -79,6 +87,9 @@ These thoughts mean stop and load the relevant rules:
 | "I remember the workflow." | The installed skill may have changed. Load it. |
 | "I'll initialize `.woostack/` to be helpful." | This skill is adoption-only; mutate project state only when requested or required by the task skill. |
 | "This is only a review comment." | Review and address flows have posting, validation, and memory rules. |
+| "I'll write another plan for this spec." | Specs and plans are 1:1. A second plan breaks the board's join — amend the one existing plan instead. See [`conventions.md`](../woostack-status/references/conventions.md). |
+| "I'll just set `status:`/`branch:` by hand." | The build loop authors those fields and the `/woostack-status` board reads them; hand-editing or blanking them causes drift flags. |
+| "I'll rename or move this spec or plan." | Renames break the spec↔plan↔PR joins (the `**Source:**` line, `branch:`, the `Spec:` PR trailer). Avoid it, or update every join at once. |
 
 ## AGENTS.md Usage
 

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -63,24 +63,32 @@ equivalent.
    if a rich view is wanted, hand the markdown to
    [`woostack-visualize`](../woostack-visualize/SKILL.md) (audience `engineer` for specs; it
    uses [references/spec-template.html](references/spec-template.html) as a starting point).
-   The HTML is a presentation target only, never the authored source.
+   The HTML is a presentation target only, never the authored source. Set the spec's
+   `status: draft` in frontmatter — the build loop owns the `status:` enum and authors a
+   transition at each step so `/woostack-status` can read it (the enum and join contracts live
+   in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md);
+   link it, do not restate it).
 3. **Harden the spec, then get spec approval.** Invoke
    [`woostack-harden`](../woostack-harden/SKILL.md) against the spec. Amend the spec
-   in place until hardening stops producing new questions. Then **always present the written
-   spec to the user and get explicit approval before planning** — this is a hard gate. Point
-   the user at the file path (offer a `woostack-visualize` render if it helps), wait for a
-   clear yes, and make any requested changes before advancing. Do **not** proceed to step 4
-   on inferred or assumed approval; silence is not a yes.
+   in place until hardening stops producing new questions, then set `status: hardened`. Then
+   **always present the written spec to the user and get explicit approval before planning** —
+   this is a hard gate. Point the user at the file path (offer a `woostack-visualize` render if
+   it helps), wait for a clear yes, and make any requested changes before advancing. When the
+   gate clears, set `status: approved`. Do **not** proceed to step 4 on inferred or assumed
+   approval; silence is not a yes.
 4. **Plan.** Once the spec is approved, invoke `superpowers:writing-plans`, saving the plan as
    **markdown** to
    `.woostack/plans/YYYY-MM-DD-<slug>.md` (plans are working checklists, not visualization
-   artifacts).
+   artifacts). The plan **must open with** a `**Source:** .woostack/specs/<file>.md` line in
+   its first ~5 lines so the board joins it 1:1 to the spec; keep plans frontmatter-free. Set
+   the spec's `status: planning`.
 5. **Decompose to PR-sized increments.** Steer work toward well-scoped PRs of **preferably
    ≤500 lines of code** — a soft target, not a gate. When the spec implies more than one
    reviewable PR, structure the plan as a sequence of independently shippable increments and
    run **one increment per build cycle**. Flag any slice that can't reasonably stay under the
    target and propose a further split before executing. Genuinely atomic changes may exceed
-   the target.
+   the target. The `spec : plan : PRs = 1 : 1 : N` invariant holds throughout: exactly one
+   plan per spec, and that one plan owns the N increment PRs.
 6. **Harden the plan.** Invoke [`woostack-harden`](../woostack-harden/SKILL.md) again, this
    time against the plan and its increment breakdown — stress-test the sequencing, the
    increment boundaries, and the verifications until hardening stops producing new questions.
@@ -111,7 +119,10 @@ equivalent.
    `.woostack/memory/` — pausing only on a blocking stop. `woostack-execute` owns the
    per-increment commit/review/distill cadence and the inline-vs-subagent mode choice (one plan
    per spec, multiple stacked PRs per plan), so it absorbs what used to be separate "distill
-   memory" and "offer the PR" steps here.
+   memory" and "offer the PR" steps here. As branches, commits, and increment PRs appear the
+   spec advances into the `executing` → `in-review` band (and `done` post-merge); the board
+   **computes** that band from the artifacts via its truth table, so a lagging authored
+   `status:` is reconciled rather than trusted blindly.
 10. **End on the chosen terminal state.** Build ends in one of two shapes, never merging either:
     - **Hand off** → only the spec+plan PR is open (no increment PRs), ready for external or
       later execute.
@@ -142,6 +153,12 @@ equivalent.
   tool. Ambiguous or no answer is not a "go."
 - **Never merge.** build ends on the terminal state (handoff PR, or reviewed stack), nothing
   further.
+- **Author `status:` through the loop.** Set the spec's `status:` at each step — `draft` (step
+  2), `hardened` then `approved` (step 3), `planning` (step 4); the execute phase advances the
+  `executing`/`in-review` band, which the board also computes from artifacts. The phase enum
+  and the `spec : plan : PRs = 1 : 1 : N` join contracts are defined once in
+  [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) —
+  link it, never restate it.
 - **One increment per cycle.** Do not let a single build cycle balloon past a reviewable PR.
 - **Distill durable knowledge only.** `woostack-execute` writes scoped, deduplicated memory
   notes per increment — never feature-specific trivia, never a duplicate of an existing note. A

--- a/skills/woostack-build/references/spec-template.md
+++ b/skills/woostack-build/references/spec-template.md
@@ -11,6 +11,8 @@ links:
 
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
 ## 1. Problem
 
 {{PROBLEM}}

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -132,9 +132,9 @@ Do not stage generated files, secrets, `.env*`, unrelated dirty files, or user w
 
 ### 4.5 Invariant check (advisory)
 
-When the staged changes touch `.woostack/specs/*.md` or `.woostack/plans/*.md`, run the cheap feature-state invariant checks on each touched spec so the `/woostack-status` board stays honest. These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
+When the staged changes touch `.woostack/specs/*.md` or `.woostack/plans/*.md`, run the cheap feature-state invariant checks on every affected spec so the `/woostack-status` board stays honest. The affected set is every directly touched spec plus the spec named by each touched plan's `**Source:** .woostack/specs/<file>.md` line. These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
 
-For each touched spec, check:
+For each affected spec, check:
 
 - **1:1 plan** — exactly one plan resolves to it: a plan whose first lines carry `**Source:** .woostack/specs/<file>.md` (legacy same-slug match is the fallback). Zero or two-or-more resolved plans is a violation.
 - **`branch:` present** — the frontmatter `branch:` is non-empty and not the literal `unknown`.

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -130,6 +130,18 @@ git add -p <file>
 
 Do not stage generated files, secrets, `.env*`, unrelated dirty files, or user work from outside this session.
 
+### 4.5 Invariant check (advisory)
+
+When the staged changes touch `.woostack/specs/*.md` or `.woostack/plans/*.md`, run the cheap feature-state invariant checks on each touched spec so the `/woostack-status` board stays honest. These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
+
+For each touched spec, check:
+
+- **1:1 plan** — exactly one plan resolves to it: a plan whose first lines carry `**Source:** .woostack/specs/<file>.md` (legacy same-slug match is the fallback). Zero or two-or-more resolved plans is a violation.
+- **`branch:` present** — the frontmatter `branch:` is non-empty and not the literal `unknown`.
+- **`status:` in the enum** — the frontmatter `status:` is one of `draft｜hardened｜approved｜planning｜executing｜in-review｜done｜abandoned`.
+
+The phase enum and the join contracts are defined once in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) — do not restate them here. If the `woostack-status` skill is not installed, skip this check silently.
+
 ### 5. Commit
 
 If a fast-subagent draft is available, use it only after validating that the proposed
@@ -212,10 +224,13 @@ Set or update the body with this structure:
 **After merge**
 
 - [ ] <step only verifiable post-merge — deploy / migration / env-gated>
+
+Spec: .woostack/specs/<file>.md
 ```
 
 Rules:
 
+- End the body with a `Spec: .woostack/specs/<file>.md` **trailer line** naming the spec this PR's increments trace to — the spec whose `branch:` matches the current branch, or the spec under active work. The `/woostack-status` board enumerates a spec's increment PRs by searching this exact trailer (`gh pr list --search "Spec: <path>"`); the contract is defined in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md). Omit the trailer only when the change traces to no spec (for example a repo-meta or tooling edit).
 - State the **Goal** as intent or the problem solved in one or two sentences — not a change list. It is distinct from Summary, which lists *what* changed. Always present it.
 - Keep Summary bullets concise and specific. Include only changes in the committed diff.
 - Under **Automated**, list the commands/tests actually run, plus the configured `commit.pre_commit` command and result when it ran. Show this group whenever an automated check (test, lint, typecheck, `pre_commit`) could have run for the change: list results, or `Not run` with the reason when one was expected but skipped. Omit `### Automated` entirely when no automated check applies to the change (for example a doc-only edit in a repo with no test harness) rather than emitting a `Not run` placeholder.

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -39,12 +39,15 @@ Two callers:
    | `.woostack/memory.md` | (create empty — **never clobber an existing file**) |
    | `.woostack/specs/` directory | (create empty) |
    | `.woostack/plans/` directory | (create empty) |
-   | `.woostack/config.json` | `templates/config.json` (`{ "review": {} }`) |
+   | `.woostack/config.json` | `templates/config.json` (`{ "review": {}, "status": { "staleDays": 14 } }`) |
    | `.woostack/.gitignore` | `templates/gitignore` |
 
-   `config.json` ships as `{ "review": {} }`. Each tool owns its own
-   namespace inside that object; for the `review` namespace see
-   [references/memory.md](references/memory.md).
+   `config.json` ships as `{ "review": {}, "status": { "staleDays": 14 } }`. Each tool owns
+   its own namespace inside that object: for the `review` namespace see
+   [references/memory.md](references/memory.md); the `status` namespace holds `staleDays`
+   (default 14 — the age in days past which an executing spec is flagged stale on the
+   `/woostack-status` board), defined in
+   [../woostack-status/references/conventions.md](../woostack-status/references/conventions.md).
 
 3. **Handle existing files.** For any file that already exists and `--force`
    is not active: prompt the user to keep or overwrite it. Under `--no-clobber`

--- a/skills/woostack-status/SKILL.md
+++ b/skills/woostack-status/SKILL.md
@@ -31,16 +31,18 @@ restate them — that file is the canonical home for the phase vocabulary, the j
 
 ## Procedure
 
-1. **Run the deriver.** From the project root, run the skill's bundled script so it reads the
-   project's `./.woostack`:
+1. **Run the deriver.** From the project root, resolve the installed skill directory, then
+   run the bundled script from that directory so it reads the project's `./.woostack`:
 
    ```
-   bash scripts/status.sh [--all] [--fetch]
+   WOO_STATUS_ACTION_PATH="<directory containing this SKILL.md>"
+   bash "$WOO_STATUS_ACTION_PATH/scripts/status.sh" [--all] [--fetch]
    ```
 
-   `WOO_DIR` defaults to `./.woostack` (override only for tests). The script is read-only and
-   exits `0` even when it emits drift flags — operational failure is the only non-zero exit —
-   so it is safe to run anywhere, including CI.
+   Keep the current working directory at the consumer project root; only the script path comes
+   from the skill bundle. `WOO_DIR` defaults to `./.woostack` (override only for tests). The
+   script is read-only and exits `0` even when it emits drift flags — operational failure is
+   the only non-zero exit — so it is safe to run anywhere, including CI.
 
 2. **Narrate the board.** Present the table as printed, then for each in-flight feature call
    out its single **next action** (the `NEXT` column). Lead with whatever is actionable now.

--- a/skills/woostack-status/SKILL.md
+++ b/skills/woostack-status/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: woostack-status
+description: Use to show the derived woostack feature board — for every spec in .woostack/, its reconciled phase, plan progress, increment-PR state, owner, age, and the single next action, plus flags for any drift between the authored status: and the artifacts on disk. Read-only; never fetches, commits, or pushes. Use for /woostack-status, "what's in flight", or "what should I do next".
+---
+
+# woostack-status
+
+## Overview
+
+Prints an on-demand, read-only **feature board** derived from the real `.woostack/`
+artifacts. For every spec it shows the reconciled phase, plan progress (`N/M` boxes), the
+increment-PR rollup, owner, age, and the single concrete **next action** — and flags any
+drift between the authored `status:` and what the artifacts actually say.
+
+The board is computed fresh each run and printed to the terminal; it is **never** written to
+a tracked file (no `STATUS.md`, no snapshot — that would churn and merge-conflict every time
+anyone advances a feature). It never fetches, commits, or pushes.
+
+The board is backed by the `spec : plan : PRs = 1 : 1 : N` invariant and the phase enum, both
+defined once in [references/conventions.md](references/conventions.md). This skill does not
+restate them — that file is the canonical home for the phase vocabulary, the join contracts
+(`**Source:**` plan line, `Spec:` PR trailer, `branch:`), and the reconcile rules.
+
+## Commands
+
+- `/woostack-status` — render the in-flight feature board for the current project.
+- `/woostack-status --all` — also expand the `done` and `abandoned` features (hidden by
+  default, surfaced as a footer count).
+- `/woostack-status --fetch` — opt in to a `git fetch` first so PR-less branch data is fresh.
+  This is the only network access the board ever does; it still never commits or pushes.
+
+## Procedure
+
+1. **Run the deriver.** From the project root, run the skill's bundled script so it reads the
+   project's `./.woostack`:
+
+   ```
+   bash scripts/status.sh [--all] [--fetch]
+   ```
+
+   `WOO_DIR` defaults to `./.woostack` (override only for tests). The script is read-only and
+   exits `0` even when it emits drift flags — operational failure is the only non-zero exit —
+   so it is safe to run anywhere, including CI.
+
+2. **Narrate the board.** Present the table as printed, then for each in-flight feature call
+   out its single **next action** (the `NEXT` column). Lead with whatever is actionable now.
+
+3. **Surface the flags.** If the `! FLAGS` block is non-empty, list each drift and what
+   resolves it — for example a second plan resolving to one spec, a blank or `unknown`
+   `branch:`, an unknown `status:` value, a head-state phase while a PR already exists, a
+   stale executing spec, or a same-branch collision. Flags are advisory, never a blocking
+   stop.
+
+4. **Note degradation.** If `gh` is absent or unauthenticated the board still renders,
+   omitting PR / increment / owner data for PR-phase rows; relay the script's notice rather
+   than hiding it. The footer also notes when PR-less branch data may be stale (pass
+   `--fetch`).
+
+## Hard constraints
+
+- **Read-only.** Never fetches (except the explicit `--fetch`), commits, pushes, or mutates
+  any spec, plan, or git state. The board only reads.
+- **No committed status file.** Print to the terminal; never write `STATUS.md` or any tracked
+  snapshot.
+- **The artifacts are the source of truth.** Display the authored `status:` for head states
+  but the *computed* phase for the execute → review → done band; a disagreement is a flag, not
+  displayed truth. The contracts live in
+  [references/conventions.md](references/conventions.md) — link it, do not restate it.
+- **Degrade, never hard-fail.** Missing `gh`, no specs, malformed frontmatter, or a missing
+  plan each produce a friendly notice or a flag and a clean exit, never a crash.

--- a/skills/woostack-status/references/conventions.md
+++ b/skills/woostack-status/references/conventions.md
@@ -28,8 +28,8 @@ band from artifacts (truth table below).
 | hardened | grilled, awaiting approval gate | 3 |
 | approved | gate cleared, no plan yet | 3 |
 | planning | plan exists, 0 boxes done | 4 |
-| executing | branch + commits, plan partial | 6 |
-| in-review | an increment PR is open | 8 |
+| executing | branch + commits, plan partial | 9 (execute) |
+| in-review | an increment PR is open | 9 (execute) |
 | done | plan 100% + all PRs merged | post-merge |
 | abandoned | shelved (terminal, hidden) | manual |
 


### PR DESCRIPTION
## Goal

Ship the `/woostack-status` command (Increment 2) plus the producer wiring that keeps its derived feature board honest — so the board's `spec : plan : PRs = 1 : 1 : N` invariant and phase enum are actually fed and enforced across the build loop. Engine shipped in #191; this is the command + producers.

## Summary

- Add `skills/woostack-status/SKILL.md` — a thin, read-only command skill that runs the bundled `status.sh` deriver, narrates the board and per-feature next action, and documents `--all` / `--fetch`. Links the canonical `conventions.md` rather than restating the enum.
- `woostack-commit`: write the `Spec: .woostack/specs/<file>.md` PR-body trailer (how the board enumerates a spec's increment PRs) and run an advisory, non-blocking invariant check on touched spec/plan files (1:1 plan, `branch:` present, `status:` ∈ enum).
- `woostack-build`: author `status:` at each step (`draft`/`hardened`/`approved`/`planning`; the execute phase advances the `executing`/`in-review` band, which the board also computes), require the plan's `**Source:**` line, and state the 1:1 invariant.
- `spec-template`: note the `status:` enum; `woostack-init`: document the `status` config namespace (`staleDays`, default 14) — its doc was stale vs. the shipped template.
- `using-woostack`: routing row, a feature-state invariant pointer, and three red-flag rows (second plan, hand-set `status:`/`branch:`, rename/move).
- Public surface 9→10 in lockstep: `AGENTS.md` (skill list, Mode B, the SKILL.md count, file map), `README` (intro list + new section), and `CONTRIBUTING.md` (public list + "Change the…" row). Corrected `conventions.md` build-step numbers to the current build loop (execute is step 9).

## Test plan

### Automated

- [x] `bash skills/woostack-status/scripts/tests/run-tests.sh` → **40 passed, 0 failed** (producer edits don't touch the engine).
- [x] `bash skills/woostack-init/scripts/doctor.sh .woostack/memory` → **0 errors, 0 warnings**.

### Manual

**Before merge**

- [x] `bash skills/woostack-status/scripts/status.sh` renders the live board, `NEXT` actions, and `! FLAGS` end-to-end against this repo's `.woostack/`.
- [ ] Read `skills/woostack-status/SKILL.md` and confirm it routes `/woostack-status` and matches the engine's real output (ASCII `! FLAGS`, `N done . M abandoned`).
- [ ] Confirm `AGENTS.md`, `README`, `CONTRIBUTING.md`, and `using-woostack` consistently say **ten** public skills / **twelve** `SKILL.md` files and list `woostack-status`.

Spec: .woostack/specs/2026-06-04-woostack-status.md
