### PR TITLE
chore(memory): bump recall telemetry for four memory-vault files

### DIFF
--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,8 +6,8 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 4
-last_recalled: 2026-06-05
+recall_count: 7
+last_recalled: 2026-06-06
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not
 contain `": "` (colon followed by space) — YAML reads it as a nested mapping-value indicator

--- a/.woostack/memory/skill-test-assert-ascii-token.md
+++ b/.woostack/memory/skill-test-assert-ascii-token.md
@@ -6,8 +6,8 @@ tags: tests, grep, assertions, encoding, ascii, unicode
 hook: Grep-based skill tests should assert an ASCII token, not a unicode literal (e.g. a → arrow); keep the readable unicode in the prose and assert on an ASCII phrase that lives in the same text.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
-recall_count: 1
-last_recalled: 2026-06-05
+recall_count: 4
+last_recalled: 2026-06-06
 ---
 woostack skills are documentation; their `scripts/tests/*.sh` guards are `rg -F`/`grep`
 presence-checks over the prose. When the prose contains a readable unicode glyph (an em-dash,

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,8 +6,8 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 14
-last_recalled: 2026-06-05
+recall_count: 17
+last_recalled: 2026-06-06
 ---
 The public-command count and skill lists are duplicated across several files and
 drift independently (the `woostack-harden` internal-sub-skill mention in README

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,8 +6,8 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 40
-last_recalled: 2026-06-05
+recall_count: 43
+last_recalled: 2026-06-06
 ---
 Feature state is derived from artifacts, not a committed status file: each spec
 has exactly one plan via `**Source:** .woostack/specs/<file>.md`, and each


### PR DESCRIPTION
## Goal

Keep the `.woostack/memory/` store in sync with the recall telemetry the memory system records, so on-disk counters match actual recall activity.

## Summary

- Bump `recall_count` and refresh `last_recalled` to 2026-06-06 in four memory-vault files: `skill-description-colon-space`, `skill-test-assert-ascii-token`, `woostack-command-surface-bookkeeping`, `woostack-feature-state-invariant`.
- Telemetry-only: no memory body/content changed.

## Test plan

### Manual

**Before merge**

- [ ] Confirm the diff touches only `recall_count` / `last_recalled` frontmatter in the four files and leaves each memory body unchanged.
