### PR TITLE
chore(status): mark shipped specs done, reconcile plans and branches

### DIFF
--- a/.woostack/plans/2026-06-02-memory-distill-gate.md
+++ b/.woostack/plans/2026-06-02-memory-distill-gate.md
@@ -39,7 +39,7 @@ Run the suite anytime with: `bash skills/woostack-init/scripts/tests/test-doctor
 - Modify: `skills/woostack-init/scripts/doctor.sh` (per-note loop, after the existing `source_path` / stale-provenance block)
 - Test: `skills/woostack-init/scripts/tests/test-doctor.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add after the existing stale-provenance assertions (after the `pr-source` block, ~line 44), still inside the `$md`/`$repo` setup:
 
@@ -51,12 +51,12 @@ assert_contains "$OUT" "no-source: missing source:" "note without source: is war
 assert_exit 0 "$CODE" "missing source: is a warning"
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: FAIL — `[...] does not contain [no-source: missing source:]` (check not implemented yet).
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 In `doctor.sh`, the `source_path` variable is already computed for the stale-provenance check. Immediately after that `case` block (the one matching `.woostack/specs/*|.woostack/plans/*`), add:
 
@@ -64,12 +64,12 @@ In `doctor.sh`, the `source_path` variable is already computed for the stale-pro
   [ -z "$source_path" ] && warn "$base: missing source: (provenance required)"
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: PASS — new assertions green. Existing assertions still green (source-less notes `ok`/`stale`/`link` are only checked via exit code or unrelated substrings).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/doctor.sh skills/woostack-init/scripts/tests/test-doctor.sh
@@ -84,7 +84,7 @@ git commit -m "feat(doctor): warn on memory notes missing source: (#161)"
 - Modify: `skills/woostack-init/scripts/doctor.sh` (per-note loop)
 - Test: `skills/woostack-init/scripts/tests/test-doctor.sh`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add after the Task 1 block (inside the `$md`/`$repo` setup so notes have `source:`+`updated:` to isolate the non-glob signal):
 
@@ -123,12 +123,12 @@ assert_not_contains "$OUT" "review-ac: non-glob scope" "address-comments note is
 
 Note: `nonglob.md`/`multilit.md` use `scope` values that won't match tracked files, so the existing stale-scope warning also fires — that's fine and independent; we assert only on the `non-glob scope` substring.
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: FAIL on the two `assert_contains "... non-glob scope"` (check not implemented).
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 In `doctor.sh`, after the missing-`source:` line from Task 1 (so `source_path` and `scope` are both in scope), add:
 
