### PR TITLE
feat(woostack-debug): wire execute/review call sites and register the command

### DIFF
--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -28,6 +28,7 @@ every site in lockstep:
   are not loop phases, so this stays a no-op for them).
 
 Internal sub-skills (ideate, harden) count toward `SKILL.md` files but NOT the public
-surface. As of woostack-plan the surface is **eleven public commands + two internal
-sub-skills = thirteen `SKILL.md` files** (`woostack-plan` is a public command). See
+surface. As of woostack-debug the surface is **twelve public commands + two internal
+sub-skills = fourteen `SKILL.md` files** (`woostack-debug` is a public command; it is also an
+internal hook invoked by execute/review, but still counts once as a public command). See
 [[woostack-feature-state-invariant]].

--- a/.woostack/plans/2026-06-05-woostack-debug.md
+++ b/.woostack/plans/2026-06-05-woostack-debug.md
@@ -242,12 +242,11 @@ never dispatches `--auto` — it owns no fix behavior and never auto-addresses f
 
 Run:
 ```bash
-grep -q '/woostack-debug' skills/woostack-review/SKILL.md && \
-grep -q 'never' skills/woostack-review/SKILL.md && \
-! grep -q 'woostack-debug.*--auto' skills/woostack-review/SKILL.md && \
+grep -q '/woostack-debug <target>' skills/woostack-review/SKILL.md && \
+grep -q 'never dispatches `woostack-debug --auto`' skills/woostack-review/SKILL.md && \
 echo PASS || echo FAIL
 ```
-Expected: PASS (mentions the gated command; never pairs `woostack-debug` with `--auto`).
+Expected: PASS (mentions the gated command **and** explicitly states review never `--auto`-dispatches debug). The contract is that review never *instructs* `--auto`; the SKILL.md states this as an explicit negation, so the check looks for that negation rather than the mere absence of the two tokens on one line.
 
 - [x] **Step 4: Commit**
 

--- a/.woostack/plans/2026-06-05-woostack-debug.md
+++ b/.woostack/plans/2026-06-05-woostack-debug.md
@@ -179,7 +179,7 @@ gt create -m "feat(woostack-debug): add systematic-debugging skill"
 
 **Files:** Modify `skills/woostack-execute/SKILL.md`
 
-- [ ] **Step 1: Confirm the current text, confirm the wiring is absent**
+- [x] **Step 1: Confirm the current text, confirm the wiring is absent**
 
 Run:
 ```bash
@@ -188,7 +188,7 @@ grep -c 'woostack-debug' skills/woostack-execute/SKILL.md
 ```
 Expected: the first prints the line (~137); the second prints `0` (no wiring yet — this is the failing state).
 
-- [ ] **Step 2: Edit the "When to stop and ask" block**
+- [x] **Step 2: Edit the "When to stop and ask" block**
 
 In the `## When to stop and ask` list, change the `A verification fails repeatedly.` bullet so a repeatedly-failing verification first routes to `woostack-debug <target> --auto` (autonomous), escalating to the user only if debug returns its ≥3-fixes architectural stop. State that this applies to both inline and subagent drivers (the block is shared), and that debug does not commit — execute commits the returned fix in its existing per-increment cadence. Link `../woostack-debug/SKILL.md`. Example replacement bullet:
 
@@ -200,7 +200,7 @@ In the `## When to stop and ask` list, change the `A verification fails repeated
   (Applies to both the inline and subagent drivers.)
 ```
 
-- [ ] **Step 3: Run the verification, confirm it passes**
+- [x] **Step 3: Run the verification, confirm it passes**
 
 Run:
 ```bash
@@ -210,7 +210,7 @@ echo PASS || echo FAIL
 ```
 Expected: PASS.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt create -m "feat(woostack-execute): route stuck verifications to woostack-debug --auto"
@@ -220,7 +220,7 @@ gt create -m "feat(woostack-execute): route stuck verifications to woostack-debu
 
 **Files:** Modify `skills/woostack-review/SKILL.md`
 
-- [ ] **Step 1: Confirm wiring absent**
+- [x] **Step 1: Confirm wiring absent**
 
 Run:
 ```bash
@@ -228,7 +228,7 @@ grep -c 'woostack-debug' skills/woostack-review/SKILL.md
 ```
 Expected: `0`.
 
