### PR TITLE
refactor(woostack-build): use woostack-plan

### DIFF
--- a/.woostack/plans/2026-06-05-woostack-plan.md
+++ b/.woostack/plans/2026-06-05-woostack-plan.md
@@ -318,12 +318,12 @@ gt modify -c -m "feat(woostack-plan): add SKILL.md (plan phase, internalizes wri
 **Files:**
 - Modify: `skills/woostack-build/SKILL.md`
 
-- [ ] **Step 1: Write the failing checks**
+- [x] **Step 1: Write the failing checks**
 
 Run: `grep -n 'Dependency preflight\|superpowers:writing-plans\|→ writing-plans →' skills/woostack-build/SKILL.md`
 Expected (before the change): matches on the `## Dependency preflight` heading, the `superpowers:writing-plans` bullet, and the overview-diagram `→ writing-plans →` — all of which must be gone after.
 
-- [ ] **Step 2: Update the frontmatter description**
+- [x] **Step 2: Update the frontmatter description**
 
 Replace (line 3):
 
@@ -337,7 +337,7 @@ with:
 description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, harden the plan, ship the spec and plan as their own PR, then implement it. Chains woostack-ideate, woostack-harden, woostack-plan, woostack-commit, and woostack-execute in a fixed, gated order; writes markdown specs and plans under .woostack/.
 ```
 
-- [ ] **Step 3: Update the overview diagram**
+- [x] **Step 3: Update the overview diagram**
 
 Replace (the first line of the ``` fenced diagram, line 16):
 
@@ -351,7 +351,7 @@ with:
 ideate → write spec (markdown) → harden spec → approve spec → plan → decompose
 ```
 
-- [ ] **Step 4: Remove the entire Dependency preflight section**
+- [x] **Step 4: Remove the entire Dependency preflight section**
 
 Delete this whole block (the `## Dependency preflight` heading through the degraded-run paragraph, lines 35–49, including the blank line after it):
 
@@ -376,7 +376,7 @@ equivalent.
 
 Result: `## Overview` (and its trailing prose) is immediately followed by `## Procedure`. The build loop now has no external dependencies and nothing to preflight.
 
-- [ ] **Step 5: Rewrite step 4 (Plan) to invoke woostack-plan**
+- [x] **Step 5: Rewrite step 4 (Plan) to invoke woostack-plan**
 
 Replace step 4 (lines 79–84):
 
@@ -400,7 +400,7 @@ with:
    ships in this collection (no install), so the build loop has no external skill dependencies.
 ```
 
-- [ ] **Step 6: Reword step 5 (Decompose) — plan now owns decomposition**
+- [x] **Step 6: Reword step 5 (Decompose) — plan now owns decomposition**
 
 Replace step 5 (lines 85–91):
 
@@ -426,7 +426,7 @@ with:
    PRs.
 ```
 
-- [ ] **Step 7: Update the two hard-constraint references**
+- [x] **Step 7: Update the two hard-constraint references**
 
 Replace (in the "Always get explicit spec approval before planning" constraint, line 145):
 
@@ -453,12 +453,12 @@ with:
   execute phase advances the
 ```
 
-- [ ] **Step 8: Confirm the checks pass**
+- [x] **Step 8: Confirm the checks pass**
 
 Run: `grep -c 'Dependency preflight\|superpowers:writing-plans\|→ writing-plans →' skills/woostack-build/SKILL.md; grep -c 'woostack-plan' skills/woostack-build/SKILL.md`
 Expected: first count `0` (all three removed), second count `≥4` (description, step 4 link, step 4 prose, hard-constraint, status-constraint).
 
-- [ ] **Step 9: Commit (first commit of Increment 2 — creates its branch, stacked on Increment 1)**
+- [x] **Step 9: Commit (first commit of Increment 2 — creates its branch, stacked on Increment 1)**
 
 ```bash
 gt create -m "refactor(woostack-build): use woostack-plan, drop dependency preflight"
@@ -469,12 +469,12 @@ gt create -m "refactor(woostack-build): use woostack-plan, drop dependency prefl
 **Files:**
 - Modify: `skills/using-woostack/SKILL.md`
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 Run: `grep -c 'woostack-plan' skills/using-woostack/SKILL.md`
 Expected: `0`.
 
-- [ ] **Step 2: Insert the routing row**
+- [x] **Step 2: Insert the routing row**
 
 In the Command Routing table, insert a new row immediately **after** the `/woostack-build` row and **before** the `/woostack-execute` row. Replace:
 
