### PR TITLE
docs(woostack-debug): spec and plan for systematic-debugging skill

### DIFF
--- a/.woostack/plans/2026-06-05-woostack-debug.md
+++ b/.woostack/plans/2026-06-05-woostack-debug.md
@@ -1,0 +1,491 @@
+**Source:** .woostack/specs/2026-06-05-woostack-debug.md
+
+# woostack-debug Skill Implementation Plan
+
+**Goal:** Ship a woostack-native systematic-debugging skill exposed as the 12th public command `/woostack-debug <target> [--auto]` and as an internal hook, then wire `woostack-execute` (autonomous `--auto` dispatch) and `woostack-review` (gated suggestion) to it and register it across the adoption surface.
+
+**Architecture:** One new self-contained skill file (`skills/woostack-debug/SKILL.md`, no `references/`) retells superpowers `systematic-debugging` (Iron Law, 4 phases, ≥3-fixes architectural escalation) in woostack vocabulary and wires it to the `.woostack/memory/` store (recall at start via `recall.sh`, distill one `gotcha` note through the reject-by-default gate at end) and to woostack's TDD/commit discipline. Mode is an explicit `--auto` flag (autonomous, no gate) vs. its absence (standalone look-before-fix gate). Increment A ships the skill standalone; Increment B edits two skills (call sites) and four docs (enumeration). Source: [.woostack/specs/2026-06-05-woostack-debug.md](../specs/2026-06-05-woostack-debug.md).
+
+**Tech Stack:** Markdown skill + doc files only. No app code, no app build, no CI for this repo. "Tests" are verification commands (grep / `bash -n` / link checks) with exact expected output — this is a skills collection with no test runner.
+
+**Out of scope (explicit):** Do NOT add a `references/` dir or port superpowers' `root-cause-tracing.md` / `defense-in-depth.md` / `condition-based-waiting.md` / the TS example / `find-polluter.sh`. Do NOT make `woostack-debug` author specs/plans/status, commit, or merge. Do NOT touch `action.yml` or the reusable review workflow. Do NOT edit the build-loop prose in `README.md` (line ~62) — debug is a sub-routine, not a build phase. Do NOT move/rename any existing `SKILL.md`. Do NOT add app code, lockfiles, or CI.
+
+---
+
+## File Structure
+
+- **Create** `skills/woostack-debug/SKILL.md` — scoped discovery frontmatter; Iron Law block; the 4 phases; the `--auto` mode model; Red-Flags/Rationalizations digest; memory recall + distill contract (links `memory.md`, never restates); out-of-scope/handback contract. One responsibility: systematic debugging. Lean, no `references/`.
+- **Modify** `skills/woostack-execute/SKILL.md` — "When to stop and ask" routes a repeatedly-failing verification to `woostack-debug … --auto` before user escalation.
+- **Modify** `skills/woostack-review/SKILL.md` — suggest the gated `/woostack-debug` for a confirmed bug; never `--auto`.
+- **Modify** `skills/using-woostack/SKILL.md` — add a Command Routing row.
+- **Modify** `AGENTS.md` (`.claude/CLAUDE.md` symlink) — counts (eleven→twelve, thirteen→fourteen), public list, Modes B command list, Quick file map.
+- **Modify** `README.md` — count + list (line ~29) and a new `### /woostack-debug` command-catalog entry.
+- **Modify** `CONTRIBUTING.md` — command-surface list + edit-map row.
+
+---
+
+## Increment 1: The `woostack-debug` skill
+
+> One independently shippable PR — its own Graphite-stacked branch on top of the spec+plan PR. Creates only `skills/woostack-debug/SKILL.md`; touches no other file, so it ships and reviews on its own before any wiring references it.
+
+### Task 1: Create `skills/woostack-debug/SKILL.md`
+
+**Files:**
+- Create: `skills/woostack-debug/SKILL.md`
+- Test: verification commands below (no test runner in this repo)
+
+- [ ] **Step 1: Write the failing verification, confirm it fails**
+
+Run:
+```bash
+test -f skills/woostack-debug/SKILL.md && echo EXISTS || echo MISSING
+```
+Expected: FAIL — prints `MISSING` (file not created yet).
+
+- [ ] **Step 2: Author the frontmatter**
+
+Write the opening frontmatter. Keep `description` scoped so it is recognized as woostack's systematic-debugging phase / the `/woostack-debug` command and is invocable by `woostack-execute`/`woostack-review`, but does NOT over-trigger on every error mention:
+
+```markdown
+---
+name: woostack-debug
+description: "Use as woostack's systematic-debugging phase — find the root cause of a bug, test failure, or unexpected behavior before any fix, then fix it minimally with a failing test first. Retells the four-phase method (root-cause investigation → pattern analysis → hypothesis/test → implementation) with the Iron Law (no fix without root cause) and the 3-fixes-→-question-architecture escalation, wired to the .woostack/memory store (recall known gotchas at start, distill one gotcha at end). Invoke via /woostack-debug <target> for a look-before-fix gate, or with --auto for autonomous operation (woostack-execute dispatches --auto on a repeatedly-failing verification; woostack-review suggests the gated command for a confirmed bug). Owns no spec/plan/status, never commits or merges."
+---
+
+# woostack-debug
+
+Find the root cause of any bug, test failure, or unexpected behavior **before** attempting a
+fix, then fix the root cause minimally with a failing test first. This is woostack's own
+systematic-debugging phase: a place every woostack skill can route a stuck verification or a
+confirmed bug instead of falling back to guess-and-check. It owns no approval gate beyond its
+standalone look-before-fix mode, never commits, and never merges — it hands the fix back.
+```
+
+- [ ] **Step 3: Author the Iron Law block**
+
+Write it as a prominent block so it survives summarization (same treatment as the ideate HARD GATE):
+
+```markdown
+<IRON-LAW>
+NO FIX WITHOUT ROOT CAUSE INVESTIGATION FIRST.
+
+A symptom fix is a failure. If you have not completed Phase 1 (root-cause investigation), you
+may not propose or apply a fix. This holds for EVERY issue regardless of perceived simplicity
+and ESPECIALLY under time pressure — systematic debugging is faster than thrashing. Even in
+`--auto` mode, the root cause is narrated before any fix so the "why" is visible.
+</IRON-LAW>
+```
+
+- [ ] **Step 4: Author the four phases**
+
+Write a `## The four phases` section. Each phase must complete before the next. Content:
+
+- **Phase 1 — Root cause investigation:** read errors/stack traces completely (note line/file/code); reproduce consistently (if not reproducible, gather data — don't guess); check recent changes (`git diff`, recent commits, new deps/config); in multi-component systems add boundary instrumentation (log data in/out at each component boundary, run once to localize *which* layer fails before touching it); trace the bad value backward to its source and fix at source, not symptom.
+- **Phase 2 — Pattern analysis:** find working examples in the same repo; read any reference implementation completely (don't skim); list every difference between working and broken ("that can't matter" is banned); map dependencies/config/environment.
+- **Phase 3 — Hypothesis & test:** state one hypothesis ("X is the root cause because Y"); test with the smallest possible change, one variable at a time; confirm → Phase 4, or form a NEW hypothesis (don't stack fixes); when you don't know, say "I don't understand X" and research/ask rather than fake it.
+- **Phase 4 — Implementation:** write a **failing test that reproduces the bug first** (reuse the TDD discipline embodied in `woostack-execute` — in a target without a test runner, a concrete verification command with exact expected output); apply **one** minimal fix at the root cause (no "while I'm here" extras, no bundled refactor); verify the test passes and nothing else broke; optionally add defense-in-depth validation at layer boundaries. **If the fix fails:** attempts `< 3` → return to Phase 1 with the new evidence; attempts `≥ 3` → STOP (see escalation block).
+
+Include a one-line inline mention of the three techniques (root-cause tracing in Phase 1, defense-in-depth in Phase 4, condition-based waiting for timeout/flaky issues) — NOT separate reference files.
+
+- [ ] **Step 5: Author the ≥3-fixes escalation block**
+
+Write it as an explicit block (load-bearing, must survive summarization):
+
+```markdown
+<ESCALATION>
+If 3+ fixes have failed, STOP. This is not a failed hypothesis — it is a wrong-architecture
+signal (each fix reveals new coupling/state elsewhere, fixes need "massive refactoring", each
+fix creates new symptoms). Question the fundamentals with the user: is this pattern sound, or
+are we continuing through inertia? Do NOT attempt fix #4 before that discussion. When invoked
+with `--auto`, this stop is the handback signal to the caller.
+</ESCALATION>
+```
+
+- [ ] **Step 6: Author the mode model (`--auto`)**
+
+Write a `## Mode: --auto vs standalone` section:
+
+- Mode is selected by an explicit `--auto` flag (mirrors `woostack-execute`'s `--inline/--subagent`), never by context-sniffing.
+- **`--auto` (autonomous):** run Phases 1–4 end to end; no per-fix gate (consistent with execute/harden owning none); Iron Law still forces narrating the root cause; the only hard stop is the ≥3-fixes escalation, which doubles as the caller handback.
+- **No `--auto` (standalone, the default):** after Phases 1–3, STOP and present the root cause + the proposed minimal fix, and wait for an explicit go-ahead before Phase 4. Then name `woostack-commit` as the next step (debug does not commit).
+- **Fail-safe:** absence/unrecognized flag ⇒ gated. An unrequested fix is never silently applied.
+- **No-arg invocation:** `/woostack-debug` with no target → ask what's broken; do not guess (mirror `woostack-execute`).
+
+- [ ] **Step 7: Author the memory contract**
+
+Write a `## Memory` section that LINKS the contract rather than restating it ([memory.md](../woostack-init/references/memory.md)):
+
+- **Recall (start):** compute the working set (the target's files — the failing test file and the code under suspicion) and run the recall procedure — `recall.sh` when the `woostack-init` scripts are present, the manual §6 procedure otherwise. Surface matching `gotcha`/`hotspot`/`pattern` notes before investigating; a matching note may already name the root cause. State whether recall was script-assisted or manual (degradation contract).
+- **Distill (end, on a confirmed fix):** write **one** `gotcha` note through the reject-by-default gate — narrow glob `scope:` (single-literal-path scope is trivia, rejected), `source:` = owning spec/plan or `pr-N`, terse body with `[[wikilinks]]`, `updated:` today. Dedupe against `MEMORY.md` first (update over add). Then run `build-index.sh` + `doctor.sh`. The note records the **root cause and its fix**, not the symptom.
+
+- [ ] **Step 8: Author Red Flags + Rationalizations digest**
+
+Write a condensed `## Red flags — stop and return to Phase 1` list (from superpowers): "quick fix for now", "just try changing X", "add multiple changes, run tests", "skip the test", "it's probably X", "one more fix attempt" (after 2+), proposing fixes before tracing data flow, "each fix reveals a new problem". And a short rationalizations table ("issue is simple" → simple issues have root causes too; "emergency, no time" → systematic is faster than thrashing; "I see the problem" → seeing symptoms ≠ understanding root cause).
+
+- [ ] **Step 9: Author the out-of-scope / handback contract**
+
+Write a `## Hard constraints` section: owns no spec/plan/status authoring (the `spec : plan : PRs = 1 : 1 : N` invariant is untouched); never commits or merges (hands the fix back — standalone names `woostack-commit`, `--auto` lets the caller commit in its cadence); no `references/`; Iron Law and ≥3-fixes escalation are load-bearing blocks; fail-safe to gated when `--auto` is absent.
+
+- [ ] **Step 10: Run the structure verification, confirm it passes**
+
+Run:
+```bash
+f=skills/woostack-debug/SKILL.md
+grep -q '^name: woostack-debug$' "$f" && \
+grep -q 'IRON-LAW' "$f" && \
+grep -q 'ESCALATION' "$f" && \
+grep -qi 'phase 1' "$f" && grep -qi 'phase 4' "$f" && \
+grep -q -- '--auto' "$f" && \
+grep -q 'recall' "$f" && grep -q 'gotcha' "$f" && \
+grep -q 'memory.md' "$f" && \
+echo PASS || echo FAIL
+```
+Expected: PASS.
+
+- [ ] **Step 11: Confirm the out-of-scope contract holds (negative checks)**
+
+Run:
+```bash
+f=skills/woostack-debug/SKILL.md
+test ! -d skills/woostack-debug/references && echo "no-references:OK" || echo "no-references:FAIL"
+grep -qiE 'gt (create|modify|submit)|git commit|git merge' "$f" && echo "commit-leak:FAIL" || echo "commit-leak:OK"
+```
+Expected: `no-references:OK` and `commit-leak:OK`.
+
+- [ ] **Step 12: Link check**
+
+Run (verify every relative link target in the new skill exists):
+```bash
+cd skills/woostack-debug && \
+grep -oE '\]\(([^)]+\.md)' SKILL.md | sed 's/](//' | while read p; do
+  [ -e "$p" ] && echo "OK  $p" || echo "DANGLING  $p"; done
+```
+Expected: every line starts with `OK` (resolves `../woostack-init/references/memory.md`, `../woostack-status/references/conventions.md`, `../woostack-execute/SKILL.md`, `../woostack-review/SKILL.md`). No `DANGLING`.
+
+- [ ] **Step 13: Commit**
+
+```bash
+# first commit in this increment:
+gt create -m "feat(woostack-debug): add systematic-debugging skill"
+```
+
+---
+
+## Increment 2: Wire call sites and register the command
+
+> One independently shippable PR stacked on Increment 1. Edits two skills (call sites) and four docs (enumeration). Reviewable as "the new command is now reachable and counted everywhere." Small doc LOC, so kept as one coherent PR; if a reviewer prefers, it splits cleanly into 2a (call sites: Tasks 2–3) and 2b (enumeration: Tasks 4–8) — but that is over-splitting for edits this small.
+
+### Task 2: Wire `woostack-execute` (autonomous `--auto` dispatch)
+
+**Files:** Modify `skills/woostack-execute/SKILL.md`
+
+- [ ] **Step 1: Confirm the current text, confirm the wiring is absent**
+
+Run:
+```bash
+grep -n 'A verification fails repeatedly' skills/woostack-execute/SKILL.md
+grep -c 'woostack-debug' skills/woostack-execute/SKILL.md
+```
+Expected: the first prints the line (~137); the second prints `0` (no wiring yet — this is the failing state).
+
+- [ ] **Step 2: Edit the "When to stop and ask" block**
+
+In the `## When to stop and ask` list, change the `A verification fails repeatedly.` bullet so a repeatedly-failing verification first routes to `woostack-debug <target> --auto` (autonomous), escalating to the user only if debug returns its ≥3-fixes architectural stop. State that this applies to both inline and subagent drivers (the block is shared), and that debug does not commit — execute commits the returned fix in its existing per-increment cadence. Link `../woostack-debug/SKILL.md`. Example replacement bullet:
+
+```markdown
+- A verification fails repeatedly — route it to [`woostack-debug`](../woostack-debug/SKILL.md)
+  in autonomous mode (`woostack-debug <target> --auto`) to find and fix the root cause before
+  escalating; escalate to the user only if debug returns its 3-fixes architectural stop. Debug
+  does not commit — execute commits the returned fix in its normal per-increment cadence.
+  (Applies to both the inline and subagent drivers.)
+```
+
+- [ ] **Step 3: Run the verification, confirm it passes**
+
+Run:
+```bash
+grep -q 'woostack-debug <target> --auto' skills/woostack-execute/SKILL.md && \
+grep -q '\[`woostack-debug`\](../woostack-debug/SKILL.md)' skills/woostack-execute/SKILL.md && \
+echo PASS || echo FAIL
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt create -m "feat(woostack-execute): route stuck verifications to woostack-debug --auto"
+```
+
+### Task 3: Wire `woostack-review` (gated suggestion, never `--auto`)
+
+**Files:** Modify `skills/woostack-review/SKILL.md`
+
+- [ ] **Step 1: Confirm wiring absent**
+
+Run:
+```bash
+grep -c 'woostack-debug' skills/woostack-review/SKILL.md
+```
+Expected: `0`.
+
+- [ ] **Step 2: Add the suggestion pointer**
+
+Add a short prose pointer (no verdict/threading change) in the place where review describes acting on confirmed findings: when a finding is a confirmed real bug (not a style nit), suggest the user run the gated `/woostack-debug <target>` to investigate it systematically. State explicitly that review never `--auto`-dispatches debug — review owns no fix behavior and never auto-addresses findings. Link `../woostack-debug/SKILL.md`. Example:
+
+```markdown
+For a confirmed bug (not a style nit), suggest the user investigate it with
+[`woostack-debug`](../woostack-debug/SKILL.md): `/woostack-debug <target>` (gated). Review
+never dispatches `--auto` — it owns no fix behavior and never auto-addresses findings.
+```
+
+- [ ] **Step 3: Run the verification, confirm it passes**
+
+Run:
+```bash
+grep -q '/woostack-debug' skills/woostack-review/SKILL.md && \
+grep -q 'never' skills/woostack-review/SKILL.md && \
+! grep -q 'woostack-debug.*--auto' skills/woostack-review/SKILL.md && \
+echo PASS || echo FAIL
+```
+Expected: PASS (mentions the gated command; never pairs `woostack-debug` with `--auto`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt modify -c -m "feat(woostack-review): suggest woostack-debug for confirmed bugs"
+```
+
+### Task 4: Add the `using-woostack` routing row
+
+**Files:** Modify `skills/using-woostack/SKILL.md`
+
+- [ ] **Step 1: Confirm absent**
+
+Run: `grep -c 'woostack-debug' skills/using-woostack/SKILL.md`
+Expected: `0`.
+
+- [ ] **Step 2: Add the Command Routing row**
+
+In the `## Command Routing` table, add a row (keep the existing column shape):
+
+```markdown
+| `/woostack-debug <target> [--auto]`, find a bug's root cause before fixing (gated; `--auto` for autonomous) | `woostack-debug` |
+```
+
+- [ ] **Step 3: Run the verification, confirm it passes**
+
+Run:
+```bash
+grep -q '| `/woostack-debug <target> \[--auto\]`' skills/using-woostack/SKILL.md && \
+grep -q '| `woostack-debug` |' skills/using-woostack/SKILL.md && echo PASS || echo FAIL
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt modify -c -m "feat(using-woostack): add woostack-debug routing row"
+```
+
+### Task 5: Update counts and lists in `AGENTS.md`
+
+**Files:** Modify `AGENTS.md` (the `.claude/CLAUDE.md` symlink points here)
+
+- [ ] **Step 1: Confirm the current counts (failing state)**
+
+Run:
+```bash
+grep -n 'eleven skills' AGENTS.md
+grep -n 'eleven-skill command surface' AGENTS.md
+grep -n 'thirteen `SKILL.md`' AGENTS.md
+grep -c 'woostack-debug' AGENTS.md
+```
+Expected: the three greps print their lines (~16, ~34, ~79); the count prints `0`.
+
+- [ ] **Step 2: Bump the public-surface count + list (line ~16)**
+
+Change `The public command/adoption surface has eleven skills:` → `twelve skills:` and add a bullet `- [`woostack-debug`](skills/woostack-debug/SKILL.md)` to the list (after `woostack-status`/`woostack-visualize`, keeping the existing order/style).
+
+- [ ] **Step 3: Fix the internal-sub-skill phrasing (line ~34)**
+
+Change `absent from the eleven-skill command surface above` → `twelve-skill command surface above` so the cross-reference stays accurate.
+
+- [ ] **Step 4: Bump the rename-protection counts (line ~79)**
+
+Change `Do not move or rename any of the thirteen `SKILL.md` files (the eleven public command/adoption …` → `fourteen `SKILL.md` files (the twelve public command/adoption …` (twelve public + the two internal sub-skills = fourteen).
+
+- [ ] **Step 5: Add `/woostack-debug` to the Mode B command list**
+
+In the `## Modes` → Mode B sentence that enumerates the slash commands, add `/woostack-debug` to the list (keep the intent-equivalent-wording clause).
+
+- [ ] **Step 6: Add a Quick file map entry**
+
+Under `## Quick file map`, add an entry:
+
+```markdown
+- Systematic-debugging engine (public command + internal hook):
+  [`skills/woostack-debug/SKILL.md`](skills/woostack-debug/SKILL.md)
+```
+
+- [ ] **Step 7: Run the verification, confirm it passes**
+
+Run:
+```bash
+grep -q 'twelve skills:' AGENTS.md && \
+grep -q 'twelve-skill command surface' AGENTS.md && \
+grep -q 'fourteen `SKILL.md`' AGENTS.md && \
+grep -q 'the twelve public command/adoption' AGENTS.md && \
+[ "$(grep -c 'woostack-debug' AGENTS.md)" -gt 0 ] && \
+echo PASS || echo FAIL
+```
+Expected: PASS. Then confirm no stale count remains:
+```bash
+grep -nE 'eleven skills|eleven-skill|thirteen `SKILL.md`' AGENTS.md && echo "STALE-FOUND" || echo "no-stale:OK"
+```
+Expected: `no-stale:OK`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+gt modify -c -m "docs(agents): register woostack-debug (eleven→twelve, file map, modes)"
+```
+
+### Task 6: Update `README.md`
+
+**Files:** Modify `README.md`
+
+- [ ] **Step 1: Confirm the failing state**
+
+Run:
+```bash
+grep -n 'public command/adoption surface is eleven skills' README.md
+grep -c '/woostack-debug' README.md
+```
+Expected: first prints line ~29; second prints `0`.
+
+- [ ] **Step 2: Bump the count + list (line ~29)**
+
+Change `The public command/adoption surface is eleven skills: …, and woostack-visualize.` → `twelve skills: …, woostack-visualize, and woostack-debug.` (keep the trailing internal-sub-skills sentence about `woostack-ideate`/`woostack-harden` unchanged).
+
+- [ ] **Step 3: Add a command-catalog entry**
+
+In the per-command catalog section (the `### /woostack-X` blocks, ~lines 50–90), add a new entry consistent with the existing blurb style:
+
+```markdown
+### `/woostack-debug <target> [--auto]`: find the root cause before fixing
+
+Runs woostack's systematic-debugging method on a bug, test failure, or unexpected behavior:
+root-cause investigation → pattern analysis → hypothesis/test → minimal fix with a failing
+test first, under the Iron Law (no fix without a root cause) and a 3-fixes-→-question-the-
+architecture escalation. It recalls known `gotcha`s from `.woostack/memory/` at the start and
+distills one at the end. Standalone it gates on the root cause before fixing; `--auto` runs
+autonomously (how `woostack-execute` calls it on a stuck verification). Never commits or
+merges. → [SKILL.md](skills/woostack-debug/SKILL.md)
+```
+
+- [ ] **Step 4: Confirm build-loop prose is untouched**
+
+Run (content-based, not line-based — the build-loop sentence names the four build phases and must NOT gain `woostack-debug`):
+```bash
+grep -n "sequences woostack's own ideate, harden, plan, and execute" README.md | grep -q 'woostack-debug' \
+  && echo "LEAK:FAIL" || echo "build-prose-clean:OK"
+```
+Expected: `build-prose-clean:OK` (the matched build-loop line contains no `woostack-debug`).
+
+- [ ] **Step 5: Run the verification, confirm it passes**
+
+Run:
+```bash
+grep -q 'twelve skills:' README.md && \
+grep -q '### `/woostack-debug <target> \[--auto\]`' README.md && \
+echo PASS || echo FAIL
+grep -nE 'surface is eleven skills' README.md && echo "STALE-FOUND" || echo "no-stale:OK"
+```
+Expected: `PASS` and `no-stale:OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+gt modify -c -m "docs(readme): register woostack-debug command (count, list, catalog)"
+```
+
+### Task 7: Update `CONTRIBUTING.md`
+
+**Files:** Modify `CONTRIBUTING.md`
+
+- [ ] **Step 1: Confirm absent**
+
+Run: `grep -c 'woostack-debug' CONTRIBUTING.md`
+Expected: `0`.
+
+- [ ] **Step 2: Add to the command-surface list (line ~3)**
+
+Add `woostack-debug` to the inline command-surface enumeration, matching the existing comma-list style (after `woostack-visualize`).
+
+- [ ] **Step 3: Add an edit-map row (if a per-skill table exists)**
+
+If `CONTRIBUTING.md` has a "where to edit" table listing per-skill entries, add a row: change the debugging behavior → `skills/woostack-debug/SKILL.md`. (If there is no such table, skip this step — confirm by `grep -n 'where to edit' CONTRIBUTING.md` first.)
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: `grep -q 'woostack-debug' CONTRIBUTING.md && echo PASS || echo FAIL`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(contributing): add woostack-debug to the command surface"
+```
+
+### Task 8: Whole-repo enumeration consistency check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: No stale counts anywhere in shipped docs**
+
+Run:
+```bash
+grep -rnE 'eleven skills|eleven-skill|thirteen `SKILL.md`' AGENTS.md README.md CONTRIBUTING.md skills/using-woostack/SKILL.md && echo "STALE-FOUND" || echo "no-stale:OK"
+```
+Expected: `no-stale:OK`.
+
+- [ ] **Step 2: `woostack-debug` present in every enumeration site**
+
+Run:
+```bash
+for f in AGENTS.md README.md CONTRIBUTING.md skills/using-woostack/SKILL.md skills/woostack-execute/SKILL.md skills/woostack-review/SKILL.md; do
+  grep -q 'woostack-debug' "$f" && echo "OK  $f" || echo "MISSING  $f"; done
+```
+Expected: every line starts with `OK`.
+
+- [ ] **Step 3: Cross-links resolve from the new skill and its referrers**
+
+Run:
+```bash
+test -f skills/woostack-debug/SKILL.md && \
+test -f skills/woostack-init/references/memory.md && \
+test -f skills/woostack-status/references/conventions.md && \
+test -f skills/woostack-execute/SKILL.md && \
+test -f skills/woostack-review/SKILL.md && echo "links:OK" || echo "links:FAIL"
+```
+Expected: `links:OK`.
+
+- [ ] **Step 4: Final commit (if any verification fix was needed)**
+
+```bash
+gt modify -c -m "docs: enumeration consistency for woostack-debug"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every spec section maps to a task: §2 goal → Task 1 (skill) + Tasks 2–7 (wiring/enum); §4.1 four phases → Task 1 Steps 4–5; §4.2 mode model → Task 1 Step 6; §4.3 memory → Task 1 Step 7; §4.4 call sites → Tasks 2–3; §5 edit set → Tasks 1–7; §6 failure modes → Task 1 Steps 6–7 + Step 11; §7 testing → the verification steps + Task 8.
+- [ ] **No placeholders** — every step has the actual content (frontmatter, Iron Law/escalation blocks verbatim, exact grep commands, expected output).
+- [ ] **Type consistency** — the flag is `--auto` everywhere; the note type is `gotcha` everywhere; the command is `/woostack-debug <target> [--auto]` everywhere; counts are twelve (public) / fourteen (SKILL.md files) consistently.
+
+> woostack plan conventions (kept):
+> - This file is **frontmatter-free** and **opens with** the `**Source:**` line.
+> - Filename mirrors the spec basename: `.woostack/plans/2026-06-05-woostack-debug.md` (the spec's date).
+> - **No** required sub-skill banner — execution is `woostack-execute`'s (woostack-build step 8, or `/woostack-execute <plan>`).
+> - This is a skills repo with no test runner, so each "failing test" is a verification command (grep / `bash` / link check) with exact expected output.

--- a/.woostack/specs/2026-06-05-woostack-debug.md
+++ b/.woostack/specs/2026-06-05-woostack-debug.md
@@ -1,0 +1,254 @@
+---
+name: woostack-debug
+type: spec
+status: planning
+date: 2026-06-05
+branch: feature/woostack-debug
+links:
+---
+
+# woostack-debug: a woostack-native systematic-debugging skill — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+woostack has no first-class debugging discipline. When a verification fails during
+`woostack-execute`, or a `woostack-review` finding turns out to be a real bug, the agent is
+left to its default behavior: guess a fix, try it, guess again. That is exactly the
+guess-and-check thrashing that wastes time and introduces new bugs — the failure mode the
+superpowers `systematic-debugging` skill exists to prevent (its "Iron Law": no fix without
+root-cause investigation first).
+
+The superpowers skill is proven but lives outside woostack and does not speak woostack's
+conventions. Specifically it has no notion of the `.woostack/memory/` store, so a root cause
+found today is re-discovered from scratch next month; it references
+`superpowers:test-driven-development` and `superpowers:verification-before-completion` for its
+test/verify steps rather than woostack's own TDD discipline (embodied inline in
+`woostack-execute`); and it has no handback contract with the build loop's execute phase.
+
+We want to own the debugging behavior so it (a) enforces root-cause-before-fix everywhere a
+bug surfaces, (b) feeds and reads the woostack memory store so root causes become durable
+`gotcha` knowledge, and (c) plugs into `woostack-execute` and `woostack-review` as the place
+those skills route a stuck verification or a confirmed bug — while carrying no external
+dependency.
+
+## 2. Goal
+
+Ship `skills/woostack-debug/SKILL.md`: a woostack-native systematic-debugging skill, exposed
+**both** as the 12th public command `/woostack-debug [target]` **and** as an internal hook the
+build-loop skills invoke. It retells superpowers' four-phase method (root-cause investigation →
+pattern analysis → hypothesis/test → implementation with a failing test first) and its
+load-bearing safeguards (the Iron Law; the "3 fixes failed → question architecture"
+escalation), and wires them to woostack systems:
+
+- **Memory recall** at the start (surface known `[[gotchas]]`/hotspots for the target files
+  before investigating).
+- **Memory distillation** at the end (write one `gotcha` note through the reject-by-default
+  gate when a confirmed root cause is fixed).
+- **Mode-dependent stop model**: autonomous when invoked internally; a look-before-fix
+  root-cause gate when run standalone.
+
+Rewire `woostack-execute` (route a repeatedly-failing verification to `woostack-debug` before
+escalating) and `woostack-review` (offer `woostack-debug` to investigate a confirmed bug), and
+register the new command across the adoption/enumeration surface.
+
+## 3. Non-goals
+
+- **No spec/plan/status authoring.** `woostack-debug` is a sub-routine, not a build-loop
+  phase. It writes no `.woostack/specs/` or `.woostack/plans/` file and never touches a spec's
+  `status:`/`branch:` frontmatter. The `spec : plan : PRs = 1 : 1 : N` invariant is untouched.
+- **No commit, no merge.** It hands the fix back. Standalone → it names `woostack-commit` as
+  the next step; invoked by `woostack-execute` → execute commits the fix in its existing
+  per-increment cadence. It never opens, updates, or merges a PR.
+- **No reference files.** The four phases and supporting techniques (root-cause tracing,
+  defense-in-depth, condition-based waiting) live inline in `SKILL.md` as brief mentions. We do
+  **not** port superpowers' `root-cause-tracing.md`, `defense-in-depth.md`,
+  `condition-based-waiting.md`, the TS example, or `find-polluter.sh`. Keep the skill lean.
+- **No new CI.** No changes to [`action.yml`](../../action.yml) or the reusable review
+  workflow; debugging is not a review angle and ships no consumer CI surface.
+- **No standalone TDD/verification skill.** Phase 4's "failing test first" reuses the TDD
+  discipline already embodied in `woostack-execute`, referenced inline — we do not create or
+  depend on a separate skill for it.
+- **No behavior change to the other skills** beyond the call-site edits and enumeration
+  updates listed in §5. `woostack-build` is unchanged (it reaches debug transitively through
+  `woostack-execute`).
+
+## 4. Approach
+
+Author one self-contained `SKILL.md` modeled on the proven superpowers structure, retold in
+woostack vocabulary and wired to woostack systems.
+
+### 4.1 The debug loop (four phases, Iron Law preserved)
+
+- **Iron Law, stated up top:** `NO FIX WITHOUT ROOT CAUSE FIRST`. A symptom fix is a failure.
+  Carried as a prominent block so it survives summarization (same treatment as the ideate
+  HARD GATE).
+- **Phase 1 — Root cause investigation:** read errors/stack traces completely; reproduce
+  consistently; check recent changes (`git diff`, recent commits); in multi-component systems
+  add boundary instrumentation to localize *which* layer fails before touching it; trace the
+  bad value backward to its source (root-cause-tracing technique, inline).
+- **Phase 2 — Pattern analysis:** find working examples in the same repo; compare working vs.
+  broken; list every difference ("that can't matter" is banned); map dependencies/config/env.
+- **Phase 3 — Hypothesis & test:** one hypothesis at a time ("X is the cause because Y");
+  test with the smallest possible change, one variable at a time; confirm or form a new
+  hypothesis; say "I don't understand X" rather than fake understanding.
+- **Phase 4 — Implementation:** write a **failing test that reproduces the bug first** (reusing
+  woostack-execute's TDD discipline); apply **one** minimal fix at the root cause (no "while
+  I'm here" extras); verify the test passes and nothing else broke; consider defense-in-depth
+  validation at layer boundaries (inline mention). Fix didn't work and <3 attempts → back to
+  Phase 1 with the new evidence; **≥3 attempts → STOP and question the architecture** (this is
+  not a failed hypothesis, it's a wrong-architecture signal).
+
+Carry a condensed Red Flags / Rationalizations list (from superpowers) so the agent
+self-catches "quick fix for now", "just try changing X", "one more fix attempt", etc.
+
+### 4.2 Mode-dependent stop model (the hybrid)
+
+The skill behaves differently depending on whether it was invoked internally or run as a
+command — mirroring how `woostack-execute` has an inline vs. subagent mode:
+
+- **Autonomous mode** (`/woostack-debug <target> --auto`): run all four phases autonomously.
+  No per-fix approval gate (consistent with `woostack-execute` / `woostack-harden` owning no
+  gate). The Iron Law still forces the root cause to be **narrated** before any fix, so the
+  "why" is visible inline. The single hard stop is the **3-fixes architectural escalation**,
+  which doubles as the handback signal to the caller.
+- **Standalone mode** (`/woostack-debug <target>`, no `--auto`): after Phases 1–3 (root cause
+  found, hypothesis confirmed), **stop and present the root cause + the proposed minimal fix,
+  and wait for an explicit go-ahead** before applying it (Phase 4). The 3-fixes escalation
+  still applies.
+
+**Mode is selected by an explicit `--auto` flag**, mirroring `woostack-execute`'s explicit
+`--inline/--subagent` precedent rather than context-sniffing. `--auto` ⇒ autonomous; its
+absence ⇒ the standalone look-before-fix gate. There is no inference: when `--auto` is not
+present the gate always applies, so an unrequested fix is never silently applied.
+
+### 4.3 Memory integration
+
+- **Recall (start).** Compute the working set (the target's files: the failing test file and
+  the code under suspicion) and run the recall procedure — `recall.sh` when the
+  `woostack-init` scripts are present, the manual §6 procedure otherwise — to surface matching
+  `gotcha`/`hotspot`/`pattern` notes before investigating. State whether recall was
+  script-assisted or manual (degradation contract). A matching note may already name the root
+  cause; honor it.
+- **Distill (end, on a confirmed fix).** Write **one** `gotcha` note through the
+  reject-by-default gate: narrow glob `scope:` covering the touched files (single-literal-path
+  scope is rejected as trivia), `source:` = the spec/plan that owns the work or `pr-N`, terse
+  body with `[[wikilinks]]` to related notes, `updated:` stamped today. Dedupe against
+  `MEMORY.md` first (update an existing note rather than add a near-duplicate). Then run
+  `build-index.sh` + `doctor.sh`. The note records the *root cause and its fix*, not the
+  symptom. All of this reuses the machinery and gate documented in
+  [memory.md](../../skills/woostack-init/references/memory.md) — link it, do not restate it.
+
+### 4.4 Wiring the existing skills
+
+- **`woostack-execute` (active dispatch, `--auto`).** Its "When to stop and ask → a
+  verification fails repeatedly" path currently stops and asks the user. Insert
+  `woostack-debug <target> --auto` as the step *before* escalating: a repeatedly-failing
+  verification routes to debug, which finds the root cause and fixes it, or hits the 3-fixes
+  escalation and *then* surfaces to the user. execute is already an autonomous loop, so the
+  autonomous dispatch fits. Applies to both inline and subagent drivers. Debug returns the fix
+  into execute's working tree; execute commits it in its normal per-increment cadence (debug
+  does not commit).
+- **`woostack-review` (suggest, gated — never `--auto`).** When a review confirms a real bug
+  (not a style nit), **suggest** `/woostack-debug <target>` to the user as the systematic way
+  to investigate it. review never `--auto`-dispatches debug: review owns no fix behavior and
+  "never auto-addresses findings", so it must not trigger an autonomous fix — it points the
+  user at the gated command. Light prose pointer; no change to review's verdict/threading
+  behavior.
+- **`woostack-build`.** No change — it reaches debug transitively through `woostack-execute`.
+
+## 5. Components & data flow
+
+Edit set. This is a single feature; the increment decomposition is `woostack-plan`'s job, but
+the natural split is **(A) the new skill + memory/loop**, then **(B) the call-site wiring +
+enumeration**, so A is independently shippable and reviewable before B references it.
+
+| File | Change |
+|---|---|
+| `skills/woostack-debug/SKILL.md` | **NEW** — the skill: frontmatter (`name`, scoped `description`), Iron Law block, the four phases, the mode-dependent stop model, the Red Flags/Rationalizations digest, memory recall + distill (link `memory.md`), and the out-of-scope/handback contract. Lean, no `references/`. |
+| `skills/woostack-execute/SKILL.md` | "When to stop and ask" (line ~137, `A verification fails repeatedly.`): route a repeatedly-failing verification to `woostack-debug <target> --auto` **before** escalating to the user — escalate only if debug hits its 3-fixes architectural stop. This block is shared by both drivers, so one edit covers inline + subagent. Note debug does not commit; execute commits the returned fix in its existing per-increment cadence. |
+| `skills/woostack-review/SKILL.md` | Prose pointer: **suggest** the gated `/woostack-debug <target>` to the user to investigate a confirmed bug finding — never `--auto` (review never auto-addresses findings). No verdict/threading change. |
+| `skills/using-woostack/SKILL.md` | Add a Command Routing row for `/woostack-debug <target> [--auto]`. |
+| `AGENTS.md` (`.claude/CLAUDE.md` symlink) | Public surface `eleven → twelve` and add `woostack-debug` to the list (line ~16); update the "eleven-skill command surface" phrasing (line ~34); `thirteen → fourteen` SKILL.md files and `eleven → twelve` public in the rename-protection constraint (line ~79); add a Quick file map entry; add `/woostack-debug` to the Mode B command list. |
+| `README.md` | Public-surface count `eleven → twelve` and add `woostack-debug` to the command list (line ~29); add a `### /woostack-debug [target]` entry in the command-catalog section (the per-command blurb block, lines ~50–90). The build-loop prose (line ~62) names build *phases* only (ideate/harden/plan/execute); debug is a sub-routine, not a phase, so it is **not** added there. |
+| `CONTRIBUTING.md` | Add `woostack-debug` to the command-surface list (line ~3); add a "where to edit the debugging behavior" row if the edit-map table lists per-skill entries. |
+
+Runtime data flow:
+
+```
+/woostack-debug <target>        woostack-execute (stuck verification)     woostack-review (confirmed bug)
+        │                                  │                                        │
+        ▼                                  ▼                                        ▼
+   standalone mode ─────────────►  woostack-debug  ◄──────────────────────  internal hook mode
+        │  (look-before-fix gate)        │  (autonomous; 3-fixes escalation)
+        │                                │
+   recall.sh (start) ◄────────── working set = target files
+        │
+   Phase 1→2→3→4  (Iron Law: root cause before fix; failing test first; minimal fix; verify)
+        │
+   fix handed back ──► standalone: name woostack-commit │ internal: execute commits in its cadence
+        │
+   distill 1 gotcha note ──► reject-by-default gate ──► build-index.sh + doctor.sh
+```
+
+## 6. Error handling
+
+- **Scripts absent (individual install).** Memory recall/distill degrade to the manual
+  procedure per the `memory.md` §10 degradation contract; the skill states which path it took
+  and never fails silently.
+- **No root cause found.** Honor superpowers' "When process reveals no root cause": after a
+  genuine investigation, document what was checked and implement appropriate handling
+  (retry/timeout/clear error + logging) rather than a blind fix — but treat this as the rare
+  case (most "no root cause" is incomplete investigation).
+- **Mode ambiguity.** Mode is an explicit `--auto` flag, so there is no inference to get
+  wrong: any invocation without `--auto` takes the **standalone look-before-fix gate**. A
+  malformed or unrecognized flag is treated as absent (gated), never as autonomous — an
+  unrequested fix is never applied.
+- **Description over-trigger.** Risk: a debugging `description` broad enough to hijack every
+  error mention. Mitigation: scope the `description` to "use as woostack's systematic-debugging
+  phase / `/woostack-debug`", recognizable to execute/review and as a command, without
+  shadowing routine error handling.
+- **3-fixes escalation as a real stop.** The "≥3 fixes failed → question architecture" stop is
+  load-bearing; state it as an explicit block so it survives summarization, like the Iron Law.
+
+## 7. Testing
+
+No app/test harness in this repo (it is a skills collection). Verification is by inspection:
+
+- New `skills/woostack-debug/SKILL.md` has valid frontmatter (`name`, `description`), the Iron
+  Law block, all four phases, the mode-dependent stop model, and the memory recall/distill
+  contract linking `memory.md` (not restating it).
+- `woostack-execute` routes a repeatedly-failing verification to `woostack-debug` before user
+  escalation; `woostack-review` offers it for a confirmed bug.
+- `using-woostack` has a `/woostack-debug` routing row.
+- Enumeration is consistent repo-wide: grep for `eleven`/`twelve`/`thirteen`/`fourteen` and the
+  command lists in `AGENTS.md`, `README.md`, `CONTRIBUTING.md` — counts and lists all include
+  `woostack-debug` and agree with each other.
+- Cross-links resolve (`woostack-debug` ↔ `woostack-execute`/`woostack-review`/`memory.md`/
+  `conventions.md`); no dangling links.
+- `woostack-debug` writes no spec/plan/status and contains no commit/merge action (grep the
+  skill for those to confirm the out-of-scope contract holds).
+
+## 8. Open questions
+
+Resolved during the spec harden pass (step 3):
+
+- **Naming** → `woostack-debug` (verb-family, matches build/commit/review/execute/plan).
+- **`target` argument shape** → free-form (failing test path, error text, PR#, or symptom);
+  no-arg standalone → ask what's broken (mirror `woostack-execute`'s no-arg behavior).
+- **Mode detection mechanism** → explicit `--auto` flag (mirrors `woostack-execute`'s
+  `--inline/--subagent`). `--auto` ⇒ autonomous (no gate); absent/unrecognized ⇒ standalone
+  look-before-fix gate. No context-sniffing; fail-safe to gated (§4.2, §6).
+- **execute vs. review dispatch** → `woostack-execute` actively dispatches `--auto` (it is
+  already an autonomous loop); `woostack-review` only **suggests** the gated `/woostack-debug`
+  and never `--auto`-dispatches, because review owns no fix behavior and never auto-addresses
+  findings (§4.4).
+- **Exact execute insertion point** → the shared "When to stop and ask → a verification fails
+  repeatedly" block (execute SKILL.md line ~137); one edit covers both inline and subagent
+  drivers, routing to debug before user escalation (§5).
+- **README touch points** → the public-surface count + list (line ~29) and a new
+  `### /woostack-debug <target>` command-catalog entry; build-loop prose (line ~62) is left
+  untouched because debug is a sub-routine, not a build phase (§5).


### PR DESCRIPTION
## Goal

Define and plan `woostack-debug` — a woostack-native systematic-debugging skill (the 12th public command plus an internal hook) that enforces root-cause-before-fix and wires into the `.woostack/memory/` store. This docs-only PR is the base of the stack; the implementation increments stack on top of it.

## Summary

- New spec `.woostack/specs/2026-06-05-woostack-debug.md` (`status: planning`): `/woostack-debug <target> [--auto]` retelling superpowers `systematic-debugging` (Iron Law, 4 phases, 3-fixes-→-question-architecture escalation) in woostack vocabulary.
- Hybrid stop model via an explicit `--auto` flag: autonomous (no gate) when dispatched; standalone defaults to a look-before-fix root-cause gate; fail-safe to gated when the flag is absent.
- Memory wired both ways: recall known `gotcha`/`hotspot` notes at the start; distill one `gotcha` note through the reject-by-default gate at the end.
- Call sites: `woostack-execute` dispatches `--auto` before user-escalating a repeatedly-failing verification; `woostack-review` only *suggests* the gated command (never `--auto`).
- New plan `.woostack/plans/2026-06-05-woostack-debug.md`: 2 PR-sized increments (A — the new skill; B — call-site wiring + enumeration), as TDD/verification-command tasks.

## Test plan

### Manual

**Before merge**

- [ ] Review the spec's design decisions: surface (public command + internal hook), memory depth (recall + distill), the `--auto` mode model, and the execute/review call-site wiring.
- [ ] Review the plan's increment decomposition (A/B boundaries) and the verification commands per task.

Spec: .woostack/specs/2026-06-05-woostack-debug.md
