### PR TITLE
refactor(review): promote tier→model table to shared model-tiers.md

### DIFF
--- a/.woostack/plans/2026-06-05-execute-vary-subagent-model.md
+++ b/.woostack/plans/2026-06-05-execute-vary-subagent-model.md
@@ -2,7 +2,7 @@
 
 **Source:** .woostack/specs/2026-06-05-execute-vary-subagent-model.md
 
-> **For agentic workers:** execute this plan with `/woostack-execute .woostack/plans/2026-06-05-execute-vary-subagent-model.md` — woostack-execute drives it as PR-sized stacked increments (one `woostack-commit` per increment, no per-task commit). Steps use checkbox (`- [ ]`) syntax for tracking. This is a skill-collection (Markdown + Bash) change with **no app test runner**: every "test" is a concrete `grep` / link-check / `load-prompt.sh` dry-run, substituted for TDD per the inline-driver rule.
+> **For agentic workers:** execute this plan with `/woostack-execute .woostack/plans/2026-06-05-execute-vary-subagent-model.md` — woostack-execute drives it as PR-sized stacked increments (one `woostack-commit` per increment, no per-task commit). Steps use checkbox (`- [x]`) syntax for tracking. This is a skill-collection (Markdown + Bash) change with **no app test runner**: every "test" is a concrete `grep` / link-check / `load-prompt.sh` dry-run, substituted for TDD per the inline-driver rule.
 
 **Goal:** Make subagent-mode `woostack-execute` vary the per-task model (quality/speed/cost) by operationalizing tier→model dispatch and adding a signal→tier heuristic, on one shared tier mapping that also de-duplicates the four copies in `woostack-review`.
 
@@ -34,7 +34,7 @@
 **Files:**
 - Test (scratch): `/tmp/woo-tiers-baseline.txt`
 
-- [ ] **Step 1: Capture today's composed prompt containing the table**
+- [x] **Step 1: Capture today's composed prompt containing the table**
 
 Run (from repo root):
 
@@ -63,7 +63,7 @@ check (no extraction needed). If `load-prompt.sh` needs more env, add the missin
 **Files:**
 - Create: `skills/using-woostack/references/model-tiers.md`
 
-- [ ] **Step 1: Write the canonical shared doc**
+- [x] **Step 1: Write the canonical shared doc**
 
 Create `skills/using-woostack/references/model-tiers.md` with exactly:
 
@@ -115,7 +115,7 @@ Each consumer binds these to its own surface. For example `woostack-review` bind
 keep it in sync with this table).
 ````
 
-- [ ] **Step 2: Verify the doc exists with all three tiers per provider**
+- [x] **Step 2: Verify the doc exists with all three tiers per provider**
 
 Run:
 
@@ -135,7 +135,7 @@ Expected: `OK`.
 **Files:**
 - Modify: `skills/woostack-review/prompts/_header.md:53-75`
 
-- [ ] **Step 1: Replace the whole `## Model Tiers (host-agnostic)` section**
+- [x] **Step 1: Replace the whole `## Model Tiers (host-agnostic)` section**
 
 Replace the block that currently starts at `## Model Tiers (host-agnostic)` (line 53) and runs
 through the per-repo-tier-overrides paragraph ending `…still win over per-repo and table defaults.`
@@ -162,7 +162,7 @@ bound to review's surface: `FORCE_TIER` (Review Context) → `inputs.model` (act
 > The review-pipeline `## Per-repo Config (/tmp/pr-review/config.json)` section that follows
 > (currently line 77+) is review plumbing, not tier vocab — **leave it unchanged.**
 
-- [ ] **Step 2: Verify `_header.md` links the shared doc, holds the marker, and no longer embeds the table**
+- [x] **Step 2: Verify `_header.md` links the shared doc, holds the marker, and no longer embeds the table**
 
 Run:
 
