### PR TITLE
chore(status): migrate four shipped specs off legacy 'ready' to done

### DIFF
--- a/.woostack/plans/2026-06-04-commit-pr-goal-test-plan.md
+++ b/.woostack/plans/2026-06-04-commit-pr-goal-test-plan.md
@@ -19,7 +19,7 @@
 **Files:**
 - Modify: `skills/woostack-commit/SKILL.md` — the template block under step 7 (currently the fenced markdown at lines ~190–200, the `## Summary` + `## Test plan` block)
 
-- [ ] **Step 1: Replace the template block**
+- [x] **Step 1: Replace the template block**
 
 Replace the existing fenced block:
 
@@ -32,8 +32,8 @@ Replace the existing fenced block:
 
 ## Test plan
 
-- [ ] <command run and result, or "Not run (reason)">
-- [ ] <manual verification step, when a meaningful one exists>
+- [x] <command run and result, or "Not run (reason)">
+- [x] <manual verification step, when a meaningful one exists>
 ```
 ````
 
@@ -54,21 +54,21 @@ with:
 
 ### Automated
 
-- [ ] <command run and result, or "Not run (reason)">
+- [x] <command run and result, or "Not run (reason)">
 
 ### Manual
 
 **Before merge**
 
-- [ ] <step a reviewer can inspect or exercise on the branch or preview>
+- [x] <step a reviewer can inspect or exercise on the branch or preview>
 
 **After merge**
 
-- [ ] <step only verifiable post-merge — deploy / migration / env-gated>
+- [x] <step only verifiable post-merge — deploy / migration / env-gated>
 ```
 ````
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Read the block back. Confirm `## Goal` precedes `## Summary`, and `## Test plan` contains `### Automated` then `### Manual` with bold `**Before merge**` / `**After merge**` groups. No stray old bullets remain.
 
@@ -79,7 +79,7 @@ Read the block back. Confirm `## Goal` precedes `## Summary`, and `## Test plan`
 **Files:**
 - Modify: `skills/woostack-commit/SKILL.md` — the `Rules:` bullet list under step 7 (currently lines ~202–211)
 
-- [ ] **Step 1: Replace the rules list**
+- [x] **Step 1: Replace the rules list**
 
 Replace the current bullet list (from `- Keep bullets concise and specific.` through `- If tests were not run, say `Not run`...`) with a list that:
 
@@ -105,7 +105,7 @@ Rules:
 - Format test-plan items as unchecked Markdown checkboxes (`- [ ] ...`) so reviewers can mark verification complete.
 ```
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Read the rules list back. Confirm every section of the new template (Goal, Summary, Automated, Manual/before, Manual/after) has a governing rule, the omit-when-empty rule is uniform, and no rule still references a single flat test-plan list.
 
@@ -116,11 +116,11 @@ Read the rules list back. Confirm every section of the new template (Goal, Summa
 **Files:**
 - Modify: `skills/woostack-commit/SKILL.md` — the "Fast-subagent drafting" bullet listing draftable text (currently lines ~48–50: "PR title candidate, Summary bullets, and Test plan bullets.")
 
-- [ ] **Step 1: Add Goal to the list**
+- [x] **Step 1: Add Goal to the list**
 
 Change the delegated-text bullet so the draftable fields read: commit subject/body candidate, PR title candidate, **Goal line**, Summary bullets, and Test plan bullets (Automated and Manual).
 
-- [ ] **Step 2: Verify**
+- [x] **Step 2: Verify**
 
 Confirm the draftable list now names the Goal and reflects the Automated/Manual test-plan shape, and the "subagent returns only proposed text / main agent validates" boundary is unchanged.
 
@@ -131,15 +131,15 @@ Confirm the draftable list now names the Goal and reflects the Automated/Manual 
 **Files:**
 - Modify: `skills/woostack-commit/SKILL.md` — `description:` frontmatter (line 3) and the step-8 "Report" return list (lines ~219–227)
 
-- [ ] **Step 1: Update the description**
+- [x] **Step 1: Update the description**
 
 Reword the trailing clause of the `description:` so it reflects the new body shape, e.g. "...update the current PR title/body with a goal, concise summary, and structured (automated + manual) test plan." Keep the trigger phrases intact.
 
-- [ ] **Step 2: Update the step-8 report list**
+- [x] **Step 2: Update the step-8 report list**
 
 Add `Goal used` to the returned fields alongside Summary bullets and Test plan bullets, so the report mirrors the body sections.
 
-- [ ] **Step 3: Verify**
+- [x] **Step 3: Verify**
 
 Confirm description still fits on sensible length, trigger phrases preserved, and the report list mentions Goal + the test-plan sections.
 
@@ -150,10 +150,10 @@ Confirm description still fits on sensible length, trigger phrases preserved, an
 **Files:**
 - Read: `skills/woostack-commit/SKILL.md` (entire file)
 
-- [ ] **Step 1: Full read-through**
+- [x] **Step 1: Full read-through**
 
 Read the whole file. Confirm: no remaining reference to a flat single-section test plan; the template, rules, fast-subagent list, description, and report all agree; the omit-when-empty and after-merge "if applicable" semantics are stated once and consistent; no placeholder text introduced.
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 Hand off to `woostack-commit` (build step 8 offers the PR). Until then, the change sits staged on the branch. Automated tests: `Not run` — this repo has no test harness for its own skill markdown (doc-only change).

--- a/.woostack/plans/2026-06-04-woostack-harden-skill.md
+++ b/.woostack/plans/2026-06-04-woostack-harden-skill.md
@@ -27,7 +27,7 @@
 
 **Files:** Create `skills/woostack-harden/SKILL.md`
 
-- [ ] **Step 1: Write the full skill file.** Author the file with exactly this content:
+- [x] **Step 1: Write the full skill file.** Author the file with exactly this content:
 
 ```markdown
 ---
