### PR TITLE
feat(woostack-review): add skills review angle

### DIFF
--- a/.woostack/plans/2026-06-05-skills-review-angle.md
+++ b/.woostack/plans/2026-06-05-skills-review-angle.md
@@ -22,7 +22,7 @@ All paths below are relative to the repo root; the review skill lives at `skills
 - Test: `skills/woostack-review/scripts/tests/test-detect-angles-skills.sh` (create)
 - Modify: `skills/woostack-review/scripts/detect-angles.sh` (add `has_skills_file()`, an `ANGLES+=("skills")` block, the `SKILL.md` exclusion in `has_docs_file()`, and header-catalog comments)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-review/scripts/tests/test-detect-angles-skills.sh`:
 
@@ -66,12 +66,12 @@ rm -rf "$work"
 finish
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `bash skills/woostack-review/scripts/tests/test-detect-angles-skills.sh`
 Expected: FAIL — first assertion errors, `SKILL.md enables skills angle` (the `skills` angle is not emitted yet; `angles.txt` for a SKILL.md-only diff currently contains `bugs security docs`).
 
-- [ ] **Step 3: Add `has_skills_file()` next to the other `has_*_file` helpers**
+- [x] **Step 3: Add `has_skills_file()` next to the other `has_*_file` helpers**
 
 In `skills/woostack-review/scripts/detect-angles.sh`, after the `has_deps_file()` function (ends at the `}` before `ANGLES=("bugs" "security")`), add:
 
@@ -82,7 +82,7 @@ has_skills_file() {
 }
 ```
 
-- [ ] **Step 4: Exclude `SKILL.md` from the `docs` gate**
+- [x] **Step 4: Exclude `SKILL.md` from the `docs` gate**
 
 In the same file, in `has_docs_file()`, add a `SKILL.md` exclusion to the trailing `*.md` filter pipe so a SKILL.md-only PR routes to `skills`, not `docs` (mirrors the existing rule-file exclusions). Change:
 
@@ -103,7 +103,7 @@ to:
     | grep -qE '\.(md|mdx)$' && return 0
 ```
 
-- [ ] **Step 5: Add the `skills` angle to the `ANGLES` assembly**
+- [x] **Step 5: Add the `skills` angle to the `ANGLES` assembly**
 
 In the same file, immediately after the `if has_docs_file; then ANGLES+=("docs") fi` block, add:
 
@@ -113,7 +113,7 @@ if has_skills_file; then
 fi
 ```
 
-- [ ] **Step 6: Update the header-comment catalog**
+- [x] **Step 6: Update the header-comment catalog**
 
 In the leading comment block of `detect-angles.sh`, (a) update the `docs` entry to note the new exclusion, and (b) add a `skills` entry. In the `docs —` comment, append `SKILL.md (owned by the skills angle)` to its existing exclusion parenthetical. After the `architecture —` catalog entry, add:
 
@@ -124,7 +124,7 @@ In the leading comment block of `detect-angles.sh`, (a) update the `docs` entry 
 #               PR routes here, not to docs.
 ```
 
-- [ ] **Step 7: Lint, then run the test, confirm it passes**
+- [x] **Step 7: Lint, then run the test, confirm it passes**
 
 Run: `bash -n skills/woostack-review/scripts/detect-angles.sh && bash skills/woostack-review/scripts/tests/test-detect-angles-skills.sh`
 Expected: PASS (no syntax error; all assertions pass; `finish` prints the success summary).
