### PR TITLE
feat(execute): vary subagent model per task (tier wiring + heuristic)

### DIFF
--- a/.woostack/plans/2026-06-05-execute-vary-subagent-model.md
+++ b/.woostack/plans/2026-06-05-execute-vary-subagent-model.md
@@ -409,7 +409,7 @@ branch (base = the spec+plan PR). PR title e.g. `refactor(review): promote tier�
 **Files:**
 - Modify: `skills/woostack-execute/references/subagent-driver.md:60,65`
 
-- [ ] **Step 1: Replace both `_header.md` references in the `## Model tiers` section**
+- [x] **Step 1: Replace both `_header.md` references in the `## Model tiers` section**
 
 In the `## Model tiers` section (line 59 onward), replace:
 
@@ -428,7 +428,7 @@ Model Tiers table in
 Each prompt template declares its `tier:` in frontmatter as the role default:
 ```
 
-- [ ] **Step 2: Verify the repoint**
+- [x] **Step 2: Verify the repoint**
 
 Run:
 
@@ -446,7 +446,7 @@ Expected: `OK`.
 **Files:**
 - Modify: `skills/woostack-execute/references/subagent-driver.md` (end of `## Model tiers`, after the existing tier bullets ~line 66)
 
-- [ ] **Step 1: Replace the closing "Where the host cannot route…" line with the full contract**
+- [x] **Step 1: Replace the closing "Where the host cannot route…" line with the full contract**
 
 Replace:
 
@@ -475,7 +475,7 @@ states for its angle spawns. **When the host cannot route per call**, run at the
 **say so** (degraded, not equivalent) — never pretend a tier ran.
 ```
 
-- [ ] **Step 2: Verify the contract landed**
+- [x] **Step 2: Verify the contract landed**
 
 Run:
 
@@ -493,7 +493,7 @@ Expected: `OK`.
 **Files:**
 - Modify: `skills/woostack-execute/references/subagent-driver.md` (the three tier bullets at lines 63–66)
 
-- [ ] **Step 1: Replace the `fast/standard/deep` static bullets**
+- [x] **Step 1: Replace the `fast/standard/deep` static bullets**
 
 Replace:
 
@@ -522,7 +522,7 @@ from complexity and risk — this table is the single home for the choice:
 The resolved effective tier feeds [Dispatch model](#dispatch-model-resolve--map--pass) above.
 ```
 
-- [ ] **Step 2: Verify the heuristic landed and the old static bullets are gone**
+- [x] **Step 2: Verify the heuristic landed and the old static bullets are gone**
 
 Run:
 
@@ -541,7 +541,7 @@ Expected: `OK`.
 **Files:**
 - Modify: `skills/woostack-execute/references/subagent-driver.md` (per-task loop steps 1, 2, 3, 4 at lines 31–50)
 
-- [ ] **Step 1: Cite the contract in the implementer dispatch (step 1)**
+- [x] **Step 1: Cite the contract in the implementer dispatch (step 1)**
 
 In step 1 (`Dispatch an implementer subagent with …implementer.md`), append to the end of the
 sentence "…the subagent never inherits this session's history.":