@@ -491,12 +491,12 @@ with:
 | `/woostack-execute <plan-path> [--inline\|--subagent]`, execute an approved plan as PR-sized stacked increments (inline or subagent-driven) | `woostack-execute` |
 ```
 
-- [ ] **Step 3: Confirm the check passes**
+- [x] **Step 3: Confirm the check passes**
 
 Run: `grep -c '`/woostack-plan <spec-path>`.*`woostack-plan`' skills/using-woostack/SKILL.md`
 Expected: `1`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "docs(using-woostack): route /woostack-plan to woostack-plan"
@@ -507,12 +507,12 @@ gt modify -c -m "docs(using-woostack): route /woostack-plan to woostack-plan"
 **Files:**
 - Modify: `skills/woostack-ideate/SKILL.md:34`
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 Run: `grep -n 'Do not invoke `writing-plans`' skills/woostack-ideate/SKILL.md`
 Expected (before): matches line 34.
 
-- [ ] **Step 2: Update the example list**
+- [x] **Step 2: Update the example list**
 
 Replace (line 34):
 
@@ -526,12 +526,12 @@ with:
 - **Chain nothing.** Do not invoke `woostack-plan`, `woostack-execute`, or any implementation
 ```
 
-- [ ] **Step 3: Confirm the check passes**
+- [x] **Step 3: Confirm the check passes**
 
 Run: `grep -c 'Do not invoke `woostack-plan`, `woostack-execute`' skills/woostack-ideate/SKILL.md`
 Expected: `1`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "docs(woostack-ideate): reference woostack-plan in chain-nothing example"
@@ -544,7 +544,7 @@ gt modify -c -m "docs(woostack-ideate): reference woostack-plan in chain-nothing
 - Modify: `skills/woostack-status/scripts/status.sh:177`
 - Modify: `skills/woostack-status/scripts/status.sh:227`
 
-- [ ] **Step 1: Update the test assertion FIRST (red)**
+- [x] **Step 1: Update the test assertion FIRST (red)**
 
 Replace (in `test-status.sh`, line 62):
 
@@ -558,12 +558,12 @@ with:
 assert_contains "$OUT" "woostack-plan" "approved next-action"
 ```
 
-- [ ] **Step 2: Run the test, confirm it now FAILS**
+- [x] **Step 2: Run the test, confirm it now FAILS**
 
 Run: `bash skills/woostack-status/scripts/tests/test-status.sh`
 Expected: FAIL on the `approved next-action` assertion — the harness still emits `write the plan (writing-plans)`, so `"woostack-plan"` is not found in `$OUT`.
 
-- [ ] **Step 3: Update status.sh next-action string (green)**
+- [x] **Step 3: Update status.sh next-action string (green)**
 
 Replace (line 177):
 
@@ -577,7 +577,7 @@ with:
     approved)   echo "write the plan (woostack-plan)" ;;
 ```
 
-- [ ] **Step 4: Update status.sh no-plan flag string**
+- [x] **Step 4: Update status.sh no-plan flag string**
 
 Replace (line 227):
 
@@ -591,12 +591,12 @@ with:
     case "$phase" in draft|hardened|approved|abandoned) : ;; *) flag "$name: no plan resolves to this spec (woostack-plan)" ;; esac
 ```
 
-- [ ] **Step 5: Run the test, confirm it PASSES; lint the script**
+- [x] **Step 5: Run the test, confirm it PASSES; lint the script**
 
 Run: `bash skills/woostack-status/scripts/tests/test-status.sh && bash -n skills/woostack-status/scripts/status.sh && echo OK`
 Expected: the test suite passes (including `approved next-action`) and `OK` prints (no syntax errors).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 gt modify -c -m "fix(woostack-status): point plan next-action at woostack-plan"
@@ -607,12 +607,12 @@ gt modify -c -m "fix(woostack-status): point plan next-action at woostack-plan"
 **Files:**
 - Modify: `AGENTS.md` (`.claude/CLAUDE.md` is a symlink — editing `AGENTS.md` updates both)
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 Run: `grep -n 'ten skills\|ten-skill command surface\|twelve `SKILL.md` files\|the ten public' AGENTS.md`
 Expected (before): matches the "ten skills" line, the "ten-skill command surface" line, and the "twelve `SKILL.md` files (the ten public …)" constraint.
 
-- [ ] **Step 2: Update the surface count and add woostack-plan to the list**
+- [x] **Step 2: Update the surface count and add woostack-plan to the list**
 
 Replace:
 
@@ -639,7 +639,7 @@ The public command/adoption surface has eleven skills:
 - [`woostack-execute`](skills/woostack-execute/SKILL.md)
 ```
 
