### PR TITLE
docs(woostack): drop superpowers refs, add TDD refactor step

### DIFF
--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -20,11 +20,10 @@ ideate → write spec (markdown) → harden spec → approve spec → plan → v
 
 Three of those gates are hard stops where the user must say yes before the chain advances:
 **design approval** (owned by `woostack-ideate`, step 1), **spec approval** (step 3), and the
-**execution handoff** (step 8). The spec-approval gate is the "user reviews the written spec"
-step that the ideate phase historically owned; because woostack-build relocated the spec
-write into its own step 2, the gate lives here now — relocating an inherited gate is not adding
-one. The execution-handoff gate is build's own: no sub-skill owns the plan→execute boundary, so
-build adds it to let you stop after planning and execute later or elsewhere.
+**execution handoff** (step 8). Because woostack-build writes the spec in step 2, it also owns
+the "user reviews the written spec" gate in step 3. The execution-handoff gate is build's own:
+no sub-skill owns the plan→execute boundary, so build adds it to let you stop after planning
+and execute later or elsewhere.
 
 Hardening runs **twice** — once on the spec (step 3) and once on the plan (step 6) — but only
 the spec harden feeds a gate (the spec-approval gate, step 3). The plan harden amends the plan

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -21,7 +21,7 @@ ideate → write spec (markdown) → harden spec → approve spec → plan → v
 Three of those gates are hard stops where the user must say yes before the chain advances:
 **design approval** (owned by `woostack-ideate`, step 1), **spec approval** (step 3), and the
 **execution handoff** (step 8). The spec-approval gate is the "user reviews the written spec"
-step that `superpowers:brainstorming` used to own; because woostack-build relocated the spec
+step that the ideate phase historically owned; because woostack-build relocated the spec
 write into its own step 2, the gate lives here now — relocating an inherited gate is not adding
 one. The execution-handoff gate is build's own: no sub-skill owns the plan→execute boundary, so
 build adds it to let you stop after planning and execute later or elsewhere.
@@ -38,8 +38,8 @@ sits after that PR. So the chain has exactly the three hard gates above.
    the problem and converge on a design. Let it run its own approval gate. It hands back an
    approved design and stops there — it writes no spec and chains no plan, so the next steps
    are yours to drive.
-2. **Write the spec as markdown.** When the design is approved, do **not** write to the
-   superpowers default `docs/superpowers/specs/`. Instead author a markdown spec to
+2. **Write the spec as markdown.** When the design is approved, do **not** write to a generic
+   `docs/specs/` location. Instead author a markdown spec to
    `.woostack/specs/YYYY-MM-DD-<slug>.md`, populating
    [references/spec-template.md](references/spec-template.md). Markdown specs are the source
    of truth: they carry `type: spec` frontmatter, are Obsidian vault nodes that can `[[link]]`
@@ -128,8 +128,8 @@ sits after that PR. So the chain has exactly the three hard gates above.
 - **Always get explicit spec approval before planning.** After the spec harden, present the
   written spec and wait for the user's clear yes. Never advance to `woostack-plan` on assumed
   or inferred approval.
-- **Markdown specs and plans, under `.woostack/`.** Never write specs to the superpowers
-  default location. HTML is a render-on-demand target only, not the authored format.
+- **Markdown specs and plans, under `.woostack/`.** Never write specs to a generic location
+  outside `.woostack/`. HTML is a render-on-demand target only, not the authored format.
 - **Spec+plan ship as their own PR before execution.** Commit the spec and plan as a docs-only
   PR (step 7) — the base of the stack — before any implementation begins. Never merge it.
 - **Stop before execute.** Never auto-run execute; always halt at the execution-handoff gate

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -31,12 +31,12 @@ step differs (see the cadence below).
 
 - **inline** ([references/inline-driver.md](references/inline-driver.md)) — the controller
   implements the increment's tasks itself with TDD, in this session. The increment's automated
-  review is `woostack-review --fast`. Analog of superpowers `executing-plans`.
+  review is `woostack-review --fast`.
 - **subagent** ([references/subagent-driver.md](references/subagent-driver.md)) — a fresh
   implementer subagent per task plus a spec→quality reviewer loop. Those per-task loops **are**
   the automated review, so subagent mode does **not** run `woostack-review --fast`; each PR is