-- [ ] **Step 2: Add the suggestion pointer**
+- [x] **Step 2: Add the suggestion pointer**
 
 Add a short prose pointer (no verdict/threading change) in the place where review describes acting on confirmed findings: when a finding is a confirmed real bug (not a style nit), suggest the user run the gated `/woostack-debug <target>` to investigate it systematically. State explicitly that review never `--auto`-dispatches debug — review owns no fix behavior and never auto-addresses findings. Link `../woostack-debug/SKILL.md`. Example:
 
@@ -238,7 +238,7 @@ For a confirmed bug (not a style nit), suggest the user investigate it with
 never dispatches `--auto` — it owns no fix behavior and never auto-addresses findings.
 ```
 
-- [ ] **Step 3: Run the verification, confirm it passes**
+- [x] **Step 3: Run the verification, confirm it passes**
 
 Run:
 ```bash
@@ -249,7 +249,7 @@ echo PASS || echo FAIL
 ```
 Expected: PASS (mentions the gated command; never pairs `woostack-debug` with `--auto`).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "feat(woostack-review): suggest woostack-debug for confirmed bugs"
@@ -259,12 +259,12 @@ gt modify -c -m "feat(woostack-review): suggest woostack-debug for confirmed bug
 
 **Files:** Modify `skills/using-woostack/SKILL.md`
 
-- [ ] **Step 1: Confirm absent**
+- [x] **Step 1: Confirm absent**
 
 Run: `grep -c 'woostack-debug' skills/using-woostack/SKILL.md`
 Expected: `0`.
 
-- [ ] **Step 2: Add the Command Routing row**
+- [x] **Step 2: Add the Command Routing row**
 
 In the `## Command Routing` table, add a row (keep the existing column shape):
 
@@ -272,7 +272,7 @@ In the `## Command Routing` table, add a row (keep the existing column shape):
 | `/woostack-debug <target> [--auto]`, find a bug's root cause before fixing (gated; `--auto` for autonomous) | `woostack-debug` |
 ```
 
-- [ ] **Step 3: Run the verification, confirm it passes**
+- [x] **Step 3: Run the verification, confirm it passes**
 
 Run:
 ```bash
@@ -281,7 +281,7 @@ grep -q '| `woostack-debug` |' skills/using-woostack/SKILL.md && echo PASS || ec
 ```
 Expected: PASS.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "feat(using-woostack): add woostack-debug routing row"
@@ -291,7 +291,7 @@ gt modify -c -m "feat(using-woostack): add woostack-debug routing row"
 
 **Files:** Modify `AGENTS.md` (the `.claude/CLAUDE.md` symlink points here)
 
-- [ ] **Step 1: Confirm the current counts (failing state)**
+- [x] **Step 1: Confirm the current counts (failing state)**
 
 Run:
 ```bash
