### PR TITLE
docs(woostack-address-comments): spec and plan for fix-plan gate

### DIFF
--- a/.woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
+++ b/.woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
@@ -1,0 +1,231 @@
+**Source:** .woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
+
+# woostack-address-comments: show the fix plan before approval — Implementation Plan
+
+**Goal:** Surface a terse one-line plan of how each FIX will land at the verdict gate, so the user approves knowing the edit — not just the verdict.
+
+**Architecture:** Documentation-only change inside `skills/woostack-address-comments/`. The worker contract already defines a `fix_plan` field (`prompts/address.md:30`) that dies on the worker boundary; this plan threads it through the parent's own staged record (Phase 1 step 5) and surfaces it at the verdict gate (Phase 2) host-agnostically — a table column on a plain host, the per-thread option text on a structured host — plus a bounded override→FIX follow-up so every applied FIX has had a plan shown. `SKILL.md` prose is aligned at a high level; the gate detail stays in the prompt. Two grep assertions in the existing shell test guard the contract.
+
+**Tech Stack:** Markdown (skill `SKILL.md` + `prompts/address.md`), Bash + ripgrep grep-assertion tests (`scripts/tests/*.sh`). No app build/CI in this repo.
+
+---
+
+## Increment 1: Fix plan at the verdict gate (single PR)
+
+> One independently shippable PR (~40 lines of prose + 2 test lines, well under the ≤500 LOC soft target) — its own Graphite-stacked branch on top of the spec+plan base PR. All three tasks edit the one `woostack-address-comments` skill and must ship together to stay internally consistent.
+
+### Task 1: Phase 2 verdict gate shows the fix plan + override→FIX follow-up
+
+**Files:**
+- Modify: `skills/woostack-address-comments/prompts/address.md` (Phase 2, lines ~59–77)
+- Test: `skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh` (add assertions after line 19)
+
+- [ ] **Step 1: Write the failing test**
+
+Add these two assertions to `test-address-worker-contract.sh`, immediately after the existing `assert_contains "$PROMPT" "fix_plan"` line (line 19):
+
+```bash
+# the verdict gate must surface the fix plan to the user, not just the verdict
+assert_contains "$PROMPT" "fix plan"
+# an override that creates a FIX must derive + confirm its plan before applying
+# (ASCII token from the override→FIX follow-up prose — robust to arrow encoding)
+assert_contains "$PROMPT" "bounded confirm"
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `bash skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh`
+Expected: FAIL — `missing pattern in skills/woostack-address-comments/prompts/address.md: fix plan` (the prompt has `fix_plan` but not the literal `fix plan`, and no `override→FIX` text yet).
+
+- [ ] **Step 3: Minimal implementation**
+
+Replace the Phase 2 body in `prompts/address.md` (from the `**Otherwise (default):**` paragraph through the host-mechanics / final-verdict bullets, lines ~64–77) with:
+
+```markdown
+**Otherwise (default):** present all staged threads for approval, showing each
+thread's **recommended verdict, reasoning, and — for a FIX — its one-line
+`fix_plan`**, so the user approves knowing *how* each fix will land, not just
+that a fix is recommended. The fix plan is a **description only**: Phase 1 makes
+no edits; the edit happens in Phase 3 on the final verdict. Then ask the user to
+either **approve all** recommendations or **override** specific threads to a
+different verdict (any of FIX / ACCEPT / CLARIFY).
+
+Show the fix plan alongside the FIX verdict **wherever the gate renders it**:
+
+- Host mechanics: a host with a structured question primitive (e.g. Claude
+  Code's `AskUserQuestion`) offers an "approve all" choice plus per-thread
+  overrides — carry the fix plan inside each FIX thread's option text; a plain
+  host prints the numbered table — columns: thread, finding, recommended
+  verdict, reasoning, **fix plan** (the fix-plan cell is the one-line `fix_plan`
+  for a FIX, `—` for ACCEPT / CLARIFY) — and asks for "approve all, or list
+  `thread#=verdict` overrides".
+- The **final verdict** per thread = the user's override where given, else your
+  recommendation. Only Phase 3 acts, and only on final verdicts.
+- **override→FIX follow-up:** if an override turns an ACCEPT/CLARIFY thread into
+  a FIX, no `fix_plan` was staged for it — derive its one-line plan and present
+  those override-created plans for **one bounded confirm** before Phase 3 acts,
+  so every applied FIX has had its plan shown. This completes the single verdict
+  gate; it is not a new chained gate and does not re-open cascading re-overrides
+  (the user confirms the derived plan or pulls that thread back off FIX).
+- **Non-interactive host, no `--auto`:** if you cannot obtain confirmation,
+  **abort** without acting — tell the user: "interactive verdict review needs a
+  user; re-run with `--auto` to address autonomously." Never act unapproved.
+```
+
+(Leave the `**If --auto was set:**` paragraph above and the `## Phase 3` heading below unchanged.)
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `bash skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh`
+Expected: PASS (no output, exit 0) — `fix plan` and `override→FIX` are now both present.
+
+- [ ] **Step 5: Commit**
+
+```bash
+# first commit in this increment:
+gt create -m "feat(woostack-address-comments): show fix plan at the verdict gate"
+```
+
+### Task 2: Phase 1 staged record carries `fix_plan` (cross-reference)
+
+**Files:**
+- Modify: `skills/woostack-address-comments/prompts/address.md` (Phase 1, step 5, lines ~48–55)
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `rg -F -q "memory_scope, fix_plan" skills/woostack-address-comments/prompts/address.md; echo $?`
+Expected: FAIL — prints `1` (the step-5 record ends `…, memory_scope }`; only the worker record on line 30 mentions `fix_plan`, never the sequence `memory_scope, fix_plan`).
+
+- [ ] **Step 2: Minimal implementation**
+
+Replace step 5 in `prompts/address.md` with (add `fix_plan` to the record tuple and define it by cross-reference, not restatement):
+
+```markdown
+5. Stage a record per thread:
+   `{ threadId, file, line, finding, recommended, reasoning, learning, memory_scope, fix_plan }`
+   — `finding` is the one-line restatement, `reasoning` is why you recommend
+   that verdict, `learning` is the reusable memory pattern to write **if** the
+   final verdict is ACCEPT (else leave empty), `memory_scope` is the narrowest
+   glob that should suppress the same accepted finding in future reviews (prefer
+   the reviewed file's package/feature path; use comma-separated globs when the
+   learning specifically covers multiple paths), and `fix_plan` is **as defined
+   for the worker record above** — a terse one-line description of the planned
+   edit for a FIX, an empty string otherwise. Staging `fix_plan` here, not only
+   in the worker fan-out, is what lets the verdict gate show *how* each FIX will
+   land.
+```
+
+- [ ] **Step 3: Run the check + full test, confirm they pass**
+
+Run: `rg -F -q "memory_scope, fix_plan" skills/woostack-address-comments/prompts/address.md && echo OK`
+Expected: prints `OK`.
+Run: `bash skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh && bash skills/woostack-address-comments/scripts/tests/test-address-comments-ownership.sh`
+Expected: PASS (no output, exit 0 from both) — existing `fix_plan` presence assertions still hold.
+
+- [ ] **Step 4: Commit**
+
+```bash
+# later commit in the same increment:
+gt modify -c -m "feat(woostack-address-comments): stage fix_plan in the parent record"
+```
+
+### Task 3: Align `SKILL.md` prose (Overview + reception-loop + verdict-gate bullets)
+
+**Files:**
+- Modify: `skills/woostack-address-comments/SKILL.md` (Overview lines ~10–16; step 3 lines ~39–46; step 4 lines ~47–51)
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `rg -F -c "fix plan" skills/woostack-address-comments/SKILL.md; echo $?`
+Expected: FAIL — prints `0` then `1` (no occurrence of `fix plan` in `SKILL.md` yet).
+
+- [ ] **Step 2: Minimal implementation**
+
+Three edits in `SKILL.md`, keeping the file high-level (the override→FIX and host-rendering detail stay in the prompt, which the verdict-gate bullet already delegates to):
+
+1. **Overview** — change the default-gate sentence so it names the fix plan. Replace:
+
+   ```markdown
+   **CLARIFY**. By **default** it presents the batched recommendations for your approval (or
+   per-thread override) before applying anything; with `--auto` it skips the gate and acts
+   autonomously.
+   ```
+
+   with:
+
+   ```markdown
+   **CLARIFY**. By **default** it presents the batched recommendations — including the
+   one-line fix plan for each FIX, so you see *how* it will fix before approving — for your
+   approval (or per-thread override) before applying anything; with `--auto` it skips the
+   gate and acts autonomously.
+   ```
+
+2. **Step 3 (reception loop)** — change the staging clause. Replace:
+
+   ```markdown
+   it stages a recommended verdict + reasoning per thread.
+   ```
+
+   with:
+
+   ```markdown
+   it stages a recommended verdict + reasoning + (for a FIX) a one-line fix plan per thread.
+   ```
+
+3. **Step 4 (verdict gate)** — name the planned fix and the override→FIX detail location. Replace:
+
+   ```markdown
+   4. **Verdict gate** — default: the user approves the batch or overrides specific threads
+      before anything is applied; `--auto` skips the gate; a non-interactive host with no
+      `--auto` aborts rather than acting unapproved. The **final** verdict per thread is the
+      override where given, else the recommendation. See `prompts/address.md` § Phase 2 for
+      the gate mechanics.
+   ```
+
+   with:
+
+   ```markdown
+   4. **Verdict gate** — default: the user approves the batch — seeing the planned fix for
+      each FIX — or overrides specific threads before anything is applied; `--auto` skips the
+      gate; a non-interactive host with no `--auto` aborts rather than acting unapproved. The
+      **final** verdict per thread is the override where given, else the recommendation. See
+      `prompts/address.md` § Phase 2 for the gate mechanics, including the override→FIX plan
+      confirm.
+   ```
+
+   (The description frontmatter line 3 already stays accurate — "fix or push back on each finding" still holds — so it needs no change.)
+
+- [ ] **Step 3: Run the check + full address-comments test suite, confirm they pass**
+
+Run: `rg -F -c "fix plan" skills/woostack-address-comments/SKILL.md`
+Expected: prints `2` (Overview + step 3).
+Run: `for t in skills/woostack-address-comments/scripts/tests/*.sh; do bash "$t" || { echo "FAIL: $t"; break; }; done; echo done`
+Expected: prints `done` with no `FAIL:` line — all three address-comments tests green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+# later commit in the same increment:
+gt modify -c -m "docs(woostack-address-comments): align SKILL prose with fix-plan gate"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every spec requirement maps to a task above.
+  - Terse one-line plan, FIX-only, `—` for ACCEPT/CLARIFY → Task 1 (gate prose) + Task 2 (`fix_plan` definition).
+  - Host-agnostic (table column on plain host, option text on structured host) → Task 1.
+  - `fix_plan` on both Phase 1 paths; step 5 cross-references line 30 → Task 2.
+  - Override→FIX bounded follow-up → Task 1.
+  - Phase 1 stays side-effect-free; `--auto` unchanged → Task 1 (left the `--auto` and Phase 3 text untouched; "description only" restatement added).
+  - SKILL.md high-level alignment → Task 3.
+  - Two grep assertions (gate names fix plan; override→FIX follow-up) → Task 1.
+- [ ] **No placeholders** — every step has the exact prose to write, the exact command, and expected output. No TBD/TODO.
+- [ ] **Type consistency** — the field is named `fix_plan` everywhere (worker record line 30, parent step-5 record, gate); the user-facing column/label is "fix plan"; the override case heading is "override→FIX follow-up" in the prompt prose, and the durable assertion greps the ASCII phrase "bounded confirm" present in that same prose (not the unicode arrow). Names match across tasks.
+
+> woostack plan conventions (kept):
+> - This file is **frontmatter-free** and **opens with** the `**Source:**` line.
+> - Filename mirrors the spec basename: `.woostack/plans/2026-06-05-address-comments-fix-plan-gate.md` (the spec's date, not today's).
+> - **No** required sub-skill banner — execution is `woostack-execute`'s (woostack-build step 8, or `/woostack-execute <plan>`).
+> - This repo has no app test runner, so each "failing test" step is a concrete grep/`rg` verification command with exact expected output, plus the durable assertions added to the existing shell test.

--- a/.woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
+++ b/.woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
@@ -1,0 +1,201 @@
+---
+name: address-comments-fix-plan-gate
+type: spec
+status: planning
+date: 2026-06-05
+branch: address-comments-fix-plan-gate
+links:
+---
+
+# woostack-address-comments: show the fix plan before approval — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+`woostack-address-comments` runs an analysis loop, then presents a batched verdict gate for
+the user to approve before any edit lands (`prompts/address.md` Phase 1 → Phase 2). The gate
+table has four columns: **thread · finding · recommended verdict · reasoning**
+(`prompts/address.md:65`).
+
+For a **FIX** verdict, that table shows *why* a fix is recommended (`reasoning`) but never
+*what edit* will be made. The user approves a fix sight-unseen — the planned change is not
+surfaced until Phase 3 has already mutated the working tree.
+
+The information already half-exists. The worker-fan-out contract defines a `fix_plan` field
+— "a short description of the needed code edit for FIX, or an empty string otherwise"
+(`prompts/address.md:30`). But it dies on the worker boundary:
+
+1. The non-fan-out staged record (Phase 1, step 5, `prompts/address.md:48–49`) lists
+   `{ threadId, file, line, finding, recommended, reasoning, learning, memory_scope }` —
+   **no `fix_plan`**. A run without worker fan-out never produces one.
+2. The Phase 2 gate table never renders `fix_plan`, so even a fan-out run that produced it
+   hides it from the approval decision.
+
+Net: approval of a FIX is uninformed about the actual change.
+
+## 2. Goal
+
+Surface, at the verdict gate, a **terse one-line plan** of how each FIX will be applied, so
+the user approves with knowledge of the edit — not just the verdict.
+
+Concretely:
+
+- The Phase 1 staged record carries `fix_plan` on **both** code paths (worker fan-out and the
+  parent's own analysis), so the two record schemas align.
+- The verdict gate shows the fix plan **alongside the FIX verdict, wherever the gate renders
+  it** — a new column on a plain numbered table, and inside the per-thread option text on a
+  structured-question host. Host-agnostic, matching `prompts/address.md:69–72`.
+- **Every applied FIX has had a plan shown.** If a gate override turns an ACCEPT/CLARIFY
+  thread into a FIX (no `fix_plan` was staged for it), derive the one-line plan for that
+  thread and present it for one bounded follow-up confirm before Phase 3 applies it — so no
+  FIX edit lands without its plan having been seen.
+- `SKILL.md` prose (Overview, reception-loop bullet, verdict-gate bullet) matches the prompt
+  contract.
+
+Scope is the prose, prompt, and tests of one skill: `skills/woostack-address-comments/`. No
+app code, no other skills.
+
+## 3. Non-goals
+
+- **No full diff/patch preview.** The plan is a one-line description, not generated code.
+  Reuses the existing `fix_plan` altitude.
+- **No edits in Phase 1.** The side-effect-free analysis invariant is preserved
+  (`prompts/address.md:14–16`); the real edit stays in Phase 3.
+- **No fix-plan column for ACCEPT / CLARIFY.** Those verdicts already carry their action in
+  the `reasoning` column (pushback) or as a posted question. `fix_plan` stays empty for them,
+  matching the line-30 contract.
+- **`--auto` path unchanged.** With `--auto` there is no gate and no table; `fix_plan` is
+  still staged but simply not presented.
+- No change to commit/push/reply/resolve/memory mechanics or the worker-ownership boundary.
+
+## 4. Approach
+
+Edit three spots in `skills/woostack-address-comments/`, plus one test assertion:
+
+1. **`prompts/address.md` — Phase 1, step 5 staged record (`:48–49`).** Add `fix_plan` to the
+   non-fan-out record, **cross-referencing** the existing worker-record definition
+   (`prompts/address.md:30`) rather than restating it — e.g. "…, `fix_plan` (as defined for
+   the worker record above)". One canonical definition (honoring the repo "cross-link, do not
+   duplicate" constraint); this aligns the parent's staged record with the worker record.
+
+2. **`prompts/address.md` — Phase 2 verdict gate (`:64–72`).** State the requirement
+   host-agnostically: the fix plan is shown alongside the FIX verdict **wherever the gate
+   renders it**. Spell out both host instances against the existing host-mechanics note
+   (`:69–72`): a plain numbered-table host gains a **fix plan** column (thread · finding ·
+   recommended verdict · reasoning · **fix plan**); a structured-question host carries the
+   fix plan inside each FIX thread's option text. Populated for FIX, `—`/empty for
+   ACCEPT / CLARIFY. Reaffirm the plan is a *description only* — Phase 1 makes no edits; the
+   edit happens in Phase 3 on the final verdict. Approve-all / per-thread override mechanics
+   are unchanged. **Add the override→FIX follow-up:** after overrides are submitted, for any
+   thread now FIX-bound with an empty `fix_plan` (i.e. it was not a recommended FIX), derive
+   the one-line plan and present those override-created plans for a single bounded confirm
+   before Phase 3 acts. The follow-up confirm is **not** a new chained gate — it completes the
+   one verdict gate, which is done only once every final FIX has had a plan shown. It does not
+   re-open arbitrary re-override cascades: the user confirms the derived plan or pulls that
+   thread back off FIX.
+
+3. **`SKILL.md` — Overview + lifecycle (`:10–16`, step 3 `:39–46`, step 4 `:47–51`).** Update
+   the reception-loop bullet so it stages "a recommended verdict + reasoning **+ fix plan**"
+   per thread, and the verdict-gate bullet so the gate "presents the batched recommendations
+   **with the planned fix** for approval." Keep `SKILL.md` high-level: the override→FIX
+   follow-up and host-rendering detail stay in `prompts/address.md` (the verdict-gate bullet
+   already delegates gate mechanics to it, `SKILL.md:50–51`). Keep the description line
+   accurate.
+
+4. **Tests — `scripts/tests/test-address-worker-contract.sh`.** Add two grep assertions on
+   stable keywords (not exact prose): (a) the Phase 2 gate surfaces the fix plan (the gate
+   section mentions `fix plan`); (b) the override→FIX follow-up is present (e.g. the prompt
+   mentions deriving/confirming a plan for an override-created FIX). Existing `fix_plan`
+   presence assertions (`test-address-worker-contract.sh:19`,
+   `test-address-comments-ownership.sh:32`) still pass.
+
+Markdown/prompt + shell-test change only; the skill is documentation an agent executes.
+
+## 5. Components & data flow
+
+**Staged record (Phase 1, both paths)** — gains the final field:
+
+```
+{ threadId, file, line, finding, recommended, reasoning, learning, memory_scope, fix_plan }
+```
+
+- `fix_plan`: terse one-line edit description for a FIX verdict; empty string for ACCEPT /
+  CLARIFY. Same semantics as the worker-record `fix_plan` (`prompts/address.md:30`).
+
+**Phase 2 gate table** — five columns:
+
+| thread | finding | recommended verdict | reasoning | fix plan |
+|--------|---------|---------------------|-----------|----------|
+| #1 | off-by-one in expiry | FIX | real bug, still present | change `<`→`<=` in auth.ts:42 |
+| #2 | rename endpoint | ACCEPT | intentional public API | — |
+| #3 | unclear retry intent | CLARIFY | cannot verify intent | — |
+
+The table above is the **plain-host** instance. On a **structured-question** host the fix
+plan rides inside each FIX thread's option text:
+
+```
+Thread #1  finding: off-by-one in expiry
+  [approve FIX]  change `<`→`<=` in auth.ts:42
+  [override → ACCEPT / CLARIFY]
+```
+
+Flow: Phase 1 stages `fix_plan` per thread → Phase 2 shows it alongside each FIX verdict
+(table column on a plain host, option text on a structured host) → user approves/overrides →
+**override→FIX follow-up**: any thread the user overrides into FIX has no staged plan, so
+derive its one-line plan and present those for one bounded confirm → Phase 3 applies the edit
+for final FIX verdicts (unchanged). The host-mechanics note (`prompts/address.md:69–72`) is
+unchanged in mechanics; both rendering paths now carry the fix plan.
+
+## 6. Error handling
+
+No new failure modes — the change is prompt/doc prose plus one grep test.
+
+- A FIX whose plan is hard to articulate → best-effort one-liner; the existing per-thread
+  `errored` guardrail (`prompts/address.md:135`) still covers a true analysis failure and
+  leaves that thread open without aborting the run.
+- Push-rejected and per-thread-error guardrails (`prompts/address.md:133–139`) are untouched.
+- `--auto`: gate skipped, no table rendered, behavior unchanged.
+
+## 7. Testing
+
+Automated: this repo has no app build/CI for its own skill markdown. The skill's own shell
+tests are the harness:
+
+- Extend `scripts/tests/test-address-worker-contract.sh` with two grep assertions: the Phase 2
+  gate section names the fix plan, and the override→FIX follow-up is present. Run the three
+  address-comments tests (`test-address-comments-ownership.sh`,
+  `test-address-helper-scripts.sh`, `test-address-worker-contract.sh`) and confirm green.
+
+Manual (before merge):
+
+- Read `prompts/address.md` and confirm: step 5 record lists `fix_plan` cross-referencing the
+  line-30 worker definition; Phase 2 shows the fix plan host-agnostically (table column on a
+  plain host, option text on a structured host) with the FIX-only / `—` rule, the "description
+  only, edit happens in Phase 3" restatement, and the override→FIX follow-up confirm.
+- Read `SKILL.md` and confirm the reception-loop and verdict-gate bullets mention the fix plan
+  and stay consistent with the prompt — no leftover four-column description.
+
+Manual (after merge): none — the skill takes effect for consumers on install; no deploy or
+runtime surface to verify post-merge for this repo.
+
+## 8. Open questions
+
+None. All decisions are resolved:
+
+- Altitude: a **terse one-line** fix plan (not a full diff); Phase 1 stays side-effect-free.
+- Scope: the new column is **FIX-only**; ACCEPT / CLARIFY render `—`, matching the
+  existing `fix_plan` empty-string contract.
+- Surface: shown alongside the FIX verdict (not a separate per-thread expansion).
+- Host-agnostic: stated once host-neutrally, then both renderings named — a table column on a
+  plain host, the per-thread option text on a structured-question host. The skill works for
+  any agent, not one host.
+- Field definition: step 5 **cross-references** the line-30 worker-record definition of
+  `fix_plan` rather than restating it (repo "cross-link, do not duplicate" rule); one
+  canonical definition.
+- Override→FIX: a gate override that creates a FIX gets its plan **derived and shown for one
+  bounded confirm** before Phase 3, so every applied FIX has had a plan seen. This completes
+  the single verdict gate; it is not a new chained gate and does not re-open cascading
+  re-overrides.


### PR DESCRIPTION
## Goal

Capture the approved design and TDD plan for surfacing the fix plan at `woostack-address-comments`' verdict gate — so the user sees *how* each FIX will land before approving, not just *that* a fix is recommended. This docs-only PR is the base of the implementation stack; it is never merged.

## Summary

- Add spec `.woostack/specs/2026-06-05-address-comments-fix-plan-gate.md` (hardened → `status: planning`): surface a terse one-line fix plan alongside each FIX verdict, host-agnostically (table column on a plain host, per-thread option text on a structured host); stage `fix_plan` on both Phase 1 paths; bounded override→FIX follow-up so every applied FIX has had a plan shown; FIX-only, side-effect-free Phase 1, `--auto` unchanged.
- Add plan `.woostack/plans/2026-06-05-address-comments-fix-plan-gate.md` — one PR-sized increment, 3 TDD tasks (gate prose + 2 grep assertions, Phase 1 record `fix_plan` cross-ref, `SKILL.md` alignment).

## Test plan

### Manual

**Before merge**

- [ ] Read the spec and confirm the eight sections are coherent and the four hardened decisions are recorded in §8 (host-agnostic rendering, field cross-reference, override→FIX, test scope).
- [ ] Read the plan and confirm the single increment is reviewable and independently shippable, every step has exact prose/command/expected output, and the TDD red-state baselines match the live files.

Spec: .woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