-  reviewed manually after execution. Analog of superpowers `subagent-driven-development`,
-  internalized — no runtime dependency on that skill.
+  reviewed manually after execution. This driver internalizes the subagent-driven
+  implementation pattern — no runtime dependency on any external skill.
 
 **Selecting the mode:** an explicit `--inline` or `--subagent` flag always wins. With no flag,
 take the **smart default**: subagent where the host can spawn subagents (an `Agent`/`Task` tool

--- a/skills/woostack-execute/prompts/implementer.md
+++ b/skills/woostack-execute/prompts/implementer.md
@@ -22,8 +22,10 @@ controller's session — everything you need is below.
 
 ## How to work
 1. Follow test-driven development: write the failing test, watch it fail, write the minimal code,
-   watch it pass. If the change has no runnable test harness (e.g. a docs/skill edit), run the
-   concrete verification the task specifies instead (grep / link check / structural assertion).
+   watch it pass, then refactor with the tests green (clean up names, duplication, and structure;
+   re-run the tests to confirm they stay green). If the change has no runnable test harness (e.g.
+   a docs/skill edit), run the concrete verification the task specifies instead (grep / link
+   check / structural assertion).
 2. Implement exactly the task — no more (no extra flags, files, or features), no less.
 3. Self-review your diff before reporting. Fix what you find.
 4. Do NOT git-commit. Leave your changes in the working tree.

--- a/skills/woostack-execute/references/inline-driver.md
+++ b/skills/woostack-execute/references/inline-driver.md
@@ -1,7 +1,7 @@
 # Inline execution driver
 
 The **inline** driver of [`woostack-execute`](../SKILL.md). The controller implements each
-increment's tasks itself, in this session — the analog of superpowers `executing-plans`. Use it
+increment's tasks itself, in this session. Use it
 when `--inline` is passed, or when the smart default resolves to inline (the host cannot spawn
 subagents). See [subagent-driver.md](subagent-driver.md) for the other mode.
 
@@ -9,11 +9,12 @@ subagents). See [subagent-driver.md](subagent-driver.md) for the other mode.
 
 For each task in the increment, in order:
 
-1. **Follow `superpowers:test-driven-development`** — write the failing test first, watch it
-   fail, write the minimal code, watch it pass. This is a principle, not a hard dependency: if
-   the skill is absent, follow TDD by hand. For a change with no runnable test harness (e.g. a
-   docs/skill edit), substitute the concrete verification the plan specifies (a `grep`, a link
-   check, a structural assertion) for the test.
+1. **Follow test-driven development** — write the failing test first, watch it
+   fail, write the minimal code, watch it pass, then **refactor** with the tests green (clean up
+   names, duplication, and structure; re-run the tests to confirm they stay green). This is a
+   principle, not a hard dependency: if no TDD skill is loaded, follow TDD by hand. For a change
+   with no runnable test harness (e.g. a docs/skill edit), substitute the concrete verification
+   the plan specifies (a `grep`, a link check, a structural assertion) for the test.
 2. **Follow each safe plan step exactly** and run the verifications the plan names.
 3. **Tick the plan's checkboxes in place** (`[ ]` → `[x]`) as each step completes.
 

--- a/skills/woostack-execute/references/subagent-driver.md
+++ b/skills/woostack-execute/references/subagent-driver.md
@@ -4,8 +4,9 @@ tier: standard
 
 # Subagent execution driver
 
-The **subagent-driven** driver of [`woostack-execute`](../SKILL.md) — the analog of superpowers
-`subagent-driven-development`, internalized so woostack has no runtime dependency on it. Use it
+The **subagent-driven** driver of [`woostack-execute`](../SKILL.md) — the subagent-driven
+implementation pattern, internalized so woostack has no runtime dependency on any external skill.
+Use it
 when `--subagent` is passed, or when the smart default resolves to subagent (the host can spawn
 subagents, e.g. an `Agent`/`Task` tool is available). See [inline-driver.md](inline-driver.md)
 for the other mode.
@@ -75,6 +76,5 @@ reviewed **manually by the human** after execution, which covers whole-increment
 ## Hand back
 
 When every task in the increment is ✅ and checked off, hand back to [SKILL.md](../SKILL.md) for
-the single `woostack-commit` and distillation. **Never-merge carve-out:** unlike
-`superpowers:subagent-driven-development`, this driver does **not** call
-`finishing-a-development-branch` and never offers or performs a merge.
+the single `woostack-commit` and distillation. **Never-merge carve-out:** this driver does
+**not** call any branch-finishing or merge step and never offers or performs a merge.

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -14,7 +14,7 @@ its spec, frontmatter-free, decomposed into independently shippable increments, 
 `status: planning` transition on the spec. It writes the plan and hands back; it owns no approval
 gate and never executes, commits, or merges.
 
-It internalizes `superpowers:writing-plans` — the same move
+It internalizes the plan-writing discipline as a native phase — the same move
 [`woostack-ideate`](../woostack-ideate/SKILL.md),
 [`woostack-harden`](../woostack-harden/SKILL.md), and
 [`woostack-execute`](../woostack-execute/SKILL.md) made on the phases around it. With this skill


### PR DESCRIPTION
## Goal

The build skill and its child skills should stand on their own without naming the external `superpowers` collection, and the execute phase should carry the full TDD cycle inline rather than deferring to an external skill for it.

## Summary

- Removed all `superpowers:*` references from `woostack-build`, `woostack-plan`, and `woostack-execute` (SKILL + both driver references), rewording each to describe the behavior natively while preserving meaning.
- Confirmed execute self-contains TDD (red→green) in both drivers and the implementer prompt; the removed lines were pointers, not the principle.
- Added the explicit **refactor** step (red→green→refactor, re-run tests green) to `inline-driver.md` and `prompts/implementer.md` so the full TDD cycle is stated in execute.

## Test plan

### Manual

**Before merge**

- [ ] `grep -rni superpower skills/woostack-build skills/woostack-plan skills/woostack-execute` returns no matches.
- [ ] Read the diff: each reworded sentence still reads correctly and keeps its original intent.
- [ ] Confirm `inline-driver.md` and `implementer.md` now name the refactor step in the TDD cycle.