@@ -551,7 +551,7 @@ sentence "…the subagent never inherits this session's history.":
    [Tier selection](#tier-selection).
 ```
 
-- [ ] **Step 2: Align the BLOCKED handling (step 2) with the heuristic**
+- [x] **Step 2: Align the BLOCKED handling (step 2) with the heuristic**
 
 In step 2's `BLOCKED` bullet, change `needs more reasoning (re-dispatch at a higher tier)` to:
 
@@ -560,7 +560,7 @@ needs more reasoning (re-dispatch one tier higher per [Tier selection](#tier-sel
 prior BLOCKED is itself a bump-UP signal)
 ```
 
-- [ ] **Step 3: Cite the contract in both reviewer dispatches (steps 3 and 4)**
+- [x] **Step 3: Cite the contract in both reviewer dispatches (steps 3 and 4)**
 
 In step 3 (spec-compliance reviewer) and step 4 (code-quality reviewer), append to each dispatch
 sentence:
@@ -570,7 +570,7 @@ Resolve and pass its model per [Dispatch model](#dispatch-model-resolve--map--pa
 [Tier selection](#tier-selection).
 ```
 
-- [ ] **Step 4: Verify all three dispatch steps reference the contract**
+- [x] **Step 4: Verify all three dispatch steps reference the contract**
 
 Run:
 
@@ -587,13 +587,13 @@ Expected: `OK` — at least the three dispatch-step citations (implementer step 
 **Files:**
 - Modify: `skills/woostack-execute/SKILL.md` (description frontmatter line 3; the subagent bullet in `## Execution mode` ~line 36)
 
-- [ ] **Step 1: Add a clause to the `description:`**
+- [x] **Step 1: Add a clause to the `description:`**
 
 In the `description:` frontmatter, change the subagent clause
 `per-task spec+quality subagent loops in subagent mode` to
 `per-task spec+quality subagent loops in subagent mode, each routed to a tier-appropriate model`.
 
-- [ ] **Step 2: Add a sentence to the subagent-mode bullet in `## Execution mode`**
+- [x] **Step 2: Add a sentence to the subagent-mode bullet in `## Execution mode`**
 
 At the end of the `- **subagent** (…subagent-driver.md…)` bullet, append:
 
@@ -603,7 +603,7 @@ At the end of the `- **subagent** (…subagent-driver.md…)` bullet, append:
   [references/subagent-driver.md](references/subagent-driver.md) → Tier selection / Dispatch model).
 ```
 
-- [ ] **Step 3: Verify the SKILL mentions model variation**
+- [x] **Step 3: Verify the SKILL mentions model variation**
 
 Run:
 
@@ -620,7 +620,7 @@ Expected: `OK`.
 
 **Files:** _(verification only)_
 
-- [ ] **Step 1: Confirm prompt `tier:` frontmatter is still the role-default source**
+- [x] **Step 1: Confirm prompt `tier:` frontmatter is still the role-default source**
 
 Run:
 
@@ -632,7 +632,7 @@ grep -q '^tier: deep' skills/woostack-execute/prompts/quality-reviewer.md && ech
 
 Expected: `OK` (unchanged — defaults match the Tier-selection table).
 
-- [ ] **Step 2: No dangling links; twelve SKILL.md files intact**
+- [x] **Step 2: No dangling links; twelve SKILL.md files intact**
 
 Run:
 
@@ -643,7 +643,7 @@ test "$(ls skills/*/SKILL.md | wc -l)" -eq 12 && echo OK
 
 Expected: `OK`.
 
-- [ ] **Step 3: Dry-run walkthrough (manual, recorded in the PR body)**
+- [x] **Step 3: Dry-run walkthrough (manual, recorded in the PR body)**
 
 Confirm by reading the driver that:
 - a trivial single-file task resolves `fast` → implementer dispatched at the fast model;
@@ -651,7 +651,7 @@ Confirm by reading the driver that:
 - quality-reviewer stays `deep` on a non-trivial diff, `standard` on a trivial one;
 - a host without per-call routing runs the session model and reports it as degraded.
 
-- [ ] **Step 4: Commit the increment**
+- [x] **Step 4: Commit the increment**
 
 Use [`woostack-commit`](../../skills/woostack-commit/SKILL.md) on this increment's Graphite branch
 (stacked on PR 1). PR title e.g. `feat(execute): vary subagent model per task (tier wiring + heuristic)`. Body: goal, the wire+adapt summary, and Steps 1–3 as the test plan.

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-execute
-description: Use to execute an approved woostack plan as a sequence of PR-sized, stacked increments via an inline or subagent-driven driver (--inline/--subagent, smart default) — implement each increment with TDD, tick the plan's checkboxes in place, commit via woostack-commit on its own Graphite branch, review each increment (woostack-review --fast inline; per-task spec+quality subagent loops in subagent mode), distill durable learnings, then continue. This is the execute phase of the woostack build loop (woostack-build step 8); also usable standalone via /woostack-execute <plan-path> [--inline|--subagent]. One plan per spec, multiple PRs per plan. Never merges.
+description: Use to execute an approved woostack plan as a sequence of PR-sized, stacked increments via an inline or subagent-driven driver (--inline/--subagent, smart default) — implement each increment with TDD, tick the plan's checkboxes in place, commit via woostack-commit on its own Graphite branch, review each increment (woostack-review --fast inline; per-task spec+quality subagent loops in subagent mode, each routed to a tier-appropriate model), distill durable learnings, then continue. This is the execute phase of the woostack build loop (woostack-build step 8); also usable standalone via /woostack-execute <plan-path> [--inline|--subagent]. One plan per spec, multiple PRs per plan. Never merges.
 ---
 
 # woostack-execute
@@ -36,7 +36,10 @@ step differs (see the cadence below).
   implementer subagent per task plus a spec→quality reviewer loop. Those per-task loops **are**
   the automated review, so subagent mode does **not** run `woostack-review --fast`; each PR is
   reviewed manually after execution. This driver internalizes the subagent-driven
-  implementation pattern — no runtime dependency on any external skill.
+  implementation pattern — no runtime dependency on any external skill. In subagent mode the
+  driver also **varies the model per task** — resolving a `fast | standard | deep` tier from task
+  complexity/risk and passing it on each dispatch (see
+  [references/subagent-driver.md](references/subagent-driver.md) → Tier selection / Dispatch model).
 
 **Selecting the mode:** an explicit `--inline` or `--subagent` flag always wins. With no flag,
 take the **smart default**: subagent where the host can spawn subagents (an `Agent`/`Task` tool

--- a/skills/woostack-execute/references/subagent-driver.md
+++ b/skills/woostack-execute/references/subagent-driver.md
@@ -31,24 +31,28 @@ For each task in the increment, in order:
 
 1. **Dispatch an implementer subagent** with [../prompts/implementer.md](../prompts/implementer.md).
    Pass the full task text and exactly the context it needs — the subagent never inherits this
-   session's history. It follows TDD, self-reviews, and **reports its changed files + diff; it
-   does not commit.**
+   session's history. Resolve and pass its model per
+   [Dispatch model](#dispatch-model-resolve--map--pass) and [Tier selection](#tier-selection). It
+   follows TDD, self-reviews, and **reports its changed files + diff; it does not commit.**
 2. **Handle its status** — one of:
    - **DONE** → proceed to spec review.
    - **DONE_WITH_CONCERNS** → read the concerns; resolve correctness/scope ones before review,
      note observations and proceed.
    - **NEEDS_CONTEXT** → provide the missing context and re-dispatch.
    - **BLOCKED** → assess: context gap (re-dispatch with more context), needs more reasoning
-     (re-dispatch at a higher tier), task too large (split it), or the plan is wrong (escalate to
-     the user). **Never** silently retry the same model unchanged.
+     (re-dispatch one tier higher per [Tier selection](#tier-selection) — a prior BLOCKED is itself
+     a bump-UP signal), task too large (split it), or the plan is wrong (escalate to the user).
+     **Never** silently retry the same model unchanged.
 3. **Dispatch a spec-compliance reviewer** with
    [../prompts/spec-reviewer.md](../prompts/spec-reviewer.md), scoped to the implementer's
    reported task diff (this isolates the current task from earlier tasks' still-uncommitted work,
    since there is no per-task SHA to diff against). If it finds gaps, the **same implementer**
-   fixes them and the reviewer re-reviews. Loop until ✅.
+   fixes them and the reviewer re-reviews. Loop until ✅. Resolve and pass its model per
+   [Dispatch model](#dispatch-model-resolve--map--pass) and [Tier selection](#tier-selection).
 4. **Dispatch a code-quality reviewer** with
    [../prompts/quality-reviewer.md](../prompts/quality-reviewer.md) — only after spec compliance
-   is ✅ — scoped to the same diff. Fix-and-re-review loop until ✅.
+   is ✅ — scoped to the same diff. Fix-and-re-review loop until ✅. Resolve and pass its model per
+   [Dispatch model](#dispatch-model-resolve--map--pass) and [Tier selection](#tier-selection).
 5. **Tick the plan's checkboxes in place** for the completed task.
 
 A reviewer finding an issue the implementer cannot resolve surfaces as **BLOCKED** → escalate to
@@ -57,15 +61,40 @@ the user. This is the blocking-stop for subagent mode; there is no `woostack-rev
 
 ## Model tiers
 
-Use woostack's shared tier vocabulary — `fast | standard | deep` — resolved through the Model
-Tiers table in [`../../woostack-review/prompts/_header.md`](../../woostack-review/prompts/_header.md).
-Each prompt template declares its `tier:` in frontmatter:
+Use woostack's shared tier vocabulary — `fast | standard | deep` — resolved through the shared
+Model Tiers table in
+[`../../using-woostack/references/model-tiers.md`](../../using-woostack/references/model-tiers.md).
+Each prompt template declares its `tier:` in frontmatter as the role default.
 
-- **`fast`** — mechanical 1–2-file tasks with a complete spec (an implementer downgrade).
-- **`standard`** — multi-file integration; the default implementer and the spec reviewer.
-- **`deep`** — design/architecture judgment and the code-quality reviewer.
+### Tier selection
 
-Where the host cannot route models per call, fall back to the session model.
+Each role has a **default** tier (its prompt's `tier:` frontmatter): implementer `standard`,
+spec-reviewer `standard`, quality-reviewer `deep`. The controller adjusts that default **per task**
+from complexity and risk — this table is the single home for the choice:
+
+| Adjust | Effective tier | When |
+|---|---|---|
+| **Bump UP** | `deep` | the task touches security / auth / crypto, data migrations, concurrency / locking, money / billing, or is cross-cutting / architectural; the task spec is highly ambiguous; or the task previously returned **BLOCKED** for "needs more reasoning". |
+| **Bump DOWN** | `fast` | the task is mechanical, fully specified, single-file, and low-risk (rename, copy/string change, mechanical refactor, config tweak, docstring/comment). |
+| **Reviewer downgrade** | `fast` / `standard` | spec-reviewer → `fast` on a trivial diff; quality-reviewer → `standard` on a trivial diff (otherwise stays `deep`). |
+| **Ambiguous signals** | role default | default-safe — never downgrade risky work on uncertainty. |
+
+### Dispatch model (resolve → map → pass)
+
+Before each subagent dispatch, resolve the task's **effective tier** (role default, adjusted per
+[Tier selection](#tier-selection) above), map it to the host's model via the shared
+[model-tiers.md](../../using-woostack/references/model-tiers.md) (use the column for the host's
+provider — usually the session's), and **pass that model on the dispatch** (the `model:` arg of
+the `Agent`/`Task` call). Pass whatever value the host's subagent API accepts — a concrete slug
+where it takes slugs, or the tier's model **family** (`haiku`/`sonnet`/`opus`) where it takes
+families.
+
+**When the host supports per-call routing, every dispatch MUST pass the resolved model.** Omitting
+it makes the subagent inherit the parent session's model (typically Opus), silently defeating tier
+routing and burning multiples of the tokens on cheap work — the same rationale
+`woostack-review`'s [`prompts/anthropic.md`](../../woostack-review/prompts/anthropic.md) already
+states for its angle spawns. **When the host cannot route per call**, run at the session model and
+**say so** (degraded, not equivalent) — never pretend a tier ran.
 
 ## Review
 

--- a/skills/woostack-execute/references/subagent-driver.md
+++ b/skills/woostack-execute/references/subagent-driver.md
@@ -40,7 +40,7 @@ For each task in the increment, in order:
      note observations and proceed.
    - **NEEDS_CONTEXT** → provide the missing context and re-dispatch.
    - **BLOCKED** → assess: context gap (re-dispatch with more context), needs more reasoning
-     (re-dispatch one tier higher per [Tier selection](#tier-selection) — a prior BLOCKED is itself
+     (re-dispatch per [Tier selection](#tier-selection) — a prior BLOCKED is itself
      a bump-UP signal), task too large (split it), or the plan is wrong (escalate to the user).
      **Never** silently retry the same model unchanged.
 3. **Dispatch a spec-compliance reviewer** with


### PR DESCRIPTION
## Goal

Operationalize per-task model variation in `woostack-execute`'s subagent driver so subagents trade quality / speed / cost — the half left descriptive by the tier work.

## Summary

- **Dispatch model contract** (`subagent-driver.md`): resolve effective tier → map via the shared `using-woostack/references/model-tiers.md` → **pass `model:` on each dispatch**. MUST-pass when the host can route per call (omitting inherits Opus, ~5× cost), else session model + said-aloud degrade.
- **Tier selection heuristic**: role defaults (impl/spec `standard`, quality `deep`) + bump-UP on security/auth/crypto/migration/concurrency/money/cross-cutting/ambiguous/prior-BLOCKED, bump-DOWN on mechanical fully-specified single-file work, reviewer downgrades on trivial diffs, default-safe on ambiguity. Single home for the choice (folds the old scattered notes).
- Per-task loop steps (implementer + both reviewers) cite the contract; the BLOCKED "more reasoning" path now bumps a tier via the heuristic. Driver cross-link repointed to the shared doc. `SKILL.md` description + subagent bullet note the model variation.

## Test plan

### Automated

- [x] Driver links the shared doc, not `_header.md`.
- [x] Dispatch-model contract + MUST-pass discipline present.
- [x] Tier-selection table present; old static `fast/standard/deep` bullets removed.
- [x] ≥3 dispatch-model citations from the loop steps (implementer + 2 reviewers).
- [x] Prompt `tier:` frontmatter unchanged (`standard`/`standard`/`deep`) — role-default source.
- [x] `SKILL.md` notes "tier-appropriate model" + "varies the model per task".
- [x] Twelve `SKILL.md` files intact.

### Manual

**Before merge**

- [ ] Read `subagent-driver.md` → Tier selection + Dispatch model; confirm trivial→`fast`, security/migration→`deep`, quality-reviewer `deep`→`standard` on trivial diff, and host-without-routing → session model + degraded.

Spec: .woostack/specs/2026-06-05-execute-vary-subagent-model.md