@@ -134,7 +134,7 @@ Expected: PASS (no syntax error; all assertions pass; `finish` prints the succes
 **Files:**
 - Modify: `skills/woostack-review/scripts/load-config.sh:85` (`VALID_ANGLES`)
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run (this is the "failing test" — config `force: ["skills"]` is rejected before the change):
 
@@ -147,7 +147,7 @@ bash skills/woostack-review/scripts/load-config.sh; echo "rc=$?"; rm -rf "$work"
 
 Expected: FAIL — non-zero exit with an annotation containing `angles.force contains unknown angle(s): skills`.
 
-- [ ] **Step 2: Add `"skills"` to `VALID_ANGLES`**
+- [x] **Step 2: Add `"skills"` to `VALID_ANGLES`**
 
 In `skills/woostack-review/scripts/load-config.sh`, change line 85 from:
 
@@ -161,7 +161,7 @@ to (append `, "skills"` before the closing brace):
 VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture", "skills"}
 ```
 
-- [ ] **Step 3: Re-run the verification, confirm it passes**
+- [x] **Step 3: Re-run the verification, confirm it passes**
 
 Run:
 
@@ -180,7 +180,7 @@ Expected: PASS — `rc=0` and the final line prints `skills`.
 **Files:**
 - Create: `skills/woostack-review/prompts/angles/skills.md`
 
-- [ ] **Step 1: Write the angle prompt**
+- [x] **Step 1: Write the angle prompt**
 
 Create `skills/woostack-review/prompts/angles/skills.md` with exactly:
 
@@ -241,7 +241,7 @@ tier: standard
 **Output.** Write findings as a JSON array to `/tmp/pr-review/findings.skills.json` using the schema in `_header.md`. Each finding gets `"angle": "skills"` and MUST populate `title` (bold headline ≤60 chars), `description` (the violation — name the file + the best-practice broken, no fix), `fix` (recommended change in prose), and `fix_type`. Anchor each finding's `line` to the most relevant diff-visible line — the frontmatter `name:` / `description:` line for frontmatter findings, the nearest changed line for structural ones — and validate it with `resolve-diff-line.sh`; DROP any finding whose line resolves to `null`. Set `fix_type: "suggestion"` only when a ≤10-line single-file drop-in replacement at `line` is safe — and populate `suggestion`. Otherwise set `fix_type: "prose"` with `suggestion: null`. See `_header.md` for the full rule.
 ```
 
-- [ ] **Step 2: Verify the prompt's shape and that it dogfoods its own rules**
+- [x] **Step 2: Verify the prompt's shape and that it dogfoods its own rules**
 
 Run:
 
@@ -262,11 +262,11 @@ Expected: line 2 is `tier: standard`; the section count prints `5` (the regex ac
 - Modify: `skills/woostack-review/prompts/_header.md` (Model Tiers `standard` row ~line 60)
 - Modify: `skills/woostack-review/prompts/anthropic.md` (tier table `standard` row ~line 51)
 
-- [ ] **Step 1: SKILL.md Stage 2 list — add `skills`**
+- [x] **Step 1: SKILL.md Stage 2 list — add `skills`**
 
 In `skills/woostack-review/SKILL.md`, in the Stage 2 paragraph that enumerates conditional angles, insert `skills` after `deps`. Change `…, \`docs\`, \`deps\`, \`architecture\` (when the diff touches general-purpose source files).` to `…, \`docs\`, \`deps\`, \`skills\` (when a \`SKILL.md\` is in the diff), \`architecture\` (when the diff touches general-purpose source files).`
 
-- [ ] **Step 2: SKILL.md Stage 3 tier table — add a `skills` row**
+- [x] **Step 2: SKILL.md Stage 3 tier table — add a `skills` row**
 
 In the Stage 3 "Tier assignments" table, after the `| \`tests\`, \`api\`, \`infra\` workers | \`standard\` | Coverage/contract/IaC reasoning. |` row, add:
 
@@ -274,15 +274,15 @@ In the Stage 3 "Tier assignments" table, after the `| \`tests\`, \`api\`, \`infr
 | `skills` worker | `standard` | Skill-authoring judgment against the best-practices guide. |
 ```
 
-- [ ] **Step 3: `_header.md` Model Tiers — add `skills` to the standard row**
+- [x] **Step 3: `_header.md` Model Tiers — add `skills` to the standard row**
 
 In `skills/woostack-review/prompts/_header.md`, in the `| \`standard\` |` Model Tiers row, append `, \`skills\`` to the parenthesized worker list so it reads `…\`tests\`, \`api\`, \`infra\`, \`skills\`)`.
 
-- [ ] **Step 4: `anthropic.md` tier table — add `skills` to the standard row**
+- [x] **Step 4: `anthropic.md` tier table — add `skills` to the standard row**
 
 In `skills/woostack-review/prompts/anthropic.md`, in the `| \`standard\` | \`claude-sonnet-4-6\` | …` row, append `, \`skills\`` to the angle list so it ends `…\`api\`, \`infra\`, \`skills\` |`.
 
-- [ ] **Step 5: Verify all four registrations**
+- [x] **Step 5: Verify all four registrations**
 
 Run:
 
@@ -297,7 +297,7 @@ Expected: each `grep` prints exactly one matching line (four matches total).
 
 ### Task 5: Full verification sweep + commit
 
-- [ ] **Step 1: Run the whole review-skill test suite**
+- [x] **Step 1: Run the whole review-skill test suite**
 
 Run:
 
@@ -307,12 +307,12 @@ for t in skills/woostack-review/scripts/tests/test-*.sh; do echo "== $t"; bash "
 
 Expected: every test prints its success summary and exits 0 — including the new `test-detect-angles-skills.sh`.
 
-- [ ] **Step 2: Lint every shell script touched**
+- [x] **Step 2: Lint every shell script touched**
 
 Run: `bash -n skills/woostack-review/scripts/detect-angles.sh && bash -n skills/woostack-review/scripts/load-config.sh && echo OK`
 Expected: prints `OK`.
 
-- [ ] **Step 3: Smoke-test the end-to-end gate against a real skill path**
+- [x] **Step 3: Smoke-test the end-to-end gate against a real skill path**
 
 Run:
 
@@ -326,7 +326,7 @@ cat "$OUTDIR/angles.txt"; rm -rf "$work"
 
 Expected: output contains `skills` and does **not** contain `docs`.
 
-- [ ] **Step 4: Commit the increment**
+- [x] **Step 4: Commit the increment**
 
 Commit via `woostack-commit` (it creates the Graphite branch, pushes, and writes the PR fields). This increment stacks on top of the spec+plan PR.
 
@@ -334,6 +334,6 @@ Commit via `woostack-commit` (it creates the Graphite branch, pushes, and writes
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — every spec requirement maps to a task: angle prompt (Task 3) ✓; gating + docs-gate exclusion (Task 1) ✓; `VALID_ANGLES` (Task 2) ✓; SKILL.md Stage 2 + Stage 3, `_header.md`, `anthropic.md` (Task 4) ✓; detect-angles test (Task 1) ✓; severity rubric embedded in the prompt (Task 3) ✓.
-- [ ] **No placeholders** — every step carries the actual code/commands and exact expected output; no TBD/TODO.
-- [ ] **Type consistency** — angle name is `skills` everywhere (artifact `findings.skills.json`, `"angle": "skills"`, `VALID_ANGLES`, all tier tables, gate function `has_skills_file`); tier is `standard` everywhere.
+- [x] **Spec coverage** — every spec requirement maps to a task: angle prompt (Task 3) ✓; gating + docs-gate exclusion (Task 1) ✓; `VALID_ANGLES` (Task 2) ✓; SKILL.md Stage 2 + Stage 3, `_header.md`, `anthropic.md` (Task 4) ✓; detect-angles test (Task 1) ✓; severity rubric embedded in the prompt (Task 3) ✓.
+- [x] **No placeholders** — every step carries the actual code/commands and exact expected output; no TBD/TODO.
+- [x] **Type consistency** — angle name is `skills` everywhere (artifact `findings.skills.json`, `"angle": "skills"`, `VALID_ANGLES`, all tier tables, gate function `has_skills_file`); tier is `standard` everywhere.

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -267,7 +267,7 @@ bash "$WOO_REVIEW_ACTION_PATH/scripts/load-config.sh"   # parses .woostack/confi
 bash "$WOO_REVIEW_ACTION_PATH/scripts/detect-angles.sh"
 ```
 
-Read the result from `$OUTDIR/angles.txt` (one angle per line). Always-on angles: `bugs`, `security`. Conditional (auto-detected from changed paths + diff body): `conventions` (when `rules.md` is present), `seo`, `aeo`, `design`, `react`, `database`, `tests`, `api`, `infra`, `observability`, `types`, `i18n`, `docs`, `deps`, `architecture` (when the diff touches general-purpose source files). See `scripts/detect-angles.sh` for per-angle gating heuristics.
+Read the result from `$OUTDIR/angles.txt` (one angle per line). Always-on angles: `bugs`, `security`. Conditional (auto-detected from changed paths + diff body): `conventions` (when `rules.md` is present), `seo`, `aeo`, `design`, `react`, `database`, `tests`, `api`, `infra`, `observability`, `types`, `i18n`, `docs`, `deps`, `skills` (when a `SKILL.md` is in the diff), `architecture` (when the diff touches general-purpose source files). See `scripts/detect-angles.sh` for per-angle gating heuristics.
 
 Prefetch also produces optional chunking artifacts when the post-ignore diff exceeds `chunking.max_loc` (default 4000 LOC). When present, the host MUST fan out one sub-agent per `(angle, chunk)` pair in Stage 3:
 
@@ -344,6 +344,7 @@ Sub-agents MUST NOT post comments, edit the PR, touch other angles' files, run `
 | `design`, `react` workers | `standard` | Heuristic + Rules-of-Hooks judgment after deterministic tools. |
 | `database` worker | `standard` | Postgres correctness, RLS reasoning, plan/index judgment. |
 | `tests`, `api`, `infra` workers | `standard` | Coverage/contract/IaC reasoning. |
+| `skills` worker | `standard` | Skill-authoring judgment against the best-practices guide. |
 | `seo`, `aeo` workers | `fast` | Rubric checklists; no novel reasoning. |
 | `observability`, `types`, `i18n`, `docs`, `deps` workers | `fast` | Pattern matching + diff-anchored hygiene checks. |
 | Skeptical Validator | `deep` | Highest-leverage step — strictest false-positive filter pays for itself. |

--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -57,7 +57,7 @@ Each angle prompt and the validator declare a `tier:` in frontmatter — `fast`,
 | Tier | Use for | Anthropic | OpenAI (Codex) | Google (Gemini) | OpenRouter |
 |---|---|---|---|---|---|
 | `fast` | rubric checklists (`seo`, `aeo`, `observability`, `types`, `i18n`, `docs`, `deps`), context summaries | `claude-haiku-4-5` | `gpt-5.3-codex-spark` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
-| `standard` | reasoning workers (`bugs`, `security`, `architecture`, `design`, `react`, `database`, `tests`, `api`, `infra`) | `claude-sonnet-4-6` | `gpt-5.4` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
+| `standard` | reasoning workers (`bugs`, `security`, `architecture`, `design`, `react`, `database`, `tests`, `api`, `infra`, `skills`) | `claude-sonnet-4-6` | `gpt-5.4` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
 | `deep` | skeptical validator (highest-leverage filter) | `claude-opus-4-7` | `gpt-5.5` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
 
 > **Provider notes:**

--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -93,7 +93,7 @@ The prefetch step parses an optional `.woostack/config.json` in the consumer rep
 
 ## Review Angles
 
-This action runs up to seventeen distinct review angles, auto-selected from the changed files. The set of enabled angles is listed in `/tmp/pr-review/angles.txt`. The per-angle prompt bodies live at `${ACTION_PATH}/prompts/angles/<angle>.md` and are loaded by the orchestrator.
+This action runs up to eighteen distinct review angles, auto-selected from the changed files. The set of enabled angles is listed in `/tmp/pr-review/angles.txt`. The per-angle prompt bodies live at `${ACTION_PATH}/prompts/angles/<angle>.md` and are loaded by the orchestrator.
 
 | Angle | Always-on | Tooling |
 |---|---|---|
@@ -111,9 +111,10 @@ This action runs up to seventeen distinct review angles, auto-selected from the 
 | `observability` | no | LLM only — gated on logging / error-handling tokens in the diff |
 | `types` | no | LLM only — gated on `*.ts` / `*.tsx` / `*.cts` / `*.mts` in diff |
 | `i18n` | no | LLM only — gated on `locales/` / `messages/` / `i18n/` / `translations/` directory trees, `*.po` / `*.pot` files, or `i18n.t(` / `useTranslations(` / `<Trans` / `<FormattedMessage` / `$t(` / `t("…")` tokens in the diff body |
-| `docs` | no | LLM only — gated on docs paths (`README*`, `CHANGELOG*`, `docs/`, `.env.example`, `*.md`/`*.mdx`, `openapi.{yaml,yml,json}`, `swagger.{yaml,yml,json}`) in diff |
+| `docs` | no | LLM only — gated on docs paths (`README*`, `CHANGELOG*`, `docs/`, `.env.example`, `*.md`/`*.mdx`, `openapi.{yaml,yml,json}`, `swagger.{yaml,yml,json}`) in diff; `SKILL.md` is excluded — owned by `skills` |
 | `deps` | no | LLM only — gated on dependency-manifest paths (`package.json`, lockfiles, `requirements.txt`, `go.mod`, `Cargo.toml`, …) in diff |
 | `architecture` | no | LLM only — gated on general-purpose source files in diff (`*.ts`/`*.js`/`*.py`/`*.go`/`*.rs`/`*.java`/`*.rb`/`*.php`/`*.cs`/…); structural-quality / code-judo pass; skips doc-only and config-only PRs |
+| `skills` | no | LLM only — gated on a `SKILL.md` in diff; audits the changed Agent Skill against Anthropic's skill best-practices guide (`SKILL.md` is excluded from the `docs` gate so a SKILL.md-only PR routes here) |
 
 Each angle writes its findings to `/tmp/pr-review/findings.<angle>.json`. The orchestrator merges them into `/tmp/pr-review/findings.json` after the validator pass, then posts inline comments via a single batched GitHub Review. PR labels MUST NOT be mutated — blocking is signalled exclusively through the native `REQUEST_CHANGES` review event.
 

--- a/skills/woostack-review/prompts/angles/skills.md
+++ b/skills/woostack-review/prompts/angles/skills.md
@@ -1,0 +1,54 @@
+---
+tier: standard
+---
+
+# Angle: Skills
+
+**Scope.** Audit Agent Skills changed by this PR against Anthropic's skill best-practices guide (https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices). This angle fires when a `SKILL.md` is in the diff. For each touched `SKILL.md`, audit the **whole file** — its full content is in `/tmp/pr-review/diff.txt` — not only the changed lines. When the working tree is available you MAY read sibling `references/*` and `scripts/*` in the same skill directory to judge progressive disclosure and script quality; when only the diff is available, audit what it contains. A newly-added `SKILL.md` is entirely `+` lines, so every finding anchors; on an edit, only findings near the changed hunks anchor (see Output).
+
+**Find:**
+
+- **Frontmatter validity (breaks discovery/load):**
+  - `name` longer than 64 chars, not matching `^[a-z0-9-]+$`, containing a reserved word (`anthropic` / `claude`), or containing XML tags.
+  - `description` empty, longer than 1024 chars, or containing XML tags.
+- **Description quality:**
+  - Vague description that won't drive discovery ("Helps with documents", "Processes data").
+  - Written in first/second person ("I can help…", "You can use this…") instead of third person.
+  - Missing the *what it does* **and** *when to use it* pair.
+- **Naming:**
+  - Vague/generic name (`helper`, `utils`, `tools`, `documents`) or one inconsistent with the collection's pattern.
+- **Body size & progressive disclosure:**
+  - SKILL.md body over ~500 lines — recommend splitting into reference files.
+  - References nested more than one level deep (SKILL.md → a.md → b.md); every reference file should link directly from SKILL.md.
+  - A reference file over ~100 lines with no table of contents.
+  - Non-descriptive bundled filenames (`doc2.md`, `file1.md`).
+- **Conciseness:**
+  - Explaining things Claude already knows (e.g. "PDF is a file format…"); paragraphs that do not justify their token cost.
+- **Content hygiene:**
+  - Time-sensitive info ("after August 2025…") not quarantined in an "old patterns" section.
+  - Inconsistent terminology for one concept.
+  - Abstract examples where concrete input/output pairs are needed.
+  - Offering many options with no recommended default.
+  - Windows-style backslash paths (`scripts\helper.py`) instead of forward slashes.
+- **Scripts (only when the skill bundles them):**
+  - A script that punts errors to Claude instead of handling them.
+  - Voodoo constants (magic numbers with no justification).
+  - Assuming a package is installed without an install step.
+  - Un-qualified MCP tool names (use `Server:tool`).
+- **Workflows:**
+  - A complex multi-step task with no clear steps/checklist, or a quality-critical task with no validate→fix feedback loop.
+
+**Skip:**
+
+- Pre-existing issues on lines the PR did not touch that cannot be anchored on the diff's RIGHT side (see Output) — do not invent a line to report them.
+- Non-`SKILL.md` markdown (README / CHANGELOG / docs) — that is the `docs` angle.
+- Subjective wording nits with no basis in the best-practices guide.
+- Plugin/host-specific frontmatter keys beyond `name` / `description`.
+
+**Severity rubric:**
+
+- `HIGH` + `blocking: true` — frontmatter that breaks discovery or loading: `name` violates charset/length/reserved-word, or `description` is empty / >1024 chars / contains XML tags.
+- `MEDIUM` + `blocking: false` — vague or non-third-person description, body over ~500 lines, nested references, a script that punts errors / uses voodoo constants / assumes installs, Windows-style paths.
+- `LOW` + `blocking: false` — vague name, missing TOC on a long reference, verbosity, inconsistent terminology, abstract examples, too-many-options, missing feedback loop.
+
+**Output.** Write findings as a JSON array to `/tmp/pr-review/findings.skills.json` using the schema in `_header.md`. Each finding gets `"angle": "skills"` and MUST populate `title` (bold headline ≤60 chars), `description` (the violation — name the file + the best-practice broken, no fix), `fix` (recommended change in prose), and `fix_type`. Anchor each finding's `line` to the most relevant diff-visible line — the frontmatter `name:` / `description:` line for frontmatter findings, the nearest changed line for structural ones — and validate it with `resolve-diff-line.sh`; DROP any finding whose line resolves to `null`. Set `fix_type: "suggestion"` only when a ≤10-line single-file drop-in replacement at `line` is safe — and populate `suggestion`. Otherwise set `fix_type: "prose"` with `suggestion: null`. See `_header.md` for the full rule.

--- a/skills/woostack-review/prompts/anthropic.md
+++ b/skills/woostack-review/prompts/anthropic.md
@@ -48,7 +48,7 @@ Then resolve via the **Model Tiers** table in `_header.md`:
 | Tier | Anthropic model | Used for |
 |---|---|---|
 | `fast` | `claude-haiku-4-5` | context+summary, `seo`, `aeo`, `observability`, `types`, `i18n`, `docs`, `deps` |
-| `standard` | `claude-sonnet-4-6` | `bugs`, `security`, `architecture`, `design`, `react`, `database`, `tests`, `api`, `infra` |
+| `standard` | `claude-sonnet-4-6` | `bugs`, `security`, `architecture`, `design`, `react`, `database`, `tests`, `api`, `infra`, `skills` |
 | `deep` | `claude-opus-4-7` | skeptical validator |
 
 **Every Task/Agent spawn MUST pass `model:` explicitly.** Omitting it makes the subagent inherit the parent session's model — typically Opus — which silently defeats tier routing and burns ~5x the tokens on rubric angles. The `tier:` frontmatter is informational unless the spawning call passes the resolved slug.

--- a/skills/woostack-review/scripts/detect-angles.sh
+++ b/skills/woostack-review/scripts/detect-angles.sh
@@ -54,8 +54,8 @@
 #               `<Trans` / `FormattedMessage` tokens in the diff body.
 #   docs      — README*, CHANGELOG*, docs/, *.md / *.mdx (excluding the rule
 #               files consumed by the conventions angle: AGENTS.md, CLAUDE.md,
-#               GEMINI.md, .cursorrules, .windsurfrules), .env.example,
-#               openapi.{yaml,yml,json}.
+#               GEMINI.md, .cursorrules, .windsurfrules, and SKILL.md, which the
+#               skills angle owns), .env.example, openapi.{yaml,yml,json}.
 #   deps      — dependency manifests / lockfiles: package.json, package-lock.json,
 #               pnpm-lock.yaml, yarn.lock, bun.lockb, requirements.txt,
 #               pyproject.toml, poetry.lock, uv.lock, go.mod, go.sum,
@@ -64,6 +64,10 @@
 #               *.{ts,tsx,cts,mts,js,jsx,mjs,cjs,py,go,rs,java,kt,kts,swift,rb,
 #               php,cs,scala,c,h,cc,cpp,hpp,cxx,m,mm}. Structural-quality /
 #               code-judo pass; skips doc-only and config-only PRs.
+#   skills    — a file named SKILL.md anywhere in the diff (Agent Skill manifest).
+#               Audits the changed skill against Anthropic's skill best-practices
+#               guide. SKILL.md is excluded from the docs gate so a SKILL.md-only
+#               PR routes here, not to docs.
 
 set -euo pipefail
 
@@ -216,6 +220,7 @@ has_docs_file() {
   echo "$CHANGED_PATHS" \
     | grep -vE '(^|/)(AGENTS|CLAUDE|GEMINI)\.md$' \
     | grep -vE '(^|/)\.(cursorrules|windsurfrules)$' \
+    | grep -vE '(^|/)SKILL\.md$' \
     | grep -qE '\.(md|mdx)$' && return 0
   return 1
 }
@@ -228,6 +233,11 @@ has_deps_file() {
   echo "$CHANGED_PATHS" | grep -qE '(^|/)(Gemfile|Gemfile\.lock)$' && return 0
   echo "$CHANGED_PATHS" | grep -qE '(^|/)(composer\.(json|lock))$' && return 0
   return 1
+}
+
+has_skills_file() {
+  # Canonical Agent Skill manifest signal: a file named SKILL.md at any depth.
+  echo "$CHANGED_PATHS" | grep -qE '(^|/)SKILL\.md$'
 }
 
 ANGLES=("bugs" "security")
@@ -282,6 +292,10 @@ fi
 
 if has_docs_file; then
   ANGLES+=("docs")
+fi
+
+if has_skills_file; then
+  ANGLES+=("skills")
 fi
 
 if has_deps_file; then

--- a/skills/woostack-review/scripts/load-config.sh
+++ b/skills/woostack-review/scripts/load-config.sh
@@ -82,7 +82,7 @@ import sys
 
 src, dst = sys.argv[1], sys.argv[2]
 
-VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture"}
+VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture", "skills"}
 VALID_FLOORS = {"low", "medium", "high"}
 FORCE_TIERS = {"fast", "deep"}
 # Keys recognized inside the `review` block (and the legacy top-level form).

--- a/skills/woostack-review/scripts/tests/test-detect-angles-skills.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-skills.sh
@@ -34,4 +34,13 @@ bash "$SCRIPT" >/dev/null 2>&1
 assert_contains "$(cat "$OUTDIR/angles.txt")" "docs" "README.md still enables docs"
 rm -rf "$work"
 
+# A mixed PR (SKILL.md + another .md) enables BOTH skills and docs — the
+# SKILL.md exclusion must not suppress docs for the sibling markdown file.
+setup "skills/foo/SKILL.md
+docs/guide.md"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "skills" "mixed diff enables skills"
+assert_contains "$(cat "$OUTDIR/angles.txt")" "docs" "mixed diff still enables docs for the other .md"
+rm -rf "$work"
+
 finish

--- a/skills/woostack-review/scripts/tests/test-detect-angles-skills.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-skills.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/detect-angles.sh"
+
+# setup $1 = newline-separated changed file paths
+setup() {
+  work="$(mktemp -d)"
+  export OUTDIR="$work/out"
+  mkdir -p "$OUTDIR"
+  printf '%s\n' "$1" | jq -R . | jq -s '{files: [.[] | {path: .}]}' > "$OUTDIR/meta.json"
+  : > "$OUTDIR/diff.txt"
+}
+
+# A SKILL.md in the diff enables the skills angle and NOT docs.
+setup "skills/foo/SKILL.md"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "skills" "SKILL.md enables skills angle"
+assert_eq "$(grep -cx 'docs' "$OUTDIR/angles.txt" || true)" "0" "SKILL.md-only does not enable docs"
+rm -rf "$work"
+
+# A non-SKILL code file does not enable skills.
+setup "src/index.ts"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(grep -cx 'skills' "$OUTDIR/angles.txt" || true)" "0" "no SKILL.md -> no skills angle"
+rm -rf "$work"
+
+# A real README still enables docs (exclusion is SKILL.md-specific, not all .md).
+setup "README.md"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "docs" "README.md still enables docs"
+rm -rf "$work"
+
+finish


### PR DESCRIPTION
## Goal

Give `woostack-review` an angle that catches skill-authoring mistakes: when a PR changes a `SKILL.md`, audit it against Anthropic's skill best-practices guide so vague descriptions, invalid frontmatter, oversized bodies, nested references, and the like are flagged in review.

## Summary

- New `prompts/angles/skills.md` worker (`tier: standard`): whole-file audit of each touched `SKILL.md` against the best-practices rubric, with a severity rubric that blocks only on frontmatter that breaks discovery/load.
- `detect-angles.sh`: new `has_skills_file()` gate (fires on a `SKILL.md` at any depth) + `ANGLES` wiring + header-catalog entry; `SKILL.md` excluded from the `docs` gate so a SKILL.md-only PR routes to `skills`, not `docs`.
- Registered `skills` everywhere the angle set is enumerated: `load-config.sh` `VALID_ANGLES`; `SKILL.md` Stage 2 list + Stage 3 tier table; `prompts/_header.md` Model Tiers table **and** the Review Angles catalog table (count bumped 17→18); `prompts/anthropic.md` tier table.
- Added `scripts/tests/test-detect-angles-skills.sh` — the first `detect-angles.sh` gating test (6 cases: SKILL.md enables `skills` and not `docs`; non-SKILL diff does not; README still enables `docs`; mixed SKILL.md + `.md` enables both).

## Test plan

### Automated

- [x] `bash scripts/tests/test-detect-angles-skills.sh` — 6 passed, 0 failed
- [x] Full review suite (`for t in scripts/tests/test-*.sh`) — all green (bounded-swarm/intersect/load-config/memory/metrics)
- [x] `bash -n detect-angles.sh load-config.sh` — lint clean
- [x] `load-config.sh` accepts `angles.force: ["skills"]` — rc=0, force list prints `skills`
- [x] Dogfood: ran `woostack-review --fast` on this PR — the `skills` angle fired on its own SKILL.md change; 0 blocking findings (two non-blocking nits found and fixed in 41ddbbc).

### Manual

**Before merge**

- [ ] Read `prompts/angles/skills.md` — confirm the rubric, severity tiers, and anchoring/output rules match the spec.
- [ ] Smoke: a SKILL.md-only changed-paths fixture yields angles `bugs security aeo skills` (skills present, docs absent).

Spec: .woostack/specs/2026-06-05-skills-review-angle.md
