### PR TITLE
docs(woostack-plan): spec and plan to internalize writing-plans

### DIFF
--- a/.woostack/plans/2026-06-05-woostack-plan.md
+++ b/.woostack/plans/2026-06-05-woostack-plan.md
@@ -1,0 +1,897 @@
+**Source:** .woostack/specs/2026-06-05-woostack-plan.md
+
+# woostack-plan Implementation Plan
+
+**Goal:** Ship `woostack-plan` — the eleventh public woostack command — internalizing `superpowers:writing-plans` as the build loop's first-party plan phase, and rewire `woostack-build` (dropping its now-empty dependency preflight) plus all count/routing surfaces.
+
+**Architecture:** Two stacked PRs. Increment 1 adds the standalone skill (`skills/woostack-plan/SKILL.md` + `references/plan-template.md`) — complete and usable on its own, referenced by nothing yet. Increment 2 wires it into `woostack-build` step 4, removes the dependency-preflight section (writing-plans was the only external dep), updates the status script + its test, and bumps the command-surface counts and routing across AGENTS.md, README, CONTRIBUTING, and using-woostack.
+
+**Tech Stack:** Markdown skill files; `bash` + `jq` for the status engine; `grep`/`bash -n` and the existing `skills/woostack-status/scripts/tests/test-status.sh` for verification (this repo is a skills collection — no app test runner).
+
+---
+
+> **Verification model:** This repo has no app test runner. "Write the failing test" therefore means: write/adjust a concrete verification command (a `grep`, a `bash -n`, or the real `test-status.sh` assertion) and confirm it fails before the change, passes after. The one genuinely executable test is `test-status.sh`; the rest are inspection commands with exact expected output.
+>
+> **Edits are content-matched, not line-matched.** Line numbers in the tasks are navigational hints against the pre-change files; apply each edit by matching the exact `old → new` block shown (the deletions in Task 3 shift later line numbers, but the find/replace text stays authoritative).
+>
+> **Cadence:** each Increment is one Graphite-stacked branch → one PR. The first commit of an Increment uses `gt create` (cuts its branch, stacked on the prior Increment); later commits within the same Increment use `gt modify -c`. `woostack-execute` drives this via `woostack-commit`; the explicit `gt` lines below are the intended commit boundaries.
+
+---
+
+## Increment 1: Add the woostack-plan skill (standalone)
+
+> One independently shippable PR. Adds a complete, usable skill that nothing references yet — harmless to ship alone. Its own Graphite-stacked branch.
+
+### Task 1: Create the plan-template skeleton
+
+**Files:**
+- Create: `skills/woostack-plan/references/plan-template.md`
+
+- [ ] **Step 1: Write the failing check**
+
+The file must not exist yet, and once created must be frontmatter-free, open with the `**Source:**` line, and carry no `REQUIRED SUB-SKILL` banner.
+
+Run: `test ! -e skills/woostack-plan/references/plan-template.md && echo MISSING`
+Expected: `MISSING`
+
+- [ ] **Step 2: Create the file**
+
+Create `skills/woostack-plan/references/plan-template.md` with exactly this content:
+
+````markdown
+**Source:** .woostack/specs/{{SPEC_BASENAME}}.md
+
+# {{FEATURE_NAME}} Implementation Plan
+
+**Goal:** {{ONE_SENTENCE_WHAT_THIS_BUILDS}}
+
+**Architecture:** {{TWO_OR_THREE_SENTENCES_ON_THE_APPROACH}}
+
+**Tech Stack:** {{KEY_TECHNOLOGIES}}
+
+---
+
+## Increment 1: {{PR_SIZED_SLICE_NAME}}
+
+> One independently shippable PR (≤500 LOC soft target) — its own Graphite-stacked branch.
+
+### Task 1: {{COMPONENT_NAME}}
+
+**Files:**
+- Create: `{{exact/path/to/new.ext}}`
+- Modify: `{{exact/path/to/existing.ext}}:{{LINES}}`
+- Test: `{{exact/path/to/test.ext}}`
+
+- [ ] **Step 1: Write the failing test**
+
+```{{lang}}
+{{actual test code — never a placeholder}}
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `{{exact command}}`
+Expected: FAIL — `{{exact expected failure}}`
+
+- [ ] **Step 3: Minimal implementation**
+
+```{{lang}}
+{{actual implementation code}}
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `{{exact command}}`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt create -m "{{type}}: {{subject}}"
+```
+
+<!-- Repeat Task N for each unit in this increment. Add Increment 2, 3, … for each PR-sized slice. -->
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every spec requirement maps to a task above.
+- [ ] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
+- [ ] **Type consistency** — types, signatures, and names match across tasks.
+
+> woostack plan conventions (keep them):
+> - This file is **frontmatter-free** and **opens with** the `**Source:**` line.
+> - Filename mirrors the spec basename: `.woostack/plans/<spec-basename>.md` (the spec's date, not today's).
+> - **No** `REQUIRED SUB-SKILL` banner — execution is `woostack-execute`'s (woostack-build step 8, or `/woostack-execute <plan>`).
+> - In a target without a test runner, a "failing test" step is a concrete verification command (grep, `bash -n`, an existing test) with exact expected output.
+````
+
+- [ ] **Step 3: Run the check, confirm it passes**
+
+Run: `head -1 skills/woostack-plan/references/plan-template.md; grep -c 'REQUIRED SUB-SKILL' skills/woostack-plan/references/plan-template.md`
+Expected: first line is `**Source:** .woostack/specs/{{SPEC_BASENAME}}.md`, and the grep count is `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt create -m "feat(woostack-plan): add plan-template skeleton"
+```
+
+### Task 2: Create the woostack-plan SKILL.md
+
+**Files:**
+- Create: `skills/woostack-plan/SKILL.md`
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `test ! -e skills/woostack-plan/SKILL.md && echo MISSING`
+Expected: `MISSING`
+
+- [ ] **Step 2: Create the file**
+
+Create `skills/woostack-plan/SKILL.md` with exactly this content:
+
+````markdown
+---
+name: woostack-plan
+description: Use to write the implementation plan for an approved woostack spec — a comprehensive, bite-sized TDD plan structured as PR-sized increments, saved frontmatter-free to .woostack/plans/<spec-basename>.md, opening with a **Source: line that joins it 1:1 to the spec, and setting the spec's status: planning. This is the plan phase of the woostack build loop (woostack-build step 4); also usable standalone via /woostack-plan <spec-path>. One plan per spec. Writes the plan and hands back — never executes, commits, or merges.
+---
+
+# woostack-plan
+
+Write a comprehensive implementation plan from one approved spec, structured as PR-sized
+increments. This is woostack's own planning phase — [`woostack-build`](../woostack-build/SKILL.md)
+step 4. It keeps the discipline that makes plans worth executing (file-structure first,
+bite-sized TDD tasks, no placeholders, a self-review pass) and adds the woostack conventions:
+markdown plans under `.woostack/plans/`, an opening `**Source:**` line that joins the plan 1:1 to
+its spec, frontmatter-free, decomposed into independently shippable increments, and a
+`status: planning` transition on the spec. It writes the plan and hands back; it owns no approval
+gate and never executes, commits, or merges.
+
+It internalizes `superpowers:writing-plans` — the same move
+[`woostack-ideate`](../woostack-ideate/SKILL.md),
+[`woostack-harden`](../woostack-harden/SKILL.md), and
+[`woostack-execute`](../woostack-execute/SKILL.md) made on the phases around it. With this skill
+the build loop has **no external skill dependencies**. It pairs with `woostack-execute` as
+produce-plan / consume-plan: `/woostack-plan <spec>` writes the plan, `/woostack-execute <plan>`
+runs it.
+
+## Commands
+
+- `/woostack-plan <spec-path>` — write the plan for the named markdown spec under
+  `.woostack/specs/`. **The spec path is required.**
+- `/woostack-plan` (no argument) — do **not** guess "the current spec." Ask which spec to plan
+  (optionally list `.woostack/specs/` candidates) and stop until one is named.
+
+When `woostack-build` reaches step 4 it invokes this skill with the approved spec path from
+step 2/3.
+
+## Read and check the spec
+
+1. Read the spec file end to end — it is the source of truth for *what* to build; the plan is
+   *how*.
+2. **Scope check.** If the spec covers multiple independent subsystems, suggest splitting into
+   separate plans — one per subsystem, each producing working, testable software on its own.
+   Don't write a monolithic plan over a multi-subsystem spec.
+3. **One plan per spec.** If a plan already resolves to this spec (a `.woostack/plans/` file with
+   a matching `**Source:**` line or the same basename), **amend that plan in place** — never write
+   a second (`spec : plan : PRs = 1 : 1 : N`; a second plan breaks the board join). Say you are
+   amending.
+
+## File structure first
+
+Before defining tasks, map which files are created or modified and each one's single
+responsibility. This locks in decomposition.
+
+- Design units with clear boundaries; one responsibility per file. Prefer small, focused files.
+- Files that change together live together. Split by responsibility, not by technical layer.
+- In an existing codebase, follow established patterns; don't unilaterally restructure. If a file
+  you must touch has grown unwieldy, folding a split into the plan is reasonable.
+
+## PR-sized increments
+
+Structure the plan as a sequence of **independently shippable increments** — preferably ≤500 LOC
+each (a soft target, not a gate) — so the plan is execute-ready: `woostack-execute` runs one
+increment per cycle as its own Graphite-stacked PR. Flag any slice that can't reasonably stay
+under the target and propose a further split; genuinely atomic changes may exceed it. This
+decomposition is part of planning (it folds `woostack-build`'s old decompose step into the plan
+engine).
+
+## Bite-sized tasks (TDD)
+
+Within each increment, decompose into bite-sized tasks; each **step** is one action
+(~2-5 minutes): write the failing test → run it, confirm it fails → minimal implementation → run
+it, confirm it passes → commit. Use checkbox (`- [ ]`) syntax for every step so
+`woostack-execute` ticks them in place as the live progress record. DRY, YAGNI, TDD, frequent
+commits throughout.
+
+In a target without a test runner (e.g. a docs/skills repo), "the failing test" becomes a
+concrete **verification command** — a `grep`, a `bash -n`, a link check, or an existing script's
+test — with exact expected output. Never a vague "verify it works."
+
+The output shape (header, `**Source:**` line, task/step structure) is captured in
+[references/plan-template.md](references/plan-template.md) — populate it; don't reinvent it.
+
+## No placeholders
+
+Every step carries the actual content an engineer needs. These are plan failures — never write
+them:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" without the actual test
+- "Similar to Task N" — repeat the code; tasks may be read out of order
+- A step that says *what* without showing *how* (code/command blocks required)
+- References to types/functions/methods defined in no task
+
+Exact file paths always. Complete code in every code step. Exact commands with expected output.
+
+## Board join: Source line, frontmatter-free, filename
+
+- **Filename:** save to `.woostack/plans/<spec-basename>.md` — the **same** `YYYY-MM-DD-<slug>`
+  basename as the spec (reuse the spec's date; **not** today's). The shared basename is the
+  slug-match fallback join.
+- **Opening line:** the plan **opens with** `**Source:** .woostack/specs/<file>.md` in its first
+  ~5 lines — the primary spec→plan join the `/woostack-status` board reads.
+- **Frontmatter-free:** plans carry no YAML frontmatter and no `REQUIRED SUB-SKILL` banner. The
+  header is the `**Source:**` line plus Goal / Architecture / Tech Stack.
+
+The phase enum and join contracts are defined once in
+[`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) —
+link, never restate.
+
+## Self-review
+
+After writing the plan, check it against the spec with fresh eyes — a checklist you run yourself,
+not a subagent dispatch:
+
+1. **Spec coverage** — every section/requirement maps to a task. List and fill any gap.
+2. **Placeholder scan** — search for the red flags above; fix them.
+3. **Type consistency** — types, signatures, and property names match across tasks (a method
+   called one name in Task 3 and another in Task 7 is a bug).
+
+Fix issues inline; no re-review needed.
+
+## Status: planning
+
+When the plan file exists, set the spec's `status: planning` (the conventions.md value for "plan
+exists, 0 boxes done"). Doing it here means a standalone `/woostack-plan` also advances the board.
+Do not tick any plan checkbox yet — execution owns checkbox progress.
+
+## Terminal state: plan written, handed back
+
+Stop when the plan is written, self-reviewed, and the spec is `planning`. Then hand back and name
+the next step:
+
+- Inside `woostack-build`: return to **step 6** (harden the plan).
+- Standalone: tell the user the plan is ready and offer `/woostack-execute <plan-path>`. Stop.
+
+Chain nothing yourself.
+
+## Gate boundary
+
+This skill owns **no approval gate**. The spec-approval gate (`woostack-build` step 3) is
+upstream; the execution-handoff gate (step 8) is downstream. It does not present-for-approval,
+execute, commit, or merge. It writes the plan and hands back — preserving `woostack-build`'s
+"inherit gates, add none."
+
+## Hard constraints
+
+- **Spec path required.** Never guess "the current spec"; ask when no argument is given.
+- **One plan per spec.** A plan already resolves to the spec → amend it; never write a second
+  (breaks the 1:1 board join).
+- **Markdown plan under `.woostack/plans/`, basename = spec basename.** Frontmatter-free, opening
+  `**Source:**` line.
+- **PR-sized increments.** Decompose into independently shippable slices (≤500 LOC soft target);
+  flag and split oversized ones.
+- **Bite-sized TDD tasks, no placeholders.** One action per step; complete code, exact commands,
+  expected output.
+- **Set `status: planning`; tick no checkbox.** Execution owns checkbox progress.
+- **Own no gate; never execute, commit, or merge.** Write the plan and hand back.
+````
+
+- [ ] **Step 3: Run the checks, confirm they pass**
+
+Run: `head -2 skills/woostack-plan/SKILL.md | grep -c 'name: woostack-plan'; grep -c 'references/plan-template.md' skills/woostack-plan/SKILL.md`
+Expected: first count `1` (valid frontmatter `name`), second count `≥1` (cross-link to the template present).
+
+- [ ] **Step 4: Verify the cross-links resolve**
+
+Run: `test -e skills/woostack-plan/references/plan-template.md && test -e skills/woostack-build/SKILL.md && test -e skills/woostack-execute/SKILL.md && test -e skills/woostack-status/references/conventions.md && echo LINKS_OK`
+Expected: `LINKS_OK` (every relative link target in SKILL.md exists).
+
+- [ ] **Step 5: Commit (same Increment-1 branch)**
+
+```bash
+gt modify -c -m "feat(woostack-plan): add SKILL.md (plan phase, internalizes writing-plans)"
+```
+
+---
+
+## Increment 2: Wire woostack-plan into the loop & update surfaces
+
+> Stacks on Increment 1. Rewires `woostack-build`, removes the dependency-preflight section, updates the status script + test, and bumps command-surface counts/routing everywhere. Its own Graphite-stacked branch on top of Increment 1.
+
+### Task 3: Rewire woostack-build (drop preflight, use woostack-plan)
+
+**Files:**
+- Modify: `skills/woostack-build/SKILL.md`
+
+- [ ] **Step 1: Write the failing checks**
+
+Run: `grep -n 'Dependency preflight\|superpowers:writing-plans\|→ writing-plans →' skills/woostack-build/SKILL.md`
+Expected (before the change): matches on the `## Dependency preflight` heading, the `superpowers:writing-plans` bullet, and the overview-diagram `→ writing-plans →` — all of which must be gone after.
+
+- [ ] **Step 2: Update the frontmatter description**
+
+Replace (line 3):
+
+```
+description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, harden the plan, ship the spec and plan as their own PR, then implement it. Chains woostack-ideate, woostack-harden, woostack-commit, woostack-execute, and superpowers writing-plans in a fixed, gated order; writes markdown specs and plans under .woostack/.
+```
+
+with:
+
+```
+description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, harden the plan, ship the spec and plan as their own PR, then implement it. Chains woostack-ideate, woostack-harden, woostack-plan, woostack-commit, and woostack-execute in a fixed, gated order; writes markdown specs and plans under .woostack/.
+```
+
+- [ ] **Step 3: Update the overview diagram**
+
+Replace (the first line of the ``` fenced diagram, line 16):
+
+```
+ideate → write spec (markdown) → harden spec → approve spec → writing-plans → decompose
+```
+
+with:
+
+```
+ideate → write spec (markdown) → harden spec → approve spec → plan → decompose
+```
+
+- [ ] **Step 4: Remove the entire Dependency preflight section**
+
+Delete this whole block (the `## Dependency preflight` heading through the degraded-run paragraph, lines 35–49, including the blank line after it):
+
+```
+## Dependency preflight
+
+The ideate, hardening (spec and plan), spec+plan-commit, and execution phases use
+[`woostack-ideate`](../woostack-ideate/SKILL.md),
+[`woostack-harden`](../woostack-harden/SKILL.md),
+[`woostack-commit`](../woostack-commit/SKILL.md), and
+[`woostack-execute`](../woostack-execute/SKILL.md), which ship in this collection — no install
+needed. Only the plan phase chains an external skill. At the start, check that it is installed:
+
+- `superpowers:writing-plans`
+
+If it is missing: name exactly what's missing and **offer to install it inline**
+(`pnpx skills add obra/superpowers`) and continue. If the user declines, fall back to
+following the skill's principle manually and **say so explicitly** — the run is degraded, not
+equivalent.
+
+```
+
+Result: `## Overview` (and its trailing prose) is immediately followed by `## Procedure`. The build loop now has no external dependencies and nothing to preflight.
+
+- [ ] **Step 5: Rewrite step 4 (Plan) to invoke woostack-plan**
+
+Replace step 4 (lines 79–84):
+
+```
+4. **Plan.** Once the spec is approved, invoke `superpowers:writing-plans`, saving the plan as
+   **markdown** to
+   `.woostack/plans/YYYY-MM-DD-<slug>.md` (plans are working checklists, not visualization
+   artifacts). The plan **must open with** a `**Source:** .woostack/specs/<file>.md` line in
+   its first ~5 lines so the board joins it 1:1 to the spec; keep plans frontmatter-free. Set
+   the spec's `status: planning`.
+```
+
+with:
+
+```
+4. **Plan.** Once the spec is approved, invoke [`woostack-plan`](../woostack-plan/SKILL.md) with
+   the approved spec path. It writes the **markdown** plan to `.woostack/plans/<spec-basename>.md`
+   (same basename as the spec), opening with the `**Source:** .woostack/specs/<file>.md` line so
+   the board joins it 1:1, frontmatter-free, structured as PR-sized increments, and it sets the
+   spec's `status: planning`. It writes the plan and hands back — owning no gate. `woostack-plan`
+   ships in this collection (no install), so the build loop has no external skill dependencies.
+```
+
+- [ ] **Step 6: Reword step 5 (Decompose) — plan now owns decomposition**
+
+Replace step 5 (lines 85–91):
+
+```
+5. **Decompose to PR-sized increments.** Steer work toward well-scoped PRs of **preferably
+   ≤500 lines of code** — a soft target, not a gate. When the spec implies more than one
+   reviewable PR, structure the plan as a sequence of independently shippable increments and
+   run **one increment per build cycle**. Flag any slice that can't reasonably stay under the
+   target and propose a further split before executing. Genuinely atomic changes may exceed
+   the target. The `spec : plan : PRs = 1 : 1 : N` invariant holds throughout: exactly one
+   plan per spec, and that one plan owns the N increment PRs.
+```
+
+with:
+
+```
+5. **Verify the increment decomposition.** `woostack-plan` (step 4) already structures the plan
+   as PR-sized increments — well-scoped PRs of **preferably ≤500 lines of code** (a soft target,
+   not a gate). Confirm the increment boundaries are sound and feed `woostack-execute`: each
+   slice independently shippable, **one increment per build cycle**, oversized slices flagged and
+   split (genuinely atomic changes may exceed the target). The `spec : plan : PRs = 1 : 1 : N`
+   invariant holds throughout: exactly one plan per spec, and that one plan owns the N increment
+   PRs.
+```
+
+- [ ] **Step 7: Update the two hard-constraint references**
+
+Replace (in the "Always get explicit spec approval before planning" constraint, line 145):
+
+```
+  written spec and wait for the user's clear yes. Never advance to `writing-plans` on assumed
+```
+
+with:
+
+```
+  written spec and wait for the user's clear yes. Never advance to `woostack-plan` on assumed
+```
+
+Then replace (in the "Author `status:`" constraint, line 157):
+
+```
+  2), `hardened` then `approved` (step 3), `planning` (step 4); the execute phase advances the
+```
+
+with:
+
+```
+  2), `hardened` then `approved` (step 3), `planning` (step 4, authored by `woostack-plan`); the
+  execute phase advances the
+```
+
+- [ ] **Step 8: Confirm the checks pass**
+
+Run: `grep -c 'Dependency preflight\|superpowers:writing-plans\|→ writing-plans →' skills/woostack-build/SKILL.md; grep -c 'woostack-plan' skills/woostack-build/SKILL.md`
+Expected: first count `0` (all three removed), second count `≥4` (description, step 4 link, step 4 prose, hard-constraint, status-constraint).
+
+- [ ] **Step 9: Commit (first commit of Increment 2 — creates its branch, stacked on Increment 1)**
+
+```bash
+gt create -m "refactor(woostack-build): use woostack-plan, drop dependency preflight"
+```
+
+### Task 4: Add the using-woostack routing row
+
+**Files:**
+- Modify: `skills/using-woostack/SKILL.md`
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `grep -c 'woostack-plan' skills/using-woostack/SKILL.md`
+Expected: `0`.
+
+- [ ] **Step 2: Insert the routing row**
+
+In the Command Routing table, insert a new row immediately **after** the `/woostack-build` row and **before** the `/woostack-execute` row. Replace:
+
+```
+| `/woostack-build <goal>`, build a feature through the woostack loop | `woostack-build` |
+| `/woostack-execute <plan-path> [--inline\|--subagent]`, execute an approved plan as PR-sized stacked increments (inline or subagent-driven) | `woostack-execute` |
+```
+
+with:
+
+```
+| `/woostack-build <goal>`, build a feature through the woostack loop | `woostack-build` |
+| `/woostack-plan <spec-path>`, write the implementation plan for an approved spec as PR-sized increments | `woostack-plan` |
+| `/woostack-execute <plan-path> [--inline\|--subagent]`, execute an approved plan as PR-sized stacked increments (inline or subagent-driven) | `woostack-execute` |
+```
+
+- [ ] **Step 3: Confirm the check passes**
+
+Run: `grep -c '`/woostack-plan <spec-path>`.*`woostack-plan`' skills/using-woostack/SKILL.md`
+Expected: `1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt modify -c -m "docs(using-woostack): route /woostack-plan to woostack-plan"
+```
+
+### Task 5: Fix the woostack-ideate chain-nothing example
+
+**Files:**
+- Modify: `skills/woostack-ideate/SKILL.md:34`
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `grep -n 'Do not invoke `writing-plans`' skills/woostack-ideate/SKILL.md`
+Expected (before): matches line 34.
+
+- [ ] **Step 2: Update the example list**
+
+Replace (line 34):
+
+```
+- **Chain nothing.** Do not invoke `writing-plans`, `woostack-execute`, or any implementation
+```
+
+with:
+
+```
+- **Chain nothing.** Do not invoke `woostack-plan`, `woostack-execute`, or any implementation
+```
+
+- [ ] **Step 3: Confirm the check passes**
+
+Run: `grep -c 'Do not invoke `woostack-plan`, `woostack-execute`' skills/woostack-ideate/SKILL.md`
+Expected: `1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt modify -c -m "docs(woostack-ideate): reference woostack-plan in chain-nothing example"
+```
+
+### Task 6: Update the status engine next-action strings (real TDD cycle)
+
+**Files:**
+- Modify: `skills/woostack-status/scripts/tests/test-status.sh:62`
+- Modify: `skills/woostack-status/scripts/status.sh:177`
+- Modify: `skills/woostack-status/scripts/status.sh:227`
+
+- [ ] **Step 1: Update the test assertion FIRST (red)**
+
+Replace (in `test-status.sh`, line 62):
+
+```
+assert_contains "$OUT" "writing-plans" "approved next-action"
+```
+
+with:
+
+```
+assert_contains "$OUT" "woostack-plan" "approved next-action"
+```
+
+- [ ] **Step 2: Run the test, confirm it now FAILS**
+
+Run: `bash skills/woostack-status/scripts/tests/test-status.sh`
+Expected: FAIL on the `approved next-action` assertion — the harness still emits `write the plan (writing-plans)`, so `"woostack-plan"` is not found in `$OUT`.
+
+- [ ] **Step 3: Update status.sh next-action string (green)**
+
+Replace (line 177):
+
+```
+    approved)   echo "write the plan (writing-plans)" ;;
+```
+
+with:
+
+```
+    approved)   echo "write the plan (woostack-plan)" ;;
+```
+
+- [ ] **Step 4: Update status.sh no-plan flag string**
+
+Replace (line 227):
+
+```
+    case "$phase" in draft|hardened|approved|abandoned) : ;; *) flag "$name: no plan resolves to this spec (writing-plans)" ;; esac
+```
+
+with:
+
+```
+    case "$phase" in draft|hardened|approved|abandoned) : ;; *) flag "$name: no plan resolves to this spec (woostack-plan)" ;; esac
+```
+
+- [ ] **Step 5: Run the test, confirm it PASSES; lint the script**
+
+Run: `bash skills/woostack-status/scripts/tests/test-status.sh && bash -n skills/woostack-status/scripts/status.sh && echo OK`
+Expected: the test suite passes (including `approved next-action`) and `OK` prints (no syntax errors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+gt modify -c -m "fix(woostack-status): point plan next-action at woostack-plan"
+```
+
+### Task 7: Bump AGENTS.md counts, list, routing, and file map
+
+**Files:**
+- Modify: `AGENTS.md` (`.claude/CLAUDE.md` is a symlink — editing `AGENTS.md` updates both)
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `grep -n 'ten skills\|ten-skill command surface\|twelve `SKILL.md` files\|the ten public' AGENTS.md`
+Expected (before): matches the "ten skills" line, the "ten-skill command surface" line, and the "twelve `SKILL.md` files (the ten public …)" constraint.
+
+- [ ] **Step 2: Update the surface count and add woostack-plan to the list**
+
+Replace:
+
+```
+The public command/adoption surface has ten skills:
+
+- [`using-woostack`](skills/using-woostack/SKILL.md)
+- [`woostack-init`](skills/woostack-init/SKILL.md)
+- [`woostack-bootstrap`](skills/woostack-bootstrap/SKILL.md)
+- [`woostack-build`](skills/woostack-build/SKILL.md)
+- [`woostack-execute`](skills/woostack-execute/SKILL.md)
+```
+
+with:
+
+```
+The public command/adoption surface has eleven skills:
+
+- [`using-woostack`](skills/using-woostack/SKILL.md)
+- [`woostack-init`](skills/woostack-init/SKILL.md)
+- [`woostack-bootstrap`](skills/woostack-bootstrap/SKILL.md)
+- [`woostack-build`](skills/woostack-build/SKILL.md)
+- [`woostack-plan`](skills/woostack-plan/SKILL.md)
+- [`woostack-execute`](skills/woostack-execute/SKILL.md)
+```
+
+- [ ] **Step 3: Update the "ten-skill command surface" mention**
+
+Replace (in the internal-sub-skill paragraph):
+
+```
+`/woostack-*` commands: they have no routing row and are absent from the ten-skill command
+surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+strays.
+```
+
+with:
+
+```
+`/woostack-*` commands: they have no routing row and are absent from the eleven-skill command
+surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+strays.
+```
+
+- [ ] **Step 4: Add /woostack-plan to the Mode B command list**
+
+Replace (in the Mode B paragraph):
+
+```
+**Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
+`/woostack-bootstrap`, `/woostack-build`, `/woostack-execute`, `/woostack-commit`,
+`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, or `/woostack-visualize`,
+```
+
+with:
+
+```
+**Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
+`/woostack-bootstrap`, `/woostack-build`, `/woostack-plan`, `/woostack-execute`, `/woostack-commit`,
+`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, or `/woostack-visualize`,
+```
+
+- [ ] **Step 5: Update the SKILL.md-count hard constraint**
+
+Replace:
+
+```
+- Do not move or rename any of the twelve `SKILL.md` files (the ten public command/adoption
+  skills plus the internal `woostack-ideate` and `woostack-harden`).
+```
+
+with:
+
+```
+- Do not move or rename any of the thirteen `SKILL.md` files (the eleven public command/adoption
+  skills plus the internal `woostack-ideate` and `woostack-harden`).
+```
+
+- [ ] **Step 6: Add the woostack-plan Quick file map entry**
+
+Replace:
+
+```
+- Build loop:
+  [`skills/woostack-build/SKILL.md`](skills/woostack-build/SKILL.md)
+- Plan-execution engine for the build loop (public command):
+  [`skills/woostack-execute/SKILL.md`](skills/woostack-execute/SKILL.md)
+```
+
+with:
+
+```
+- Build loop:
+  [`skills/woostack-build/SKILL.md`](skills/woostack-build/SKILL.md)
+- Plan-writing engine for the build loop (public command):
+  [`skills/woostack-plan/SKILL.md`](skills/woostack-plan/SKILL.md)
+- Plan-execution engine for the build loop (public command):
+  [`skills/woostack-execute/SKILL.md`](skills/woostack-execute/SKILL.md)
+```
+
+- [ ] **Step 7: Confirm the checks pass**
+
+Run: `grep -c 'eleven skills\|eleven-skill command surface\|thirteen `SKILL.md` files\|skills/woostack-plan/SKILL.md\|`/woostack-plan`' AGENTS.md; grep -c 'ten skills\|ten-skill command surface\|twelve `SKILL.md`' AGENTS.md`
+Expected: first count `≥5` (all new mentions present), second count `0` (no stale ten/twelve counts remain).
+
+- [ ] **Step 8: Commit**
+
+```bash
+gt modify -c -m "docs(agents): add woostack-plan to surface (eleven public, thirteen SKILL.md)"
+```
+
+### Task 8: Update README counts, list, build-loop prose, and add a command subsection
+
+**Files:**
+- Modify: `README.md:29`
+- Modify: `README.md:62`
+- Modify: `README.md` (How it works — add a woostack-plan subsection before woostack-execute)
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `grep -c 'surface is ten skills\|woostack-plan' README.md`
+Expected: a match on `surface is ten skills` and `0` matches on `woostack-plan`.
+
+- [ ] **Step 2: Update the Install-section surface count and list**
+
+Replace (line 29):
+
+```
+This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is ten skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, and woostack-visualize. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+```
+
+with:
+
+```
+This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is eleven skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-plan, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, and woostack-visualize. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+```
+
+- [ ] **Step 3: Update the build-loop sequencing prose**
+
+Replace (line 62):
+
+```
+It sequences woostack's own ideate, harden, and execute phases (`woostack-ideate`, `woostack-harden`, `woostack-execute`) with the proven superpowers `writing-plans` sub-skill, inheriting the ideate design gate and hosting the relocated spec-approval gate before planning. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed (`woostack-review --fast`), and distilled. It ends on the reviewed PR stack. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+```
+
+with:
+
+```
+It sequences woostack's own ideate, harden, plan, and execute phases (`woostack-ideate`, `woostack-harden`, `woostack-plan`, `woostack-execute`), inheriting the ideate design gate and hosting the relocated spec-approval gate before planning — the build loop has no external skill dependencies. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed (`woostack-review --fast`), and distilled. It ends on the reviewed PR stack. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+```
+
+- [ ] **Step 4: Add a `/woostack-plan` command subsection**
+
+Insert a new subsection immediately **before** the `### `/woostack-execute <plan-path>`: run a plan as stacked PRs` heading. Replace:
+
+```
+### `/woostack-execute <plan-path>`: run a plan as stacked PRs
+```
+
+with:
+
+```
+### `/woostack-plan <spec-path>`: write a plan from a spec
+
+Writes a comprehensive implementation plan for an approved markdown spec from `.woostack/specs/` — file-structure first, bite-sized TDD tasks with no placeholders, structured as PR-sized increments — saved frontmatter-free to `.woostack/plans/<spec-basename>.md` with an opening `**Source:**` line that joins it 1:1 to the spec, and sets the spec's `status: planning`. It is the plan phase `woostack-build` step 4 delegates to, and is usable standalone. Pairs with `woostack-execute` (produce-plan / consume-plan). Writes the plan and hands back; never executes or merges. → [SKILL.md](skills/woostack-plan/SKILL.md)
+
+### `/woostack-execute <plan-path>`: run a plan as stacked PRs
+```
+
+- [ ] **Step 5: Confirm the checks pass**
+
+Run: `grep -c 'is eleven skills\|woostack-plan <spec-path>`: write a plan\|`woostack-plan`' README.md; grep -c 'is ten skills\|proven superpowers `writing-plans`' README.md`
+Expected: first count `≥3` (new count, new subsection, prose mention), second count `0` (stale count and the writing-plans dependency phrasing gone).
+
+- [ ] **Step 6: Commit**
+
+```bash
+gt modify -c -m "docs(readme): document woostack-plan; eleven public skills, no external deps"
+```
+
+### Task 9: Update CONTRIBUTING surface list and add a plan-phase row
+
+**Files:**
+- Modify: `CONTRIBUTING.md:3`
+- Modify: `CONTRIBUTING.md` (What to change table — add plan row)
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `grep -c 'woostack-plan' CONTRIBUTING.md`
+Expected: `0`.
+
+- [ ] **Step 2: Add woostack-plan to the surface sentence**
+
+Replace (line 3):
+
+```
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, and `woostack-visualize`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+```
+
+with:
+
+```
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-plan`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, and `woostack-visualize`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+```
+
+- [ ] **Step 3: Add the "Change the plan phase" row**
+
+In the "What to change" table, insert a new row immediately **after** the harden-phase row and **before** the execute-phase row. Replace:
+
+```
+| Change the harden phase (the build loop's stress-test step) | `skills/woostack-harden/SKILL.md` |
+| Change the execute phase (the build loop's implementation step) | `skills/woostack-execute/SKILL.md` |
+```
+
+with:
+
+```
+| Change the harden phase (the build loop's stress-test step) | `skills/woostack-harden/SKILL.md` |
+| Change the plan phase (the build loop's planning step) | `skills/woostack-plan/SKILL.md` |
+| Change the execute phase (the build loop's implementation step) | `skills/woostack-execute/SKILL.md` |
+```
+
+- [ ] **Step 4: Confirm the check passes**
+
+Run: `grep -c 'woostack-plan' CONTRIBUTING.md`
+Expected: `2` (the surface sentence and the new table row).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(contributing): list woostack-plan and its change-here row"
+```
+
+### Task 10: Repo-wide consistency sweep
+
+**Files:**
+- Verify only (no new edits unless a stray is found).
+
+- [ ] **Step 1: Confirm no stale writing-plans wiring remains**
+
+Run: `grep -rn 'writing-plans\|superpowers:writing' skills/ AGENTS.md README.md CONTRIBUTING.md action.yml .github/ | grep -v '.woostack/'`
+Expected: the **only** remaining match is the single lineage-credit line inside `skills/woostack-plan/SKILL.md` ("It internalizes `superpowers:writing-plans` …"), exactly as `woostack-execute/SKILL.md` still credits `executing-plans`. No matches in `woostack-build`, `status.sh`, `test-status.sh`, `using-woostack`, `woostack-ideate`, README, CONTRIBUTING, or AGENTS.md. If anything else matches, fix it.
+
+- [ ] **Step 2: Confirm the surface counts agree everywhere**
+
+Run: `grep -rn 'eleven skills\|eleven-skill\|thirteen `SKILL.md`\|is eleven skills' AGENTS.md README.md; grep -rn 'ten skills\|ten-skill\|twelve `SKILL.md`' AGENTS.md README.md CONTRIBUTING.md`
+Expected: the first grep shows the eleven/thirteen counts present in AGENTS.md and README; the second grep returns nothing (no stale ten/twelve counts anywhere).
+
+- [ ] **Step 3: Re-run the status test and lint all touched scripts**
+
+Run: `bash skills/woostack-status/scripts/tests/test-status.sh && bash -n skills/woostack-status/scripts/status.sh && echo ALL_GREEN`
+Expected: the suite passes and `ALL_GREEN` prints.
+
+- [ ] **Step 4: Commit (only if Step 1 surfaced a stray to fix; otherwise skip)**
+
+```bash
+gt modify -c -m "docs: sweep stray writing-plans references"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — every spec requirement maps to a task:
+
+- New `skills/woostack-plan/SKILL.md` (description, required `<spec-path>`, core loop, increments, board join, `status: planning`, hand-back, gate boundary, hard constraints) → **Task 2**.
+- New `references/plan-template.md` (frontmatter-free, `**Source:**` line, no banner, TDD task structure) → **Task 1**.
+- Remove build's Dependency preflight + rewire step 4 / reword step 5 + description + diagram + hard-constraint mentions → **Task 3**.
+- using-woostack routing row → **Task 4**.
+- woostack-ideate chain-nothing example → **Task 5**.
+- status.sh two strings + test-status.sh assertion → **Task 6**.
+- AGENTS.md counts/list/routing/file-map → **Task 7**.
+- README counts/list/prose/subsection → **Task 8**.
+- CONTRIBUTING list + plan-phase row → **Task 9**.
+- Repo-wide grep (no stale writing-plans wiring; lineage credit allowed), count consistency, status test green → **Task 10** (spec §7 Testing).
+
+No gaps.
+
+**2. Placeholder scan** — the only `{{…}}` tokens live inside the `plan-template.md` body (Task 1), which is a fill-in skeleton by design; they are the template's intended placeholders, not plan placeholders. Every plan step has exact paths, full file content or exact find/replace blocks, and exact verification commands with expected output.
+
+**3. Type consistency** — names are stable across tasks: the skill is `woostack-plan` throughout; the template path is `skills/woostack-plan/references/plan-template.md` in both Task 1 and Task 2's cross-link; counts are uniformly "eleven public skills" / "thirteen `SKILL.md` files"; next-action string `write the plan (woostack-plan)` matches between status.sh (Task 6 Step 3) and the test assertion (Task 6 Step 1). The lineage-credit allowance in Task 10 matches the exact string written in Task 2.
+</content>

--- a/.woostack/specs/2026-06-05-woostack-plan.md
+++ b/.woostack/specs/2026-06-05-woostack-plan.md
@@ -1,0 +1,280 @@
+---
+name: 2026-06-05-woostack-plan
+type: spec
+status: planning
+date: 2026-06-05
+branch: feature/woostack-plan
+links:
+  - "[[2026-06-03-woostack-ideate]]"
+  - "[[2026-06-04-woostack-harden]]"
+  - "[[2026-06-04-woostack-execute]]"
+---
+
+# woostack-plan: a woostack-native plan-writing command — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+`woostack-build` step 4 delegates plan authoring to the external `superpowers:writing-plans`
+skill. That skill is the **last remaining external dependency** in the flagship build loop,
+after [`woostack-ideate`](../../skills/woostack-ideate/SKILL.md) replaced
+`superpowers:brainstorming`, [`woostack-harden`](../../skills/woostack-harden/SKILL.md)
+replaced `grill-me`, and [`woostack-execute`](../../skills/woostack-execute/SKILL.md) replaced
+`superpowers:executing-plans`. It is a poor fit for the woostack loop in three ways:
+
+1. **External dependency for a core loop step.** The plan phase is the sole survivor in
+   `woostack-build`'s dependency preflight — it must be detected, offered for inline install,
+   and degraded when absent. That whole preflight section exists only for this one skill. Once
+   plan is first-party, the preflight disappears and every build phase is owned in-collection.
+2. **Off-the-shelf, not woostack-shaped.** `superpowers:writing-plans` saves to
+   `docs/superpowers/plans/`, prescribes a plan header with a `REQUIRED SUB-SKILL:
+   subagent-driven-development / executing-plans` banner, and ends with an "Execution Handoff"
+   that offers subagent-vs-inline execution. None of that matches woostack: plans live under
+   `.woostack/plans/`, are frontmatter-free, open with a `**Source:**` line that joins them
+   1:1 to their spec, and hand the execution choice to `woostack-build`'s execution-handoff
+   gate (step 8) and `woostack-execute`. Today all of that lives as narration in
+   `woostack-build`'s prose around the delegation rather than in the plan engine itself.
+3. **No board-join awareness.** woostack plans must carry the `**Source:** .woostack/specs/<file>.md`
+   line, stay frontmatter-free, structure work as PR-sized increments, and advance the spec's
+   `status:` to `planning`. `superpowers:writing-plans` knows none of these conventions, so the
+   build loop has to bolt them on after the fact.
+
+We want to own the plan-writing behavior so the build loop's plan phase fits woostack
+conventions, the board join is part of the engine, and the build loop has **zero external
+skill dependencies**.
+
+## 2. Goal
+
+Ship `skills/woostack-plan/SKILL.md`: a woostack command that takes one approved markdown
+spec (**supplied as a required argument**) and writes a comprehensive implementation plan to
+`.woostack/plans/<spec-basename>.md`, structured as **PR-sized increments**. The plan opens
+with the `**Source:** .woostack/specs/<file>.md` line in its first ~5 lines (the 1:1 board
+join), stays frontmatter-free, decomposes work into bite-sized TDD tasks with no placeholders,
+runs a self-review pass, and sets the spec's `status: planning`. It writes the plan and hands
+back; it owns no approval gate and chains no execution.
+
+Rewire `woostack-build` step 4 (and **remove** its dependency-preflight section) to use it, and
+fold build step 5's decomposition into the plan engine. Keep the parts of
+`superpowers:writing-plans` that earn their place — file-structure-first decomposition,
+bite-sized one-action TDD steps, the no-placeholders discipline, the self-review checklist, the
+scope check, DRY/YAGNI/TDD/frequent-commits — and add the woostack conventions it lacks.
+
+This is the same internalization move `woostack-ideate`, `woostack-harden`, and
+`woostack-execute` made on the phases around it. Settled in ideate: **`woostack-plan` ships as
+a public command** (the eleventh), pairing with `woostack-execute` as produce-plan /
+consume-plan (`/woostack-plan <spec>` then `/woostack-execute <plan>`), and directly useful to
+invoke by name on an approved spec.
+
+## 3. Non-goals
+
+- **Adds no approval gate.** `woostack-build` keeps its two HARD GATES (design approval, spec
+  approval) upstream and the execution-handoff gate (step 8) downstream. `woostack-plan`
+  inherits gates and adds none. It writes the plan and hands back.
+- **Does not author specs.** It consumes an approved spec under `.woostack/specs/`; it does not
+  write or rewrite specs. (It does set the spec's `status: planning` frontmatter field — a
+  one-line phase transition, not authoring spec content.)
+- **Does not execute.** No implementation, no TDD-in-the-loop, no commits, no PRs. Those are
+  `woostack-execute`. The plan is the deliverable; the execution choice is `woostack-build`
+  step 8's and `woostack-execute`'s.
+- **Does not write a second plan for a spec.** The `spec : plan : PRs = 1 : 1 : N` invariant
+  holds: exactly one plan per spec. If a plan already resolves to the spec, `woostack-plan`
+  amends it in place rather than creating a duplicate (a second plan breaks the board join).
+- **No rewrite of history.** Historical `.woostack/specs/` and `.woostack/plans/` references to
+  `superpowers:writing-plans` are records of past work and are left as-is.
+
+## 4. Approach
+
+Author `SKILL.md` plus a `references/plan-template.md` fill-in skeleton (symmetric with the
+spec's [spec-template.md](../../skills/woostack-build/references/spec-template.md)). The SKILL.md
+holds the plan-writing *logic*; the template holds the *output shape* the plan fills in — the
+two are different concerns, so this is an output-artifact template, not a logic split. It mirrors
+`superpowers:writing-plans`' proven core and adds the woostack conventions, parallel to how
+`woostack-execute` mirrored `executing-plans` but added the PR cadence.
+
+- **Frontmatter `description`** scoped so it is recognized as `woostack-build`'s plan phase and
+  as a standalone "write the plan / plan this spec" trigger, and routed by `using-woostack` —
+  broad enough to be invocable by name, narrow enough not to shadow unrelated skills or hijack
+  generic "make a plan" requests.
+- **Commands**:
+  - `/woostack-plan <spec-path>` — write the plan for the named spec file. **The spec path is a
+    required argument.**
+  - `/woostack-plan` with no argument — do **not** guess "the current spec." Ask the user which
+    spec to plan (optionally list `.woostack/specs/` candidates) and stop until one is named.
+    When `woostack-build` invokes plan it always passes the spec path from step 2/3, so this
+    no-arg path is the standalone-misuse guard, not a routine resolution.
+- **Core plan-writing loop** (kept from `superpowers:writing-plans`):
+  - **Scope check** — if the spec covers multiple independent subsystems, suggest splitting into
+    separate plans (one per subsystem), each producing working, testable software on its own.
+  - **File-structure-first** — map which files are created/modified and each one's single
+    responsibility before defining tasks; this locks in decomposition. Prefer small, focused
+    files; follow existing-codebase patterns.
+  - **Bite-sized tasks** — each step is one action (~2-5 min): write the failing test → run it
+    to confirm it fails → minimal implementation → run to confirm it passes → commit. Checkbox
+    (`- [ ]`) syntax so `woostack-execute` ticks them in place.
+  - **No placeholders** — every step carries the actual content: exact file paths, complete code
+    in every code step, exact commands with expected output. No TBD/TODO/"handle edge cases"/
+    "similar to Task N".
+  - **Self-review** — after writing, check the plan against the spec: spec coverage (every
+    requirement maps to a task), placeholder scan, type/signature consistency across tasks. Fix
+    inline.
+  - DRY / YAGNI / TDD / frequent commits throughout.
+- **PR-sized increments** (woostack): structure the plan as a sequence of independently
+  shippable increments (≤500 LOC soft target, not a gate) so a standalone plan is
+  execute-ready. Flag any slice that can't reasonably stay under the target and propose a
+  further split; genuinely atomic changes may exceed it. This **folds build step 5's
+  decomposition into the plan engine** — exactly as `woostack-execute` absorbed decomposition
+  for standalone runs.
+- **Board join + frontmatter-free** (woostack): the plan **opens with**
+  `**Source:** .woostack/specs/<file>.md` in its first ~5 lines (the spec→plan join). Plans
+  carry **no** YAML frontmatter. Header is Goal / Architecture / Tech-stack plus the `**Source:**`
+  line — **not** the superpowers `REQUIRED SUB-SKILL` banner. This shape is captured in
+  `references/plan-template.md`, which the skill populates (the way build step 2 populates
+  spec-template.md).
+- **Filename mirrors the spec basename** (woostack): the plan is named
+  `.woostack/plans/<spec-basename>.md` — the **same** `YYYY-MM-DD-<slug>` basename as its spec
+  (the spec's creation date, reused — *not* today's date). Every existing pair shares a basename,
+  which is what makes the slug-match fallback join work alongside the `**Source:**` line. If the
+  derived basename is already taken, that plan resolves to this spec → amend it, never write a
+  second (see Error handling).
+- **Status authoring** (woostack): on writing the plan, set the spec's `status: planning` (the
+  conventions.md enum value for "plan exists, 0 boxes done"). Doing this in the plan engine means
+  a standalone `/woostack-plan` also advances the board correctly, mirroring how
+  `woostack-execute` owns the executing/review band. The enum and join contracts live in
+  [conventions.md](../../skills/woostack-status/references/conventions.md) — link, never restate.
+- **Drop from superpowers** (woostack): the `docs/superpowers/plans/` default location, the
+  `REQUIRED SUB-SKILL` plan-header banner, and the entire "Execution Handoff" section (the
+  subagent-vs-inline offer) — that boundary is `woostack-build` step 8's gate and
+  `woostack-execute`'s, not the plan engine's.
+- **Hand back** (woostack): after writing the plan and setting `status: planning`, state the
+  plan path and hand back — to `woostack-build` step 6 (harden the plan) when invoked by build,
+  or to the user (offer `/woostack-execute <plan>`) when standalone. Chain nothing.
+- **Gate boundary**: an explicit statement that the skill owns no approval gate, does not
+  execute, and does not merge — preserving `woostack-build`'s "inherit gates, add none."
+
+### Wiring `woostack-build`
+
+- **Dependency preflight**: `superpowers:writing-plans` was the **only** external skill listed.
+  Remove the entire `## Dependency preflight` section — every build phase is now first-party
+  (`woostack-ideate`, `woostack-harden`, `woostack-plan`, `woostack-commit`, `woostack-execute`),
+  so there is nothing to preflight, install inline, or degrade.
+- **Step 4 (Plan)**: invoke `woostack-plan` (passing the approved spec path) instead of
+  `superpowers:writing-plans`. `woostack-plan` now owns saving the markdown plan under
+  `.woostack/plans/`, the `**Source:**` line, frontmatter-free shape, and the `status: planning`
+  transition — so build step 4's prose collapses into the delegation.
+- **Step 5 (Decompose)**: `woostack-plan` now structures the plan as PR-sized increments, so
+  step 5's decomposition is folded into the plan engine. Reword step 5 to "the plan already
+  decomposes into PR-sized increments; verify the boundaries feed `woostack-execute`" — parallel
+  to how the execute rewire treated decomposition.
+- **Overview diagram + `description`**: replace `writing-plans` with `plan` in the step chain;
+  drop "and superpowers writing-plans" from the build `description`. The plan phase is now
+  woostack's own — **the build loop has no external skill dependencies.**
+
+## 5. Components & data flow
+
+Edit set (decomposed into PR-sized increments in the plan):
+
+| File | Change |
+|---|---|
+| `skills/woostack-plan/SKILL.md` | **NEW** — the skill (the status step *references* conventions.md rather than duplicating it): scoped `description`, required `/woostack-plan <spec-path>` command, core plan-writing loop (scope check, file-structure-first, bite-sized TDD tasks, no-placeholders, self-review), PR-sized increments, board join (`**Source:**` line, frontmatter-free), `status: planning` authoring, hand-back, gate boundary, hard constraints. Points at `references/plan-template.md` for the output shape. |
+| `skills/woostack-plan/references/plan-template.md` | **NEW** — fill-in plan skeleton, symmetric with `skills/woostack-build/references/spec-template.md`: the `**Source:**` line, Goal / Architecture / Tech-stack header (no frontmatter, no `REQUIRED SUB-SKILL` banner), and the bite-sized TDD task structure (`### Task N`, `**Files:**`, checkbox `- [ ]` steps with code/commands/expected-output). The canonical "what a woostack plan looks like" reference for woostack-execute/woostack-status. |
+| `skills/woostack-build/SKILL.md` | **Remove the entire `## Dependency preflight` section** (writing-plans was the only external dep). Overview diagram: `writing-plans` → `plan`. Step 4: invoke `woostack-plan`. Step 5: reword — plan owns decomposition, step 5 verifies boundaries feed execute. `description` frontmatter: drop "and superpowers writing-plans"; plan is now woostack's own (build loop fully first-party). Hard-constraints/prose mentions of `writing-plans` updated to `woostack-plan`. |
+| `skills/using-woostack/SKILL.md` | **Add a routing row** to the Command Routing table for `/woostack-plan <spec-path>` → `woostack-plan` (public command, like execute). |
+| `.claude/CLAUDE.md` (= `AGENTS.md`) | "ten skills" public surface → **eleven**, add `woostack-plan` to the public list and Quick file map. "ten-skill command surface" → eleven. "twelve `SKILL.md` files (ten public + two internal)" → **thirteen (eleven public + two internal)**. Internal sub-skill list stays two (`woostack-ideate`, `woostack-harden`). Protect `woostack-plan` from deletion like the other shipped skills. |
+| `README.md` | Public-skill count "ten" → **eleven**, add `woostack-plan`. Build-loop prose: `writing-plans` → `plan` (woostack's own); note the build loop now has **no external skill dependencies** / superpowers fully internalized. |
+| `CONTRIBUTING.md` | Loop summary already reads `…→ plan → execute` — verify. **Add a "Change the plan phase" pointer row** → `skills/woostack-plan/SKILL.md`, parallel to the existing ideate/harden/execute rows. |
+| `skills/woostack-status/scripts/status.sh` | The `approved` next-action string `"write the plan (writing-plans)"` → `"write the plan (woostack-plan)"`; the no-plan flag `"... (writing-plans)"` → `"... (woostack-plan)"`. Keeps the board's guidance pointing at the woostack command. |
+| `skills/woostack-status/scripts/tests/test-status.sh` | The assertion `assert_contains "$OUT" "writing-plans"` → `"woostack-plan"` to match the updated next-action string. |
+| `skills/woostack-ideate/SKILL.md` | Minor consistency touch: the "do not chain `writing-plans`, `woostack-execute`, …" example list updates `writing-plans` → `woostack-plan` now that plan is woostack's own command. |
+
+Data flow at runtime: `woostack-build` step 4 (or a direct `/woostack-plan <spec-path>`) → read
+the approved markdown spec from `.woostack/specs/` → scope check → map file structure → write
+the plan to `.woostack/plans/<spec-basename>.md` (opening `**Source:**` line, frontmatter-free,
+PR-sized increments, bite-sized TDD tasks, no placeholders) → self-review against the spec → set
+spec `status: planning` → hand back (to build step 6 harden, or to the user with an
+`/woostack-execute` offer). No execution, no commits, no merge.
+
+## 6. Error handling
+
+- **Skill missing at runtime.** Because it ships in the collection, absence means a broken
+  install. Build's preflight no longer exists (it was removed), so there is nothing to install
+  inline; if the file is genuinely missing, `woostack-build` falls back to following the
+  plan-writing principle manually and says so (degraded, not equivalent).
+- **No spec argument.** The spec path is required. `/woostack-plan` with no argument → ask which
+  spec to plan (optionally list `.woostack/specs/` candidates) and stop until one is named;
+  never guess "the current spec."
+- **Plan already exists for the spec.** A plan already resolves to the spec (via `**Source:**`
+  line or slug) → **amend the existing plan**, do not write a second (a second plan breaks the
+  `1:1` board join). Surface that the plan exists and that it is being amended.
+- **Spec not approved.** `woostack-plan` consumes a spec; the design/spec approval gates are
+  build's upstream. If invoked standalone on an unhardened/unapproved spec, proceed (the user
+  asked to plan it) but note that the upstream gates were not observed.
+- **Spec covers multiple subsystems.** Scope check → suggest splitting into separate plans (one
+  per subsystem), each independently testable, before writing a monolithic plan.
+- **Slice too large.** An increment that can't stay near the ≤500 LOC target → propose a further
+  split before finalizing; genuinely atomic changes may exceed the target.
+- **Memory/store missing.** `woostack-plan` does not distill memory (that is execute's job), so a
+  missing `.woostack/memory/` is irrelevant here. It only needs `.woostack/specs/` (to read) and
+  `.woostack/plans/` (to write); if `.woostack/plans/` is absent, create it (or offer
+  `/woostack-init`).
+- **Description over-trigger.** Risk: a `description` broad enough to hijack generic "make a
+  plan" requests. Mitigation: scope it to "write the implementation plan for an approved
+  woostack spec" plus the build plan phase — not a generic planning trigger.
+
+## 7. Testing
+
+No app/test harness in this repo (it is a skills collection). Verification is by inspection,
+plus the existing status-script test:
+
+- New `SKILL.md` has valid frontmatter (`name`, `description`), a required `<spec-path>`
+  argument, the core plan-writing loop (scope check, file-structure-first, bite-sized TDD tasks,
+  no-placeholders, self-review), PR-sized increments, the `**Source:**`/frontmatter-free board
+  join, the `status: planning` authoring, hand-back, the gate-boundary statement, and a link to
+  `references/plan-template.md`.
+- `references/plan-template.md` exists, is frontmatter-free, opens with the `**Source:**` line,
+  carries no `REQUIRED SUB-SKILL` banner, shows the bite-sized TDD task structure, and is
+  cross-linked from `SKILL.md` (link resolves).
+- `woostack-build` no longer has a `## Dependency preflight` section; step 4 names
+  `woostack-plan`; the overview diagram and `description` say `plan`, not `writing-plans`.
+- Repo-wide grep: **no remaining `writing-plans` reference in shipped docs/skills/scripts**
+  (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, skill files, status scripts) except the
+  `.woostack/` history (this new spec and historical specs/plans may mention it). No remaining
+  `superpowers:` runtime dependency anywhere in the build loop.
+- `using-woostack` has a `/woostack-plan` routing row.
+- `skills/woostack-status/scripts/tests/test-status.sh` passes with the updated assertion
+  (`woostack-plan` in the approved next-action), and `status.sh` emits the woostack-plan
+  guidance string.
+- Cross-links resolve (`woostack-build` ↔ `woostack-plan`; `woostack-plan` → `woostack-execute`,
+  conventions.md).
+- Command-surface count is consistent everywhere: `AGENTS.md`, `README.md`, `using-woostack`,
+  CONTRIBUTING all reflect **eleven** public commands; the "do not rename" hard constraint
+  reflects **thirteen** `SKILL.md` files (eleven public + two internal).
+
+## 8. Open questions
+
+All resolved. Settled during ideate:
+
+- **Shape** → **public command** (the eleventh), pairing with `woostack-execute` as
+  produce-plan / consume-plan. Adds `/woostack-plan <spec-path>`, a routing row, and bumps the
+  surface counts.
+- **Argument** → the spec path is a **required argument**. No no-arg "current spec" guessing; no
+  argument → ask and stop. `woostack-build` always passes the path from step 2/3.
+- **Plan output template** → **ship `references/plan-template.md`**: a fill-in plan skeleton
+  symmetric with the spec's `spec-template.md`. The SKILL.md holds the plan-writing logic and
+  references the template for the output shape (the status step likewise references conventions.md
+  rather than duplicating it). This is an output-artifact template, not a logic split — the skill
+  is still one `SKILL.md`.
+- **Status ownership** → **`woostack-plan` sets `status: planning`** itself (so standalone plan
+  also advances the board), mirroring execute owning the executing/review band.
+- **Decomposition ownership** → **plan owns PR-sized decomposition** (folds build step 5 into the
+  plan engine; step 5 rewords to "verify boundaries feed execute"), parallel to the execute
+  rewire.
+- **Build rewire** → **now**: step 4 delegates to `woostack-plan`, **the dependency-preflight
+  section is removed entirely** (writing-plans was the only external dep), counts updated across
+  README/CONTRIBUTING/AGENTS.md/using-woostack. The build loop becomes fully first-party.
+- **Naming** → `woostack-plan` (user-specified; verb-family, matches
+  build/execute/commit/review/init/visualize/ideate/harden).
+</content>
+</invoke>


### PR DESCRIPTION
## Goal

Internalize `superpowers:writing-plans` as `woostack-plan`, the build loop's first-party plan phase. It is the **last** external dependency in `woostack-build`; owning it lets the build loop become fully first-party and drop its dependency-preflight section. This PR ships the spec and plan only — the base of the stack.

## Summary

- `.woostack/specs/2026-06-05-woostack-plan.md` — design spec: `woostack-plan` as the eleventh **public** command (`/woostack-plan <spec-path>`), keeping writing-plans' proven core (file-structure-first, bite-sized TDD tasks, no-placeholders, self-review) and adding woostack conventions (plan under `.woostack/plans/<spec-basename>.md`, opening `**Source:**` line, frontmatter-free, PR-sized increments, sets spec `status: planning`).
- `.woostack/plans/2026-06-05-woostack-plan.md` — implementation plan in two PR-sized increments: (1) add the skill + `references/plan-template.md`; (2) wire into `woostack-build` (remove preflight), update `using-woostack`, `woostack-ideate`, the status script + its test, and the surface counts in AGENTS.md / README / CONTRIBUTING.

## Test plan

### Manual

**Before merge**

- [ ] Read the spec — confirm the public-command shape, the dropped-preflight rewire, and the `references/plan-template.md` decision are sound.
- [ ] Read the plan — confirm the 2-increment split, the Graphite cadence (Increment 1 = one branch, Increment 2 stacks via `gt create`), and the content-matched edit blocks are executable.

Spec: .woostack/specs/2026-06-05-woostack-plan.md
