### PR TITLE
feat(woostack-plan): add standalone plan skill

### DIFF
--- a/.woostack/plans/2026-06-05-woostack-plan.md
+++ b/.woostack/plans/2026-06-05-woostack-plan.md
@@ -27,14 +27,14 @@
 **Files:**
 - Create: `skills/woostack-plan/references/plan-template.md`
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 The file must not exist yet, and once created must be frontmatter-free, open with the `**Source:**` line, and carry no `REQUIRED SUB-SKILL` banner.
 
 Run: `test ! -e skills/woostack-plan/references/plan-template.md && echo MISSING`
 Expected: `MISSING`
 
-- [ ] **Step 2: Create the file**
+- [x] **Step 2: Create the file**
 
 Create `skills/woostack-plan/references/plan-template.md` with exactly this content:
 
@@ -107,12 +107,12 @@ gt create -m "{{type}}: {{subject}}"
 > - In a target without a test runner, a "failing test" step is a concrete verification command (grep, `bash -n`, an existing test) with exact expected output.
 ````
 
-- [ ] **Step 3: Run the check, confirm it passes**
+- [x] **Step 3: Run the check, confirm it passes**
 
 Run: `head -1 skills/woostack-plan/references/plan-template.md; grep -c 'REQUIRED SUB-SKILL' skills/woostack-plan/references/plan-template.md`
 Expected: first line is `**Source:** .woostack/specs/{{SPEC_BASENAME}}.md`, and the grep count is `0`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt create -m "feat(woostack-plan): add plan-template skeleton"
@@ -123,12 +123,12 @@ gt create -m "feat(woostack-plan): add plan-template skeleton"
 **Files:**
 - Create: `skills/woostack-plan/SKILL.md`
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 Run: `test ! -e skills/woostack-plan/SKILL.md && echo MISSING`
 Expected: `MISSING`
 
-- [ ] **Step 2: Create the file**
+- [x] **Step 2: Create the file**
 
 Create `skills/woostack-plan/SKILL.md` with exactly this content:
 