@@ -91,8 +91,8 @@ the caller is what preserves woostack-build's "inherit gates, add none."
 - **Own no gate.** Hand back at "no new questions"; never solicit final approval or merge.
 ```
 
-- [ ] **Step 2: Verify frontmatter parses.** Run: `head -4 skills/woostack-harden/SKILL.md` — expect a `---` / `name: woostack-harden` / `description: ...` / `---` block.
-- [ ] **Step 3: Commit.**
+- [x] **Step 2: Verify frontmatter parses.** Run: `head -4 skills/woostack-harden/SKILL.md` — expect a `---` / `name: woostack-harden` / `description: ...` / `---` block.
+- [x] **Step 3: Commit.**
 
 ```bash
 git add skills/woostack-harden/SKILL.md
@@ -103,13 +103,13 @@ git commit -m "feat: add woostack-harden skill"
 
 **Files:** Modify `skills/woostack-build/SKILL.md`
 
-- [ ] **Step 1: Frontmatter `description`.** Change `Chains woostack-ideate, superpowers writing-plans/executing-plans, and grill-me in a fixed, gated order;` to `Chains woostack-ideate, woostack-harden, and superpowers writing-plans/executing-plans in a fixed, gated order;`.
-- [ ] **Step 2: Overview chain diagram.** In the chain on line ~15, change `grill-me` to `harden`:
+- [x] **Step 1: Frontmatter `description`.** Change `Chains woostack-ideate, superpowers writing-plans/executing-plans, and grill-me in a fixed, gated order;` to `Chains woostack-ideate, woostack-harden, and superpowers writing-plans/executing-plans in a fixed, gated order;`.
+- [x] **Step 2: Overview chain diagram.** In the chain on line ~15, change `grill-me` to `harden`:
   `ideate → write spec (markdown) → harden → approve spec → writing-plans → executing-plans → distill memory → ask: open PR?`