-- [ ] **Step 3: Update the "ten-skill command surface" mention**
+- [x] **Step 3: Update the "ten-skill command surface" mention**
 
 Replace (in the internal-sub-skill paragraph):
 
@@ -657,7 +657,7 @@ surface above. Like [`action.yml`](action.yml), they are shipped assets — do n
 strays.
 ```
 
-- [ ] **Step 4: Add /woostack-plan to the Mode B command list**
+- [x] **Step 4: Add /woostack-plan to the Mode B command list**
 
 Replace (in the Mode B paragraph):
 
@@ -675,7 +675,7 @@ with:
 `/woostack-review`, `/woostack-address-comments`, `/woostack-status`, or `/woostack-visualize`,
 ```
 
-- [ ] **Step 5: Update the SKILL.md-count hard constraint**
+- [x] **Step 5: Update the SKILL.md-count hard constraint**
 
 Replace:
 
@@ -691,7 +691,7 @@ with:
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 ```
 
-- [ ] **Step 6: Add the woostack-plan Quick file map entry**
+- [x] **Step 6: Add the woostack-plan Quick file map entry**
 
 Replace:
 
@@ -713,12 +713,12 @@ with:
   [`skills/woostack-execute/SKILL.md`](skills/woostack-execute/SKILL.md)
 ```
 
-- [ ] **Step 7: Confirm the checks pass**
+- [x] **Step 7: Confirm the checks pass**
 
 Run: `grep -c 'eleven skills\|eleven-skill command surface\|thirteen `SKILL.md` files\|skills/woostack-plan/SKILL.md\|`/woostack-plan`' AGENTS.md; grep -c 'ten skills\|ten-skill command surface\|twelve `SKILL.md`' AGENTS.md`
 Expected: first count `≥5` (all new mentions present), second count `0` (no stale ten/twelve counts remain).
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 gt modify -c -m "docs(agents): add woostack-plan to surface (eleven public, thirteen SKILL.md)"
@@ -731,12 +731,12 @@ gt modify -c -m "docs(agents): add woostack-plan to surface (eleven public, thir
 - Modify: `README.md:62`
 - Modify: `README.md` (How it works — add a woostack-plan subsection before woostack-execute)
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 Run: `grep -c 'surface is ten skills\|woostack-plan' README.md`
 Expected: a match on `surface is ten skills` and `0` matches on `woostack-plan`.
 
-- [ ] **Step 2: Update the Install-section surface count and list**
+- [x] **Step 2: Update the Install-section surface count and list**
 
 Replace (line 29):
 
@@ -750,7 +750,7 @@ with:
 This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is eleven skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-plan, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, and woostack-visualize. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 ```
 
-- [ ] **Step 3: Update the build-loop sequencing prose**
+- [x] **Step 3: Update the build-loop sequencing prose**
 
 Replace (line 62):
 
@@ -764,7 +764,7 @@ with:
 It sequences woostack's own ideate, harden, plan, and execute phases (`woostack-ideate`, `woostack-harden`, `woostack-plan`, `woostack-execute`), inheriting the ideate design gate and hosting the relocated spec-approval gate before planning — the build loop has no external skill dependencies. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed (`woostack-review --fast`), and distilled. It ends on the reviewed PR stack. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
 ```
 
-- [ ] **Step 4: Add a `/woostack-plan` command subsection**
+- [x] **Step 4: Add a `/woostack-plan` command subsection**
 
 Insert a new subsection immediately **before** the `### `/woostack-execute <plan-path>`: run a plan as stacked PRs` heading. Replace:
 
@@ -782,12 +782,12 @@ Writes a comprehensive implementation plan for an approved markdown spec from `.
 ### `/woostack-execute <plan-path>`: run a plan as stacked PRs
 ```
 
-- [ ] **Step 5: Confirm the checks pass**
+- [x] **Step 5: Confirm the checks pass**
 
 Run: `grep -c 'is eleven skills\|woostack-plan <spec-path>`: write a plan\|`woostack-plan`' README.md; grep -c 'is ten skills\|proven superpowers `writing-plans`' README.md`
 Expected: first count `≥3` (new count, new subsection, prose mention), second count `0` (stale count and the writing-plans dependency phrasing gone).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 gt modify -c -m "docs(readme): document woostack-plan; eleven public skills, no external deps"