@@ -291,17 +291,17 @@ execute, commit, or merge. It writes the plan and hands back — preserving `woo
 - **Own no gate; never execute, commit, or merge.** Write the plan and hand back.
 ````
 
-- [ ] **Step 3: Run the checks, confirm they pass**
+- [x] **Step 3: Run the checks, confirm they pass**
 
 Run: `head -2 skills/woostack-plan/SKILL.md | grep -c 'name: woostack-plan'; grep -c 'references/plan-template.md' skills/woostack-plan/SKILL.md`
 Expected: first count `1` (valid frontmatter `name`), second count `≥1` (cross-link to the template present).
 
-- [ ] **Step 4: Verify the cross-links resolve**
+- [x] **Step 4: Verify the cross-links resolve**
 
 Run: `test -e skills/woostack-plan/references/plan-template.md && test -e skills/woostack-build/SKILL.md && test -e skills/woostack-execute/SKILL.md && test -e skills/woostack-status/references/conventions.md && echo LINKS_OK`
 Expected: `LINKS_OK` (every relative link target in SKILL.md exists).
 
-- [ ] **Step 5: Commit (same Increment-1 branch)**
+- [x] **Step 5: Commit (same Increment-1 branch)**
 
 ```bash
 gt modify -c -m "feat(woostack-plan): add SKILL.md (plan phase, internalizes writing-plans)"

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: woostack-plan
+description: "Use to write the implementation plan for an approved woostack spec — a comprehensive, bite-sized TDD plan structured as PR-sized increments, saved frontmatter-free to .woostack/plans/<spec-basename>.md, opening with a `**Source:**` line that joins it 1:1 to the spec, and setting the spec's status: planning. This is the plan phase of the woostack build loop (woostack-build step 4); also usable standalone via /woostack-plan <spec-path>. One plan per spec. Writes the plan and hands back — never executes, commits, or merges."
+---
+
+# woostack-plan
+
+Write a comprehensive implementation plan from one approved spec, structured as PR-sized
+increments. This is woostack's own planning phase — [`woostack-build`](../woostack-build/SKILL.md)
+step 4. It keeps the discipline that makes plans worth executing (file-structure first,
+bite-sized TDD tasks, no placeholders, a self-review pass) and adds the woostack conventions:
+markdown plans under `.woostack/plans/`, an opening `**Source:**` line that joins the plan 1:1 to
+its spec, frontmatter-free, decomposed into independently shippable increments, and a
+`status: planning` transition on the spec. It writes the plan and hands back; it owns no approval
+gate and never executes, commits, or merges.
+
+It internalizes `superpowers:writing-plans` — the same move
+[`woostack-ideate`](../woostack-ideate/SKILL.md),
+[`woostack-harden`](../woostack-harden/SKILL.md), and
+[`woostack-execute`](../woostack-execute/SKILL.md) made on the phases around it. With this skill
+the build loop has **no external skill dependencies**. It pairs with `woostack-execute` as
+produce-plan / consume-plan: `/woostack-plan <spec>` writes the plan, `/woostack-execute <plan>`
+runs it.
+
+## Commands
+
+- `/woostack-plan <spec-path>` — write the plan for the named markdown spec under
+  `.woostack/specs/`. **The spec path is required.**
+- `/woostack-plan` (no argument) — do **not** guess "the current spec." Ask which spec to plan
+  (optionally list `.woostack/specs/` candidates) and stop until one is named.
+
+When `woostack-build` reaches step 4 it invokes this skill with the approved spec path from
+step 2/3.
+
+## Read and check the spec
+
+1. Read the spec file end to end — it is the source of truth for *what* to build; the plan is
+   *how*.
+2. **Scope check.** If the spec covers multiple independent subsystems, suggest splitting into
+   separate specs first — one per subsystem, each producing working, testable software on its own
+   — then write one plan per resulting spec. Don't write a monolithic plan over a
+   multi-subsystem spec.
+3. **One plan per spec.** If a plan already resolves to this spec (a `.woostack/plans/` file with
+   a matching `**Source:**` line or the same basename), **amend that plan in place** — never write
+   a second (`spec : plan : PRs = 1 : 1 : N`; a second plan breaks the board join). Say you are
+   amending.
+
+## File structure first
+
+Before defining tasks, map which files are created or modified and each one's single
+responsibility. This locks in decomposition.
+
+- Design units with clear boundaries; one responsibility per file. Prefer small, focused files.
+- Files that change together live together. Split by responsibility, not by technical layer.
+- In an existing codebase, follow established patterns; don't unilaterally restructure. If a file
+  you must touch has grown unwieldy, folding a split into the plan is reasonable.
+
+## PR-sized increments
+
+Structure the plan as a sequence of **independently shippable increments** — preferably ≤500 LOC
+each (a soft target, not a gate) — so the plan is execute-ready: `woostack-execute` runs one
+increment per cycle as its own Graphite-stacked PR. Flag any slice that can't reasonably stay
+under the target and propose a further split; genuinely atomic changes may exceed it. This
+decomposition is part of planning (it folds `woostack-build`'s old decompose step into the plan
+engine).
+
+## Bite-sized tasks (TDD)
+
+Within each increment, decompose into bite-sized tasks; each **step** is one action
+(~2-5 minutes): write the failing test → run it, confirm it fails → minimal implementation → run
+it, confirm it passes → commit. Use checkbox (`- [ ]`) syntax for every step so
+`woostack-execute` ticks them in place as the live progress record. DRY, YAGNI, TDD, frequent
+commits throughout.
+
+In a target without a test runner (e.g. a docs/skills repo), "the failing test" becomes a
+concrete **verification command** — a `grep`, a `bash -n`, a link check, or an existing script's
+test — with exact expected output. Never a vague "verify it works."
+
+The output shape (header, `**Source:**` line, task/step structure) is captured in
+[references/plan-template.md](references/plan-template.md) — populate it; don't reinvent it.
+
+## No placeholders
+
+Every step carries the actual content an engineer needs. These are plan failures — never write
+them:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" without the actual test
+- "Similar to Task N" — repeat the code; tasks may be read out of order
+- A step that says *what* without showing *how* (code/command blocks required)
+- References to types/functions/methods defined in no task
+
+Exact file paths always. Complete code in every code step. Exact commands with expected output.
+
+## Board join: Source line, frontmatter-free, filename
+
+- **Filename:** save to `.woostack/plans/<spec-basename>.md` — the **same** `YYYY-MM-DD-<slug>`
+  basename as the spec (reuse the spec's date; **not** today's). The shared basename is the
+  slug-match fallback join.
+- **Opening line:** the plan's first line is `**Source:** .woostack/specs/<file>.md` — the
+  primary spec→plan join the `/woostack-status` board reads.
+- **Frontmatter-free:** plans carry no YAML frontmatter and no `REQUIRED SUB-SKILL` banner. The
+  header is the `**Source:**` line plus Goal / Architecture / Tech Stack.
+
+The phase enum and join contracts are defined once in
+[`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) —
+link, never restate.
+
+## Self-review
+
+After writing the plan, check it against the spec with fresh eyes — a checklist you run yourself,
+not a subagent dispatch:
+
+1. **Spec coverage** — every section/requirement maps to a task. List and fill any gap.
+2. **Placeholder scan** — search for the red flags above; fix them.
+3. **Type consistency** — types, signatures, and property names match across tasks (a method
+   called one name in Task 3 and another in Task 7 is a bug).
+
+Fix issues inline; no re-review needed.
+
+## Status: planning
+
+When the plan file exists, set the spec's `status: planning` (the conventions.md value for "plan
+exists, 0 boxes done"). Doing it here means a standalone `/woostack-plan` also advances the board.
+Do not tick any plan checkbox yet — execution owns checkbox progress.
+
+## Terminal state: plan written, handed back
+
+Stop when the plan is written, self-reviewed, and the spec is `planning`. Then hand back and name
+the next step:
+
+- Inside `woostack-build`: return to **step 6** (harden the plan).
+- Standalone: tell the user the plan is ready and offer `/woostack-execute <plan-path>`. Stop.
+
+Chain nothing yourself.
+
+## Gate boundary
+
+This skill owns **no approval gate**. The spec-approval gate (`woostack-build` step 3) is
+upstream; the execution-handoff gate (step 8) is downstream. It does not present-for-approval,
+execute, commit, or merge. It writes the plan and hands back — preserving `woostack-build`'s
+"inherit gates, add none."
+
+## Hard constraints
+
+- **Spec path required.** Never guess "the current spec"; ask when no argument is given.
+- **One plan per spec.** A plan already resolves to the spec → amend it; never write a second
+  (breaks the 1:1 board join).
+- **Markdown plan under `.woostack/plans/`, basename = spec basename.** Frontmatter-free, opening
+  `**Source:**` line.
+- **PR-sized increments.** Decompose into independently shippable slices (≤500 LOC soft target);
+  flag and split oversized ones.
+- **Bite-sized TDD tasks, no placeholders.** One action per step; complete code, exact commands,
+  expected output.
+- **Set `status: planning`; tick no checkbox.** Execution owns checkbox progress.
+- **Own no gate; never execute, commit, or merge.** Write the plan and hand back.

--- a/skills/woostack-plan/references/plan-template.md
+++ b/skills/woostack-plan/references/plan-template.md
@@ -1,0 +1,69 @@
+**Source:** .woostack/specs/{{SPEC_BASENAME}}.md
+
+# {{FEATURE_NAME}} Implementation Plan
+
+**Goal:** {{ONE_SENTENCE_WHAT_THIS_BUILDS}}
+
+**Architecture:** {{TWO_OR_THREE_SENTENCES_ON_THE_APPROACH}}
+
+**Tech Stack:** {{KEY_TECHNOLOGIES}}
+
+---
+
+## Increment 1: {{PR_SIZED_SLICE_NAME}}
+
+> One independently shippable PR (≤500 LOC soft target) — its own Graphite-stacked branch.
+
+### Task 1: {{COMPONENT_NAME}}
+
+**Files:**
+- Create: `{{exact/path/to/new.ext}}`
+- Modify: `{{exact/path/to/existing.ext}}:{{LINES}}`
+- Test: `{{exact/path/to/test.ext}}`
+
+- [ ] **Step 1: Write the failing test**
+
+```{{lang}}
+{{actual test code — never a placeholder}}
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `{{exact command}}`
+Expected: FAIL — `{{exact expected failure}}`
+
+- [ ] **Step 3: Minimal implementation**
+
+```{{lang}}
+{{actual implementation code}}
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `{{exact command}}`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+# first commit in this increment:
+gt create -m "{{type}}: {{subject}}"
+# later commits in the same increment:
+gt modify -c -m "{{type}}: {{subject}}"
+```
+
+<!-- Repeat Task N for each unit in this increment. Add Increment 2, 3, … for each PR-sized slice. -->
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every spec requirement maps to a task above.
+- [ ] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
+- [ ] **Type consistency** — types, signatures, and names match across tasks.
+
+> woostack plan conventions (keep them):
+> - This file is **frontmatter-free** and **opens with** the `**Source:**` line.
+> - Filename mirrors the spec basename: `.woostack/plans/<spec-basename>.md` (the spec's date, not today's).
+> - **No** required sub-skill banner — execution is `woostack-execute`'s (woostack-build step 8, or `/woostack-execute <plan>`).
+> - In a target without a test runner, a "failing test" step is a concrete verification command (grep, `bash -n`, an existing test) with exact expected output.


### PR DESCRIPTION
## Goal

Add the standalone `woostack-plan` skill as the first executable slice of the plan-writing command work, without wiring it into the public routing surface in this PR.

## Summary

- Adds `skills/woostack-plan/SKILL.md`, defining the plan-writing command, board join rules, planning status transition, terminal behavior, and hard constraints.
- Adds `skills/woostack-plan/references/plan-template.md` as the reusable frontmatter-free plan skeleton opened by a `**Source:**` line.
- Ticks Increment 1 plan progress for the completed standalone skill tasks.

## Test plan

### Automated

- [ ] `head -1 skills/woostack-plan/references/plan-template.md; grep -c 'REQUIRED SUB-SKILL' skills/woostack-plan/references/plan-template.md` -> `**Source:** .woostack/specs/{{SPEC_BASENAME}}.md` and `0`.
- [ ] `head -2 skills/woostack-plan/SKILL.md | grep -c 'name: woostack-plan'; grep -c 'references/plan-template.md' skills/woostack-plan/SKILL.md` -> `1` and `1`.
- [ ] `test -e skills/woostack-plan/references/plan-template.md && test -e skills/woostack-build/SKILL.md && test -e skills/woostack-execute/SKILL.md && test -e skills/woostack-status/references/conventions.md && echo LINKS_OK` -> `LINKS_OK`.
- [ ] `ruby -e 'require "yaml"; s=File.read("skills/woostack-plan/SKILL.md"); fm=s.split(/^---\s*$/)[1]; y=YAML.safe_load(fm); abort "missing name" unless y["name"]=="woostack-plan"; abort "missing source" unless y["description"].include?("`**Source:**` line"); puts "YAML_OK"'` -> `YAML_OK`.
- [ ] `git diff --check` -> no output.

### Manual

**Before merge**

- [ ] Review the new skill and template for consistency with the approved spec and with the existing woostack skill style.
- [ ] Confirm this PR remains standalone: it adds the skill asset only; routing/build/status/docs wiring follows in PR #211.

Spec: .woostack/specs/2026-06-05-woostack-plan.md