@@ -181,7 +181,7 @@ Expected: `OK` (links shared doc, has the marker, table rows gone from the sourc
 **Files:**
 - Modify: `skills/woostack-review/scripts/load-prompt.sh` (compose step ~163; `default_model_for()` ~56)
 
-- [ ] **Step 1: Add the inline step before the compose line**
+- [x] **Step 1: Add the inline step before the compose line**
 
 Find (line ~163):
 
@@ -216,7 +216,7 @@ PROMPT_CONTENT=$(printf '%s\n\n%s\n\n%s\n' "$CONTEXT_HEAD" "$HEADER_INLINED" "$(
 > expanded replacement are data, not delimiters. If a future host's bash chokes on a very large
 > replacement, the drop-in fallback is `awk -v tf="$TIERS_FILE" '/WOO_MODEL_TIERS_TABLE/{while((getline l<tf)>0)print l;next}1'` over `$HEADER_FILE`.
 
-- [ ] **Step 2: Add the sync comment above `default_model_for()`**
+- [x] **Step 2: Add the sync comment above `default_model_for()`**
 
 Find (line ~56):
 
@@ -232,7 +232,7 @@ Insert immediately above it:
 default_model_for() {
 ```
 
-- [ ] **Step 3: Verify the script still parses**
+- [x] **Step 3: Verify the script still parses**
 
 Run: `bash -n skills/woostack-review/scripts/load-prompt.sh && echo OK`
 Expected: `OK`.
@@ -244,7 +244,7 @@ Expected: `OK`.
 **Files:**
 - Modify: `skills/woostack-review/prompts/anthropic.md:46-71`
 
-- [ ] **Step 1: Replace the table + resolution prose, keep the MUST-pass discipline + example**
+- [x] **Step 1: Replace the table + resolution prose, keep the MUST-pass discipline + example**
 
 Replace lines 46–52 (the `Then resolve via the **Model Tiers** table in _header.md:` line through
 the embedded 3-row table ending `| deep | claude-opus-4-7 | skeptical validator |`) with:
@@ -256,7 +256,7 @@ and inlined into `_header.md` above (Anthropic column: `fast` → `claude-haiku-
 `standard` → `claude-sonnet-4-6`, `deep` → `claude-opus-4-7`).
 ```
 
-- [ ] **Step 2: Repoint the "tier table above" back-reference**
+- [x] **Step 2: Repoint the "tier table above" back-reference**
 
 In the `Resolution rule per spawn:` list (line ~69), change:
 
@@ -274,7 +274,7 @@ to:
 > concrete `Task({…model:…})` example), 70–71 (the per-repo override `jq` + pass-the-slug rule),
 > and 73 (validator-Opus rule) **unchanged** — they are the Anthropic runtime binding.
 
-- [ ] **Step 3: Verify anthropic.md no longer embeds the table and links the shared doc**
+- [x] **Step 3: Verify anthropic.md no longer embeds the table and links the shared doc**
 
 Run:
 
@@ -293,7 +293,7 @@ Expected: `OK` (links shared doc, embedded table row gone, MUST-pass discipline 
 **Files:**
 - Modify: `skills/woostack-review/prompts/opencode.md:17`
 
-- [ ] **Step 1: Repoint the "table in _header.md" reference**
+- [x] **Step 1: Repoint the "table in _header.md" reference**
 
 Change line 17:
 
@@ -312,7 +312,7 @@ inlined into `_header.md` above); the OpenRouter column is:
 > Leave lines 19–25 (the three `fast/standard/deep` → DeepSeek slugs, the `reasoning_effort`
 > note, and the per-repo override `jq` precedence) **unchanged** — that is the OpenRouter binding.
 
-- [ ] **Step 2: Verify opencode.md links the shared doc**
+- [x] **Step 2: Verify opencode.md links the shared doc**
 
 Run:
 
@@ -329,7 +329,7 @@ Expected: `OK` (links shared doc; keeps its OpenRouter binding slugs).
 
 **Files:** _(verification only)_
 
-- [ ] **Step 1: Re-compose the prompt and assert the table text survives inlining**
+- [x] **Step 1: Re-compose the prompt and assert the table text survives inlining**
 
 Run (same env as Task 1.0):
 
@@ -346,7 +346,7 @@ Expected: `exit=0` and slug count **≥ 3** in the **post-edit** composed prompt
 replaced with the inlined shared table). Compare to the Task 1.0 baseline (~16) — output
 neutrality holds. Grep the raw `$GITHUB_OUTPUT` file directly (no `sed` extraction).
 
-- [ ] **Step 2: Assert fail-loud when the shared doc is missing**
+- [x] **Step 2: Assert fail-loud when the shared doc is missing**
 
 Run:
 
@@ -361,7 +361,7 @@ mv /tmp/mt.bak skills/using-woostack/references/model-tiers.md
 
 Expected: prints an `::error::shared model-tiers doc not found` line and `exit=1` (non-zero).
 
-- [ ] **Step 3: Dedup grep — no review prompt embeds the table or claims it lives in `_header.md`**
+- [x] **Step 3: Dedup grep — no review prompt embeds the table or claims it lives in `_header.md`**
 
 Run:
 
@@ -372,7 +372,7 @@ Run:
 
 Expected: `OK` (no embedded tier table rows remain in review prompts; no stale "table in `_header.md`" locator).
 
-- [ ] **Step 4: Mirror-sync — `default_model_for()` Anthropic slugs equal the shared doc column**
+- [x] **Step 4: Mirror-sync — `default_model_for()` Anthropic slugs equal the shared doc column**
 
 Run:
 
@@ -386,7 +386,7 @@ done; echo done
 
 Expected: `done` with no `DRIFT` line.
 
-- [ ] **Step 5: Commit the increment**
+- [x] **Step 5: Commit the increment**
 
 Use [`woostack-commit`](../../skills/woostack-commit/SKILL.md) on this increment's Graphite-stacked
 branch (base = the spec+plan PR). PR title e.g. `refactor(review): promote tier→model table to shared model-tiers.md`. Body: the goal, the deep-dedup summary, and the output-neutral evidence from Steps 1–4 as the test plan.

--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -1,0 +1,45 @@
+# Model Tiers (shared, host-agnostic)
+
+Canonical tier→model mapping for the woostack collection. Both `woostack-review` (angle workers +
+validator) and `woostack-execute` (subagent driver) resolve tiers through this file. Each consumer
+keeps only its own **runtime bindings** (env vars, config paths, dispatch calls) and points at the
+precedence rules below — there is no second copy of this table.
+
+Tiers are `fast | standard | deep`. A prompt or template declares a `tier:` in frontmatter; the
+host resolves it to a concrete model via the table. The context/summary helper subagent is
+implicitly `fast`.
+
+| Tier | Use for | Anthropic | OpenAI (Codex) | Google (Gemini) | OpenRouter |
+|---|---|---|---|---|---|
+| `fast` | rubric checklists, mechanical fully-specified 1–2-file tasks, context summaries | `claude-haiku-4-5` | `gpt-5.3-codex-spark` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
+| `standard` | reasoning workers, multi-file integration | `claude-sonnet-4-6` | `gpt-5.4` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
+| `deep` | skeptical validation, design/architecture judgment, code-quality review | `claude-opus-4-7` | `gpt-5.5` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
+
+> **Provider notes:**
+> - **Google** currently ships only `gemini-3-5-flash` in the 3.5 line; no Pro/Ultra/Thinking variant exists yet, so all tiers collapse onto flash (tier routing is effectively a no-op until Google releases a larger model).
+> - **OpenAI** GPT-5-family reasoning is a parameter on the same slug, not a slug suffix. Use `gpt-5.5` for complex review and the skeptical validator, `gpt-5.4` for everyday coding review, and `gpt-5.3-codex-spark` for simple/cost-sensitive rubric workers and latency-first real-time coding checks. Use `gpt-5.4-mini` only as the non-Spark cost-sensitive fallback when Spark is unavailable. There is no `gpt-5-pro`.
+> - **OpenRouter** DeepSeek exposes exactly two slugs — `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-pro`. Reasoning is a `reasoning_effort` parameter (`high` / `xhigh`, where `xhigh` maps to max). Use plain `v4-pro` for standard and `v4-pro` with `reasoning_effort: xhigh` for deep. Do not route to `deepseek-r1` — V4 supersedes it.
+
+## Routing by host capability (generic)
+
+- **Per-call routing** (Claude Code `Task`, opencode `@subagent`): resolve the effective tier =
+  a forced tier if the host sets one, else the prompt's own `tier:` frontmatter; map it to the
+  column for the active provider; **pass that model on every spawn.**
+- **Single model per session** (Codex Action, Gemini CLI): resolve one run model up front;
+  per-tier behavior collapses onto that one model for the whole job.
+
+## Override precedence (generic)
+
+When a host supports per-repo / per-run overrides, resolve highest-precedence first:
+
+1. **Forced tier** — a one-run tier override.
+2. **Explicit model** — an explicit model-id input.
+3. **Per-provider per-tier** override key.
+4. **Flat per-tier** override key.
+5. **Table default** (above).
+
+Each consumer binds these to its own surface. For example `woostack-review` binds them to
+`FORCE_TIER` (Review Context) › `inputs.model` (action.yml) › `models.<provider>.<tier>` /
+`models.<tier>` in `/tmp/pr-review/config.json`, resolved by `scripts/load-prompt.sh`
+(`default_model_for()` is the Bash mirror of the Anthropic/OpenAI/Google/OpenRouter columns —
+keep it in sync with this table).

--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -52,27 +52,19 @@ export HEAD_SHA
 
 ## Model Tiers (host-agnostic)
 
-Each angle prompt and the validator declare a `tier:` in frontmatter — `fast`, `standard`, or `deep`. The host/runner resolves the tier to a concrete model from the table below. The context+summary subagent (defined in each provider prompt) is implicitly `fast`.
+The canonical tier→model table, provider notes, and generic routing/precedence rules live in the
+shared reference [`../../using-woostack/references/model-tiers.md`](../../using-woostack/references/model-tiers.md)
+— one source, shared by woostack-review and woostack-execute. The loader **inlines** it here so
+single-prompt runners stay self-contained:
 
-| Tier | Use for | Anthropic | OpenAI (Codex) | Google (Gemini) | OpenRouter |
-|---|---|---|---|---|---|
-| `fast` | rubric checklists (`seo`, `aeo`, `observability`, `types`, `i18n`, `docs`, `deps`), context summaries | `claude-haiku-4-5` | `gpt-5.3-codex-spark` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
-| `standard` | reasoning workers (`bugs`, `security`, `architecture`, `design`, `react`, `database`, `tests`, `api`, `infra`, `skills`) | `claude-sonnet-4-6` | `gpt-5.4` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
-| `deep` | skeptical validator (highest-leverage filter) | `claude-opus-4-7` | `gpt-5.5` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
+<!-- WOO_MODEL_TIERS_TABLE -->
 
-> **Provider notes:**
-> - **Google** currently ships only `gemini-3-5-flash` in the 3.5 line; no Pro/Ultra/Thinking variant exists yet, so all tiers collapse onto flash (tier routing is effectively a no-op until Google releases a larger model).
-> - **OpenAI** GPT-5-family reasoning is a parameter on the same slug, not a slug suffix. Use `gpt-5.5` for complex review and the skeptical validator, `gpt-5.4` for everyday coding review, and `gpt-5.3-codex-spark` for simple/cost-sensitive rubric workers and latency-first real-time coding checks. Use `gpt-5.4-mini` only as the non-Spark cost-sensitive fallback when Spark is unavailable. There is no `gpt-5-pro`.
-> - **OpenRouter** DeepSeek exposes exactly two slugs — `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-pro`. Reasoning is a `reasoning_effort` parameter (`high` / `xhigh`, where `xhigh` maps to max). Use plain `v4-pro` for standard and `v4-pro` with `reasoning_effort: xhigh` for deep. Do not route to `deepseek-r1` — V4 supersedes it.
-
-**Routing rules by host capability:**
-
-- **Per-call routing supported** (Claude Code `Task`, opencode `@subagent`): if `FORCE_TIER` is set in Review Context (`fast` or `deep`), use that as the effective tier for all routed calls first; otherwise use each prompt's own tier. Then apply provider overrides and table defaults.
-- **Single model per session** (Codex Action, Gemini CLI): resolve one run model from `run_model` in Load Prompt (which already applies precedence below). You lose per-angle tier behavior; all calls in the session run that one model.
-- **Override**: explicit `FORCE_TIER` and `run_model` win before per-repo/per-tier overrides. `run_model` already incorporates action input `model` when no `FORCE_TIER` override applies.
-
-**Per-repo tier overrides (`.woostack/config.json`):** for per-call hosts, resolve effective tier as `FORCE_TIER` if set, else prompt `tier`. Then apply provider overrides from `/tmp/pr-review/config.json`: prefer provider-specific keys first, then flat tier fallbacks: `models.<provider>.<tier>` > `models.<tier>` > table default. Example for OpenAI deep: `jq -r '.models.openai.deep // .models.deep // empty' /tmp/pr-review/config.json` — empty means use the table default.
-`inputs.model` (action.yml) and `run_model` (resolved in load-prompt) still win over per-repo and table defaults.
+**Review's tier-resolution binding.** Resolve the effective tier per the shared doc's precedence,
+bound to review's surface: `FORCE_TIER` (Review Context) → `inputs.model` (action.yml) →
+`models.<provider>.<tier>` / `models.<tier>` in `/tmp/pr-review/config.json` → table default.
+`run_model` (resolved in `load-prompt.sh`) pins single-session hosts; explicit `FORCE_TIER` and
+`run_model` win before per-repo/per-tier overrides. The context+summary subagent is implicitly
+`fast`.
 
 ## Per-repo Config (`/tmp/pr-review/config.json`)
 

--- a/skills/woostack-review/prompts/anthropic.md
+++ b/skills/woostack-review/prompts/anthropic.md
@@ -43,13 +43,10 @@ Claude Code's `Task` tool supports per-subagent model routing. Resolve each spaw
 2. Otherwise the angle prompt `tier:` frontmatter.
 3. Then per-repo overrides and table defaults in `_header.md`.
 
-Then resolve via the **Model Tiers** table in `_header.md`:
-
-| Tier | Anthropic model | Used for |
-|---|---|---|
-| `fast` | `claude-haiku-4-5` | context+summary, `seo`, `aeo`, `observability`, `types`, `i18n`, `docs`, `deps` |
-| `standard` | `claude-sonnet-4-6` | `bugs`, `security`, `architecture`, `design`, `react`, `database`, `tests`, `api`, `infra`, `skills` |
-| `deep` | `claude-opus-4-7` | skeptical validator |
+Then resolve via the shared **Model Tiers** table — canonical at
+[`../../using-woostack/references/model-tiers.md`](../../using-woostack/references/model-tiers.md)
+and inlined into `_header.md` above (Anthropic column: `fast` → `claude-haiku-4-5`,
+`standard` → `claude-sonnet-4-6`, `deep` → `claude-opus-4-7`).
 
 **Every Task/Agent spawn MUST pass `model:` explicitly.** Omitting it makes the subagent inherit the parent session's model — typically Opus — which silently defeats tier routing and burns ~5x the tokens on rubric angles. The `tier:` frontmatter is informational unless the spawning call passes the resolved slug.
 
@@ -66,7 +63,7 @@ Task({
 
 Resolution rule per spawn:
 1. Determine effective tier.
-2. Look up the Anthropic column in the tier table above.
+2. Look up the Anthropic column in the shared Model Tiers table (inlined in `_header.md` above).
 3. **Per-repo override**: check `$OUTDIR/config.json` for `models.anthropic.<effective_tier>`, then flat `models.<effective_tier>` (e.g. when `run_tier=deep`: `jq -r '.models.anthropic.deep // .models.deep // empty' $OUTDIR/config.json`). If non-empty, use that slug instead of the table value.
 4. Pass the resolved slug as `model:` on the Task call.
 

--- a/skills/woostack-review/prompts/opencode.md
+++ b/skills/woostack-review/prompts/opencode.md
@@ -14,7 +14,9 @@ OpenCode + OpenRouter can route per-subagent if the OpenCode runtime supports it
 1. `FORCE_TIER` in Review Context (`fast`/`deep`) when present.
 2. Otherwise the angle/validator `tier:` frontmatter.
 
-Then resolve that effective tier via the **Model Tiers** table in `_header.md`:
+Then resolve that effective tier via the shared **Model Tiers** table (canonical at
+[`../../using-woostack/references/model-tiers.md`](../../using-woostack/references/model-tiers.md),
+inlined into `_header.md` above); the OpenRouter column is:
 
 - `fast` → `openrouter/deepseek/deepseek-v4-flash`
 - `standard` → `openrouter/deepseek/deepseek-v4-pro`

--- a/skills/woostack-review/scripts/load-prompt.sh
+++ b/skills/woostack-review/scripts/load-prompt.sh
@@ -53,6 +53,8 @@ sanitize_untrusted() {
 
 safe_comment_body=$(sanitize_untrusted "${COMMENT_BODY:-}" 2000)
 
+# canonical source: skills/using-woostack/references/model-tiers.md — keep these slugs in sync
+# with that table (Bash cannot read the markdown table, so this is its executable mirror).
 default_model_for() {
   local provider="$1" tier="$2"
   case "$provider" in
@@ -160,7 +162,22 @@ ${safe_comment_body}
 CTX_EOF
 )
 
-PROMPT_CONTENT=$(printf '%s\n\n%s\n\n%s\n' "$CONTEXT_HEAD" "$(cat "$HEADER_FILE")" "$(cat "$BODY_FILE")")
+# Inline the shared tier→model table into the header so single-prompt runners (which follow no
+# markdown links) stay self-contained. Canonical source:
+# skills/using-woostack/references/model-tiers.md — kept in sync with default_model_for() above.
+TIERS_FILE="$ACTION_PATH/../using-woostack/references/model-tiers.md"
+if [ ! -f "$TIERS_FILE" ]; then
+  echo "::error::shared model-tiers doc not found: $TIERS_FILE"
+  exit 1
+fi
+HEADER_RAW="$(cat "$HEADER_FILE")"
+if ! printf '%s' "$HEADER_RAW" | grep -q 'WOO_MODEL_TIERS_TABLE'; then
+  echo "::error::_header.md is missing the <!-- WOO_MODEL_TIERS_TABLE --> inline marker"
+  exit 1
+fi
+# Literal single-occurrence replacement of the marker with the shared doc body.
+HEADER_INLINED="${HEADER_RAW/<!-- WOO_MODEL_TIERS_TABLE -->/$(cat "$TIERS_FILE")}"
+PROMPT_CONTENT=$(printf '%s\n\n%s\n\n%s\n' "$CONTEXT_HEAD" "$HEADER_INLINED" "$(cat "$BODY_FILE")")
 
 BYTES=$(printf '%s' "$PROMPT_CONTENT" | wc -c)
 echo "Loaded prompt size: $BYTES bytes"

--- a/skills/woostack-review/scripts/load-prompt.sh
+++ b/skills/woostack-review/scripts/load-prompt.sh
@@ -171,7 +171,7 @@ if [ ! -f "$TIERS_FILE" ]; then
   exit 1
 fi
 HEADER_RAW="$(cat "$HEADER_FILE")"
-if ! printf '%s' "$HEADER_RAW" | grep -q 'WOO_MODEL_TIERS_TABLE'; then
+if ! printf '%s' "$HEADER_RAW" | grep -qF '<!-- WOO_MODEL_TIERS_TABLE -->'; then
   echo "::error::_header.md is missing the <!-- WOO_MODEL_TIERS_TABLE --> inline marker"
   exit 1
 fi


### PR DESCRIPTION
## Goal

Single-source the `fast|standard|deep` tier→model mapping so `woostack-review` and `woostack-execute` share one table, removing four drift-prone copies. **Output-neutral** for the review action.

## Summary

- New shared `skills/using-woostack/references/model-tiers.md` — canonical table + tier semantics + provider notes + generic routing/precedence.
- `_header.md`, `anthropic.md`, `opencode.md` repointed to it; embedded/duplicate tables removed; each prompt keeps only its runtime binding.
- `load-prompt.sh` inlines the shared table into the composed CI prompt at a `<!-- WOO_MODEL_TIERS_TABLE -->` marker (**fail-loud** if the doc is missing); `default_model_for()` keeps a sync comment as the Bash mirror.

## Test plan

### Automated

- [x] `bash -n load-prompt.sh` parses.
- [x] Composed-prompt check: tier table still present after inlining (15 slug-lines vs 16 baseline — the −1 is the intended `anthropic.md` table→1-line dedup), marker replaced (0 literal), `exit=0`.
- [x] Fail-loud: missing shared doc → `::error::shared model-tiers doc not found` + `exit=1`.
- [x] Dedup grep: no embedded tier-table rows in review prompts; no stale "table in `_header.md`".
- [x] Mirror sync: `default_model_for()` Anthropic slugs == shared doc column.

### Manual

**Before merge**

- [ ] Skim the composed review prompt and confirm the Model Tiers section reads identically to before the repoint.

Spec: .woostack/specs/2026-06-05-execute-vary-subagent-model.md