@@ -799,12 +799,12 @@ gt modify -c -m "docs(readme): document woostack-plan; eleven public skills, no 
 - Modify: `CONTRIBUTING.md:3`
 - Modify: `CONTRIBUTING.md` (What to change table — add plan row)
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 Run: `grep -c 'woostack-plan' CONTRIBUTING.md`
 Expected: `0`.
 
-- [ ] **Step 2: Add woostack-plan to the surface sentence**
+- [x] **Step 2: Add woostack-plan to the surface sentence**
 
 Replace (line 3):
 
@@ -818,7 +818,7 @@ with:
 This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-plan`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, and `woostack-visualize`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
 ```
 
-- [ ] **Step 3: Add the "Change the plan phase" row**
+- [x] **Step 3: Add the "Change the plan phase" row**
 
 In the "What to change" table, insert a new row immediately **after** the harden-phase row and **before** the execute-phase row. Replace:
 
@@ -835,12 +835,12 @@ with:
 | Change the execute phase (the build loop's implementation step) | `skills/woostack-execute/SKILL.md` |
 ```
 
-- [ ] **Step 4: Confirm the check passes**
+- [x] **Step 4: Confirm the check passes**
 
 Run: `grep -c 'woostack-plan' CONTRIBUTING.md`
 Expected: `2` (the surface sentence and the new table row).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs(contributing): list woostack-plan and its change-here row"
@@ -851,22 +851,22 @@ gt modify -c -m "docs(contributing): list woostack-plan and its change-here row"
 **Files:**
 - Verify only (no new edits unless a stray is found).
 
-- [ ] **Step 1: Confirm no stale writing-plans wiring remains**
+- [x] **Step 1: Confirm no stale writing-plans wiring remains**
 
 Run: `grep -rn 'writing-plans\|superpowers:writing' skills/ AGENTS.md README.md CONTRIBUTING.md action.yml .github/ | grep -v '.woostack/'`
 Expected: the **only** remaining match is the single lineage-credit line inside `skills/woostack-plan/SKILL.md` ("It internalizes `superpowers:writing-plans` …"), exactly as `woostack-execute/SKILL.md` still credits `executing-plans`. No matches in `woostack-build`, `status.sh`, `test-status.sh`, `using-woostack`, `woostack-ideate`, README, CONTRIBUTING, or AGENTS.md. If anything else matches, fix it.
 
-- [ ] **Step 2: Confirm the surface counts agree everywhere**
+- [x] **Step 2: Confirm the surface counts agree everywhere**
 
 Run: `grep -rn 'eleven skills\|eleven-skill\|thirteen `SKILL.md`\|is eleven skills' AGENTS.md README.md; grep -rn 'ten skills\|ten-skill\|twelve `SKILL.md`' AGENTS.md README.md CONTRIBUTING.md`
 Expected: the first grep shows the eleven/thirteen counts present in AGENTS.md and README; the second grep returns nothing (no stale ten/twelve counts anywhere).
 
-- [ ] **Step 3: Re-run the status test and lint all touched scripts**
+- [x] **Step 3: Re-run the status test and lint all touched scripts**
 
 Run: `bash skills/woostack-status/scripts/tests/test-status.sh && bash -n skills/woostack-status/scripts/status.sh && echo ALL_GREEN`
 Expected: the suite passes and `ALL_GREEN` prints.
 
-- [ ] **Step 4: Commit (only if Step 1 surfaced a stray to fix; otherwise skip)**
+- [x] **Step 4: Commit (only if Step 1 surfaced a stray to fix; otherwise skip)**
 
 ```bash
 gt modify -c -m "docs: sweep stray writing-plans references"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,12 +13,13 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `npx skills add howarewoo/woostack`.
 
-The public command/adoption surface has ten skills:
+The public command/adoption surface has eleven skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
 - [`woostack-bootstrap`](skills/woostack-bootstrap/SKILL.md)
 - [`woostack-build`](skills/woostack-build/SKILL.md)
+- [`woostack-plan`](skills/woostack-plan/SKILL.md)
 - [`woostack-execute`](skills/woostack-execute/SKILL.md)
 - [`woostack-commit`](skills/woostack-commit/SKILL.md)
 - [`woostack-review`](skills/woostack-review/SKILL.md)
@@ -30,7 +31,7 @@ The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the ten-skill command
+`/woostack-*` commands: they have no routing row and are absent from the eleven-skill command
 surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
@@ -51,7 +52,7 @@ docs, HTML templates, review scripts, prompts, or JSON config. Keep edits in ski
 do not add application code, app build configs, or app lockfiles.
 
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
-`/woostack-bootstrap`, `/woostack-build`, `/woostack-execute`, `/woostack-commit`,
+`/woostack-bootstrap`, `/woostack-build`, `/woostack-plan`, `/woostack-execute`, `/woostack-commit`,
 `/woostack-review`, `/woostack-address-comments`, `/woostack-status`, or `/woostack-visualize`,
 including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
@@ -75,7 +76,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the twelve `SKILL.md` files (the ten public command/adoption
+- Do not move or rename any of the thirteen `SKILL.md` files (the eleven public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -91,6 +92,8 @@ directory, not in this repo.
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/)
 - Build loop:
   [`skills/woostack-build/SKILL.md`](skills/woostack-build/SKILL.md)
+- Plan-writing engine for the build loop (public command):
+  [`skills/woostack-plan/SKILL.md`](skills/woostack-plan/SKILL.md)
 - Plan-execution engine for the build loop (public command):
   [`skills/woostack-execute/SKILL.md`](skills/woostack-execute/SKILL.md)
 - Ideate phase engine for the build loop (internal sub-skill):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, and `woostack-visualize`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-plan`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, and `woostack-visualize`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 
@@ -21,6 +21,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Change the build loop (ideate→spec→harden→approve spec→plan→execute) | `skills/woostack-build/SKILL.md` |
 | Change the ideate phase (the build loop's first step) | `skills/woostack-ideate/SKILL.md` |
 | Change the harden phase (the build loop's stress-test step) | `skills/woostack-harden/SKILL.md` |
+| Change the plan phase (the build loop's planning step) | `skills/woostack-plan/SKILL.md` |
 | Change the execute phase (the build loop's implementation step) | `skills/woostack-execute/SKILL.md` |
 | Change the commit / PR update workflow | `skills/woostack-commit/SKILL.md` |
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is ten skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, and woostack-visualize. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is eleven skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-plan, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, and woostack-visualize. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 
@@ -59,11 +59,15 @@ A fixed, gated chain that drives one feature from idea to implementation:
 ideate → markdown spec → harden → approve spec → plan → execute (TDD) → reviewed PR stack
 ```
 
-It sequences woostack's own ideate, harden, and execute phases (`woostack-ideate`, `woostack-harden`, `woostack-execute`) with the proven superpowers `writing-plans` sub-skill, inheriting the ideate design gate and hosting the relocated spec-approval gate before planning. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed (`woostack-review --fast`), and distilled. It ends on the reviewed PR stack. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+It sequences woostack's own ideate, harden, plan, and execute phases (`woostack-ideate`, `woostack-harden`, `woostack-plan`, `woostack-execute`), inheriting the ideate design gate and hosting the relocated spec-approval gate before planning — the build loop has no external skill dependencies. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed (`woostack-review --fast`), and distilled. It ends on the reviewed PR stack. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+
+### `/woostack-plan <spec-path>`: write a plan from a spec
+
+Writes a comprehensive implementation plan for an approved markdown spec from `.woostack/specs/` — file-structure first, bite-sized TDD tasks with no placeholders, structured as PR-sized increments — saved frontmatter-free to `.woostack/plans/<spec-basename>.md` with an opening `**Source:**` line that joins it 1:1 to the spec, and sets the spec's `status: planning`. It is the plan phase `woostack-build` step 4 delegates to, and is usable standalone. Pairs with `woostack-execute` (produce-plan / consume-plan). Writes the plan and hands back; never executes or merges. → [SKILL.md](skills/woostack-plan/SKILL.md)
 
 ### `/woostack-execute <plan-path>`: run a plan as stacked PRs
 
-Executes an approved markdown plan from `.woostack/plans/` as a sequence of PR-sized, stacked increments — implementing each with TDD, ticking the plan's checkboxes in place, committing via `woostack-commit` on its own Graphite branch, reviewing it with `woostack-review --fast`, and distilling durable learnings — pausing only on a blocking review. One plan per spec, multiple PRs per plan. It is the execute phase `woostack-build` step 6 delegates to, and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute/SKILL.md)
+Executes an approved markdown plan from `.woostack/plans/` as a sequence of PR-sized, stacked increments — implementing each with TDD, ticking the plan's checkboxes in place, committing via `woostack-commit` on its own Graphite branch, reviewing it with `woostack-review --fast`, and distilling durable learnings — pausing only on a blocking review. One plan per spec, multiple PRs per plan. It is the execute phase `woostack-build` step 9 delegates to, and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute/SKILL.md)
 
 ### `/woostack-review [PR#]`: parallel review swarm
 

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -66,6 +66,7 @@ link it, never restate it.
 | `/woostack-init [path]`, initialize or repair the `.woostack/` workspace | `woostack-init` |
 | `/woostack-bootstrap <goal>`, scaffold a new web/mobile/API project | `woostack-bootstrap` |
 | `/woostack-build <goal>`, build a feature through the woostack loop | `woostack-build` |
+| `/woostack-plan <spec-path>`, write the implementation plan for an approved spec as PR-sized increments | `woostack-plan` |
 | `/woostack-execute <plan-path> [--inline\|--subagent]`, execute an approved plan as PR-sized stacked increments (inline or subagent-driven) | `woostack-execute` |
 | `/woostack-commit`, commit session-relevant changes and update PR fields | `woostack-commit` |
 | `/woostack-review [PR#]`, review a PR or local diff | `woostack-review` |

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-build
-description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, harden the plan, ship the spec and plan as their own PR, then implement it. Chains woostack-ideate, woostack-harden, woostack-commit, woostack-execute, and superpowers writing-plans in a fixed, gated order; writes markdown specs and plans under .woostack/.
+description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, harden the plan, ship the spec and plan as their own PR, then implement it. Chains woostack-ideate, woostack-harden, woostack-plan, woostack-commit, and woostack-execute in a fixed, gated order; writes markdown specs and plans under .woostack/.
 ---
 
 # woostack-build
@@ -13,7 +13,7 @@ adds exactly one of its own** — the execution handoff — because the plan→e
 belongs to no sub-skill. The value is the order and the handoffs.
 
 ```
-ideate → write spec (markdown) → harden spec → approve spec → writing-plans → decompose
+ideate → write spec (markdown) → harden spec → approve spec → plan → verify decomposition
   → harden plan → commit spec+plan as their own PR → stop before execute (handoff gate)
   → execute (per increment: implement → commit → review → distill) → reviewed PR stack
 ```
@@ -31,22 +31,6 @@ the spec harden feeds a gate (the spec-approval gate, step 3). The plan harden a
 in place and hands straight back, and committing the spec+plan PR (step 7) is a work step, not
 an approval stop. The execution-handoff gate (step 8) is build-owned, not harden-owned, and
 sits after that PR. So the chain has exactly the three hard gates above.
-
-## Dependency preflight
-
-The ideate, hardening (spec and plan), spec+plan-commit, and execution phases use
-[`woostack-ideate`](../woostack-ideate/SKILL.md),
-[`woostack-harden`](../woostack-harden/SKILL.md),
-[`woostack-commit`](../woostack-commit/SKILL.md), and
-[`woostack-execute`](../woostack-execute/SKILL.md), which ship in this collection — no install
-needed. Only the plan phase chains an external skill. At the start, check that it is installed:
-
-- `superpowers:writing-plans`
-
-If it is missing: name exactly what's missing and **offer to install it inline**
-(`pnpx skills add obra/superpowers`) and continue. If the user declines, fall back to
-following the skill's principle manually and **say so explicitly** — the run is degraded, not
-equivalent.
 
 ## Procedure
 
@@ -76,19 +60,19 @@ equivalent.
    it helps), wait for a clear yes, and make any requested changes before advancing. When the
    gate clears, set `status: approved`. Do **not** proceed to step 4 on inferred or assumed
    approval; silence is not a yes.
-4. **Plan.** Once the spec is approved, invoke `superpowers:writing-plans`, saving the plan as
-   **markdown** to
-   `.woostack/plans/YYYY-MM-DD-<slug>.md` (plans are working checklists, not visualization
-   artifacts). The plan **must open with** a `**Source:** .woostack/specs/<file>.md` line in
-   its first ~5 lines so the board joins it 1:1 to the spec; keep plans frontmatter-free. Set
-   the spec's `status: planning`.
-5. **Decompose to PR-sized increments.** Steer work toward well-scoped PRs of **preferably
-   ≤500 lines of code** — a soft target, not a gate. When the spec implies more than one
-   reviewable PR, structure the plan as a sequence of independently shippable increments and
-   run **one increment per build cycle**. Flag any slice that can't reasonably stay under the
-   target and propose a further split before executing. Genuinely atomic changes may exceed
-   the target. The `spec : plan : PRs = 1 : 1 : N` invariant holds throughout: exactly one
-   plan per spec, and that one plan owns the N increment PRs.
+4. **Plan.** Once the spec is approved, invoke
+   [`woostack-plan`](../woostack-plan/SKILL.md) with the approved spec path. It writes the
+   plan to `.woostack/plans/<spec-basename>.md` (same basename as the spec), opens with the
+   `**Source:** .woostack/specs/<file>.md` line so the board joins it 1:1, stays
+   frontmatter-free, structures it as PR-sized increments, and sets the spec's
+   `status: planning`. It writes the plan and hands back, owning no gate. `woostack-plan`
+   ships in this collection, so the build loop has no external skill dependencies.
+5. **Verify the increment decomposition.** `woostack-plan` already structures the plan as
+   PR-sized increments; build confirms the increment boundaries are reviewable, independently
+   shippable, and feed cleanly into `woostack-execute`. Flag any slice that is not reviewable
+   or independently shippable and propose a further split before executing. The
+   `spec : plan : PRs = 1 : 1 : N` invariant holds throughout: exactly one plan per spec, and
+   that one plan owns the N increment PRs.
 6. **Harden the plan.** Invoke [`woostack-harden`](../woostack-harden/SKILL.md) again, this
    time against the plan and its increment breakdown — stress-test the sequencing, the
    increment boundaries, and the verifications until hardening stops producing new questions.
@@ -142,7 +126,7 @@ equivalent.
   separate and build-owned, not a plan-*quality* gate; never turn the plan harden into a
   plan-approval gate.
 - **Always get explicit spec approval before planning.** After the spec harden, present the
-  written spec and wait for the user's clear yes. Never advance to `writing-plans` on assumed
+  written spec and wait for the user's clear yes. Never advance to `woostack-plan` on assumed
   or inferred approval.
 - **Markdown specs and plans, under `.woostack/`.** Never write specs to the superpowers
   default location. HTML is a render-on-demand target only, not the authored format.
@@ -154,9 +138,9 @@ equivalent.
 - **Never merge.** build ends on the terminal state (handoff PR, or reviewed stack), nothing
   further.
 - **Author `status:` through the loop.** Set the spec's `status:` at each step — `draft` (step
-  2), `hardened` then `approved` (step 3), `planning` (step 4); the execute phase advances the
-  `executing`/`in-review` band, which the board also computes from artifacts. The phase enum
-  and the `spec : plan : PRs = 1 : 1 : N` join contracts are defined once in
+  2), `hardened` then `approved` (step 3), `planning` (step 4, authored by woostack-plan); the
+  execute phase advances the `executing`/`in-review` band, which the board also computes from
+  artifacts. The phase enum and the `spec : plan : PRs = 1 : 1 : N` join contracts are defined once in
   [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) —
   link it, never restate it.
 - **One increment per cycle.** Do not let a single build cycle balloon past a reviewable PR.

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -31,7 +31,7 @@ The skill ends the moment the user approves the design. At that point:
 
 - **Write nothing.** Do not create a spec file, a plan, or any artifact. The approved design
   lives in the conversation.