-- [ ] **Step 3: Dependency preflight.** In the "Dependency preflight" section: (a) drop `- `grill-me`` from the bullet list of chained external skills, leaving `superpowers:writing-plans`, `superpowers:executing-plans`; (b) remove `grill-me` from the prose that names the hardening phase as an external chain — state that the harden phase uses the in-collection `woostack-harden` (no install needed), mirroring the existing `woostack-ideate` note; (c) in the "offer to install" line, remove `pnpx skills add mattpocock/skills for grill-me`, keeping `pnpx skills add obra/superpowers`.
-- [ ] **Step 4: Procedure step 3 ("Harden it…").** Change `Invoke `grill-me` against the spec.` to `Invoke [`woostack-harden`](../woostack-harden/SKILL.md) against the spec.` and `until grilling stops producing new questions` to `until hardening stops producing new questions`. Leave the spec-approval HARD GATE that follows ("always present the written spec to the user and get explicit approval before planning") unchanged.
-- [ ] **Step 5: Verify the gate text survives.** Run: `grep -n "explicit approval before planning\|hard gate" skills/woostack-build/SKILL.md` — expect the spec-approval gate language still present.
-- [ ] **Step 6: Commit.**
+- [x] **Step 3: Dependency preflight.** In the "Dependency preflight" section: (a) drop `- `grill-me`` from the bullet list of chained external skills, leaving `superpowers:writing-plans`, `superpowers:executing-plans`; (b) remove `grill-me` from the prose that names the hardening phase as an external chain — state that the harden phase uses the in-collection `woostack-harden` (no install needed), mirroring the existing `woostack-ideate` note; (c) in the "offer to install" line, remove `pnpx skills add mattpocock/skills for grill-me`, keeping `pnpx skills add obra/superpowers`.
+- [x] **Step 4: Procedure step 3 ("Harden it…").** Change `Invoke `grill-me` against the spec.` to `Invoke [`woostack-harden`](../woostack-harden/SKILL.md) against the spec.` and `until grilling stops producing new questions` to `until hardening stops producing new questions`. Leave the spec-approval HARD GATE that follows ("always present the written spec to the user and get explicit approval before planning") unchanged.
+- [x] **Step 5: Verify the gate text survives.** Run: `grep -n "explicit approval before planning\|hard gate" skills/woostack-build/SKILL.md` — expect the spec-approval gate language still present.
+- [x] **Step 6: Commit.**
 
 ```bash
 git add skills/woostack-build/SKILL.md
@@ -120,12 +120,12 @@ git commit -m "feat: rewire woostack-build harden phase to woostack-harden"
 
 **Files:** Modify `.claude/CLAUDE.md` (canonical; `.claude/CLAUDE.md` is the symlinked source-of-truth per the file's own note — edit the real file `AGENTS.md` content)
 
-- [ ] **Step 1: Sub-skill note.** Update the paragraph that begins "The collection also installs a ninth, internal sub-skill: `woostack-ideate`." to describe **two** internal sub-skills: `woostack-ideate` (build's ideate phase) and `woostack-harden` (build's harden phase). Keep the framing: building blocks, not `/woostack-*` commands; no routing row; absent from the eight-skill command surface; shipped assets like `action.yml`, not strays to delete.
-- [ ] **Step 2: Hard-constraint count.** Update the constraint "Do not move or rename any of the nine `SKILL.md` files (the eight public command/adoption skills plus the internal `woostack-ideate`)." to **ten** files — "the eight public command/adoption skills plus the internal `woostack-ideate` and `woostack-harden`".
-- [ ] **Step 3: Quick file map.** Add an entry under "Quick file map", parallel to the ideate entry:
+- [x] **Step 1: Sub-skill note.** Update the paragraph that begins "The collection also installs a ninth, internal sub-skill: `woostack-ideate`." to describe **two** internal sub-skills: `woostack-ideate` (build's ideate phase) and `woostack-harden` (build's harden phase). Keep the framing: building blocks, not `/woostack-*` commands; no routing row; absent from the eight-skill command surface; shipped assets like `action.yml`, not strays to delete.
+- [x] **Step 2: Hard-constraint count.** Update the constraint "Do not move or rename any of the nine `SKILL.md` files (the eight public command/adoption skills plus the internal `woostack-ideate`)." to **ten** files — "the eight public command/adoption skills plus the internal `woostack-ideate` and `woostack-harden`".
+- [x] **Step 3: Quick file map.** Add an entry under "Quick file map", parallel to the ideate entry:
   `- Hardening engine for the build loop (internal sub-skill): [`skills/woostack-harden/SKILL.md`](skills/woostack-harden/SKILL.md)`.
-- [ ] **Step 4: Verify.** Run: `grep -n "woostack-harden\|ten\|nine" .claude/CLAUDE.md` — expect the new sub-skill named, count updated to ten, no stray "nine".
-- [ ] **Step 5: Commit.**
+- [x] **Step 4: Verify.** Run: `grep -n "woostack-harden\|ten\|nine" .claude/CLAUDE.md` — expect the new sub-skill named, count updated to ten, no stray "nine".
+- [x] **Step 5: Commit.**
 
 ```bash
 git add .claude/CLAUDE.md AGENTS.md
@@ -136,12 +136,12 @@ git commit -m "docs: document woostack-harden as second internal sub-skill"
 
 **Files:** Modify `README.md`, `CONTRIBUTING.md`, `skills/woostack-bootstrap/references/development.md`
 
