### PR TITLE
docs(woostack-bootstrap): stop restating build chain in dev loop table

### DIFF
--- a/skills/woostack-bootstrap/references/development.md
+++ b/skills/woostack-bootstrap/references/development.md
@@ -9,7 +9,7 @@ for each phase:
 
 | Phase | Skill |
 |---|---|
-| Ideate → markdown spec → harden → approve spec → plan → execute | `woostack-build` |
+| Build a feature, idea → implementation (gated chain — the skill owns the steps) | `woostack-build` |
 | Review | `woostack-review` |
 | Address review feedback | `woostack-address-comments` |
 


### PR DESCRIPTION
## Goal

The dev-loop table in `development.md` restated `woostack-build`'s chain inline, and that restatement had already gone stale — it dropped the plan harden, the spec+plan PR, and the execution-handoff gate. Remove the restatement so the table can't drift when build's gates change.

## Summary

- Replace the enumerated phase cell in `skills/woostack-bootstrap/references/development.md` with a non-lossy label (`Build a feature, idea → implementation (gated chain — the skill owns the steps)`) that defers the step list to `woostack-build`, which the same row already names as source of truth.

## Test plan

### Manual

**Before merge**

- [ ] Read `skills/woostack-bootstrap/references/development.md:12` — confirm the loop table no longer enumerates build's gates and still names `woostack-build` as the source of truth.