-- **Chain nothing.** Do not invoke `writing-plans`, `woostack-execute`, or any implementation
+- **Chain nothing.** Do not invoke `woostack-plan`, `woostack-execute`, or any implementation
   skill yourself.
 - **Hand back.** State that the design is approved and name the next step:
   - Inside `woostack-build`: its **step 2** captures this design as a markdown spec under

--- a/skills/woostack-status/scripts/status.sh
+++ b/skills/woostack-status/scripts/status.sh
@@ -174,8 +174,8 @@ next_action() {
   case "$1" in
     draft)      echo "run grill-me on the spec" ;;
     hardened)   echo "get spec approval (hard gate)" ;;
-    approved)   echo "write the plan (writing-plans)" ;;
-    planning)   echo "decompose to increments, then execute" ;;
+    approved)   echo "write the plan (woostack-plan)" ;;
+    planning)   echo "harden plan, then open spec+plan PR" ;;
     executing)  if [ "${5:-0}" -gt 0 ]; then echo "finish plan ($2/$3); $4/$5 increments shipped";
                 else echo "finish plan ($2/$3) - open first increment PR"; fi ;;
     in-review)  echo "address comments / merge when green" ;;
@@ -224,7 +224,7 @@ for f in "${specs[@]}"; do
   while IFS= read -r ln; do [ -n "$ln" ] && plans+=("$ln"); done < <(plan_for "$f")
   plan_cell="-"; done=0; total=0; planfile=""
   if [ "${#plans[@]}" -eq 0 ]; then