@@ -143,12 +143,12 @@ In `doctor.sh`, after the missing-`source:` line from Task 1 (so `source_path` a
 
 `${scope#*\*}` strips the shortest prefix ending in a literal `*`; it equals `$scope` only when `scope` contains no `*` at all.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: PASS — all Task 2 assertions green; existing assertions still green (no existing fixture has a non-glob, non-review scope).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/doctor.sh skills/woostack-init/scripts/tests/test-doctor.sh
@@ -163,7 +163,7 @@ git commit -m "feat(doctor): warn on non-glob memory scope, exempt review notes 
 - Modify: `skills/woostack-init/scripts/doctor.sh` (dead-note block)
 - Modify: `skills/woostack-init/scripts/tests/test-doctor.sh` (3 existing fixtures + new tests)
 
-- [ ] **Step 1: Fix the 3 existing fixtures that the new check would flag**
+- [x] **Step 1: Fix the 3 existing fixtures that the new check would flag**
 
 In `test-doctor.sh`, add `\nupdated: 2026-06-02` to the frontmatter of these three `mk_note` calls so the missing-`updated:` warning does not trip their `assert_not_contains`:
 
@@ -173,7 +173,7 @@ mk_note "$md" live-source-plan.md $'name: live-source-plan\ntype: pattern\nscope
 mk_note "$md" pr-source.md $'name: pr-source\ntype: convention\nscope: packages/api/**\nsource: pr-165\nupdated: 2026-06-02' 'body'
 ```
 
-- [ ] **Step 2: Write the failing test**
+- [x] **Step 2: Write the failing test**
 
 Add a dedicated missing-`updated:` test (use its own temp dir to isolate, mirroring the dead-note block style):
 
@@ -188,12 +188,12 @@ assert_not_contains "$OUT" "dead note" "missing updated: does not also emit a de
 rm -rf "$mu"
 ```
 
-- [ ] **Step 3: Run test to verify it fails**
+- [x] **Step 3: Run test to verify it fails**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: FAIL — `[...] does not contain [noupd2: missing updated:]`.
 
-- [ ] **Step 4: Write minimal implementation**
+- [x] **Step 4: Write minimal implementation**
 
 In `doctor.sh`, the dead-note block is `upd="$(field "$f" updated)"; if [ -n "$upd" ]; then ... fi`. Add an `else` branch so a note with no `updated:` is warned instead of silently skipped:
 
@@ -215,17 +215,17 @@ In `doctor.sh`, the dead-note block is `upd="$(field "$f" updated)"; if [ -n "$u
   fi
 ```
 
-- [ ] **Step 5: Run the full suite to verify pass + no regressions**
+- [x] **Step 5: Run the full suite to verify pass + no regressions**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: PASS — new assertion green; the previously-fixed fixtures (Step 1) keep lines ~42-44 green; the existing `dd4 noupd` dead-note assertion still holds (it checks `assert_not_contains "dead note"`, and our new warning text differs).
 
-- [ ] **Step 6: Run the whole init test runner as a final guard**
+- [x] **Step 6: Run the whole init test runner as a final guard**
 
 Run: `bash skills/woostack-init/scripts/tests/run-tests.sh`
 Expected: every `test-*.sh` reports `0 failed`, runner exits 0.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/doctor.sh skills/woostack-init/scripts/tests/test-doctor.sh
@@ -239,7 +239,7 @@ git commit -m "feat(doctor): warn on memory notes missing updated: (#167)"
 **Files:**
 - Modify: `skills/woostack-init/references/memory.md` (§7 Distillation, §8 Scripts staleness warnings)
 
-- [ ] **Step 1: Add the reject-by-default gate to §7**
+- [x] **Step 1: Add the reject-by-default gate to §7**
 
 In `## 7. Distillation (write path)`, after the existing bullet list (`type` / `scope` / `source` / body) and before the "Distillation **dedupes against `MEMORY.md` first**" paragraph, insert:
 
@@ -254,7 +254,7 @@ In `## 7. Distillation (write path)`, after the existing bullet list (`type` / `
 `doctor.sh` backstops items 1, 2, and 4 with warning-only checks (§8) — they catch escapes but never hard-block.
 ```
 
-- [ ] **Step 2: Document the 3 new warnings in §8**
+- [x] **Step 2: Document the 3 new warnings in §8**
 
 In `## 8. Scripts`, in the **Staleness warnings** list (after the **Dead note** bullet), add:
 
@@ -264,12 +264,12 @@ In `## 8. Scripts`, in the **Staleness warnings** list (after the **Dead note** 
 - **Missing age basis:** a note with no `updated:` field is flagged — it cannot be aged by the dead-note check above. (Both write paths stamp `updated:`; a note without it is anomalous.)
 ```
 
-- [ ] **Step 3: Verify cross-links + render**
+- [x] **Step 3: Verify cross-links + render**
 
 Run: `grep -n "Reject-by-default\|Non-glob scope\|Missing provenance\|Missing age basis" skills/woostack-init/references/memory.md`
 Expected: all four anchors present. Eyeball that §7 and §8 read cleanly and the §8 additions sit under the existing staleness list.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add skills/woostack-init/references/memory.md
@@ -283,7 +283,7 @@ git commit -m "docs(memory): document distillation gate + doctor backstop warnin
 **Files:**
 - Modify: `skills/woostack-build/SKILL.md` (Procedure step 7, "Distill memory")
 
-- [ ] **Step 1: Add the gate pointer to step 7**
+- [x] **Step 1: Add the gate pointer to step 7**
 
 In step 7, after the existing sentence describing dedupe-first and before "Then run `woostack-init`'s `build-index.sh` and `doctor.sh`", insert a terse pointer (do NOT restate the four criteria — `memory.md` §7 is canonical, per the cross-link-don't-duplicate rule):
 
@@ -291,12 +291,12 @@ In step 7, after the existing sentence describing dedupe-first and before "Then 
    Apply the **reject-by-default distillation gate** (see the [memory contract](../woostack-init/references/memory.md) §7): single-file scope, missing `source:`, or a near-duplicate `hook:` ⇒ do not write the note; and **stamp `updated:`** (today's ISO date) on every note you create or update.
 ```
 
-- [ ] **Step 2: Verify the cross-link resolves**
+- [x] **Step 2: Verify the cross-link resolves**
 
 Run: `ls skills/woostack-init/references/memory.md && grep -n "reject-by-default distillation gate" skills/woostack-build/SKILL.md`
 Expected: file exists; the new pointer line is present. Confirm the relative path `../woostack-init/references/memory.md` is correct from `skills/woostack-build/SKILL.md` (sibling `skills/` subdir).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/woostack-build/SKILL.md

--- a/.woostack/plans/2026-06-02-memory-distill.md
+++ b/.woostack/plans/2026-06-02-memory-distill.md
@@ -1,0 +1,19 @@
+# Memory distill + skill wiring (Increment C) — Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax. Docs-only increment — no new scripts; reuses A's `build-index`/`doctor` and B's `recall.sh`.
+
+**Goal:** Wire the remaining three skills to the memory system — distill learnings back from the build loop, scaffold `.woostack/` from bootstrap, and document address-comments' inherited scope-routed memory.
+
+**Architecture:** Agent-behavior + doc edits only. The build loop gains a post-execute distill step; bootstrap invokes `/woostack-init`; the memory contract documents the distill write-path.
+
+**Source:** specs/2026-06-02-memory-distill.md (Increment C of 4; shipped in #156).
+
+> Reconstructed after the fact: this increment shipped docs-only in PR #156 before plan-checkbox tracking existed. Tasks below mirror the spec's delivered scope and are checked to reflect the merged work.
+
+## Tasks
+
+- [x] Add a build-loop distill step (post-execute): extract durable learnings from spec+plan into scoped memory notes with `source:` provenance.
+- [x] Rebuild the memory index and run the store linter after distillation.
+- [x] Wire bootstrap to invoke `/woostack-init` so a fresh repo gets `.woostack/`.
+- [x] Document that woostack-address-comments already inherits scope-routed memory via increment B (no behavior change).
+- [x] Update the memory contract to describe the distill write-path.

--- a/.woostack/plans/2026-06-02-memory-obsidian.md
+++ b/.woostack/plans/2026-06-02-memory-obsidian.md
@@ -33,7 +33,7 @@
 - Create: `skills/woostack-init/scripts/graph.sh`
 - Test: `skills/woostack-init/scripts/tests/test-graph.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-init/scripts/tests/test-graph.sh`:
 
@@ -89,9 +89,9 @@ rm -rf "$md"
 finish
 ```
 
-- [ ] **Step 2: Run, confirm FAIL** (graph.sh missing).
+- [x] **Step 2: Run, confirm FAIL** (graph.sh missing).
 
-- [ ] **Step 3: Write `graph.sh`**
+- [x] **Step 3: Write `graph.sh`**
 
 Create `skills/woostack-init/scripts/graph.sh`:
 
@@ -144,9 +144,9 @@ case "$MODE" in
 esac
 ```
 
-- [ ] **Step 4: Run test (all pass) + full suite + shellcheck.** `bash skills/woostack-init/scripts/tests/run-tests.sh` exit 0. shellcheck info-level OK.
+- [x] **Step 4: Run test (all pass) + full suite + shellcheck.** `bash skills/woostack-init/scripts/tests/run-tests.sh` exit 0. shellcheck info-level OK.
 
-- [ ] **Step 5: Commit** — `feat(woostack-init): graph.sh links/backlinks helper (grep + obsidian fallback) + tests`
+- [x] **Step 5: Commit** — `feat(woostack-init): graph.sh links/backlinks helper (grep + obsidian fallback) + tests`
 
 ---
 
@@ -156,7 +156,7 @@ esac
 - Create: `skills/woostack-init/templates/obsidian/app.json`, `graph.json`
 - Modify: `skills/woostack-init/templates/gitignore`, `skills/woostack-init/SKILL.md`, `skills/woostack-init/references/memory.md`, `AGENTS.md`
 
-- [ ] **Step 1: Obsidian config templates.**
+- [x] **Step 1: Obsidian config templates.**
 
 `skills/woostack-init/templates/obsidian/app.json`:
 ```json
@@ -177,23 +177,23 @@ esac
 }
 ```
 
-- [ ] **Step 2: gitignore template.** Append to `skills/woostack-init/templates/gitignore`:
+- [x] **Step 2: gitignore template.** Append to `skills/woostack-init/templates/gitignore`:
 ```
 # Obsidian per-user UI state (the shared .obsidian/*.json config IS tracked).
 .obsidian/workspace*
 .obsidian/cache
 ```
 
-- [ ] **Step 3: SKILL.md flags + scaffold step.** In `skills/woostack-init/SKILL.md`:
+- [x] **Step 3: SKILL.md flags + scaffold step.** In `skills/woostack-init/SKILL.md`:
 - Add `--obsidian` and `--no-obsidian` to the **Flags** section: force-enable / force-skip the optional Obsidian vault config; with neither, the skill **prompts** (default no).
 - In the Procedure, add a step (after the core scaffold, before build-index/doctor): "If `--obsidian` (or the user accepts the prompt), scaffold `.woostack/.obsidian/` from `templates/obsidian/` (never clobbering an existing `.obsidian/`). This makes `.woostack/` an Obsidian vault (memory + specs + plans as a `[[wikilink]]` graph). Obsidian is **optional** — all memory tooling works without it."
 - Add a hard-constraint/Reference note that Obsidian is never required.
 
-- [ ] **Step 4: Contract "Obsidian (optional)" section.** In `skills/woostack-init/references/memory.md`, add a new section (renumber Degradation last): the vault is already Obsidian-compatible (markdown + `[[wikilinks]]`); `/woostack-init --obsidian` scaffolds `.woostack/.obsidian/`; `graph.sh <memdir> <note> --links|--backlinks` queries the graph (grep by default, `obsidian eval` when `WOOSTACK_OBSIDIAN=1` + app present); **all core tooling (`recall`, `doctor`, `build-index`) works without Obsidian**.
+- [x] **Step 4: Contract "Obsidian (optional)" section.** In `skills/woostack-init/references/memory.md`, add a new section (renumber Degradation last): the vault is already Obsidian-compatible (markdown + `[[wikilinks]]`); `/woostack-init --obsidian` scaffolds `.woostack/.obsidian/`; `graph.sh <memdir> <note> --links|--backlinks` queries the graph (grep by default, `obsidian eval` when `WOOSTACK_OBSIDIAN=1` + app present); **all core tooling (`recall`, `doctor`, `build-index`) works without Obsidian**.
 
-- [ ] **Step 5: AGENTS.md.** In the woostack-init `templates/` layout entry, mention `obsidian/` (Obsidian vault config). Keep it a one-liner.
+- [x] **Step 5: AGENTS.md.** In the woostack-init `templates/` layout entry, mention `obsidian/` (Obsidian vault config). Keep it a one-liner.
 
-- [ ] **Step 6: Verify.**
+- [x] **Step 6: Verify.**
 ```bash
 # templates are valid JSON
 for j in skills/woostack-init/templates/obsidian/*.json; do python3 -m json.tool "$j" >/dev/null && echo "ok $j"; done
@@ -204,13 +204,13 @@ bash skills/woostack-init/scripts/tests/run-tests.sh >/dev/null 2>&1 && echo "su
 ```
 Expected: both JSONs ok, gitignore ok, suite green.
 
-- [ ] **Step 7: Commit** — `feat(woostack-init): opt-in Obsidian vault config + graph docs`
+- [x] **Step 7: Commit** — `feat(woostack-init): opt-in Obsidian vault config + graph docs`
 
 ---
 
 ## Task 3: Final verify + PR
 
-- [ ] **Step 1: Full suite + scope guard.**
+- [x] **Step 1: Full suite + scope guard.**
 ```bash
 bash skills/woostack-init/scripts/tests/run-tests.sh; echo "suite exit=$?"
 # D touches only woostack-init (graph.sh, templates, SKILL, contract) + AGENTS.md
@@ -218,9 +218,9 @@ git diff --stat feat/woostack-memory-distill..HEAD -- skills/woostack-review ski
 ```
 Expected: suite exit 0; other skills untouched.
 
-- [ ] **Step 2: Dogfood graph.sh** on the example note set (build a quick fixture; confirm `--links`/`--backlinks`).
+- [x] **Step 2: Dogfood graph.sh** on the example note set (build a quick fixture; confirm `--links`/`--backlinks`).
 
-- [ ] **Step 3: Push + open PR** (stacked on `feat/woostack-memory-distill`) — ask the user first per the build loop.
+- [x] **Step 3: Push + open PR** (stacked on `feat/woostack-memory-distill`) — ask the user first per the build loop.
 
 ---
 

--- a/.woostack/plans/2026-06-02-memory-overlap-clusters.md
+++ b/.woostack/plans/2026-06-02-memory-overlap-clusters.md
@@ -38,7 +38,7 @@ Run suites with: `bash skills/woostack-init/scripts/tests/run-tests.sh`
 - Modify: `skills/woostack-init/scripts/recall.sh` (matched emission ~line 36; sort ~line 44)
 - Test: `skills/woostack-init/scripts/tests/test-recall.sh`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Append before the final `finish` (after the telemetry block, line ~98). Each uses its own fixture so it is order-independent:
 
@@ -76,12 +76,12 @@ assert_not_contains "$cap_out" "OLDER body" "older note dropped first under cap 
 rm -rf "$woo6" "$p6" "$woo7" "$p7"
 ```
 
-- [ ] **Step 2: Run to verify the new tests fail**
+- [x] **Step 2: Run to verify the new tests fail**
 
 Run: `bash skills/woostack-init/scripts/tests/test-recall.sh`
 Expected: FAIL on `recency tie` and `older note dropped first` (current sort ignores `updated:`, so tie order is arbitrary/insertion — at least one assertion fails). The undated test MAY pass by luck; the recency + cap tests will not be reliably green until Step 3.
 
-- [ ] **Step 3: Implement the tiebreak**
+- [x] **Step 3: Implement the tiebreak**
 
 In `recall.sh`, the matched-note emission currently is (line ~36):
 
@@ -112,12 +112,12 @@ done < <(sort -t"$(printf '\t')" -k1,1nr -k2,2r "$matched" | cut -f3-)
 
 `-k1,1nr` keeps match-count primary (numeric, descending); `-k2,2r` orders the `updated:` column descending (ISO dates sort chronologically; an empty column sorts last under reverse, so undated loses the tie); `cut -f3-` recovers the path now that it is the third column.
 
-- [ ] **Step 4: Run to verify pass + no regressions**
+- [x] **Step 4: Run to verify pass + no regressions**
 
 Run: `bash skills/woostack-init/scripts/tests/test-recall.sh`
 Expected: PASS — all new assertions green. The existing match-count ordering test (wide/narrow, different counts) still passes because the primary key is unchanged.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/recall.sh skills/woostack-init/scripts/tests/test-recall.sh
@@ -132,7 +132,7 @@ git commit -m "feat(recall): break match-count ties by updated: recency (#162)"
 - Modify: `skills/woostack-init/scripts/doctor.sh` (`seen` setup; the scope/stale block; after the per-note loop; cleanup)
 - Test: `skills/woostack-init/scripts/tests/test-doctor.sh`
 
-- [ ] **Step 1: Write the failing tests (isolated git fixture repo)**
+- [x] **Step 1: Write the failing tests (isolated git fixture repo)**
 
 The shared `$repo`/`$md` store already holds many `packages/api/**` notes that would all cluster; overlap tests MUST use their own git repo. Append after the dead-note block (before the `finish` at the end of `test-doctor.sh`):
 
@@ -184,12 +184,12 @@ rm -rf "$orepo" "$ostale"
 
 Note: the fixture notes carry `source:`/`updated:` so the #161 missing-source / missing-updated warnings don't add noise to `$OUT` that could confuse the `assert_not_contains` checks. `c2.md` uses a multi-glob scope including the literal `packages/api/x.ts`, guaranteeing it co-matches `c1.md` on that file.
 
-- [ ] **Step 2: Run to verify the new tests fail**
+- [x] **Step 2: Run to verify the new tests fail**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: FAIL on every `overlap cluster: …` assertion (no clustering implemented yet).
 
-- [ ] **Step 3: Add the pairs temp file to setup**
+- [x] **Step 3: Add the pairs temp file to setup**
 
 In `doctor.sh`, the setup block has `seen="$(mktemp)"`. Add a sibling temp file right after it:
 
@@ -198,7 +198,7 @@ seen="$(mktemp)"
 overlap_pairs="$(mktemp)"
 ```
 
-- [ ] **Step 4: Capture matched files in the scope/stale block (replace, don't double, the scope-match call)**
+- [x] **Step 4: Capture matched files in the scope/stale block (replace, don't double, the scope-match call)**
 
 The current block is:
 
@@ -227,7 +227,7 @@ Replace it with a single scope-match call whose output is captured and reused fo
   fi
 ```
 
-- [ ] **Step 5: Emit cluster warnings after the per-note loop**
+- [x] **Step 5: Emit cluster warnings after the per-note loop**
 
 The loop ends with `done` then `rm -f "$seen"`. Insert the cluster block between them:
 
@@ -263,17 +263,17 @@ rm -f "$seen" "$overlap_pairs"
 
 How it works: the first awk unions notes that share a file and, for each component, emits `min-member<TAB>note` for every member; `sort -u` orders members within a component; the second awk groups by the canonical id and keeps only ≥2-member clusters; the final `sort` orders the cluster lines; the `while` loop turns each into a warning. A note that shares no file with any other never gets unioned → its component has one member → dropped by `cnt >= 2`.
 
-- [ ] **Step 6: Run to verify pass + no regressions**
+- [x] **Step 6: Run to verify pass + no regressions**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: PASS — all overlap assertions green; the pre-existing stale-scope assertion still fires (the stale branch behavior is unchanged); every other assertion unaffected (the shared `$repo` store has tracked files but its notes are validated only via exit code / specific substrings — `overlap cluster` is a new substring not referenced by old assertions). If the shared store happens to emit an `overlap cluster` line, no existing `assert_not_contains` targets that string, so it is harmless.
 
-- [ ] **Step 7: Run the full init suite**
+- [x] **Step 7: Run the full init suite**
 
 Run: `bash skills/woostack-init/scripts/tests/run-tests.sh`
 Expected: every `test-*.sh` reports `0 failed`; runner exits 0.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/doctor.sh skills/woostack-init/scripts/tests/test-doctor.sh
@@ -287,7 +287,7 @@ git commit -m "feat(doctor): warn on scope-overlap clusters of memory notes (#16
 **Files:**
 - Modify: `skills/woostack-init/references/memory.md` (§6 Recall Procedure, §8 Scripts staleness warnings)
 
-- [ ] **Step 1: Document the recency tiebreak in §6**
+- [x] **Step 1: Document the recency tiebreak in §6**
 
 In `## 6. Recall Procedure`, step 3 currently ends describing scope-match load. Append a sentence to step 3 (the scope-match step):
 
@@ -295,7 +295,7 @@ In `## 6. Recall Procedure`, step 3 currently ends describing scope-match load. 
    When two matched notes have the **same** match-count, the tie is broken by `updated:` recency — the newer note ranks first, and a note without `updated:` ranks last (so under cap pressure the older / undated note is dropped first). Match-count remains the primary key.
 ```
 
-- [ ] **Step 2: Document the overlap-cluster warning in §8**
+- [x] **Step 2: Document the overlap-cluster warning in §8**
 
 In `## 8. Scripts`, in the **Staleness warnings** list, add after the existing bullets:
 
@@ -303,7 +303,7 @@ In `## 8. Scripts`, in the **Staleness warnings** list, add after the existing b
 - **Overlap cluster:** non-global notes whose `scope:` globs match at least one common tracked file are grouped into a cluster and flagged for human review (`overlap cluster: a.md, b.md — intersecting scope, review for contradiction`). doctor cannot judge whether the advice actually contradicts — it surfaces the co-load so a human can. Global notes (`*`/absent) co-load with everything by design and are exempt; a note whose scope matches no tracked file is stale, not clustered. Overlap is measured by shared tracked files (via `scope-match.sh`), so it is skipped when there is no git repo.
 ```
 
-- [ ] **Step 3: Verify + commit**
+- [x] **Step 3: Verify + commit**
 
 Run: `grep -n "Overlap cluster\|broken by .updated. recency" skills/woostack-init/references/memory.md`
 Expected: both additions present.

--- a/.woostack/plans/2026-06-02-memory-recall.md
+++ b/.woostack/plans/2026-06-02-memory-recall.md
@@ -30,7 +30,7 @@
 - Create: `skills/woostack-init/scripts/recall.sh`
 - Test: `skills/woostack-init/scripts/tests/test-recall.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-init/scripts/tests/test-recall.sh`:
 
@@ -87,11 +87,11 @@ rm -rf "$woo" "$woo2" "$woo3"
 finish
 ```
 
-- [ ] **Step 2: Run, confirm FAIL** (recall.sh missing).
+- [x] **Step 2: Run, confirm FAIL** (recall.sh missing).
 
 Run: `bash skills/woostack-init/scripts/tests/test-recall.sh; echo exit=$?` → FAIL.
 
-- [ ] **Step 3: Write `recall.sh`**
+- [x] **Step 3: Write `recall.sh`**
 
 Create `skills/woostack-init/scripts/recall.sh`:
 
@@ -179,12 +179,12 @@ fi
 exit 0
 ```
 
-- [ ] **Step 4: Run, confirm all pass, full suite green.**
+- [x] **Step 4: Run, confirm all pass, full suite green.**
 
 Run: `bash skills/woostack-init/scripts/tests/test-recall.sh; echo exit=$?` then `bash skills/woostack-init/scripts/tests/run-tests.sh`.
 Expected: recall test all pass; whole suite exit 0. Run shellcheck; info-level OK.
 
-- [ ] **Step 5: Commit** — `feat(woostack-init): recall.sh — scope-routed memory composition + tests`
+- [x] **Step 5: Commit** — `feat(woostack-init): recall.sh — scope-routed memory composition + tests`
 
 ---
 
@@ -193,9 +193,9 @@ Expected: recall test all pass; whole suite exit 0. Run shellcheck; info-level O
 **Files:**
 - Modify: `skills/woostack-review/scripts/prefetch.sh` (memory block ~679-697)
 
-- [ ] **Step 1: Read the current block.** Read `skills/woostack-review/scripts/prefetch.sh` lines 679-700 (the `MEMORY_SRC`/`MEMORY_OUT` block). Note `SCRIPT_DIR` is defined at line 251 as `$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)`.
+- [x] **Step 1: Read the current block.** Read `skills/woostack-review/scripts/prefetch.sh` lines 679-700 (the `MEMORY_SRC`/`MEMORY_OUT` block). Note `SCRIPT_DIR` is defined at line 251 as `$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)`.
 
-- [ ] **Step 2: Replace the block** with recall-first, flat-copy fallback. New block:
+- [x] **Step 2: Replace the block** with recall-first, flat-copy fallback. New block:
 
 ```bash
 # Cross-PR memory — composed per-PR via recall.sh when a scope-routed store
@@ -240,7 +240,7 @@ else
 fi
 ```
 
-- [ ] **Step 3: Syntax check + targeted integration test.**
+- [x] **Step 3: Syntax check + targeted integration test.**
 
 Run:
 ```bash
@@ -260,9 +260,9 @@ rm -rf "$tmp"
 ```
 Expected: `syntax ok` and `INTEGRATION OK` (the API note is recalled, the WEB note is not, for an api-only change).
 
-- [ ] **Step 4: Confirm scope guard.** `git diff origin/main -- skills/woostack-review/scripts/prefetch.sh` shows ONLY the memory block changed (plus the added `changed-paths.txt` derivation). No other prefetch logic touched.
+- [x] **Step 4: Confirm scope guard.** `git diff origin/main -- skills/woostack-review/scripts/prefetch.sh` shows ONLY the memory block changed (plus the added `changed-paths.txt` derivation). No other prefetch logic touched.
 
-- [ ] **Step 5: Commit** — `feat(woostack-review): prefetch composes memory via recall.sh (scope-routed)`
+- [x] **Step 5: Commit** — `feat(woostack-review): prefetch composes memory via recall.sh (scope-routed)`
 
 ---
 
@@ -272,11 +272,11 @@ Expected: `syntax ok` and `INTEGRATION OK` (the API note is recalled, the WEB no
 - Modify: `skills/woostack-review/prompts/_header.md`
 - Modify: `skills/woostack-review/SKILL.md`
 
-- [ ] **Step 1: Update `_header.md`.** In the *Cross-PR memory* bullet (the one describing `/tmp/pr-review/memory.md`), add a sentence: when the repo has a `.woostack/memory/` store, this file is **scope-routed** — it contains the notes whose `scope` matches the PR's changed files, any one-hop linked notes, plus the always-included global shard. Still: do NOT re-flag an issue the memory records as known/accepted. Keep it brief; do not restate the contract.
+- [x] **Step 1: Update `_header.md`.** In the *Cross-PR memory* bullet (the one describing `/tmp/pr-review/memory.md`), add a sentence: when the repo has a `.woostack/memory/` store, this file is **scope-routed** — it contains the notes whose `scope` matches the PR's changed files, any one-hop linked notes, plus the always-included global shard. Still: do NOT re-flag an issue the memory records as known/accepted. Keep it brief; do not restate the contract.
 
-- [ ] **Step 2: Update review `SKILL.md`.** In the *Cross-PR Memory* section, add a short paragraph: when a scope-routed store exists, `prefetch.sh` composes the per-PR memory via `recall.sh` (link `../woostack-init/references/memory.md`) instead of dumping the whole file; the flat `memory.md` remains the always-loaded global shard. One or two sentences.
+- [x] **Step 2: Update review `SKILL.md`.** In the *Cross-PR Memory* section, add a short paragraph: when a scope-routed store exists, `prefetch.sh` composes the per-PR memory via `recall.sh` (link `../woostack-init/references/memory.md`) instead of dumping the whole file; the flat `memory.md` remains the always-loaded global shard. One or two sentences.
 
-- [ ] **Step 3: Verify cross-links + full suite.**
+- [x] **Step 3: Verify cross-links + full suite.**
 
 Run:
 ```bash
@@ -287,7 +287,7 @@ grep -oE '\]\(([^)]+)\)' skills/woostack-review/SKILL.md | sed -E 's/\]\(//; s/\
 ```
 Expected: suite exit 0; no BROKEN lines (the `../woostack-init/...` relative link resolves from `skills/woostack-review/`).
 
-- [ ] **Step 4: Commit** — `docs(woostack-review): document scope-routed memory recall`
+- [x] **Step 4: Commit** — `docs(woostack-review): document scope-routed memory recall`
 
 ---
 

--- a/.woostack/plans/2026-06-02-review-metrics-overlap.md
+++ b/.woostack/plans/2026-06-02-review-metrics-overlap.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Bash + embedded Python 3 + `jq`; bash test harness under `skills/woostack-review/scripts/tests/` sourcing `skills/woostack-init/scripts/tests/assert.sh`.
 
-**Spec:** `.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md` (Increment 1).
+**Source:** specs/2026-06-02-review-metrics-tokens-overlap.md (Increment 1; tokens deferred per spec §8).
 
 ---
 
@@ -28,7 +28,7 @@
 - Test: `skills/woostack-review/scripts/tests/test-intersect-overlap.sh` (create)
 - Modify: `skills/woostack-review/scripts/intersect-findings.sh` (the `emit_angle_metrics` Python heredoc)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-review/scripts/tests/test-intersect-overlap.sh`:
 
@@ -93,12 +93,12 @@ rm -rf "$work"
 finish
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bash skills/woostack-review/scripts/tests/test-intersect-overlap.sh`
 Expected: FAIL — `overlap_total` is `null` (jq prints `null`, not `2`), and `schema_version` is `1`. (The script still produces `findings.metrics.json`, so the first assert passes; the overlap asserts fail.)
 
-- [ ] **Step 3: Implement overlap in the `emit_angle_metrics` heredoc**
+- [x] **Step 3: Implement overlap in the `emit_angle_metrics` heredoc**
 
 In `skills/woostack-review/scripts/intersect-findings.sh`, find the Python heredoc inside `emit_angle_metrics()`. Make three edits.
 
@@ -165,12 +165,12 @@ Then, inside the `for a in angles:` loop, **after** the `rec = { ... }` literal 
     rec["overlap_total"] = sum(ow.values())
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bash skills/woostack-review/scripts/tests/test-intersect-overlap.sh`
 Expected: PASS — `0 failed`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add skills/woostack-review/scripts/intersect-findings.sh skills/woostack-review/scripts/tests/test-intersect-overlap.sh
@@ -185,7 +185,7 @@ git commit -m "feat(review): per-angle cross-angle overlap in findings.metrics.j
 - Test: `skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh` (create)
 - Modify: `skills/woostack-review/scripts/metrics-fold.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh`:
 
@@ -248,12 +248,12 @@ rm -rf "$work"
 finish
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh`
 Expected: FAIL — with `SCHEMA_VERSION=1` the stale v1 file is treated as current (no `.bak`, `schema_version` stays 1), and `overlap_total` folds to `null`.
 
-- [ ] **Step 3: Bump the schema version**
+- [x] **Step 3: Bump the schema version**
 
 In `skills/woostack-review/scripts/metrics-fold.sh`, change:
 
@@ -265,7 +265,7 @@ to:
 SCHEMA_VERSION=2
 ```
 
-- [ ] **Step 4: Add overlap to the slot template and accumulation**
+- [x] **Step 4: Add overlap to the slot template and accumulation**
 
 In the Python heredoc of `metrics-fold.sh`, the per-angle slot is created with `agg["angles"].setdefault(angle, { ... })`. Add the two overlap keys to that template dict (alongside `"severity_total"`):
 
@@ -293,12 +293,12 @@ add immediately after it:
         slot["overlap_with"][b] = num(slot["overlap_with"].get(b)) + num(n)
 ```
 
-- [ ] **Step 5: Run test to verify it passes**
+- [x] **Step 5: Run test to verify it passes**
 
 Run: `bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh`
 Expected: PASS — `0 failed`.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add skills/woostack-review/scripts/metrics-fold.sh skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh
@@ -312,7 +312,7 @@ git commit -m "feat(review): fold cross-angle overlap into rolling metrics, sche
 **Files:**
 - Modify: `skills/woostack-review/SKILL.md`
 
-- [ ] **Step 1: Update the `findings.metrics.json` artifact-table row**
+- [x] **Step 1: Update the `findings.metrics.json` artifact-table row**
 
 Find the table row (around line 222) beginning:
 
@@ -326,7 +326,7 @@ Append the two new keys to its key list so it ends:
 … `blocking_count`, `nonblocking_count`, `severity`, `overlap_total`, `overlap_with` (per-other-angle co-occurrence counts on the raw set; schema v2) |
 ```
 
-- [ ] **Step 2: Update the `metrics` config note**
+- [x] **Step 2: Update the `metrics` config note**
 
 Find the bullet (around line 165):
 
@@ -340,12 +340,12 @@ Replace it with:
 - **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). Each angle also carries `overlap_total` + `overlap_with` (how often another angle raised the same issue, on the raw pre-validation set — a redundancy signal). Aggregate schema is v2; an older v1 aggregate is reseeded on first fold. See Stage 6.5.
 ```
 
-- [ ] **Step 3: Verify no cross-links broke**
+- [x] **Step 3: Verify no cross-links broke**
 
 Run: `grep -n "findings.metrics.json\|review.metrics\|overlap" skills/woostack-review/SKILL.md`
 Expected: the updated row + bullet appear; no other reference contradicts the new keys.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add skills/woostack-review/SKILL.md
@@ -358,7 +358,7 @@ git commit -m "docs(review): document overlap metric + schema v2 in SKILL.md"
 
 **Files:** none (verification only)
 
-- [ ] **Step 1: Run both new tests**
+- [x] **Step 1: Run both new tests**
 
 Run:
 ```bash
@@ -367,7 +367,7 @@ bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh
 ```
 Expected: each prints `0 failed`.
 
-- [ ] **Step 2: Run the rest of the review/init test suite to catch regressions**
+- [x] **Step 2: Run the rest of the review/init test suite to catch regressions**
 
 Run:
 ```bash
@@ -377,12 +377,12 @@ done
 ```
 Expected: every test reports `0 failed`; no `FAILED:` line.
 
-- [ ] **Step 3: Lint the touched shell scripts**
+- [x] **Step 3: Lint the touched shell scripts**
 
 Run: `shellcheck skills/woostack-review/scripts/intersect-findings.sh skills/woostack-review/scripts/metrics-fold.sh`
 Expected: no new warnings introduced by these edits. (If `shellcheck` is unavailable, note it and skip — the embedded Python is not shellcheck-covered anyway.)
 
-- [ ] **Step 4: Sanity-check JSON shape end-to-end**
+- [x] **Step 4: Sanity-check JSON shape end-to-end**
 
 Run the Task 1 fixture once more and pretty-print:
 ```bash

--- a/.woostack/plans/2026-06-02-woostack-init.md
+++ b/.woostack/plans/2026-06-02-woostack-init.md
@@ -40,7 +40,7 @@
 - Create: `skills/woostack-init/scripts/tests/assert.sh`
 - Create: `skills/woostack-init/scripts/tests/run-tests.sh`
 
-- [ ] **Step 1: Write the assert helpers**
+- [x] **Step 1: Write the assert helpers**
 
 Create `skills/woostack-init/scripts/tests/assert.sh`:
 
@@ -75,7 +75,7 @@ mk_memdir() { mktemp -d; }
 mk_note() { printf -- '---\n%s\n---\n%s\n' "$3" "$4" > "$1/$2"; }
 ```
 
-- [ ] **Step 2: Write the runner**
+- [x] **Step 2: Write the runner**
 
 Create `skills/woostack-init/scripts/tests/run-tests.sh`:
 
@@ -92,7 +92,7 @@ done
 exit "$rc"
 ```
 
-- [ ] **Step 3: Make executable and verify the runner runs with no tests**
+- [x] **Step 3: Make executable and verify the runner runs with no tests**
 
 Run:
 ```bash
@@ -101,7 +101,7 @@ bash skills/woostack-init/scripts/tests/run-tests.sh; echo "exit=$?"
 ```
 Expected: no `test-*.sh` yet → prints nothing under a loop, `exit=0`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/tests/assert.sh skills/woostack-init/scripts/tests/run-tests.sh
@@ -116,7 +116,7 @@ git commit -m "test(woostack-init): bash assert harness + runner"
 - Create: `skills/woostack-init/scripts/lib.sh`
 - Test: `skills/woostack-init/scripts/tests/test-lib.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-init/scripts/tests/test-lib.sh`:
 
@@ -140,12 +140,12 @@ rm -rf "$d"
 finish
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bash skills/woostack-init/scripts/tests/test-lib.sh; echo "exit=$?"`
 Expected: FAIL — `lib.sh` does not exist (source error), `exit` non-zero.
 
-- [ ] **Step 3: Write `lib.sh`**
+- [x] **Step 3: Write `lib.sh`**
 
 Create `skills/woostack-init/scripts/lib.sh`:
 
@@ -172,12 +172,12 @@ first_body_line() {
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bash skills/woostack-init/scripts/tests/test-lib.sh; echo "exit=$?"`
 Expected: `6 passed, 0 failed`, `exit=0`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/lib.sh skills/woostack-init/scripts/tests/test-lib.sh
@@ -192,7 +192,7 @@ git commit -m "feat(woostack-init): frontmatter helper lib + tests"
 - Create: `skills/woostack-init/scripts/scope-match.sh`
 - Test: `skills/woostack-init/scripts/tests/test-scope-match.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-init/scripts/tests/test-scope-match.sh`:
 
@@ -243,12 +243,12 @@ assert_exit 1 "$code" "no match exits 1"
 finish
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bash skills/woostack-init/scripts/tests/test-scope-match.sh; echo "exit=$?"`
 Expected: FAIL — `scope-match.sh` missing.
 
-- [ ] **Step 3: Write `scope-match.sh`**
+- [x] **Step 3: Write `scope-match.sh`**
 
 Create `skills/woostack-init/scripts/scope-match.sh`:
 
@@ -295,12 +295,12 @@ done
 if grep -E "$ERE"; then exit 0; else exit 1; fi
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bash skills/woostack-init/scripts/tests/test-scope-match.sh; echo "exit=$?"`
 Expected: all assertions pass, `exit=0`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/scope-match.sh skills/woostack-init/scripts/tests/test-scope-match.sh
@@ -315,7 +315,7 @@ git commit -m "feat(woostack-init): scope-match glob primitive + tests"
 - Create: `skills/woostack-init/scripts/build-index.sh`
 - Test: `skills/woostack-init/scripts/tests/test-build-index.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-init/scripts/tests/test-build-index.sh`:
 
@@ -357,12 +357,12 @@ rm -rf "$d"
 finish
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bash skills/woostack-init/scripts/tests/test-build-index.sh; echo "exit=$?"`
 Expected: FAIL — `build-index.sh` missing.
 
-- [ ] **Step 3: Write `build-index.sh`**
+- [x] **Step 3: Write `build-index.sh`**
 
 Create `skills/woostack-init/scripts/build-index.sh`:
 
@@ -400,12 +400,12 @@ done
 rm -f "$tmp"
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bash skills/woostack-init/scripts/tests/test-build-index.sh; echo "exit=$?"`
 Expected: all pass, `exit=0`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/build-index.sh skills/woostack-init/scripts/tests/test-build-index.sh
@@ -420,7 +420,7 @@ git commit -m "feat(woostack-init): derived MEMORY.md index builder + tests"
 - Create: `skills/woostack-init/scripts/doctor.sh`
 - Test: `skills/woostack-init/scripts/tests/test-doctor.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-init/scripts/tests/test-doctor.sh`:
 
@@ -475,12 +475,12 @@ rm -rf "$repo"
 finish
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh; echo "exit=$?"`
 Expected: FAIL — `doctor.sh` missing.
 
-- [ ] **Step 3: Write `doctor.sh`**
+- [x] **Step 3: Write `doctor.sh`**
 
 Create `skills/woostack-init/scripts/doctor.sh`:
 
@@ -543,17 +543,17 @@ echo "doctor: $errors error(s), $warnings warning(s)" >&2
 [ "$errors" -eq 0 ]
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh; echo "exit=$?"`
 Expected: all pass, `exit=0`.
 
-- [ ] **Step 5: Run the whole suite**
+- [x] **Step 5: Run the whole suite**
 
 Run: `bash skills/woostack-init/scripts/tests/run-tests.sh; echo "exit=$?"`
 Expected: every `test-*.sh` reports `0 failed`, `exit=0`.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add skills/woostack-init/scripts/doctor.sh skills/woostack-init/scripts/tests/test-doctor.sh
@@ -569,7 +569,7 @@ git commit -m "feat(woostack-init): store linter (doctor) + tests"
 - Create: `skills/woostack-init/templates/gitignore`
 - Create: `skills/woostack-init/templates/example-note.md`
 
-- [ ] **Step 1: Write the templates**
+- [x] **Step 1: Write the templates**
 
 `skills/woostack-init/templates/config.json`:
 ```json
@@ -601,7 +601,7 @@ Notes link each other in the body with wikilinks like [[example-note]].
 Recall loads this only when a working-set path matches `scope`.
 ```
 
-- [ ] **Step 2: Verify the example note passes doctor and indexes**
+- [x] **Step 2: Verify the example note passes doctor and indexes**
 
 Run:
 ```bash
@@ -612,7 +612,7 @@ bash skills/woostack-init/scripts/doctor.sh "$tmp"; echo "doctor exit=$?"
 ```
 Expected: index line `- [example-note](example-note.md) \`convention\` scope=\`*\` — Delete me — example of the memory note format`; doctor reports **no unresolved-link warning** (the example self-links `[[example-note]]`, which resolves) and **exits 0**. Confirm `doctor exit=0`.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/woostack-init/templates/
@@ -626,7 +626,7 @@ git commit -m "feat(woostack-init): workspace templates (config, gitignore, exam
 **Files:**
 - Create: `skills/woostack-init/references/memory.md`
 
-- [ ] **Step 1: Write the contract doc**
+- [x] **Step 1: Write the contract doc**
 
 Create `skills/woostack-init/references/memory.md` with these sections (prose, normal English — NOT caveman):
 
@@ -641,7 +641,7 @@ Create `skills/woostack-init/references/memory.md` with these sections (prose, n
 
 Cross-link rule: link to `../../woostack-review/SKILL.md` for the `review` config namespace; do **not** restate it.
 
-- [ ] **Step 2: Verify cross-links resolve**
+- [x] **Step 2: Verify cross-links resolve**
 
 Run:
 ```bash
@@ -653,7 +653,7 @@ done; echo "link check done"
 ```
 Expected: `link check done` with no `BROKEN:` lines.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/woostack-init/references/memory.md
@@ -667,7 +667,7 @@ git commit -m "docs(woostack-init): canonical scope-routed memory contract"
 **Files:**
 - Create: `skills/woostack-init/SKILL.md`
 
-- [ ] **Step 1: Write SKILL.md**
+- [x] **Step 1: Write SKILL.md**
 
 Create `skills/woostack-init/SKILL.md`. Frontmatter `description` must drive discovery (mention: initialize/scaffold/repair the `.woostack/` workspace, memory store, specs/plans, config). Body sections:
 
@@ -682,12 +682,12 @@ Create `skills/woostack-init/SKILL.md`. Frontmatter `description` must drive dis
 - **Hard constraints** — never clobber `memory.md`/notes/`config.json` without explicit overwrite; the flat `memory.md` and other skills' files are out of scope; pure-bash scripts, no new runtime dep.
 - **Reference** — link to `references/memory.md` for the store contract.
 
-- [ ] **Step 2: Lint-check the skill's own scripts still pass**
+- [x] **Step 2: Lint-check the skill's own scripts still pass**
 
 Run: `bash skills/woostack-init/scripts/tests/run-tests.sh; echo "exit=$?"`
 Expected: `exit=0` (unchanged by docs).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add skills/woostack-init/SKILL.md
@@ -701,7 +701,7 @@ git commit -m "feat(woostack-init): /woostack-init verb (scaffold + repair works
 **Files:**
 - Modify: `AGENTS.md`
 
-- [ ] **Step 1: Update the four→five references**
+- [x] **Step 1: Update the four→five references**
 
 Edit `AGENTS.md`:
 - "What this repo is": change "The four skills are: …" to list five, adding `woostack-init`.
@@ -710,7 +710,7 @@ Edit `AGENTS.md`:
 - "Quick reference" table: add a row `| Initialize the .woostack workspace | skills/woostack-init/SKILL.md |` and `| Change the memory contract | skills/woostack-init/references/memory.md |`.
 - Anywhere "four SKILL.md files" is enumerated as a do-not-move list: add the fifth path `skills/woostack-init/SKILL.md`.
 
-- [ ] **Step 2: Verify the count is consistent**
+- [x] **Step 2: Verify the count is consistent**
 
 Run:
 ```bash
@@ -719,7 +719,7 @@ grep -c "woostack-init" AGENTS.md
 ```
 Expected: `no stale 'four' references`; `woostack-init` count ≥ 4 (intro, layout, command table, quick-ref).
 
-- [ ] **Step 3: Verify all AGENTS.md cross-links resolve**
+- [x] **Step 3: Verify all AGENTS.md cross-links resolve**
 
 Run:
 ```bash
@@ -731,7 +731,7 @@ done; echo "agents link check done"
 ```
 Expected: `agents link check done`, no `BROKEN:` lines.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add AGENTS.md
@@ -742,12 +742,12 @@ git commit -m "docs: register woostack-init as the fifth skill"
 
 ## Task 10: Final verification + dogfood
 
-- [ ] **Step 1: Full test suite**
+- [x] **Step 1: Full test suite**
 
 Run: `bash skills/woostack-init/scripts/tests/run-tests.sh; echo "exit=$?"`
 Expected: every suite `0 failed`, `exit=0`.
 
-- [ ] **Step 2: Dogfood the scripts on this very repo's `.woostack/`**
+- [x] **Step 2: Dogfood the scripts on this very repo's `.woostack/`**
 
 Run:
 ```bash
@@ -761,17 +761,17 @@ rmdir .woostack/memory 2>/dev/null || true
 ```
 Expected: index builds; the example's `[[example-note]]` self-link resolves (no unresolved-link warning) and `doctor exit=0`.
 
-- [ ] **Step 3: shellcheck (if available)**
+- [x] **Step 3: shellcheck (if available)**
 
 Run: `command -v shellcheck >/dev/null && shellcheck skills/woostack-init/scripts/*.sh || echo "shellcheck not installed — skipped"`
 Expected: no errors, or the skip notice. Fix any error-level findings.
 
-- [ ] **Step 4: Confirm nothing outside scope was touched**
+- [x] **Step 4: Confirm nothing outside scope was touched**
 
 Run: `git diff --stat origin/main -- skills/woostack-review skills/woostack-build skills/woostack-bootstrap skills/woostack-address-comments .woostack/memory.md`
 Expected: **empty** — increment A touches none of the other skills, the review pipeline, or the flat `memory.md`.
 
-- [ ] **Step 5: Push + open PR (build skill step 7 — ask first)**
+- [x] **Step 5: Push + open PR (build skill step 7 — ask first)**
 
 Per woostack-build, ask the user before opening the PR. On yes:
 ```bash

--- a/.woostack/plans/2026-06-03-bounded-review-swarms.md
+++ b/.woostack/plans/2026-06-03-bounded-review-swarms.md
@@ -24,7 +24,7 @@
 **Files:**
 - Create: `skills/woostack-review/scripts/run-bounded-swarm.sh`
 
-- [ ] **Step 1: Write the helper script**
+- [x] **Step 1: Write the helper script**
 
 Create `skills/woostack-review/scripts/run-bounded-swarm.sh` with this content:
 
@@ -219,7 +219,7 @@ if [ "$degraded" = true ]; then
 fi
 ```
 
-- [ ] **Step 2: Make the helper executable**
+- [x] **Step 2: Make the helper executable**
 
 Run:
 
@@ -234,7 +234,7 @@ Expected: command exits `0`.
 **Files:**
 - Create: `skills/woostack-review/scripts/tests/test-bounded-swarm.sh`
 
-- [ ] **Step 1: Write the test script**
+- [x] **Step 1: Write the test script**
 
 Create `skills/woostack-review/scripts/tests/test-bounded-swarm.sh` with this content:
 
@@ -346,7 +346,7 @@ rm -rf "$work2"
 finish
 ```
 
-- [ ] **Step 2: Make the test executable**
+- [x] **Step 2: Make the test executable**
 
 Run:
 
@@ -356,7 +356,7 @@ chmod +x skills/woostack-review/scripts/tests/test-bounded-swarm.sh
 
 Expected: command exits `0`.
 
-- [ ] **Step 3: Run the new test**
+- [x] **Step 3: Run the new test**
 
 Run:
 
@@ -371,7 +371,7 @@ Expected: PASS output from `finish`, with no failed assertions.
 **Files:**
 - Modify: `skills/woostack-review/SKILL.md`
 
-- [ ] **Step 1: Replace the Stage 3 opening with bounded local orchestration**
+- [x] **Step 1: Replace the Stage 3 opening with bounded local orchestration**
 
 In `skills/woostack-review/SKILL.md`, replace the Stage 3 title and opening guidance with text equivalent to:
 
@@ -395,7 +395,7 @@ For unchunked reviews, the expected artifact is `$OUTDIR/findings.<angle>.json`.
 
 Keep the existing host examples, but revise them so they describe host-native bounded queues instead of unrestricted one-call-per-angle parallelism.
 
-- [ ] **Step 2: Add helper usage guidance**
+- [x] **Step 2: Add helper usage guidance**
 
 Add a subsection near the Stage 3 brief:
 
@@ -415,7 +415,7 @@ When a host cannot express sub-agent work as a shell command, implement the same
 
 Do not claim the helper can directly spawn Codex/Claude/Gemini sub-agents unless the host provides a shell command for that.
 
-- [ ] **Step 3: Preserve tier/model routing guidance**
+- [x] **Step 3: Preserve tier/model routing guidance**
 
 In the Stage 3 model-routing section, add this invariant:
 
@@ -423,7 +423,7 @@ In the Stage 3 model-routing section, add this invariant:
 Bounded runners MUST preserve the resolved tier/model context for every queued worker. In single-model hosts, pass the resolved run-tier (`FORCE_TIER` when set, otherwise the host's standard tier) to every worker. In per-call-routing hosts, apply each angle prompt's `tier:` while still preserving any explicit `FORCE_TIER` override. Bounded scheduling must not cause later queued angles to fall back to default model settings.
 ```
 
-- [ ] **Step 4: Add summary disclosure guidance**
+- [x] **Step 4: Add summary disclosure guidance**
 
 In Stage 5 local reporting guidance, add:
 
@@ -431,7 +431,7 @@ In Stage 5 local reporting guidance, add:
 If `$OUTDIR/swarm-metrics.json` exists, include a one-line swarm summary. Mention bounded mode and `max_concurrency`. If `.degraded == true`, name the `still_invalid` angles or `(angle, chunk)` items and state that those artifacts contributed `[]` after one retry.
 ```
 
-- [ ] **Step 5: Update troubleshooting**
+- [x] **Step 5: Update troubleshooting**
 
 Update the existing troubleshooting entry for dead sub-agents to reference `swarm-metrics.json` and bounded retry behavior:
 
@@ -444,7 +444,7 @@ Update the existing troubleshooting entry for dead sub-agents to reference `swar
 **Files:**
 - Test: `skills/woostack-review/scripts/tests/test-bounded-swarm.sh`
 
-- [ ] **Step 1: Run the bounded swarm test**
+- [x] **Step 1: Run the bounded swarm test**
 
 Run:
 
@@ -454,7 +454,7 @@ bash skills/woostack-review/scripts/tests/test-bounded-swarm.sh
 
 Expected: PASS output from `finish`, with no failed assertions.
 
-- [ ] **Step 2: Run one existing adjacent script test**
+- [x] **Step 2: Run one existing adjacent script test**
 
 Run:
 
@@ -473,7 +473,7 @@ Expected: PASS output from `finish`, with no failed assertions.
 - `.woostack/specs/2026-06-03-bounded-review-swarms.md`
 - `.woostack/plans/2026-06-03-bounded-review-swarms.md`
 
-- [ ] **Step 1: Inspect the resulting diff manually**
+- [x] **Step 1: Inspect the resulting diff manually**
 
 Run:
 
@@ -483,6 +483,6 @@ git diff -- skills/woostack-review/scripts/run-bounded-swarm.sh skills/woostack-
 
 Expected: diff contains only the helper, tests, review-skill docs, spec, and plan.
 
-- [ ] **Step 2: Commit if requested by the user**
+- [x] **Step 2: Commit if requested by the user**
 
 Only if the user asks to commit, use the repo's Graphite-preferred flow from `AGENTS.md`. Do not merge.

--- a/.woostack/plans/2026-06-03-woostack-ideate.md
+++ b/.woostack/plans/2026-06-03-woostack-ideate.md
@@ -26,42 +26,42 @@
 
 **Files:** Create `skills/woostack-ideate/SKILL.md`
 
-- [ ] **Step 1: Frontmatter.** `name: woostack-ideate`. `description` scoped to the woostack build loop's design phase — recognizable as woostack-build's ideate step and usable standalone, but NOT a generic "before any creative work" trigger that would shadow other skills. Mention it stops at an approved design and writes nothing.
-- [ ] **Step 2: HARD GATE block.** State as an explicit block element: no implementation action — no code, no scaffold, no downstream skill, no spec write — until a design is presented and the user approves. Include the "too simple to need a design" anti-pattern note.
-- [ ] **Step 3: Process section.** Explore project context → offer `woostack-visualize` only for genuinely visual questions (one-line pointer, not a consent server) → clarifying questions one at a time, multiple-choice preferred → propose 2-3 approaches with a recommendation → present design in sections scaled to complexity, approval per section. Include scope-decomposition guidance (flag multi-subsystem asks; decompose before refining) and design-for-isolation guidance (small units, clear interfaces).
-- [ ] **Step 4: Terminal state.** Explicit: the skill ends at an approved design and hands it back to the caller. It does NOT write a spec file and does NOT invoke `writing-plans`. Name the caller's next step (woostack-build step 2 writes the markdown spec); when run standalone, tell the user the design is ready to capture as a spec.
-- [ ] **Step 5: Hard constraints + key principles.** YAGNI, one-question-at-a-time, 2-3 approaches, incremental validation; the "writes no files / chains no skill" rule; visual treatment via woostack-visualize.
+- [x] **Step 1: Frontmatter.** `name: woostack-ideate`. `description` scoped to the woostack build loop's design phase — recognizable as woostack-build's ideate step and usable standalone, but NOT a generic "before any creative work" trigger that would shadow other skills. Mention it stops at an approved design and writes nothing.
+- [x] **Step 2: HARD GATE block.** State as an explicit block element: no implementation action — no code, no scaffold, no downstream skill, no spec write — until a design is presented and the user approves. Include the "too simple to need a design" anti-pattern note.
+- [x] **Step 3: Process section.** Explore project context → offer `woostack-visualize` only for genuinely visual questions (one-line pointer, not a consent server) → clarifying questions one at a time, multiple-choice preferred → propose 2-3 approaches with a recommendation → present design in sections scaled to complexity, approval per section. Include scope-decomposition guidance (flag multi-subsystem asks; decompose before refining) and design-for-isolation guidance (small units, clear interfaces).
+- [x] **Step 4: Terminal state.** Explicit: the skill ends at an approved design and hands it back to the caller. It does NOT write a spec file and does NOT invoke `writing-plans`. Name the caller's next step (woostack-build step 2 writes the markdown spec); when run standalone, tell the user the design is ready to capture as a spec.
+- [x] **Step 5: Hard constraints + key principles.** YAGNI, one-question-at-a-time, 2-3 approaches, incremental validation; the "writes no files / chains no skill" rule; visual treatment via woostack-visualize.
 
 ## Task 2: Rewire `skills/woostack-build/SKILL.md`
 
 **Files:** Modify `skills/woostack-build/SKILL.md`
 
-- [ ] **Step 1: Frontmatter `description`.** Change "Chains superpowers (brainstorming, writing-plans, executing-plans) and grill-me" so brainstorming is no longer attributed to superpowers (e.g. "Chains woostack-ideate, superpowers writing-plans/executing-plans, and grill-me").
-- [ ] **Step 2: Overview chain + prose.** Rename the chain diagram's first node to `ideate` (the phase label is now "ideate"); ensure no prose claims the ideate phase is superpowers'.
-- [ ] **Step 3: Dependency preflight.** Remove `superpowers:brainstorming` from the external-skill bullet. Keep `superpowers:writing-plans`, `superpowers:executing-plans`, `grill-me`. Optionally note `woostack-ideate` ships in the collection (internal, no install).
-- [ ] **Step 4: Procedure step 1.** "Invoke `superpowers:brainstorming`" → "Invoke `woostack-ideate`", linking `../woostack-ideate/SKILL.md`. Preserve "let it run its own approval gate"; note it hands back an approved design (no spec write, no plan chain).
-- [ ] **Step 5: Spec-approval gate.** Preserve the required gate after hardening: present the written spec, get explicit user approval, then proceed to planning. Reflect `approve spec` in the overview chain and hard constraints.
+- [x] **Step 1: Frontmatter `description`.** Change "Chains superpowers (brainstorming, writing-plans, executing-plans) and grill-me" so brainstorming is no longer attributed to superpowers (e.g. "Chains woostack-ideate, superpowers writing-plans/executing-plans, and grill-me").
+- [x] **Step 2: Overview chain + prose.** Rename the chain diagram's first node to `ideate` (the phase label is now "ideate"); ensure no prose claims the ideate phase is superpowers'.
+- [x] **Step 3: Dependency preflight.** Remove `superpowers:brainstorming` from the external-skill bullet. Keep `superpowers:writing-plans`, `superpowers:executing-plans`, `grill-me`. Optionally note `woostack-ideate` ships in the collection (internal, no install).
+- [x] **Step 4: Procedure step 1.** "Invoke `superpowers:brainstorming`" → "Invoke `woostack-ideate`", linking `../woostack-ideate/SKILL.md`. Preserve "let it run its own approval gate"; note it hands back an approved design (no spec write, no plan chain).
+- [x] **Step 5: Spec-approval gate.** Preserve the required gate after hardening: present the written spec, get explicit user approval, then proceed to planning. Reflect `approve spec` in the overview chain and hard constraints.
 
 ## Task 3: Document the internal sub-skill in `AGENTS.md`
 
 **Files:** Modify `AGENTS.md`
 
-- [ ] **Step 1: Sub-skill note.** After the eight-skill public surface list, add a sentence: woostack-build delegates its ideate phase to the bundled internal `woostack-ideate` sub-skill — a building block, not a ninth `/woostack-*` command. Keep the public command/adoption surface at eight skills.
-- [ ] **Step 2: Protect from deletion.** In the constraints/notes, treat `skills/woostack-ideate/SKILL.md` like `action.yml`: a shipped internal asset, not a stray to be deleted.
-- [ ] **Step 3: Quick file map.** Add an entry pointing to `skills/woostack-ideate/SKILL.md` (ideate phase engine for the build loop).
+- [x] **Step 1: Sub-skill note.** After the eight-skill public surface list, add a sentence: woostack-build delegates its ideate phase to the bundled internal `woostack-ideate` sub-skill — a building block, not a ninth `/woostack-*` command. Keep the public command/adoption surface at eight skills.
+- [x] **Step 2: Protect from deletion.** In the constraints/notes, treat `skills/woostack-ideate/SKILL.md` like `action.yml`: a shipped internal asset, not a stray to be deleted.
+- [x] **Step 3: Quick file map.** Add an entry pointing to `skills/woostack-ideate/SKILL.md` (ideate phase engine for the build loop).
 
 ## Task 4: Update `README.md` + `CONTRIBUTING.md`
 
 **Files:** Modify `README.md`, `CONTRIBUTING.md`
 
-- [ ] **Step 1: README build-loop prose.** Change "sequences proven sub-skills (superpowers brainstorming/writing-plans/executing-plans + grill-me)" to credit `woostack-ideate` for the ideate phase and superpowers for writing-plans/executing-plans. Include `approve spec` between `grill` and `plan`. Make the Install section distinguish the eight public command/adoption skills from the installed internal sub-skill.
-- [ ] **Step 2: CONTRIBUTING row.** Add a table row: "Change the ideate phase → `skills/woostack-ideate/SKILL.md`" near the existing build-loop row.
-- [ ] **Step 3: Bootstrap development reference.** Update `skills/woostack-bootstrap/references/development.md` so the shipped loop summary says `ideate → markdown spec → grill → approve spec → plan → execute`.
+- [x] **Step 1: README build-loop prose.** Change "sequences proven sub-skills (superpowers brainstorming/writing-plans/executing-plans + grill-me)" to credit `woostack-ideate` for the ideate phase and superpowers for writing-plans/executing-plans. Include `approve spec` between `grill` and `plan`. Make the Install section distinguish the eight public command/adoption skills from the installed internal sub-skill.
+- [x] **Step 2: CONTRIBUTING row.** Add a table row: "Change the ideate phase → `skills/woostack-ideate/SKILL.md`" near the existing build-loop row.
+- [x] **Step 3: Bootstrap development reference.** Update `skills/woostack-bootstrap/references/development.md` so the shipped loop summary says `ideate → markdown spec → grill → approve spec → plan → execute`.
 
 ## Task 5: Verify
 
-- [ ] **Step 1: Grep.** No `superpowers:brainstorming` / "superpowers brainstorming" reference remains in shipped docs (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `skills/**/SKILL.md`). `.woostack/` history files left as-is.
-- [ ] **Step 2: Frontmatter + gate.** New `SKILL.md` has valid `name`/`description` and the HARD GATE block.
-- [ ] **Step 3: Cross-links.** woostack-build ↔ woostack-ideate links resolve; woostack-visualize pointer resolves; AGENTS file-map link resolves.
-- [ ] **Step 4: Count.** `AGENTS.md` still presents an eight-skill public command/adoption surface, and documents `woostack-ideate` as an installed internal sub-skill.
-- [ ] **Step 5: Build-flow summaries.** Shipped summaries (`README.md`, `CONTRIBUTING.md`, `skills/woostack-bootstrap/references/development.md`, and `skills/woostack-build/SKILL.md`) all include the required `approve spec` gate before planning.
+- [x] **Step 1: Grep.** No `superpowers:brainstorming` / "superpowers brainstorming" reference remains in shipped docs (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `skills/**/SKILL.md`). `.woostack/` history files left as-is.
+- [x] **Step 2: Frontmatter + gate.** New `SKILL.md` has valid `name`/`description` and the HARD GATE block.
+- [x] **Step 3: Cross-links.** woostack-build ↔ woostack-ideate links resolve; woostack-visualize pointer resolves; AGENTS file-map link resolves.
+- [x] **Step 4: Count.** `AGENTS.md` still presents an eight-skill public command/adoption surface, and documents `woostack-ideate` as an installed internal sub-skill.
+- [x] **Step 5: Build-flow summaries.** Shipped summaries (`README.md`, `CONTRIBUTING.md`, `skills/woostack-bootstrap/references/development.md`, and `skills/woostack-build/SKILL.md`) all include the required `approve spec` gate before planning.

--- a/.woostack/plans/2026-06-03-woostack-visualize.md
+++ b/.woostack/plans/2026-06-03-woostack-visualize.md
@@ -31,7 +31,7 @@
 - Create: `skills/woostack-visualize/references/audiences.md`
 - Modify: `.gitignore`
 
-- [ ] **Step 1: Write `skills/woostack-visualize/SKILL.md`**
+- [x] **Step 1: Write `skills/woostack-visualize/SKILL.md`**
 
 ```markdown
 ---
@@ -94,7 +94,7 @@ The Markdown/code source stays the source of truth; the HTML is a disposable ren
 - **No browser without consent.** Report the path; open only if the user agrees.
 ```
 
-- [ ] **Step 2: Write `skills/woostack-visualize/references/audiences.md`**
+- [x] **Step 2: Write `skills/woostack-visualize/references/audiences.md`**
 
 ```markdown
 # Audience profiles
@@ -148,7 +148,7 @@ vocabulary; a "designer" wants flows, states, and UI surface at moderate depth. 
 inferred framing briefly at the top of the visual so the reader knows the lens.
 ```
 
-- [ ] **Step 3: Add the visuals gitignore line**
+- [x] **Step 3: Add the visuals gitignore line**
 
 Modify `.gitignore`. Under the existing `# woostack:` block (after the `.woostack/metrics.json` line, near the `.woostack/memory/` line), add:
 
@@ -157,7 +157,7 @@ Modify `.gitignore`. Under the existing `# woostack:` block (after the `.woostac
 .woostack/visuals/
 ```
 
-- [ ] **Step 4: Verify structure**
+- [x] **Step 4: Verify structure**
 
 Run:
 ```bash
@@ -168,7 +168,7 @@ git ls-files skills/ | grep -c SKILL.md              # still 7 tracked SKILL.md 
 ```
 Expected: `files OK`; frontmatter shows `name: woostack-visualize`; gitignore line printed; existing SKILL.md count unchanged (no renames).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add skills/woostack-visualize/SKILL.md skills/woostack-visualize/references/audiences.md .gitignore
@@ -185,7 +185,7 @@ git commit -m "feat: add woostack-visualize skill bundle"
 - Modify: `AGENTS.md` (count + list + file map)
 - Modify: `README.md` (install list + How it works)
 
-- [ ] **Step 1: Delegate woostack-build's render-on-demand to the new skill**
+- [x] **Step 1: Delegate woostack-build's render-on-demand to the new skill**
 
 In `skills/woostack-build/SKILL.md`, in Procedure step 2 ("Write the spec as markdown"), the
 "Visualize on demand" sentence currently points directly at `references/spec-template.html`.
@@ -198,7 +198,7 @@ Old (the trailing sentence of step 2):
 New:
 > **Visualize on demand** — if a rich view is wanted, hand the markdown to [`woostack-visualize`](../woostack-visualize/SKILL.md) (audience `engineer` for specs; it uses [references/spec-template.html](references/spec-template.html) as a starting point). The HTML is a presentation target only, never the authored source.
 
-- [ ] **Step 2: Add the routing row in using-woostack**
+- [x] **Step 2: Add the routing row in using-woostack**
 
 In `skills/using-woostack/SKILL.md`, in the Command Routing table, add a row (keep table
 alignment with the existing rows):
@@ -207,7 +207,7 @@ alignment with the existing rows):
 | `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |
 ```
 
-- [ ] **Step 3: Update AGENTS.md count, list, and file map**
+- [x] **Step 3: Update AGENTS.md count, list, and file map**
 
 In `AGENTS.md`:
 - Change "The seven shipped skills are:" → "The eight shipped skills are:".
@@ -221,7 +221,7 @@ In `AGENTS.md`:
     [`skills/woostack-visualize/`](skills/woostack-visualize/SKILL.md)
   ```
 
-- [ ] **Step 4: Update README.md**
+- [x] **Step 4: Update README.md**
 
 In `README.md`:
 - In the Install section, the parenthetical skills list currently reads
@@ -239,7 +239,7 @@ In `README.md`:
   external dependencies. `woostack-build` delegates its spec render to this skill. → [SKILL.md](skills/woostack-visualize/SKILL.md)
   ```
 
-- [ ] **Step 5: Verify cross-links and count**
+- [x] **Step 5: Verify cross-links and count**
 
 Run:
 ```bash
@@ -249,7 +249,7 @@ grep -c "woostack-visualize" README.md          # >=2 (install list + how-it-wor
 ```
 Expected: AGENTS.md says "eight"; each file references `woostack-visualize`; README hit count ≥ 2. Manually confirm no broken relative paths (each links to an existing file).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add skills/woostack-build/SKILL.md skills/using-woostack/SKILL.md AGENTS.md README.md
@@ -263,7 +263,7 @@ git commit -m "docs: register woostack-visualize and delegate spec render to it"
 **Files:**
 - Output (gitignored, not committed): `.woostack/visuals/*.html`
 
-- [ ] **Step 1: Render this spec for all three presets**
+- [x] **Step 1: Render this spec for all three presets**
 
 Following `skills/woostack-visualize/SKILL.md`, render
 `.woostack/specs/2026-06-03-woostack-visualize.md` three times:
@@ -271,7 +271,7 @@ Following `skills/woostack-visualize/SKILL.md`, render
 - `for non-technical` → `...-non-technical.html`
 - `for investor` → `...-investor.html`
 
-- [ ] **Step 2: Verify self-contained + offline + differentiation**
+- [x] **Step 2: Verify self-contained + offline + differentiation**
 
 Run:
 ```bash
@@ -287,7 +287,7 @@ Then inspect each file:
 
 Expected: `offline OK`; three differentiated files; investor file fabricates nothing.
 
-- [ ] **Step 3: Confirm renders are gitignored**
+- [x] **Step 3: Confirm renders are gitignored**
 
 Run:
 ```bash
@@ -296,7 +296,7 @@ git check-ignore .woostack/visuals/2026-06-03-woostack-visualize-engineer.html  
 ```
 Expected: status shows nothing under `visuals/`; `check-ignore` prints the path.
 
-- [ ] **Step 4: No commit**
+- [x] **Step 4: No commit**
 
 Renders are disposable and gitignored — nothing to commit. Task 3 is verification only.
 

--- a/.woostack/specs/2026-06-02-memory-distill-gate.md
+++ b/.woostack/specs/2026-06-02-memory-distill-gate.md
@@ -1,7 +1,7 @@
 ---
 name: memory-distill-gate
 type: spec
-status: draft
+status: done
 date: 2026-06-02
 branch: feature/memory-distill-gate
 links:

--- a/.woostack/specs/2026-06-02-memory-distill.md
+++ b/.woostack/specs/2026-06-02-memory-distill.md
@@ -1,7 +1,7 @@
 ---
 name: memory-distill
 type: spec
-status: draft
+status: done
 date: 2026-06-02
 branch: feat/woostack-memory-distill
 increment: C of 4

--- a/.woostack/specs/2026-06-02-memory-obsidian.md
+++ b/.woostack/specs/2026-06-02-memory-obsidian.md
@@ -1,7 +1,7 @@
 ---
 name: memory-obsidian
 type: spec
-status: draft
+status: done
 date: 2026-06-02
 branch: feat/woostack-memory-obsidian
 increment: D of 4

--- a/.woostack/specs/2026-06-02-memory-overlap-clusters.md
+++ b/.woostack/specs/2026-06-02-memory-overlap-clusters.md
@@ -1,7 +1,7 @@
 ---
 name: memory-overlap-clusters
 type: spec
-status: draft
+status: done
 date: 2026-06-02
 branch: feature/memory-overlap-clusters
 links:

--- a/.woostack/specs/2026-06-02-memory-recall.md
+++ b/.woostack/specs/2026-06-02-memory-recall.md
@@ -1,7 +1,7 @@
 ---
 name: memory-recall
 type: spec
-status: draft
+status: done
 date: 2026-06-02
 branch: feat/woostack-memory-recall
 increment: B of 4

--- a/.woostack/specs/2026-06-02-memory-staleness-guard.md
+++ b/.woostack/specs/2026-06-02-memory-staleness-guard.md
@@ -1,7 +1,7 @@
 ---
 name: memory-staleness-guard
 type: spec
-status: approved
+status: done
 date: 2026-06-02
 branch: memory-staleness-guard
 links:

--- a/.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
+++ b/.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
@@ -1,7 +1,7 @@
 ---
 name: review-metrics-tokens-overlap
 type: spec
-status: draft
+status: done
 date: 2026-06-02
 branch: feature/review-metrics-overlap
 links:

--- a/.woostack/specs/2026-06-02-woostack-init.md
+++ b/.woostack/specs/2026-06-02-woostack-init.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-init
 type: spec
-status: hardened
+status: done
 date: 2026-06-02
 branch: feat/woostack-init
 increment: A of 4

--- a/.woostack/specs/2026-06-03-bounded-review-swarms.md
+++ b/.woostack/specs/2026-06-03-bounded-review-swarms.md
@@ -1,9 +1,9 @@
 ---
 name: bounded-review-swarms
 type: spec
-status: draft
+status: done
 date: 2026-06-03
-branch: bounded-review-swarms
+branch: feature/bounded-review-swarms
 links:
   - https://github.com/howarewoo/woostack/issues/182
 ---

--- a/.woostack/specs/2026-06-03-woostack-ideate.md
+++ b/.woostack/specs/2026-06-03-woostack-ideate.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-ideate
 type: spec
-status: approved
+status: done
 date: 2026-06-03
 branch: feature/woostack-ideate
 links:

--- a/.woostack/specs/2026-06-03-woostack-visualize.md
+++ b/.woostack/specs/2026-06-03-woostack-visualize.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-visualize
 type: spec
-status: draft
+status: done
 date: 2026-06-03
 branch: feature/woostack-visualize
 links:

--- a/.woostack/specs/2026-06-04-execute-dual-mode-execution.md
+++ b/.woostack/specs/2026-06-04-execute-dual-mode-execution.md
@@ -1,7 +1,7 @@
 ---
 name: execute-dual-mode-execution
 type: spec
-status: approved
+status: done
 date: 2026-06-04
 branch: feature/execute-dual-mode
 links:

--- a/.woostack/specs/2026-06-04-review-nit-comments.md
+++ b/.woostack/specs/2026-06-04-review-nit-comments.md
@@ -1,9 +1,9 @@
 ---
 name: review-nit-comments
 type: spec
-status: draft
+status: done
 date: 2026-06-04
-branch: review-nit-comments
+branch: feature/review-nit-comments
 links:
 ---
 

--- a/.woostack/specs/2026-06-04-woostack-status.md
+++ b/.woostack/specs/2026-06-04-woostack-status.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-status
 type: spec
-status: approved
+status: done
 date: 2026-06-04
 branch: feature/woostack-status
 links:


### PR DESCRIPTION
## Goal

The `/woostack-status` board showed 14 features as in-flight that had actually shipped. Their specs and plans were authored before the status tool existed, so the `status:` field and plan checkboxes never advanced past their authored values. This reconciles the artifacts to the real merged state so the board reflects reality.

## Summary

- Bump 14 shipped specs `status:` → `done`, each verified against its merged implementation PR.
- Tick 9 increment plans to 100% to match their merged PRs (including `woostack-init` 43/43).
- Fix 2 spec `branch:` fields to match the actual merged PR head (`bounded-review-swarms`, `review-nit-comments`).
- Repair the review-metrics plan join (`**Spec:**` → canonical `**Source:**`, unquoted path) so it resolves to its spec.
- Add a reconstructed `memory-distill` plan (docs-only increment C, shipped in #156) — none existed before.

## Test plan

### Automated

- [x] `bash skills/woostack-status/scripts/status.sh` → `18 done . 0 abandoned`, 0 in-flight rows, 0 flags (ran; clean).

### Manual

**Before merge**

- [ ] Spot-check a bumped spec — e.g. `woostack-init` `status: done` traces to merged PR #154.
- [ ] Re-run the status board and confirm no spec reverts to `executing`/in-flight.