@@ -302,23 +302,23 @@ grep -c 'woostack-debug' AGENTS.md
 ```
 Expected: the three greps print their lines (~16, ~34, ~79); the count prints `0`.
 
-- [ ] **Step 2: Bump the public-surface count + list (line ~16)**
+- [x] **Step 2: Bump the public-surface count + list (line ~16)**
 
 Change `The public command/adoption surface has eleven skills:` → `twelve skills:` and add a bullet `- [`woostack-debug`](skills/woostack-debug/SKILL.md)` to the list (after `woostack-status`/`woostack-visualize`, keeping the existing order/style).
 
-- [ ] **Step 3: Fix the internal-sub-skill phrasing (line ~34)**
+- [x] **Step 3: Fix the internal-sub-skill phrasing (line ~34)**
 
 Change `absent from the eleven-skill command surface above` → `twelve-skill command surface above` so the cross-reference stays accurate.
 
-- [ ] **Step 4: Bump the rename-protection counts (line ~79)**
+- [x] **Step 4: Bump the rename-protection counts (line ~79)**
 
 Change `Do not move or rename any of the thirteen `SKILL.md` files (the eleven public command/adoption …` → `fourteen `SKILL.md` files (the twelve public command/adoption …` (twelve public + the two internal sub-skills = fourteen).
 
-- [ ] **Step 5: Add `/woostack-debug` to the Mode B command list**
+- [x] **Step 5: Add `/woostack-debug` to the Mode B command list**
 
 In the `## Modes` → Mode B sentence that enumerates the slash commands, add `/woostack-debug` to the list (keep the intent-equivalent-wording clause).
 
-- [ ] **Step 6: Add a Quick file map entry**
+- [x] **Step 6: Add a Quick file map entry**
 
 Under `## Quick file map`, add an entry:
 
@@ -327,7 +327,7 @@ Under `## Quick file map`, add an entry:
   [`skills/woostack-debug/SKILL.md`](skills/woostack-debug/SKILL.md)
 ```
 
-- [ ] **Step 7: Run the verification, confirm it passes**
+- [x] **Step 7: Run the verification, confirm it passes**
 
 Run:
 ```bash
@@ -344,7 +344,7 @@ grep -nE 'eleven skills|eleven-skill|thirteen `SKILL.md`' AGENTS.md && echo "STA
 ```
 Expected: `no-stale:OK`.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 gt modify -c -m "docs(agents): register woostack-debug (eleven→twelve, file map, modes)"
@@ -354,7 +354,7 @@ gt modify -c -m "docs(agents): register woostack-debug (eleven→twelve, file ma
 
 **Files:** Modify `README.md`
 
-- [ ] **Step 1: Confirm the failing state**
+- [x] **Step 1: Confirm the failing state**
 
 Run:
 ```bash
@@ -363,11 +363,11 @@ grep -c '/woostack-debug' README.md
 ```
 Expected: first prints line ~29; second prints `0`.
 
-- [ ] **Step 2: Bump the count + list (line ~29)**
+- [x] **Step 2: Bump the count + list (line ~29)**
 
 Change `The public command/adoption surface is eleven skills: …, and woostack-visualize.` → `twelve skills: …, woostack-visualize, and woostack-debug.` (keep the trailing internal-sub-skills sentence about `woostack-ideate`/`woostack-harden` unchanged).
 
-- [ ] **Step 3: Add a command-catalog entry**
+- [x] **Step 3: Add a command-catalog entry**
 
 In the per-command catalog section (the `### /woostack-X` blocks, ~lines 50–90), add a new entry consistent with the existing blurb style:
 
@@ -383,7 +383,7 @@ autonomously (how `woostack-execute` calls it on a stuck verification). Never co
 merges. → [SKILL.md](skills/woostack-debug/SKILL.md)
 ```
 
-- [ ] **Step 4: Confirm build-loop prose is untouched**
+- [x] **Step 4: Confirm build-loop prose is untouched**
 
 Run (content-based, not line-based — the build-loop sentence names the four build phases and must NOT gain `woostack-debug`):
 ```bash
@@ -392,7 +392,7 @@ grep -n "sequences woostack's own ideate, harden, plan, and execute" README.md |
 ```
 Expected: `build-prose-clean:OK` (the matched build-loop line contains no `woostack-debug`).
 
-- [ ] **Step 5: Run the verification, confirm it passes**
+- [x] **Step 5: Run the verification, confirm it passes**
 
 Run:
 ```bash
@@ -403,7 +403,7 @@ grep -nE 'surface is eleven skills' README.md && echo "STALE-FOUND" || echo "no-
 ```
 Expected: `PASS` and `no-stale:OK`.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 gt modify -c -m "docs(readme): register woostack-debug command (count, list, catalog)"
@@ -413,25 +413,25 @@ gt modify -c -m "docs(readme): register woostack-debug command (count, list, cat
 
 **Files:** Modify `CONTRIBUTING.md`
 
-- [ ] **Step 1: Confirm absent**
+- [x] **Step 1: Confirm absent**
 
 Run: `grep -c 'woostack-debug' CONTRIBUTING.md`
 Expected: `0`.
 
-- [ ] **Step 2: Add to the command-surface list (line ~3)**
+- [x] **Step 2: Add to the command-surface list (line ~3)**
 
 Add `woostack-debug` to the inline command-surface enumeration, matching the existing comma-list style (after `woostack-visualize`).
 
-- [ ] **Step 3: Add an edit-map row (if a per-skill table exists)**
+- [x] **Step 3: Add an edit-map row (if a per-skill table exists)**
 
 If `CONTRIBUTING.md` has a "where to edit" table listing per-skill entries, add a row: change the debugging behavior → `skills/woostack-debug/SKILL.md`. (If there is no such table, skip this step — confirm by `grep -n 'where to edit' CONTRIBUTING.md` first.)
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -q 'woostack-debug' CONTRIBUTING.md && echo PASS || echo FAIL`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs(contributing): add woostack-debug to the command surface"
@@ -441,7 +441,7 @@ gt modify -c -m "docs(contributing): add woostack-debug to the command surface"
 
 **Files:** none (verification only)
 
-- [ ] **Step 1: No stale counts anywhere in shipped docs**
+- [x] **Step 1: No stale counts anywhere in shipped docs**
 
 Run:
 ```bash
@@ -449,7 +449,7 @@ grep -rnE 'eleven skills|eleven-skill|thirteen `SKILL.md`' AGENTS.md README.md C
 ```
 Expected: `no-stale:OK`.
 
-- [ ] **Step 2: `woostack-debug` present in every enumeration site**
+- [x] **Step 2: `woostack-debug` present in every enumeration site**
 
 Run:
 ```bash
@@ -458,7 +458,7 @@ for f in AGENTS.md README.md CONTRIBUTING.md skills/using-woostack/SKILL.md skil
 ```
 Expected: every line starts with `OK`.
 
-- [ ] **Step 3: Cross-links resolve from the new skill and its referrers**
+- [x] **Step 3: Cross-links resolve from the new skill and its referrers**
 
 Run:
 ```bash
@@ -470,7 +470,7 @@ test -f skills/woostack-review/SKILL.md && echo "links:OK" || echo "links:FAIL"
 ```
 Expected: `links:OK`.
 
-- [ ] **Step 4: Final commit (if any verification fix was needed)**
+- [x] **Step 4: Final commit (if any verification fix was needed)**
 
 ```bash
 gt modify -c -m "docs: enumeration consistency for woostack-debug"
@@ -480,9 +480,9 @@ gt modify -c -m "docs: enumeration consistency for woostack-debug"
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — every spec section maps to a task: §2 goal → Task 1 (skill) + Tasks 2–7 (wiring/enum); §4.1 four phases → Task 1 Steps 4–5; §4.2 mode model → Task 1 Step 6; §4.3 memory → Task 1 Step 7; §4.4 call sites → Tasks 2–3; §5 edit set → Tasks 1–7; §6 failure modes → Task 1 Steps 6–7 + Step 11; §7 testing → the verification steps + Task 8.
-- [ ] **No placeholders** — every step has the actual content (frontmatter, Iron Law/escalation blocks verbatim, exact grep commands, expected output).
-- [ ] **Type consistency** — the flag is `--auto` everywhere; the note type is `gotcha` everywhere; the command is `/woostack-debug <target> [--auto]` everywhere; counts are twelve (public) / fourteen (SKILL.md files) consistently.
+- [x] **Spec coverage** — every spec section maps to a task: §2 goal → Task 1 (skill) + Tasks 2–7 (wiring/enum); §4.1 four phases → Task 1 Steps 4–5; §4.2 mode model → Task 1 Step 6; §4.3 memory → Task 1 Step 7; §4.4 call sites → Tasks 2–3; §5 edit set → Tasks 1–7; §6 failure modes → Task 1 Steps 6–7 + Step 11; §7 testing → the verification steps + Task 8.
+- [x] **No placeholders** — every step has the actual content (frontmatter, Iron Law/escalation blocks verbatim, exact grep commands, expected output).
+- [x] **Type consistency** — the flag is `--auto` everywhere; the note type is `gotcha` everywhere; the command is `/woostack-debug <target> [--auto]` everywhere; counts are twelve (public) / fourteen (SKILL.md files) consistently.
 
 > woostack plan conventions (kept):
 > - This file is **frontmatter-free** and **opens with** the `**Source:**` line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `npx skills add howarewoo/woostack`.
 
-The public command/adoption surface has eleven skills:
+The public command/adoption surface has twelve skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -26,12 +26,13 @@ The public command/adoption surface has eleven skills:
 - [`woostack-address-comments`](skills/woostack-address-comments/SKILL.md)
 - [`woostack-status`](skills/woostack-status/SKILL.md)
 - [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
+- [`woostack-debug`](skills/woostack-debug/SKILL.md)
 
 The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the eleven-skill command
+`/woostack-*` commands: they have no routing row and are absent from the twelve-skill command
 surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
@@ -53,8 +54,8 @@ do not add application code, app build configs, or app lockfiles.
 
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
 `/woostack-bootstrap`, `/woostack-build`, `/woostack-plan`, `/woostack-execute`, `/woostack-commit`,
-`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, or `/woostack-visualize`,
-including intent-equivalent wording. Load the matching skill
+`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, or
+`/woostack-debug`, including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
 directory, not in this repo.
 
@@ -76,7 +77,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the thirteen `SKILL.md` files (the eleven public command/adoption
+- Do not move or rename any of the fourteen `SKILL.md` files (the twelve public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -104,6 +105,8 @@ directory, not in this repo.
   [`skills/woostack-commit/SKILL.md`](skills/woostack-commit/SKILL.md)
 - Review engine:
   [`skills/woostack-review/`](skills/woostack-review/)
+- Systematic-debugging engine (public command + internal hook invoked by execute/review):
+  [`skills/woostack-debug/SKILL.md`](skills/woostack-debug/SKILL.md)
 - Visualization engine (audience-tailored HTML renders):
   [`skills/woostack-visualize/SKILL.md`](skills/woostack-visualize/SKILL.md)
 - Address-comments delegator:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-plan`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, and `woostack-visualize`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-plan`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, and `woostack-debug`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 
@@ -25,6 +25,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Change the execute phase (the build loop's implementation step) | `skills/woostack-execute/SKILL.md` |
 | Change the commit / PR update workflow | `skills/woostack-commit/SKILL.md` |
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |
+| Change the systematic-debugging behavior (`/woostack-debug`) | `skills/woostack-debug/SKILL.md` |
 | Change the address-comments delegator | `skills/woostack-address-comments/SKILL.md` |
 | Change the status board / feature-state conventions | `skills/woostack-status/SKILL.md`, `skills/woostack-status/references/conventions.md`, `skills/woostack-status/scripts/` |
 | Update agent instructions (Claude or any) | `AGENTS.md` (`.claude/CLAUDE.md` is a symlink to it) |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is eleven skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-plan, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, and woostack-visualize. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is twelve skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-plan, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, woostack-visualize, and woostack-debug. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 
@@ -88,6 +88,10 @@ A read-only, on-demand board derived fresh from your `.woostack/` artifacts: for
 ### `/woostack-visualize <source> [for <audience>]`: audience-tailored HTML render
 
 A discovery command for rendering source material as an audience-tailored HTML view while keeping the source authoritative. → [SKILL.md](skills/woostack-visualize/SKILL.md)
+
+### `/woostack-debug <target> [--auto]`: find the root cause before fixing
+
+Runs woostack's systematic-debugging method on a bug, test failure, or unexpected behavior: root-cause investigation → pattern analysis → hypothesis/test → a minimal fix with a failing test first, under the Iron Law (no fix without a root cause) and a 3-fixes-→-question-the-architecture escalation. It recalls known `gotcha`s from `.woostack/memory/` at the start and distills one at the end. Standalone it gates on the root cause before fixing (the gated form `woostack-review` points you at for a confirmed bug); `--auto` runs autonomously (how `woostack-execute` calls it on a stuck verification). Never commits or merges. → [SKILL.md](skills/woostack-debug/SKILL.md)
 
 ### Growing scope
 

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -73,6 +73,7 @@ link it, never restate it.
 | `/woostack-address-comments [PR#]`, address unresolved review threads | `woostack-address-comments` |
 | `/woostack-status [--all] [--fetch]`, show the derived feature board (what's in flight, what to do next) | `woostack-status` |
 | `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |
+| `/woostack-debug <target> [--auto]`, find a bug's root cause before fixing (gated; `--auto` for autonomous) | `woostack-debug` |
 
 If the user asks for the behavior without using the exact command name, route by intent.
 For example, "use woostack to review this PR" means load `woostack-review`.

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -134,7 +134,11 @@ Stop immediately and ask — never guess — when:
 
 - A blocker hits (missing dependency, failing verification, unclear instruction).
 - The plan has critical gaps preventing a start.
-- A verification fails repeatedly.
+- A verification fails repeatedly — route it to [`woostack-debug`](../woostack-debug/SKILL.md)
+  in autonomous mode (`woostack-debug <target> --auto`) to find and fix the root cause before
+  escalating; escalate to the user only if debug returns its 3-fixes architectural stop. Debug
+  does not commit — execute commits the returned fix in its normal per-increment cadence. This
+  applies to both the inline and subagent drivers.
 - A review returns REQUEST_CHANGES — handle the findings before continuing.
 
 Return to the plan-review step if the plan is updated or the approach needs rethinking.

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -130,15 +130,16 @@ mode. **Never merge.**
 
 ## When to stop and ask
 
-Stop immediately and ask — never guess — when:
+Stop — never guess — when one of these hits. Most surface to the user immediately; a
+repeatedly-failing verification instead routes to [`woostack-debug`](../woostack-debug/SKILL.md)
+first and escalates to the user only on debug's 3-fixes architectural stop:
 
 - A blocker hits (missing dependency, failing verification, unclear instruction).
 - The plan has critical gaps preventing a start.
-- A verification fails repeatedly — route it to [`woostack-debug`](../woostack-debug/SKILL.md)
-  in autonomous mode (`woostack-debug <target> --auto`) to find and fix the root cause before
-  escalating; escalate to the user only if debug returns its 3-fixes architectural stop. Debug
-  does not commit — execute commits the returned fix in its normal per-increment cadence. This
-  applies to both the inline and subagent drivers.
+- A verification fails repeatedly — route it to `woostack-debug <target> --auto` (autonomous)
+  to find and fix the root cause; escalate to the user only if debug returns its 3-fixes
+  architectural stop. Debug does not commit — execute commits the returned fix in its normal
+  per-increment cadence. Applies to both the inline and subagent drivers.
 - A review returns REQUEST_CHANGES — handle the findings before continuing.
 
 Return to the plan-review step if the plan is updated or the approach needs rethinking.

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -534,6 +534,7 @@ The `if:` gate restricts comment-triggered runs to the repo owner / members / co
 - Trust the Skeptical Validator. Disabling it produces noisy reviews.
 - Honor angle-prompt tiers (`fast`/`standard`/`deep`) when the host supports per-call model routing. Hosts that run one model per session should pin `gpt-5.5` for maximum validator quality, or `gpt-5.4` when cost matters more than deep validation.
 - Pass `disable_angles` to skip optional angles when scope is narrow (e.g. backend-only PR → `disable_angles: "seo,aeo,design,react,i18n"`).
+- For a confirmed bug (not a style nit) that the author wants to fix, suggest investigating it with [`woostack-debug`](../woostack-debug/SKILL.md): `/woostack-debug <target>` (gated — it finds the root cause before any fix). Review never dispatches `woostack-debug --auto`: it owns no fix behavior and never auto-addresses findings, so it only points the author at the gated command.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Goal

Make `woostack-debug` reachable and counted everywhere. Increment 2 of the woostack-debug stack: wires the call sites (`woostack-execute` dispatches `--auto` on a stuck verification; `woostack-review` suggests the gated command) and registers the new command across the adoption surface.

## Summary

- **woostack-execute**: "When to stop and ask" routes a repeatedly-failing verification to `woostack-debug <target> --auto` before user escalation (both inline + subagent drivers); intro reworded so the reroute case doesn't contradict the "stop and ask" framing.
- **woostack-review**: Best Practices suggests the gated `/woostack-debug` for a confirmed bug — explicitly never `--auto` (review owns no fix behavior, never auto-addresses findings).
- **using-woostack**: new Command Routing row.
- **AGENTS.md**: eleven→twelve public, thirteen→fourteen `SKILL.md` files, list entry, Mode B trigger, Quick file map.
- **README.md**: count + list + a new `### /woostack-debug` catalog entry (build-loop prose left untouched — debug is a sub-routine, not a build phase).
- **CONTRIBUTING.md**: command-surface list + edit-map row.
- **Memory**: updated the `woostack-command-surface-bookkeeping` note to twelve/fourteen.

## Test plan

### Automated

- [x] Per-task verification greps (execute routing + link, review gated mention + explicit never-`--auto`, using-woostack row, AGENTS counts, README count + catalog, CONTRIBUTING): PASS
- [x] No-stale sweep — no `eleven`/`eleven-skill`/`thirteen \`SKILL.md\`` remain across AGENTS/README/CONTRIBUTING/using-woostack/execute/review: OK
- [x] `woostack-debug` present in every enumeration site; all cross-links resolve (execute/review → woostack-debug, AGENTS file-map): OK
- [x] `development.md` no-op confirmed (no command-surface enumeration there)
- [x] `woostack-review --fast` (local, fast tier): surfaced 2 real consistency findings (execute intro vs. header; stale plan verification grep) — both fixed, re-verified PASS
- [x] memory `doctor.sh`: 0 errors (1 pre-existing advisory overlap-cluster warning)

### Manual

**Before merge**

- [ ] Read the execute "When to stop and ask" change + the review pointer; confirm the `--auto` (execute) vs. gated (review) split reads correctly.
- [ ] Skim AGENTS/README/CONTRIBUTING enumeration for count/list consistency (twelve public, fourteen `SKILL.md`).

Spec: .woostack/specs/2026-06-05-woostack-debug.md