-    case "$phase" in draft|hardened|approved|abandoned) : ;; *) flag "$name: no plan resolves to this spec (writing-plans)" ;; esac
+    case "$phase" in draft|hardened|approved|abandoned) : ;; *) flag "$name: no plan resolves to this spec (woostack-plan)" ;; esac
   elif [ "${#plans[@]}" -ge 2 ]; then
     flag "$name: ${#plans[@]} plans resolve to this spec - spec<->plan must be 1:1"
     planfile="${plans[0]}"

--- a/skills/woostack-status/scripts/tests/test-status.sh
+++ b/skills/woostack-status/scripts/tests/test-status.sh
@@ -59,7 +59,7 @@ assert_contains "$OUT" "alpha" "alpha row present"
 assert_contains "$OUT" "draft" "alpha phase shown"
 assert_contains "$OUT" "run grill-me" "draft next-action"
 assert_contains "$OUT" "get spec approval" "hardened next-action"
-assert_contains "$OUT" "writing-plans" "approved next-action"
+assert_contains "$OUT" "woostack-plan" "approved next-action"
 assert_not_contains "$OUT" "orphan-design" "html spec is ignored"
 
 p="$(mktemp -d)/.woostack"
@@ -67,6 +67,7 @@ mkspec "$p" delta planning feature/delta
 mkplan "$p" delta 2026-06-01-delta.md 3 7
 run_status "$p"
 assert_contains "$OUT" "3/10" "plan progress counted"
