### PR TITLE
chore: trim enabled plugins in local settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,11 @@
 {
-  "env": {
-    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "70",
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-  },
-  "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true,
-    "ralph-loop@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true
-  },
-  "planDir": "./.claude/plans"
+	"env": {
+		"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "70",
+		"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+	},
+	"enabledPlugins": {
+		"frontend-design@claude-plugins-official": true,
+		"typescript-lsp@claude-plugins-official": true
+	},
+	"planDir": "./.claude/plans"
 }


### PR DESCRIPTION
## Goal

Trim the locally enabled Claude Code plugin set to just the two in active use, removing five that are no longer needed.

## Summary

- Drop five enabled plugins: `ralph-loop`, `superpowers`, `code-simplifier`, `claude-md-management`, `pr-review-toolkit`.
- Keep `frontend-design` and `typescript-lsp`.
- Reindent `.claude/settings.json` to tabs; `env` and `planDir` unchanged.

## Test plan

### Manual

**Before merge**

- [ ] Read the diff: confirm only the `enabledPlugins` list shrank and indentation changed — `env` keys and `planDir` are untouched.
- [ ] Confirm `.claude/settings.json` is still valid JSON (`jq . .claude/settings.json`).
