### PR TITLE
docs(skills-review-angle): spec and plan for skills review angle

### DIFF
--- a/.woostack/plans/2026-06-05-skills-review-angle.md
+++ b/.woostack/plans/2026-06-05-skills-review-angle.md
@@ -1,0 +1,339 @@
+**Source:** .woostack/specs/2026-06-05-skills-review-angle.md
+
+# Skills Review Angle Implementation Plan
+
+**Goal:** Add a `skills` review angle to `woostack-review` that audits changed `SKILL.md` files against Anthropic's skill best-practices guide, wired into the existing detect → swarm → merge → validate pipeline.
+
+**Architecture:** Reuse the established angle contract end to end — a new `prompts/angles/skills.md` worker prompt (`tier: standard`), a gate in `detect-angles.sh` (fires on a `SKILL.md` in the diff) that also hands `SKILL.md` ownership over from the `docs` gate, registration in the `VALID_ANGLES` config allow-list and the three angle→tier enumerations (`SKILL.md`, `_header.md`, `anthropic.md`), and a focused `detect-angles.sh` gating test. No new runtime machinery.
+
+**Tech Stack:** Bash (POSIX-ish, macOS Bash 3.2 safe), `jq`, Python3 (existing scripts), the `scripts/tests/*.sh` + `assert.sh` test harness, Markdown angle prompts.
+
+---
+
+## Increment 1: skills angle (gating, prompt, registration, test)
+
+> One independently shippable PR (≤500 LOC soft target) — its own Graphite-stacked branch. All seven touch points are small and tightly coupled; the spec sets `spec : plan : PRs = 1 : 1 : 1`.
+
+All paths below are relative to the repo root; the review skill lives at `skills/woostack-review/`.
+
+### Task 1: Gate the angle in `detect-angles.sh` (+ hand `SKILL.md` off the `docs` gate)
+
+**Files:**
+- Test: `skills/woostack-review/scripts/tests/test-detect-angles-skills.sh` (create)
+- Modify: `skills/woostack-review/scripts/detect-angles.sh` (add `has_skills_file()`, an `ANGLES+=("skills")` block, the `SKILL.md` exclusion in `has_docs_file()`, and header-catalog comments)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `skills/woostack-review/scripts/tests/test-detect-angles-skills.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/detect-angles.sh"
+
+# setup $1 = newline-separated changed file paths
+setup() {
+  work="$(mktemp -d)"
+  export OUTDIR="$work/out"
+  mkdir -p "$OUTDIR"
+  printf '%s\n' "$1" | jq -R . | jq -s '{files: [.[] | {path: .}]}' > "$OUTDIR/meta.json"
+  : > "$OUTDIR/diff.txt"
+}
+
+# A SKILL.md in the diff enables the skills angle and NOT docs.
+setup "skills/foo/SKILL.md"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "skills" "SKILL.md enables skills angle"
+assert_eq "$(grep -cx 'docs' "$OUTDIR/angles.txt" || true)" "0" "SKILL.md-only does not enable docs"
+rm -rf "$work"
+
+# A non-SKILL code file does not enable skills.
+setup "src/index.ts"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(grep -cx 'skills' "$OUTDIR/angles.txt" || true)" "0" "no SKILL.md -> no skills angle"
+rm -rf "$work"
+
+# A real README still enables docs (exclusion is SKILL.md-specific, not all .md).
+setup "README.md"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "docs" "README.md still enables docs"
+rm -rf "$work"
+
+finish
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `bash skills/woostack-review/scripts/tests/test-detect-angles-skills.sh`
+Expected: FAIL — first assertion errors, `SKILL.md enables skills angle` (the `skills` angle is not emitted yet; `angles.txt` for a SKILL.md-only diff currently contains `bugs security docs`).
+
+- [ ] **Step 3: Add `has_skills_file()` next to the other `has_*_file` helpers**
+
+In `skills/woostack-review/scripts/detect-angles.sh`, after the `has_deps_file()` function (ends at the `}` before `ANGLES=("bugs" "security")`), add:
+
+```bash
+has_skills_file() {
+  # Canonical Agent Skill manifest signal: a file named SKILL.md at any depth.
+  echo "$CHANGED_PATHS" | grep -qE '(^|/)SKILL\.md$'
+}
+```
+
+- [ ] **Step 4: Exclude `SKILL.md` from the `docs` gate**
+
+In the same file, in `has_docs_file()`, add a `SKILL.md` exclusion to the trailing `*.md` filter pipe so a SKILL.md-only PR routes to `skills`, not `docs` (mirrors the existing rule-file exclusions). Change:
+
+```bash
+  echo "$CHANGED_PATHS" \
+    | grep -vE '(^|/)(AGENTS|CLAUDE|GEMINI)\.md$' \
+    | grep -vE '(^|/)\.(cursorrules|windsurfrules)$' \
+    | grep -qE '\.(md|mdx)$' && return 0
+```
+
+to:
+
+```bash
+  echo "$CHANGED_PATHS" \
+    | grep -vE '(^|/)(AGENTS|CLAUDE|GEMINI)\.md$' \
+    | grep -vE '(^|/)\.(cursorrules|windsurfrules)$' \
+    | grep -vE '(^|/)SKILL\.md$' \
+    | grep -qE '\.(md|mdx)$' && return 0
+```
+
+- [ ] **Step 5: Add the `skills` angle to the `ANGLES` assembly**
+
+In the same file, immediately after the `if has_docs_file; then ANGLES+=("docs") fi` block, add:
+
+```bash
+if has_skills_file; then
+  ANGLES+=("skills")
+fi
+```
+
+- [ ] **Step 6: Update the header-comment catalog**
+
+In the leading comment block of `detect-angles.sh`, (a) update the `docs` entry to note the new exclusion, and (b) add a `skills` entry. In the `docs —` comment, append `SKILL.md (owned by the skills angle)` to its existing exclusion parenthetical. After the `architecture —` catalog entry, add:
+
+```bash
+#   skills    — a file named SKILL.md anywhere in the diff (Agent Skill manifest).
+#               Audits the changed skill against Anthropic's skill best-practices
+#               guide. SKILL.md is excluded from the docs gate so a SKILL.md-only
+#               PR routes here, not to docs.
+```
+
+- [ ] **Step 7: Lint, then run the test, confirm it passes**
+
+Run: `bash -n skills/woostack-review/scripts/detect-angles.sh && bash skills/woostack-review/scripts/tests/test-detect-angles-skills.sh`
+Expected: PASS (no syntax error; all assertions pass; `finish` prints the success summary).
+
+### Task 2: Register `skills` in the config allow-list (`load-config.sh`)
+
+**Files:**
+- Modify: `skills/woostack-review/scripts/load-config.sh:85` (`VALID_ANGLES`)
+
+- [ ] **Step 1: Write the failing verification**
+
+Run (this is the "failing test" — config `force: ["skills"]` is rejected before the change):
+
+```bash
+work="$(mktemp -d)"; export OUTDIR="$work/out"; export GITHUB_WORKSPACE="$work/repo"
+mkdir -p "$OUTDIR" "$GITHUB_WORKSPACE/.woostack"
+printf '%s\n' '{"review":{"angles":{"force":["skills"]}}}' > "$GITHUB_WORKSPACE/.woostack/config.json"
+bash skills/woostack-review/scripts/load-config.sh; echo "rc=$?"; rm -rf "$work"
+```
+
+Expected: FAIL — non-zero exit with an annotation containing `angles.force contains unknown angle(s): skills`.
+
+- [ ] **Step 2: Add `"skills"` to `VALID_ANGLES`**
+
+In `skills/woostack-review/scripts/load-config.sh`, change line 85 from:
+
+```python
+VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture"}
+```
+
+to (append `, "skills"` before the closing brace):
+
+```python
+VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture", "skills"}
+```
+
+- [ ] **Step 3: Re-run the verification, confirm it passes**
+
+Run:
+
+```bash
+work="$(mktemp -d)"; export OUTDIR="$work/out"; export GITHUB_WORKSPACE="$work/repo"
+mkdir -p "$OUTDIR" "$GITHUB_WORKSPACE/.woostack"
+printf '%s\n' '{"review":{"angles":{"force":["skills"]}}}' > "$GITHUB_WORKSPACE/.woostack/config.json"
+bash skills/woostack-review/scripts/load-config.sh; echo "rc=$?"
+jq -r '.angles.force[]' "$OUTDIR/config.json"; rm -rf "$work"
+```
+
+Expected: PASS — `rc=0` and the final line prints `skills`.
+
+### Task 3: Create the `skills` angle prompt
+
+**Files:**
+- Create: `skills/woostack-review/prompts/angles/skills.md`
+
+- [ ] **Step 1: Write the angle prompt**
+
+Create `skills/woostack-review/prompts/angles/skills.md` with exactly:
+
+```markdown
+---
+tier: standard
+---
+
+# Angle: Skills
+
+**Scope.** Audit Agent Skills changed by this PR against Anthropic's skill best-practices guide (https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices). This angle fires when a `SKILL.md` is in the diff. For each touched `SKILL.md`, audit the **whole file** — its full content is in `/tmp/pr-review/diff.txt` — not only the changed lines. When the working tree is available you MAY read sibling `references/*` and `scripts/*` in the same skill directory to judge progressive disclosure and script quality; when only the diff is available, audit what it contains. A newly-added `SKILL.md` is entirely `+` lines, so every finding anchors; on an edit, only findings near the changed hunks anchor (see Output).
+
+**Find:**
+
+- **Frontmatter validity (breaks discovery/load):**
+  - `name` longer than 64 chars, not matching `^[a-z0-9-]+$`, containing a reserved word (`anthropic` / `claude`), or containing XML tags.
+  - `description` empty, longer than 1024 chars, or containing XML tags.
+- **Description quality:**
+  - Vague description that won't drive discovery ("Helps with documents", "Processes data").
+  - Written in first/second person ("I can help…", "You can use this…") instead of third person.
+  - Missing the *what it does* **and** *when to use it* pair.
+- **Naming:**
+  - Vague/generic name (`helper`, `utils`, `tools`, `documents`) or one inconsistent with the collection's pattern.
+- **Body size & progressive disclosure:**
+  - SKILL.md body over ~500 lines — recommend splitting into reference files.
+  - References nested more than one level deep (SKILL.md → a.md → b.md); every reference file should link directly from SKILL.md.
+  - A reference file over ~100 lines with no table of contents.
+  - Non-descriptive bundled filenames (`doc2.md`, `file1.md`).
+- **Conciseness:**
+  - Explaining things Claude already knows (e.g. "PDF is a file format…"); paragraphs that do not justify their token cost.
+- **Content hygiene:**
+  - Time-sensitive info ("after August 2025…") not quarantined in an "old patterns" section.
+  - Inconsistent terminology for one concept.
+  - Abstract examples where concrete input/output pairs are needed.
+  - Offering many options with no recommended default.
+  - Windows-style backslash paths (`scripts\helper.py`) instead of forward slashes.
+- **Scripts (only when the skill bundles them):**
+  - A script that punts errors to Claude instead of handling them.
+  - Voodoo constants (magic numbers with no justification).
+  - Assuming a package is installed without an install step.
+  - Un-qualified MCP tool names (use `Server:tool`).
+- **Workflows:**
+  - A complex multi-step task with no clear steps/checklist, or a quality-critical task with no validate→fix feedback loop.
+
+**Skip:**
+
+- Pre-existing issues on lines the PR did not touch that cannot be anchored on the diff's RIGHT side (see Output) — do not invent a line to report them.
+- Non-`SKILL.md` markdown (README / CHANGELOG / docs) — that is the `docs` angle.
+- Subjective wording nits with no basis in the best-practices guide.
+- Plugin/host-specific frontmatter keys beyond `name` / `description`.
+
+**Severity rubric:**
+
+- `HIGH` + `blocking: true` — frontmatter that breaks discovery or loading: `name` violates charset/length/reserved-word, or `description` is empty / >1024 chars / contains XML tags.
+- `MEDIUM` + `blocking: false` — vague or non-third-person description, body over ~500 lines, nested references, a script that punts errors / uses voodoo constants / assumes installs, Windows-style paths.
+- `LOW` + `blocking: false` — vague name, missing TOC on a long reference, verbosity, inconsistent terminology, abstract examples, too-many-options, missing feedback loop.
+
+**Output.** Write findings as a JSON array to `/tmp/pr-review/findings.skills.json` using the schema in `_header.md`. Each finding gets `"angle": "skills"` and MUST populate `title` (bold headline ≤60 chars), `description` (the violation — name the file + the best-practice broken, no fix), `fix` (recommended change in prose), and `fix_type`. Anchor each finding's `line` to the most relevant diff-visible line — the frontmatter `name:` / `description:` line for frontmatter findings, the nearest changed line for structural ones — and validate it with `resolve-diff-line.sh`; DROP any finding whose line resolves to `null`. Set `fix_type: "suggestion"` only when a ≤10-line single-file drop-in replacement at `line` is safe — and populate `suggestion`. Otherwise set `fix_type: "prose"` with `suggestion: null`. See `_header.md` for the full rule.
+```
+
+- [ ] **Step 2: Verify the prompt's shape and that it dogfoods its own rules**
+
+Run:
+
+```bash
+f=skills/woostack-review/prompts/angles/skills.md
+head -3 "$f"                                                           # tier frontmatter
+grep -cE '^\*\*(Scope|Find|Skip|Severity rubric|Output)[.:]\*\*' "$f"  # the 5 sections (. or : terminator)
+grep -c 'findings.skills.json' "$f"                                    # writes the right artifact
+wc -l < "$f"                                                           # body well under 500 lines
+```
+
+Expected: line 2 is `tier: standard`; the section count prints `5` (the regex accepts both the `.` terminator of Scope/Output and the `:` terminator of Find/Skip/Severity rubric); the artifact count prints `1`; the line count is well under 500 (≈80).
+
+### Task 4: Register `skills` in the three angle→tier enumerations + Stage 2 list
+
+**Files:**
+- Modify: `skills/woostack-review/SKILL.md` (Stage 2 conditional-angle list ~line 270; Stage 3 tier table ~line 348)
+- Modify: `skills/woostack-review/prompts/_header.md` (Model Tiers `standard` row ~line 60)
+- Modify: `skills/woostack-review/prompts/anthropic.md` (tier table `standard` row ~line 51)
+
+- [ ] **Step 1: SKILL.md Stage 2 list — add `skills`**
+
+In `skills/woostack-review/SKILL.md`, in the Stage 2 paragraph that enumerates conditional angles, insert `skills` after `deps`. Change `…, \`docs\`, \`deps\`, \`architecture\` (when the diff touches general-purpose source files).` to `…, \`docs\`, \`deps\`, \`skills\` (when a \`SKILL.md\` is in the diff), \`architecture\` (when the diff touches general-purpose source files).`
+
+- [ ] **Step 2: SKILL.md Stage 3 tier table — add a `skills` row**
+
+In the Stage 3 "Tier assignments" table, after the `| \`tests\`, \`api\`, \`infra\` workers | \`standard\` | Coverage/contract/IaC reasoning. |` row, add:
+
+```markdown
+| `skills` worker | `standard` | Skill-authoring judgment against the best-practices guide. |
+```
+
+- [ ] **Step 3: `_header.md` Model Tiers — add `skills` to the standard row**
+
+In `skills/woostack-review/prompts/_header.md`, in the `| \`standard\` |` Model Tiers row, append `, \`skills\`` to the parenthesized worker list so it reads `…\`tests\`, \`api\`, \`infra\`, \`skills\`)`.
+
+- [ ] **Step 4: `anthropic.md` tier table — add `skills` to the standard row**
+
+In `skills/woostack-review/prompts/anthropic.md`, in the `| \`standard\` | \`claude-sonnet-4-6\` | …` row, append `, \`skills\`` to the angle list so it ends `…\`api\`, \`infra\`, \`skills\` |`.
+
+- [ ] **Step 5: Verify all four registrations**
+
+Run:
+
+```bash
+grep -n '`skills` (when a `SKILL.md`' skills/woostack-review/SKILL.md
+grep -n '`skills` worker' skills/woostack-review/SKILL.md
+grep -n 'skills`)' skills/woostack-review/prompts/_header.md
+grep -n 'infra`, `skills`' skills/woostack-review/prompts/anthropic.md
+```
+
+Expected: each `grep` prints exactly one matching line (four matches total).
+
+### Task 5: Full verification sweep + commit
+
+- [ ] **Step 1: Run the whole review-skill test suite**
+
+Run:
+
+```bash
+for t in skills/woostack-review/scripts/tests/test-*.sh; do echo "== $t"; bash "$t"; done
+```
+
+Expected: every test prints its success summary and exits 0 — including the new `test-detect-angles-skills.sh`.
+
+- [ ] **Step 2: Lint every shell script touched**
+
+Run: `bash -n skills/woostack-review/scripts/detect-angles.sh && bash -n skills/woostack-review/scripts/load-config.sh && echo OK`
+Expected: prints `OK`.
+
+- [ ] **Step 3: Smoke-test the end-to-end gate against a real skill path**
+
+Run:
+
+```bash
+work="$(mktemp -d)"; export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+printf '%s\n' "skills/woostack-review/SKILL.md" | jq -R . | jq -s '{files: [.[] | {path: .}]}' > "$OUTDIR/meta.json"
+: > "$OUTDIR/diff.txt"
+bash skills/woostack-review/scripts/detect-angles.sh >/dev/null 2>&1
+cat "$OUTDIR/angles.txt"; rm -rf "$work"
+```
+
+Expected: output contains `skills` and does **not** contain `docs`.
+
+- [ ] **Step 4: Commit the increment**
+
+Commit via `woostack-commit` (it creates the Graphite branch, pushes, and writes the PR fields). This increment stacks on top of the spec+plan PR.
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every spec requirement maps to a task: angle prompt (Task 3) ✓; gating + docs-gate exclusion (Task 1) ✓; `VALID_ANGLES` (Task 2) ✓; SKILL.md Stage 2 + Stage 3, `_header.md`, `anthropic.md` (Task 4) ✓; detect-angles test (Task 1) ✓; severity rubric embedded in the prompt (Task 3) ✓.
+- [ ] **No placeholders** — every step carries the actual code/commands and exact expected output; no TBD/TODO.
+- [ ] **Type consistency** — angle name is `skills` everywhere (artifact `findings.skills.json`, `"angle": "skills"`, `VALID_ANGLES`, all tier tables, gate function `has_skills_file`); tier is `standard` everywhere.

--- a/.woostack/specs/2026-06-05-skills-review-angle.md
+++ b/.woostack/specs/2026-06-05-skills-review-angle.md
@@ -1,0 +1,191 @@
+---
+name: skills-review-angle
+type: spec
+status: planning
+date: 2026-06-05
+branch: feature/skills-review-angle
+links:
+---
+
+# Skills Review Angle — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
+## 1. Problem
+
+`woostack-review` fans out a swarm of angle reviewers, each scoped to one dimension
+(`bugs`, `security`, `docs`, `conventions`, …). There is no angle that reviews **Agent
+Skills** against their own authoring best practices. When a PR adds or edits a `SKILL.md`,
+nothing in the review catches the failure modes Anthropic's
+[skill best-practices guide](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+warns about: a vague or second-person `description` that breaks discovery, a `name` that
+violates the frontmatter charset/length/reserved-word rules, a body over 500 lines, nested
+references, scripts that punt errors, Windows-style paths, and so on. This repo is itself a
+published skills collection, so the gap is felt on its own PRs first.
+
+## 2. Goal
+
+Add one new review angle, `skills`, that audits changed skills against the best-practices
+guide and reports violations as standard woostack-review findings. The rubric ships embedded
+in the prompt (self-sufficient, like `seo`/`aeo`), with the canonical URL cited for
+provenance. The angle is conditional — it fires only when a `SKILL.md` is in the diff — and
+slots into the existing detect → swarm → merge → validate → post pipeline with no new
+machinery.
+
+## 3. Non-goals
+
+- **No new pipeline machinery.** Reuse the existing angle contract end to end: gating in
+  `detect-angles.sh`, the `_header.md` JSON-array output schema, `resolve-diff-line.sh`
+  anchoring, merge/validator/intersect, tier routing. No new scripts beyond a test.
+- **No always-on behavior.** `skills` is conditional like `docs`; it does not join the
+  always-on `bugs`/`security` pair.
+- **No live network fetch of the guide.** The rubric is embedded, not fetched at review time
+  (consistent with the self-sufficiency rule in `SKILL.md` Knowledge Aggregation).
+- **No general skill linting outside review.** This is a review angle only — not a standalone
+  `lint-skills` command, not a pre-commit hook.
+- **No broadening the trigger to non-`SKILL.md` skill assets.** A PR that edits only a
+  reference file or script without touching `SKILL.md` does not fire the angle. (Once fired,
+  the angle may *read* those sibling files to judge the skill, but they are not a trigger.)
+
+## 4. Approach
+
+A new angle reuses the established pattern exactly. Decisions locked during ideation:
+
+- **Name:** `skills` — single-token, matching the existing convention (`docs`, `deps`,
+  `tests`, `types`). Maps to `prompts/angles/skills.md`, `findings.skills.json`,
+  `"angle": "skills"`.
+- **Tier:** `standard`. The audit is judgment-heavy (is this description vague? does this
+  paragraph justify its tokens? is the freedom level appropriate?), closer to `conventions`
+  (standard) than mechanical `docs` (fast). Frontmatter charset/length checks are mechanical,
+  but the high-value findings need reasoning.
+- **Gating:** fires when any changed path has basename `SKILL.md` (any depth, forward-slash).
+  Conditional, like `docs`.
+- **Scope:** whole-file audit. When a PR adds or edits a `SKILL.md`, the angle audits the
+  entire skill against the rubric, not only the changed lines. It may read sibling
+  `references/*` and `scripts/*` in the same skill directory to judge progressive disclosure
+  and script quality. Findings anchor to diff-visible lines via `resolve-diff-line.sh`;
+  unanchorable findings are dropped per the standard `_header.md` rule (a newly-added
+  `SKILL.md` anchors fully, since all its lines are on the diff's RIGHT side).
+- **Rubric:** embedded in the prompt, distilled from the best-practices guide, organized into
+  the standard angle sections (Scope / Find / Skip / Severity rubric / Output).
+
+## 5. Components & data flow
+
+Seven touch points; no new runtime components.
+
+1. **`skills/woostack-review/prompts/angles/skills.md`** (new). Frontmatter `tier: standard`.
+   Sections mirror the existing angle prompts:
+   - **Scope** — audit each touched `SKILL.md` (whole file) against the best-practices guide.
+     The full `SKILL.md` content is in `diff.txt`, so the core checks (frontmatter, description,
+     naming, body length, content hygiene) need nothing else. Reading sibling
+     `references/*`/`scripts/*` is **best-effort**: when the working tree is available (local
+     `/woostack-review`, or CI with a checkout) the worker reads them to judge
+     progressive-disclosure depth and script quality; when only `diff.txt` is available, those
+     sibling-dependent checks degrade gracefully and the worker audits what is in the diff. Cite
+     the guide URL.
+   - **Find** — grouped by best-practices area:
+     - *Frontmatter validity:* `name` >64 chars, not `^[a-z0-9-]+$`, contains a reserved word
+       (`anthropic`/`claude`), or XML tags; `description` empty, >1024 chars, or XML tags.
+     - *Description quality:* vague ("helps with documents"), written in 1st/2nd person
+       instead of 3rd, or missing the "what + when to use" pair.
+     - *Naming:* vague names (`helper`, `utils`, `tools`), inconsistent with the collection.
+     - *Body size:* SKILL.md body over ~500 lines → recommend splitting into reference files.
+     - *Progressive disclosure:* references nested more than one level deep; reference files
+       over ~100 lines without a table of contents; non-descriptive filenames (`doc2.md`).
+     - *Conciseness:* explaining things Claude already knows; paragraphs that don't justify
+       their token cost.
+     - *Content hygiene:* time-sensitive info not quarantined in an "old patterns" section;
+       inconsistent terminology; abstract (not concrete) examples; offering too many options
+       without a default.
+     - *Scripts (when the skill bundles them):* punting errors to Claude instead of handling
+       them; voodoo constants; assuming packages are installed; un-qualified MCP tool names;
+       Windows-style backslash paths.
+     - *Workflows:* complex multi-step tasks lacking clear steps/checklists or feedback loops
+       where quality is critical.
+   - **Skip** — pre-existing issues on lines the PR did not touch *and* cannot be anchored;
+     non-`SKILL.md` markdown (owned by `docs`); subjective wording nits with no
+     best-practice basis.
+   - **Severity rubric** — see §6.
+   - **Output** — write `findings.skills.json` per the `_header.md` schema; each finding gets
+     `"angle": "skills"`, populated `title`/`description`/`fix`/`fix_type`.
+2. **`skills/woostack-review/scripts/detect-angles.sh`** — add `has_skills_file()` (basename
+   `SKILL.md` match against `CHANGED_PATHS`), an `ANGLES+=("skills")` block, and a catalog
+   entry in the leading header comment. **Also exclude `SKILL.md` from `has_docs_file()`'s
+   `\.md$` catch** by adding it to the existing `grep -vE` exclusion list (alongside
+   `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`), so a SKILL.md-only PR routes to `skills` rather than
+   firing `docs` too. Update the `docs` catalog comment to note the new exclusion.
+3. **`skills/woostack-review/scripts/load-config.sh`** — add `"skills"` to the `VALID_ANGLES`
+   set (line ~85). Without this, a consumer's `.woostack/config.json` with
+   `review.angles.force`/`skip: ["skills"]` fails the loader with "unknown angle".
+4. **`skills/woostack-review/SKILL.md`** — add `skills` to the Stage 2 conditional-angle list
+   (line ~270) and to the Stage 3 tier-assignment table (line ~348, `standard` group).
+5. **`skills/woostack-review/prompts/_header.md`** — add `skills` to the Model Tiers table
+   `standard` row's angle list.
+6. **`skills/woostack-review/prompts/anthropic.md`** — add `skills` to the per-provider tier
+   table's `standard` row (line ~51). The `openai`/`google`/`opencode` prompts read each
+   angle's tier from its frontmatter and do **not** enumerate angles, so they need no edit.
+7. **`skills/woostack-review/scripts/tests/`** — a focused test that constructs a diff/meta
+   fixture touching a `SKILL.md` and asserts `detect-angles.sh` enables `skills` (and that a
+   no-`SKILL.md` diff does not), following the existing `test-*.sh` harness (`assert.sh`,
+   `OUTDIR`+`meta.json`+`diff.txt` fixtures). `detect-angles.sh` has no test today; this locks
+   the gate. May optionally also assert `load-config.sh` accepts `skills` in `force`/`skip`.
+
+Data flow is unchanged: `detect-angles.sh` → `angles.txt` includes `skills` → Stage 3 swarm
+spawns the `skills` worker reading `prompts/angles/skills.md` + diff → `findings.skills.json`
+→ `merge-findings.sh` → validator/intersect → posted review.
+
+## 6. Error handling
+
+- **Angle worker contract.** The worker writes `[]` to `findings.skills.json` first, replaces
+  it with the real array before exit, and drops any finding whose `line` does not resolve via
+  `resolve-diff-line.sh` — identical to every other angle. No bespoke error handling.
+- **Anchoring file-level findings.** `resolve-diff-line.sh` only accepts `+`/context lines, so
+  for a *new* `SKILL.md` every line anchors and the audit posts in full; for an *edit*, only
+  findings near the changed hunks anchor. File-level findings with no single natural line (body
+  over ~500 lines, missing TOC) anchor to the most relevant diff-visible line — the frontmatter
+  `name:`/`description:` line for frontmatter findings, the nearest changed line for structural
+  ones — and are dropped when nothing anchors. This is the standard contract, not new behavior.
+- **Severity rubric (false-positive control):**
+  - `HIGH` + `blocking: true` — frontmatter that breaks discovery or loading: `name` violates
+    charset/length/reserved-word, or `description` is empty / >1024 chars / contains XML tags.
+    These genuinely break the skill.
+  - `MEDIUM` + `blocking: false` — vague or 2nd-person `description` (hurts discovery), body
+    over ~500 lines, nested references, scripts that punt errors / use voodoo constants /
+    assume installs, Windows-style paths.
+  - `LOW` + `blocking: false` — vague name, missing TOC on a long reference, verbosity,
+    inconsistent terminology, abstract examples, too-many-options.
+- **Noise control.** The angle inherits the standard `severity_floor` (default `high`) and
+  nits behavior, and the adversarial validator intersection. LOW/MEDIUM findings surface as
+  non-blocking nits under the default floor — the angle does not gate PRs on style.
+- **Self-review guard.** Because this repo's own PRs touch `SKILL.md`, the angle will review
+  itself; the `~500`/`~100`-line thresholds are soft ("over" with a recommendation), never
+  hard failures, to avoid the angle flagging its own prompt or large legitimate skills.
+
+## 7. Testing
+
+- **Automated:** add a `detect-angles.sh` gating test under `scripts/tests/`, following the
+  existing harness (`source ../../woostack-init/scripts/tests/assert.sh`; `mktemp -d` for
+  `OUTDIR`; write `meta.json` with `.files[].path` + a `diff.txt`) — a `SKILL.md` in the
+  synthesized changed-paths enables `skills`; a diff with no `SKILL.md` does not. Run alongside
+  the existing `scripts/tests/test-*.sh`.
+- **Manual:** run `/woostack-review` locally on a branch that edits a `SKILL.md` (e.g. this
+  repo's own) and confirm (a) `skills` appears in `angles.txt`, (b) the worker writes a valid
+  `findings.skills.json`, (c) seeded violations (a vague description, a reserved-word name)
+  surface with the expected severities, and (d) a diff with no `SKILL.md` does not enable the
+  angle.
+
+## 8. Open questions
+
+None open. Resolved during ideation and hardening:
+
+- **Name `skills`, tier `standard`** — settled in ideation.
+- **`docs`/`skills` gate overlap** — exclude `SKILL.md` from the `docs` gate so a SKILL.md-only
+  PR routes to `skills` (mirrors the existing rule-file exclusions). See §5 item 2.
+- **Whole-file audit vs. line anchoring** — `resolve-diff-line.sh` only anchors `+`/context
+  lines, so the audit posts in full on a new `SKILL.md` and near-the-change on an edit; sibling
+  `references/*`/`scripts/*` reads are best-effort (graceful degradation when only `diff.txt` is
+  available). See §5 item 1 and §6.
+- **Touch-point completeness** — hardening found two enumeration sites beyond the original five:
+  `load-config.sh` `VALID_ANGLES` and `anthropic.md`'s tier table. Total is seven (§5).


### PR DESCRIPTION
## Goal

Add a `skills` review angle to `woostack-review` that audits changed `SKILL.md` files against Anthropic's skill best-practices guide. This PR ships the design spec and implementation plan as the base of the build stack; the implementation increment stacks on top.

## Summary

- `.woostack/specs/2026-06-05-skills-review-angle.md` — hardened design spec: a new conditional `skills` angle (tier `standard`) that fires when a `SKILL.md` is in the diff, audits the whole file against the best-practices rubric, and registers across 7 enumeration touch points.
- `.woostack/plans/2026-06-05-skills-review-angle.md` — TDD implementation plan, one PR-sized increment: detect-angles gate + `docs`-gate handoff, `VALID_ANGLES`, the angle prompt, the three angle→tier registrations, and a detect-angles gating test.

## Test plan

### Manual

**Before merge**

- [ ] Read the spec — confirm angle scope, `SKILL.md` gating, whole-file audit, and the severity rubric match intent.
- [ ] Read the plan — confirm the 7 touch points and the TDD tasks are complete and placeholder-free.

Spec: .woostack/specs/2026-06-05-skills-review-angle.md