-- [ ] **Step 1: README chain diagram.** Change the build-loop code block `ideate → markdown spec → grill → approve spec → plan → execute (TDD) → offer PR` to `ideate → markdown spec → harden → approve spec → plan → execute (TDD) → offer PR`.
-- [ ] **Step 2: README prose.** Change `with proven sub-skills (superpowers writing-plans/executing-plans + grill-me)` to credit the in-collection harden phase, e.g. `with woostack's own harden phase (`woostack-harden`) and proven superpowers sub-skills (writing-plans/executing-plans)`. Keep the Install/command surface at eight; `woostack-harden` is internal, not advertised as a command.
-- [ ] **Step 3: CONTRIBUTING build-loop row.** Change the row `Change the build loop (ideate→spec→grill→approve spec→plan→execute)` to `(ideate→spec→harden→approve spec→plan→execute)`.
-- [ ] **Step 4: CONTRIBUTING harden pointer row.** Add a row immediately after the "Change the ideate phase" row: `| Change the harden phase (the build loop's stress-test step) | `skills/woostack-harden/SKILL.md` |`.
-- [ ] **Step 5: development.md loop row.** Change the table row `| Ideate → markdown spec → grill → approve spec → plan → execute | `woostack-build` |` to `| Ideate → markdown spec → harden → approve spec → plan → execute | `woostack-build` |`.
-- [ ] **Step 6: Commit.**
+- [x] **Step 1: README chain diagram.** Change the build-loop code block `ideate → markdown spec → grill → approve spec → plan → execute (TDD) → offer PR` to `ideate → markdown spec → harden → approve spec → plan → execute (TDD) → offer PR`.
+- [x] **Step 2: README prose.** Change `with proven sub-skills (superpowers writing-plans/executing-plans + grill-me)` to credit the in-collection harden phase, e.g. `with woostack's own harden phase (`woostack-harden`) and proven superpowers sub-skills (writing-plans/executing-plans)`. Keep the Install/command surface at eight; `woostack-harden` is internal, not advertised as a command.
+- [x] **Step 3: CONTRIBUTING build-loop row.** Change the row `Change the build loop (ideate→spec→grill→approve spec→plan→execute)` to `(ideate→spec→harden→approve spec→plan→execute)`.
+- [x] **Step 4: CONTRIBUTING harden pointer row.** Add a row immediately after the "Change the ideate phase" row: `| Change the harden phase (the build loop's stress-test step) | `skills/woostack-harden/SKILL.md` |`.
+- [x] **Step 5: development.md loop row.** Change the table row `| Ideate → markdown spec → grill → approve spec → plan → execute | `woostack-build` |` to `| Ideate → markdown spec → harden → approve spec → plan → execute | `woostack-build` |`.
+- [x] **Step 6: Commit.**
 
 ```bash
 git add README.md CONTRIBUTING.md skills/woostack-bootstrap/references/development.md
@@ -150,11 +150,11 @@ git commit -m "docs: update build-loop summaries for woostack-harden"
 
 ## Task 5: Verify
 
-- [ ] **Step 1: Grep for live grill-me.** Run: `grep -rn "grill-me\|grill me\|grilling" --include='*.md' --include='*.yml' --include='*.json' . | grep -v '.woostack/specs/' | grep -v '.woostack/plans/'` — expect **no** results outside historical `.woostack/specs|plans/` artifacts (the new harden spec/plan may reference grill-me descriptively; that is allowed).
-- [ ] **Step 2: Frontmatter + sections.** Run: `head -4 skills/woostack-harden/SKILL.md` (valid `name`/`description`) and `grep -n "Gate boundary\|Terminal state\|no new questions" skills/woostack-harden/SKILL.md` (terminal-state + gate-boundary statements present).
-- [ ] **Step 3: Cross-links.** Confirm `skills/woostack-build/SKILL.md` links `../woostack-harden/SKILL.md` and `.claude/CLAUDE.md` file-map links `skills/woostack-harden/SKILL.md`; both target files exist.
-- [ ] **Step 4: Counts.** Run: `ls skills/*/SKILL.md | wc -l` — expect 10. Confirm `AGENTS.md`/`README.md` still present an eight-skill public command/adoption surface and document two internal sub-skills.
-- [ ] **Step 5: Build-flow summaries.** Run: `grep -rn "harden" README.md CONTRIBUTING.md skills/woostack-bootstrap/references/development.md skills/woostack-build/SKILL.md` — expect every shipped loop summary now shows `harden` (and still `approve spec` before planning).
+- [x] **Step 1: Grep for live grill-me.** Run: `grep -rn "grill-me\|grill me\|grilling" --include='*.md' --include='*.yml' --include='*.json' . | grep -v '.woostack/specs/' | grep -v '.woostack/plans/'` — expect **no** results outside historical `.woostack/specs|plans/` artifacts (the new harden spec/plan may reference grill-me descriptively; that is allowed).
+- [x] **Step 2: Frontmatter + sections.** Run: `head -4 skills/woostack-harden/SKILL.md` (valid `name`/`description`) and `grep -n "Gate boundary\|Terminal state\|no new questions" skills/woostack-harden/SKILL.md` (terminal-state + gate-boundary statements present).
+- [x] **Step 3: Cross-links.** Confirm `skills/woostack-build/SKILL.md` links `../woostack-harden/SKILL.md` and `.claude/CLAUDE.md` file-map links `skills/woostack-harden/SKILL.md`; both target files exist.
+- [x] **Step 4: Counts.** Run: `ls skills/*/SKILL.md | wc -l` — expect 10. Confirm `AGENTS.md`/`README.md` still present an eight-skill public command/adoption surface and document two internal sub-skills.
+- [x] **Step 5: Build-flow summaries.** Run: `grep -rn "harden" README.md CONTRIBUTING.md skills/woostack-bootstrap/references/development.md skills/woostack-build/SKILL.md` — expect every shipped loop summary now shows `harden` (and still `approve spec` before planning).
 
 ---
 

--- a/.woostack/specs/2026-06-04-build-execution-handoff-gate.md
+++ b/.woostack/specs/2026-06-04-build-execution-handoff-gate.md
@@ -1,7 +1,7 @@
 ---
 name: build-execution-handoff-gate
 type: spec
-status: ready
+status: done
 date: 2026-06-04
 branch: worktree-nested-wishing-hanrahan
 links:

--- a/.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
+++ b/.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
@@ -1,7 +1,7 @@
 ---
 name: commit-pr-goal-test-plan
 type: spec
-status: ready
+status: done
 date: 2026-06-04
 branch: worktree-delightful-pondering-thimble
 links:

--- a/.woostack/specs/2026-06-04-woostack-execute-skill.md
+++ b/.woostack/specs/2026-06-04-woostack-execute-skill.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-execute-skill
 type: spec
-status: ready
+status: done
 date: 2026-06-04
 branch: feature/woostack-execute
 links:

--- a/.woostack/specs/2026-06-04-woostack-harden-skill.md
+++ b/.woostack/specs/2026-06-04-woostack-harden-skill.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-harden-skill
 type: spec
-status: ready
+status: done
 date: 2026-06-04
 branch: worktree-tender-exploring-swing
 links:


### PR DESCRIPTION
## Goal

Clear the `/woostack-status` board's "unknown phase" flags on four shipped features that still carried the invalid legacy `status: ready`. Stacked on #202 (the board + producer wiring) — these flags are the first real drift the new board surfaced.

## Summary

- `status: ready → done` on four specs whose implementation is already merged on `main`: `build-execution-handoff-gate` (#201), `commit-pr-goal-test-plan` (#194), `woostack-execute-skill` (#193/#199), `woostack-harden-skill` (#192).
- Tick the two un-ticked plans to 100% — `commit-pr-goal-test-plan` (0→16/16) and `woostack-harden-skill` (0→25/25) — both single-increment plans whose work fully shipped, so `done` renders cleanly (the board only shows `done` at plan 100%).

## Known limitation (engine, not data)

`woostack-execute-skill` and `woostack-harden-skill` still display `in-review`, not `done`: the board's `gh pr list --search "Spec: <path>"` fuzzily matches the still-open #202 (shared `woostack`/`Spec` tokens). These legacy PRs predate the `Spec:` trailer woostack-commit now writes, so the search has nothing precise to match — spec §8's open question on search precision. It self-resolves when #202 merges; the real fix is an engine follow-up (exact-match the trailer / `--json body` + grep), out of scope for a data migration.

## Test plan

### Automated

- [x] `bash skills/woostack-status/scripts/status.sh` — **zero `unknown phase` flags remain** (was 4).

### Manual

**Before merge**

- [x] `bash skills/woostack-status/scripts/status.sh --all` shows `build-execution-handoff-gate` and `commit-pr-goal-test-plan` as `done`; the other two as `in-review` (the documented #202 fuzzy-match).
- [ ] Confirm each migrated spec's `status: done` matches a genuinely merged feature on `main`.

Spec: .woostack/specs/2026-06-04-woostack-status.md