+assert_contains "$OUT" "harden plan, then open spec+plan PR" "planning next-action"
 legacy="$(mktemp -d)/.woostack"
 mkspec "$legacy" legacy planning feature/legacy
 mkdir -p "$legacy/plans"


### PR DESCRIPTION
## Goal

Wire the standalone woostack-plan command into the woostack build loop and public command surfaces so planning is first-party and the build loop no longer depends on external writing-plans.

## Summary

- Rewires `woostack-build` to invoke `woostack-plan`, verify its increment decomposition, and drop the old dependency preflight.
- Adds `/woostack-plan` routing and public-surface documentation across `using-woostack`, `AGENTS.md`, `README.md`, and `CONTRIBUTING.md`.
- Updates ideate wording and status-board next actions/tests from `writing-plans` to `woostack-plan`, including the planning-phase next action.
- Ticks the implementation plan through the completed wiring and sweep tasks.

## Test plan

### Automated

- [ ] `bash skills/woostack-status/scripts/tests/test-status.sh && bash -n skills/woostack-status/scripts/status.sh && echo ALL_GREEN` -> `59 passed, 0 failed`, `ALL_GREEN`.
- [ ] `grep -rn 'writing-plans\|superpowers:writing' skills/ AGENTS.md README.md CONTRIBUTING.md action.yml .github/ | grep -v '.woostack/' || true` -> only `skills/woostack-plan/SKILL.md` lineage-credit line remains.
- [ ] `grep -rn 'eleven skills\|eleven-skill\|thirteen `SKILL.md`\|is eleven skills' AGENTS.md README.md; grep -rn 'ten skills\|ten-skill\|twelve `SKILL.md`' AGENTS.md README.md CONTRIBUTING.md || true` -> expected eleven/thirteen hits, no stale ten/twelve hits.
- [ ] `ruby -e 'require "yaml"; Dir["skills/*/SKILL.md"].sort.each { |f| YAML.safe_load(File.read(f).split(/^---\s*$/)[1]) }; puts "SKILL_YAML_OK #{Dir["skills/*/SKILL.md"].size}"'` -> `SKILL_YAML_OK 13`.
- [ ] `git diff --check` -> no output.

### Manual

**Before merge**

- [ ] Review `/woostack-plan` references across command routing, README, CONTRIBUTING, AGENTS, and the build/status skills for consistent command naming and counts.
- [ ] Confirm PR #211 stacks on PR #210 and leaves the new skill asset PR independently reviewable.

Spec: .woostack/specs/2026-06-05-woostack-plan.md
