### PR TITLE
docs(woostack-execute-overnight): spec and plan for unattended overnight execute

### DIFF
--- a/.woostack/plans/2026-06-06-woostack-execute-overnight.md
+++ b/.woostack/plans/2026-06-06-woostack-execute-overnight.md
@@ -1,0 +1,748 @@
+**Source:** .woostack/specs/2026-06-06-woostack-execute-overnight.md
+
+# woostack-execute-overnight Implementation Plan
+
+**Goal:** Ship `skills/woostack-execute-overnight/SKILL.md` (public command #13) — a sibling of `woostack-execute` that drives an approved plan to a reviewed stack **unattended**, swapping execute's stop-and-ask gates for resolve-or-log-and-continue, honoring an optional `## Track:` parallelism, and writing a morning report under `.woostack/overnight/`. Wire it as the third option at `woostack-build`'s execution-handoff gate and register it across the doc surface (twelve → thirteen public commands).
+
+**Architecture:** One thin self-contained `SKILL.md` plus a `references/report-template.md`. The skill **reuses** `woostack-execute`'s cadence, drivers, safety, and memory contract by cross-link and documents only the deltas: pre-flight refuse-to-start, the three autonomy overrides (incl. the inline/subagent review split), the `## Track:` consumption + per-track halt, and the morning report. The author-facing track convention is added to `woostack-plan` and noted in the status conventions in the same change so the skill's track claim is true on landing. No app code, no CI — verification is by grep/inspection.
+
+**Tech Stack:** Markdown skill files only. No code, no app build, no test harness — "failing test" steps are concrete verification commands (`grep`, `test -f`, `git check-ignore`) with exact expected output.
+
+**Decomposition (build step 5):** **One PR-sized increment** (~320 LOC of new/changed markdown, well under 500). Hardened from an earlier 2-increment split: the skill references the `## Track:` convention that `woostack-plan` documents, so the two halves must land together — splitting them would leave an inconsistent intermediate state and a forward reference. This matches the `woostack-execute` precedent for tightly-coupled skill+doc changes. Executed as sequential, TDD-style task commits on one branch (`gt create` then `gt modify -c`) → one PR, stacked on the spec+plan PR base. `spec : plan : PRs = 1 : 1 : 1`.
+
+**Out of scope (explicit):** Do NOT modify `woostack-execute` (tracks are overnight-only; execute stays linear). Do NOT make `woostack-plan` auto-partition tracks (author-driven only). Do NOT add a new `status:` phase-enum value. Do NOT make the skill merge, force-push, or relax the untrusted-plan-step safety rule. Do NOT add app code, lockfiles, or CI. Do NOT move/rename any existing `SKILL.md`. Do NOT rewrite historical `.woostack/` references.
+
+---
+
+## Increment 1: woostack-execute-overnight — the command, its wiring, and the track convention
+
+> One independently shippable PR — the new skill, its report template, the report `.gitignore`, full registration across build + the doc surface, and the optional `## Track:` convention (producer doc + status note). Its own Graphite-stacked branch on top of the spec+plan PR base.
+
+### Task 1: Create `skills/woostack-execute-overnight/SKILL.md`
+
+**Files:**
+- Create: `skills/woostack-execute-overnight/SKILL.md`
+
+- [ ] **Step 1: Write the skill file (complete content)**
+
+````markdown
+---
+name: woostack-execute-overnight
+description: Use to execute an approved woostack plan UNATTENDED overnight — one autonomous run with no user input after launch that drives every increment to a reviewed stack, swapping woostack-execute's stop-and-ask gates for resolve-or-log-and-continue (woostack-debug --auto on stuck verifications; bounded auto-address on a blocking review; halt-the-track on anything unsafe or ambiguous), honoring an optional `## Track:` parallelism in the plan, and writing a morning report under .woostack/overnight/ for a human to test in the morning. It is the third choice at woostack-build's execution-handoff gate (Go / Hand off / Run overnight); also usable standalone via /woostack-execute-overnight <plan-path> [--inline|--subagent]. One plan per spec, multiple PRs per plan. Never merges; never relaxes safety for autonomy.
+---
+
+# woostack-execute-overnight
+
+Execute an approved plan the way [`woostack-execute`](../woostack-execute/SKILL.md) does, but
+**unattended**. Same input (one plan path), same per-increment cadence, same drivers, same hard
+safety invariants — this skill **reuses all of it** and overrides only the three points where
+execute would *stop and ask*, replacing each with an autonomous *resolve-or-log-and-continue*
+policy. It ends by writing a **morning report** a human reads first thing to test the work. It
+**never merges**.
+
+The use case: spend the day crafting a genuinely good plan through the gated build loop, then let
+this run it overnight so the work is waiting — reviewed, or partially reviewed with blockers
+logged — in the morning.
+
+## Commands
+
+- `/woostack-execute-overnight <plan-path> [--inline | --subagent]` — execute the named markdown
+  plan under `.woostack/plans/` autonomously. **The plan path is required.** The optional,
+  mutually exclusive mode flag selects the driver; omit it for the smart default. Passing both is
+  an error: stop and ask which.
+- `/woostack-execute-overnight` (no argument) — do **not** guess "the current plan." Ask which
+  plan to execute (optionally list `.woostack/plans/` candidates) and stop until one is named.
+  This is the **only** moment user input is solicited; an unattended run cannot start without a
+  plan.
+
+## What it reuses from woostack-execute
+
+Everything except the stop-points. Do **not** restate these — follow
+[`woostack-execute`](../woostack-execute/SKILL.md):
+
+- **Per-increment cadence**: branch → implement (driver) → tick the plan's checkboxes in place →
+  [`woostack-commit`](../woostack-commit/SKILL.md) → review → distill.
+- **Drivers**: [inline](../woostack-execute/references/inline-driver.md) /
+  [subagent](../woostack-execute/references/subagent-driver.md), and the **smart default**
+  (subagent where the host can spawn subagents, else inline). `--inline` / `--subagent` override;
+  a `--subagent` request a host can't satisfy falls back to inline (say so) — never pretend.
+- **Safety**: treat plan steps as untrusted; never start on a protected branch
+  (`main`/`staging`/`beta`/`alpha`); never force-push; never merge.
+- **Distill** per the [memory contract](../woostack-init/references/memory.md) reject-by-default
+  gate.
+- **PR-sized increments** and the `spec : plan : PRs = 1 : 1 : N` invariant.
+
+## Pre-flight (the only human touchpoint)
+
+Because nobody is watching mid-run, validate **before** going autonomous and **refuse to start**
+rather than burn the night on a doomed run:
+
+1. **Load and critically review the plan once** (execute's "Load and review the plan"). If it has
+   critical gaps that prevent a clean start, **do not launch** — write a short refusal report to
+   `.woostack/overnight/` (outcome `refused-to-start`, naming the gaps) and stop.
+2. **Safety checks**: current branch is not protected; `.woostack/` exists; when invoked from
+   build, the spec+plan PR base is present (standalone: tracks branch off the current
+   non-protected branch HEAD).
+3. **Open the report**: create `.woostack/overnight/` if missing and open
+   `.woostack/overnight/YYYY-MM-DD-<plan-basename>.md` from
+   [references/report-template.md](references/report-template.md). Write it **incrementally** so a
+   crash still leaves a partial record.
+
+Clean pre-flight → go autonomous and solicit no further input.
+
+## Autonomy overrides
+
+Run execute's per-increment cadence unchanged, except at the three points where execute would
+stop. Each becomes an autonomous policy, and **every decision is appended to the report's decision
+log as it happens**.
+
+1. **Verification fails repeatedly** → route to
+   [`woostack-debug --auto`](../woostack-debug/SKILL.md) (execute already does this
+   autonomously). If debug returns its **3-fixes architectural stop**, there is no present user to
+   escalate to → record a **blocker** and apply the halt policy.
+2. **Blocking review** — driver-specific:
+   - **inline**: `woostack-review --fast` posts a batched GitHub Review on the increment PR. On
+     REQUEST_CHANGES, run
+     [`woostack-address-comments --auto`](../woostack-address-comments/SKILL.md) (it reads the
+     PR's unresolved threads, fixes/replies/resolves/pushes; its clean-tree + branch=PR-head
+     precondition holds right after the increment commit), then re-review — **up to 2 rounds**.
+     Still blocking after the cap → **blocker** → halt policy.
+   - **subagent**: there is no PR-level review; the per-task spec→quality reviewer loops are the
+     bounded review and their **`BLOCKED`** escalation is the terminal outcome → treat it directly
+     as a **blocker** → halt policy (the loop already was the retry; no separate auto-address).
+3. **Unsafe or ambiguous plan step** → **safety is never relaxed for autonomy.** A
+   destructive / secret-touching / auth-mutating / network step, or a genuinely ambiguous
+   instruction, is **never auto-approved** → **blocker** → halt policy.
+
+## Tracks & halt policy
+
+A plan may group its increments under top-level **`## Track:` headings**. Each track is its own
+linear `gt` stack branched off the **common base** (the spec+plan PR when invoked from build, else
+the current non-protected branch HEAD). A plan with **no** track headings has **one implicit
+track** — exactly `woostack-execute`'s linear behavior. The convention is **author-driven**:
+[`woostack-plan`](../woostack-plan/SKILL.md) documents and allows it; this skill is the only
+consumer.
+
+Process tracks **in order, sequentially** (single session — no real concurrency); within a track,
+increments in order. On a **blocker**:
+
+- **End the current track** at the blocker — never stack new work on broken work; work already
+  committed stays committed (no rollback).
+- **Advance to the next track**, branching its first increment off the common base. Record the
+  blocked track's remaining increments as `not-attempted`.
+- A single-track (default) plan therefore halts the remainder at the blocker — expected and
+  reported, not an error.
+
+## Morning report
+
+Written incrementally to `.woostack/overnight/YYYY-MM-DD-<plan-basename>.md` from
+[references/report-template.md](references/report-template.md). It is **gitignored** (a per-run
+artifact, like `.woostack/visuals/`), so it never rides into an increment PR and never dirties the
+tree for the review / address-comments clean-tree preconditions. Sections:
+
+- **Needs you** (top): blockers, and a morning **test checklist** (what to verify, the HEAD branch
+  per track).
+- **Run summary**: plan, driver, start/end, outcome (`clean` / `partial+blockers` /
+  `refused-to-start`).
+- **Per-increment table**: status (`done` / `done-with-findings` / `blocked` / `not-attempted`),
+  branch + PR URL, review verdict, auto-address rounds used.
+- **Decision log**: every autonomous decision with its rationale.
+
+## Terminal state
+
+Stop when every track has either completed or halted at a blocker. The result is a Graphite stack
+(linear, or tree-stacked across tracks) of reviewed / partially-reviewed increment PRs, plus a
+complete morning report. Report the path. **Never merge.**
+
+## Gate boundary
+
+This skill owns **no approval gate** — there is no human at runtime to gate. The pre-flight
+refuse-to-start is a **safety check**, not a gate. `woostack-build`'s upstream HARD GATES (design,
+spec) are unchanged; "Run overnight" is an explicit chosen go-ahead at build's step-8 gate, never
+an inference. It never merges and never relaxes safety for autonomy.
+
+## Hard constraints
+
+- **Plan path required.** Never guess "the current plan"; ask when no argument is given.
+- **Unattended after launch.** Pre-flight (and the no-arg plan prompt) is the only input; once
+  running, solicit nothing.
+- **Refuse a doomed run.** A plan with critical gaps → refuse at pre-flight with a report; don't
+  start.
+- **Resolve-or-log-and-continue, never relax safety.** debug --auto / bounded auto-address /
+  blocker-and-halt as above; destructive/secret/auth/network/ambiguous steps are never
+  auto-approved.
+- **Tracks: author-driven, overnight-only.** Honor `## Track:` headings (default one implicit
+  track); a blocker ends only its track. Never force-build on broken work.
+- **Morning report every run**, incremental and gitignored under `.woostack/overnight/`.
+- **Reuse execute; don't restate it.** Cross-link the cadence, drivers, safety, and memory
+  contract.
+- **Never merge, never force-push, never start on a protected branch. Own no gate.**
+````
+
+- [ ] **Step 2: Verify the file exists with valid frontmatter and required sections**
+
+Run: `test -f skills/woostack-execute-overnight/SKILL.md && grep -c -E "^name: woostack-execute-overnight$|^## Commands$|^## Pre-flight|^## Autonomy overrides$|^## Tracks|^## Morning report$|^## Gate boundary$|^## Hard constraints$" skills/woostack-execute-overnight/SKILL.md`
+Expected: `8`
+
+- [ ] **Step 3: Verify it cross-links execute (does not restate it)**
+
+Run: `grep -c -E "woostack-execute/SKILL.md|inline-driver.md|subagent-driver.md" skills/woostack-execute-overnight/SKILL.md`
+Expected: a count `>= 3` (references to execute + both drivers).
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt create -m "feat(woostack-execute-overnight): add unattended overnight execute skill"
+```
+
+### Task 2: Create `skills/woostack-execute-overnight/references/report-template.md`
+
+**Files:**
+- Create: `skills/woostack-execute-overnight/references/report-template.md`
+
+- [ ] **Step 1: Write the morning-report skeleton (complete content)**
+
+````markdown
+<!-- woostack-execute-overnight morning report. Per-run artifact, gitignored. Written incrementally. -->
+
+# Overnight run — {{PLAN_BASENAME}}
+
+> Outcome: {{clean / partial+blockers / refused-to-start}} · Driver: {{inline / subagent}} · Started: {{START}} · Ended: {{END}}
+
+## ⚠ Needs you
+
+{{Blockers requiring a human, most important first. "None — clean stack." if there are none.}}
+
+### Morning test checklist
+
+- [ ] {{What to manually verify, and where (branch / PR / track HEAD).}}
+
+## Run summary
+
+- **Plan:** `.woostack/plans/{{PLAN_BASENAME}}.md`
+- **Spec:** `.woostack/specs/{{SPEC_BASENAME}}.md`
+- **Base:** {{spec+plan PR # / branch the tracks stack on}}
+- **Driver:** {{inline / subagent}}
+- **Tracks:** {{N tracks, or "1 (implicit / linear)"}}
+
+## Per-increment
+
+| Track | Increment | Status | Branch / PR | Review | Auto-address rounds |
+|---|---|---|---|---|---|
+| {{A}} | {{1}} | {{done / done-with-findings / blocked / not-attempted}} | {{branch / PR URL}} | {{verdict}} | {{0–2}} |
+
+## Decision log
+
+<!-- Appended live, one line per autonomous decision. -->
+
+- {{stamp}} — {{decision (debug fix / auto-address round / BLOCKED / blocker recorded / track ended / increment not-attempted) + rationale}}
+````
+
+- [ ] **Step 2: Verify the template has the four sections**
+
+Run: `grep -c -E "^## ⚠ Needs you$|^## Run summary$|^## Per-increment$|^## Decision log$" skills/woostack-execute-overnight/references/report-template.md`
+Expected: `4`
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "feat(woostack-execute-overnight): add morning-report template"
+```
+
+### Task 3: Gitignore the per-run report directory
+
+**Files:**
+- Modify: `.gitignore` (root, after the `.woostack/visuals/` block near line 54)
+
+- [ ] **Step 1: Add the overnight ignore (Edit)**
+
+Find:
+```
+# woostack: disposable HTML renders (regenerated from source)
+.woostack/visuals/
+```
+Replace with:
+```
+# woostack: disposable HTML renders (regenerated from source)
+.woostack/visuals/
+# woostack: per-run overnight execution reports (regenerated each run)
+.woostack/overnight/
+```
+
+- [ ] **Step 2: Verify it is ignored**
+
+Run: `git check-ignore .woostack/overnight/x.md`
+Expected: `.woostack/overnight/x.md`
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "chore(gitignore): ignore .woostack/overnight per-run reports"
+```
+
+### Task 4: Wire the three-way handoff into `woostack-build`
+
+**Files:**
+- Modify: `skills/woostack-build/SKILL.md` (step 8, step 9 opener, step 10, the "Stop before execute" constraint)
+
+- [ ] **Step 1: Add "Run overnight" to step 8 (Edit)**
+
+Find:
+```
+   - **Go** → proceed to step 9 and run `woostack-execute` in this session.
+   - **Hand off** → stop here. The user takes the plan PR and executes later or elsewhere (e.g.
+     Codex, or a fresh session via `/woostack-execute <plan-path>`).
+   Ambiguous or no answer is **not** a "go": never auto-run execute without an explicit
+   go-ahead. This is the chain's last hard gate.
+```
+Replace with:
+```
+   - **Go** → proceed to step 9 and run `woostack-execute` in this session.
+   - **Run overnight** → proceed to step 9 but run
+     [`woostack-execute-overnight`](../woostack-execute-overnight/SKILL.md) instead: it drives the
+     whole plan **unattended** (autonomous, no further input) and leaves a morning report under
+     `.woostack/overnight/` for you to test. Use this to let a well-made plan run overnight.
+   - **Hand off** → stop here. The user takes the plan PR and executes later or elsewhere (e.g.
+     Codex, or a fresh session via `/woostack-execute <plan-path>`).
+   Ambiguous or no answer is **not** a "go": never auto-run execute (supervised or overnight)
+   without an explicit go-ahead. This is the chain's last hard gate.
+```
+
+- [ ] **Step 2: Note the overnight driver in step 9 (Edit)**
+
+Find:
+```
+9. **Execute.** Invoke [`woostack-execute`](../woostack-execute/SKILL.md) with the plan path to
+   work the plan as PR-sized stacked increments on top of the spec+plan PR — each implemented
+```
+Replace with:
+```
+9. **Execute.** Invoke [`woostack-execute`](../woostack-execute/SKILL.md) — or, if the user chose
+   **Run overnight** at step 8, [`woostack-execute-overnight`](../woostack-execute-overnight/SKILL.md)
+   (unattended) — with the plan path to
+   work the plan as PR-sized stacked increments on top of the spec+plan PR — each implemented
+```
+
+- [ ] **Step 3: Add the overnight terminal shape to step 10 (Edit)**
+
+Find:
+```
+10. **End on the chosen terminal state.** Build ends in one of two shapes, never merging either:
+    - **Hand off** → only the spec+plan PR is open (no increment PRs), ready for external or
+      later execute.
+    - **Go** → a Graphite stack with the spec+plan PR at the base and a reviewed increment PR
+      above each step.
+    Build does not separately ask to open a PR (step 7 and `woostack-execute` open them as work
+    steps) and **never merges**.
+```
+Replace with:
+```
+10. **End on the chosen terminal state.** Build ends in one of three shapes, never merging any:
+    - **Hand off** → only the spec+plan PR is open (no increment PRs), ready for external or
+      later execute.
+    - **Go** → a Graphite stack with the spec+plan PR at the base and a reviewed increment PR
+      above each step.
+    - **Run overnight** → an autonomous `woostack-execute-overnight` run: a reviewed (or partially
+      reviewed, blockers logged) stack — linear or tree-stacked across `## Track:`s — plus a
+      morning report under `.woostack/overnight/`.
+    Build does not separately ask to open a PR (step 7 and the execute phase open them as work
+    steps) and **never merges**.
+```
+
+- [ ] **Step 4: Reword the "Stop before execute" hard constraint (Edit)**
+
+Find:
+```
+- **Stop before execute.** Never auto-run execute; always halt at the execution-handoff gate
+  (step 8) after the spec+plan PR. The plan PR is the artifact for executing here or in another
+  tool. Ambiguous or no answer is not a "go."
+```
+Replace with:
+```
+- **Stop before execute.** Never auto-run execute — supervised `woostack-execute` or unattended
+  `woostack-execute-overnight`; always halt at the execution-handoff gate (step 8) after the
+  spec+plan PR and let the user choose Go / Run overnight / Hand off. The plan PR is the artifact
+  for executing here or in another tool. Ambiguous or no answer is not a "go."
+```
+
+- [ ] **Step 5: Verify build now offers three options and references overnight**
+
+Run: `grep -c "woostack-execute-overnight" skills/woostack-build/SKILL.md`
+Expected: `4` (step 8, step 9, step 10, constraint).
+
+Run: `grep -c -E "Run overnight" skills/woostack-build/SKILL.md`
+Expected: `3` (step 8 bullet, step 10 bullet, constraint).
+
+- [ ] **Step 6: Commit**
+
+```bash
+gt modify -c -m "feat(woostack-build): offer Run overnight at the execution-handoff gate"
+```
+
+### Task 5: Add the `using-woostack` routing row
+
+**Files:**
+- Modify: `skills/using-woostack/SKILL.md` (Command Routing table, after the `woostack-execute` row)
+
+- [ ] **Step 1: Insert the routing row (Edit)**
+
+Find:
+```
+| `/woostack-execute <plan-path> [--inline\|--subagent]`, execute an approved plan as PR-sized stacked increments (inline or subagent-driven) | `woostack-execute` |
+```
+Replace with:
+```
+| `/woostack-execute <plan-path> [--inline\|--subagent]`, execute an approved plan as PR-sized stacked increments (inline or subagent-driven) | `woostack-execute` |
+| `/woostack-execute-overnight <plan-path> [--inline\|--subagent]`, execute an approved plan unattended overnight (autonomous, morning report) | `woostack-execute-overnight` |
+```
+
+- [ ] **Step 2: Verify the row exists**
+
+Run: `grep -c "woostack-execute-overnight" skills/using-woostack/SKILL.md`
+Expected: `1`
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "docs(using-woostack): route /woostack-execute-overnight"
+```
+
+### Task 6: Register the 13th command in `AGENTS.md`
+
+**Files:**
+- Modify: `AGENTS.md` (`.claude/CLAUDE.md` is a symlink; edit `AGENTS.md`)
+
+- [ ] **Step 1: Bump the public-surface count and list (Edit)**
+
+Find:
+```
+The public command/adoption surface has twelve skills:
+```
+Replace with:
+```
+The public command/adoption surface has thirteen skills:
+```
+
+- [ ] **Step 2: Add the list entry (Edit)**
+
+Find:
+```
+- [`woostack-execute`](skills/woostack-execute/SKILL.md)
+- [`woostack-commit`](skills/woostack-commit/SKILL.md)
+```
+Replace with:
+```
+- [`woostack-execute`](skills/woostack-execute/SKILL.md)
+- [`woostack-execute-overnight`](skills/woostack-execute-overnight/SKILL.md)
+- [`woostack-commit`](skills/woostack-commit/SKILL.md)
+```
+
+- [ ] **Step 3: Fix the "twelve-skill command surface" mention (Edit)**
+
+Find:
+```
+`/woostack-*` commands: they have no routing row and are absent from the twelve-skill command
+```
+Replace with:
+```
+`/woostack-*` commands: they have no routing row and are absent from the thirteen-skill command
+```
+
+- [ ] **Step 4: Add the command to the Mode B list (Edit)**
+
+Find:
+```
+**Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
+`/woostack-bootstrap`, `/woostack-build`, `/woostack-plan`, `/woostack-execute`, `/woostack-commit`,
+```
+Replace with:
+```
+**Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
+`/woostack-bootstrap`, `/woostack-build`, `/woostack-plan`, `/woostack-execute`, `/woostack-execute-overnight`, `/woostack-commit`,
+```
+
+- [ ] **Step 5: Bump the rename hard constraint (fourteen → fifteen) (Edit)**
+
+Find:
+```
+- Do not move or rename any of the fourteen `SKILL.md` files (the twelve public command/adoption
+  skills plus the internal `woostack-ideate` and `woostack-harden`).
+```
+Replace with:
+```
+- Do not move or rename any of the fifteen `SKILL.md` files (the thirteen public command/adoption
+  skills plus the internal `woostack-ideate` and `woostack-harden`).
+```
+
+- [ ] **Step 6: Add the Quick file map entry (Edit)**
+
+Find:
+```
+- Plan-execution engine for the build loop (public command):
+  [`skills/woostack-execute/SKILL.md`](skills/woostack-execute/SKILL.md)
+```
+Replace with:
+```
+- Plan-execution engine for the build loop (public command):
+  [`skills/woostack-execute/SKILL.md`](skills/woostack-execute/SKILL.md)
+- Overnight (unattended, autonomous) plan-execution engine (public command):
+  [`skills/woostack-execute-overnight/SKILL.md`](skills/woostack-execute-overnight/SKILL.md)
+```
+
+- [ ] **Step 7: Verify counts and entries are consistent**
+
+Run: `grep -c -E "thirteen skills|thirteen-skill command surface|fifteen \`SKILL.md\`|thirteen public command/adoption" AGENTS.md`
+Expected: `3` (three matching lines: the count line, the "thirteen-skill command surface" line, and the rename-constraint line that carries both "fifteen `SKILL.md`" and "thirteen public command/adoption").
+
+Run: `grep -c "woostack-execute-overnight" AGENTS.md`
+Expected: `3` (three matching lines: the list entry, the Mode B list, and the Quick file map link line).
+
+- [ ] **Step 8: Commit**
+
+```bash
+gt modify -c -m "docs(agents): register woostack-execute-overnight as the 13th command"
+```
+
+### Task 7: Update `README.md`
+
+**Files:**
+- Modify: `README.md` (install count/list ~line 29, build-loop prose ~line 62, new subsection after the execute subsection ~line 70)
+
+- [ ] **Step 1: Bump the install count and list (Edit)**
+
+Find:
+```
+The public command/adoption surface is twelve skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-plan, woostack-execute, woostack-commit, woostack-review, woostack-address-comments, woostack-status, woostack-visualize, and woostack-debug.
+```
+Replace with:
+```
+The public command/adoption surface is thirteen skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-plan, woostack-execute, woostack-execute-overnight, woostack-commit, woostack-review, woostack-address-comments, woostack-status, woostack-visualize, and woostack-debug.
+```
+
+- [ ] **Step 2: Mention the overnight option in the build-loop prose (Edit)**
+
+Find:
+```
+Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed (`woostack-review --fast`), and distilled. It ends on the reviewed PR stack. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+```
+Replace with:
+```
+Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed (`woostack-review --fast`), and distilled. The execution-handoff gate lets you Go (execute now), Hand off (execute later/elsewhere), or Run overnight (`woostack-execute-overnight`, unattended). It ends on the reviewed PR stack. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+```
+
+- [ ] **Step 3: Add the skill subsection after the execute one (Edit)**
+
+Find:
+```
+Executes an approved markdown plan from `.woostack/plans/` as a sequence of PR-sized, stacked increments — implementing each with TDD, ticking the plan's checkboxes in place, committing via `woostack-commit` on its own Graphite branch, reviewing it with `woostack-review --fast`, and distilling durable learnings — pausing only on a blocking review. One plan per spec, multiple PRs per plan. It is the execute phase `woostack-build` step 9 delegates to, and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute/SKILL.md)
+```
+Replace with:
+```
+Executes an approved markdown plan from `.woostack/plans/` as a sequence of PR-sized, stacked increments — implementing each with TDD, ticking the plan's checkboxes in place, committing via `woostack-commit` on its own Graphite branch, reviewing it with `woostack-review --fast`, and distilling durable learnings — pausing only on a blocking review. One plan per spec, multiple PRs per plan. It is the execute phase `woostack-build` step 9 delegates to, and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute/SKILL.md)
+
+### `/woostack-execute-overnight <plan-path>`: run a plan unattended overnight
+
+Executes an approved plan the way `woostack-execute` does, but **unattended** — one autonomous run with no input after launch. It reuses execute's per-increment cadence and drivers and overrides only the stop-points: a stuck verification routes to `woostack-debug --auto`, a blocking review is auto-addressed (`woostack-address-comments --auto`, bounded) or escalated, and anything unsafe or ambiguous becomes a logged blocker — safety is never relaxed for autonomy. A blocker ends its track (plans may group increments under optional `## Track:` headings; default is one linear stack) and the run continues. It writes a **morning report** to `.woostack/overnight/` for a human to test in the morning. It is the third choice at `woostack-build`'s execution-handoff gate (Go / Hand off / Run overnight), and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute-overnight/SKILL.md)
+```
+
+- [ ] **Step 4: Verify README is consistent**
+
+Run: `grep -c "thirteen skills" README.md`
+Expected: `1`
+
+Run: `grep -c "woostack-execute-overnight" README.md`
+Expected: `4` (install list, build prose, subsection heading, subsection-body SKILL.md link).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(readme): document woostack-execute-overnight (13th command)"
+```
+
+### Task 8: Update `CONTRIBUTING.md`
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (surface list ~line 3, pointer-row table after the execute row ~line 25)
+
+- [ ] **Step 1: Add to the surface list (Edit)**
+
+Find:
+```
+The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-plan`, `woostack-execute`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, and `woostack-debug`.
+```
+Replace with:
+```
+The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, and `woostack-debug`.
+```
+
+- [ ] **Step 2: Add the pointer row (Edit)**
+
+Find:
+```
+| Change the execute phase (the build loop's implementation step) | `skills/woostack-execute/SKILL.md` |
+```
+Replace with:
+```
+| Change the execute phase (the build loop's implementation step) | `skills/woostack-execute/SKILL.md` |
+| Change the overnight execute phase (unattended autonomous run, morning report) | `skills/woostack-execute-overnight/SKILL.md` |
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -c "woostack-execute-overnight" CONTRIBUTING.md`
+Expected: `2` (surface list, pointer row).
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt modify -c -m "docs(contributing): point at the overnight execute phase"
+```
+
+### Task 9: Document the optional `## Track:` grouping in `woostack-plan`
+
+**Files:**
+- Modify: `skills/woostack-plan/SKILL.md` (new section after "## PR-sized increments", before "## Bite-sized tasks (TDD)")
+
+- [ ] **Step 1: Insert the track-convention section (Edit)**
+
+Find:
+```
+decomposition is part of planning (it folds `woostack-build`'s old decompose step into the plan
+engine).
+
+## Bite-sized tasks (TDD)
+```
+Replace with:
+```
+decomposition is part of planning (it folds `woostack-build`'s old decompose step into the plan
+engine).
+
+## Optional: parallel tracks (for overnight runs)
+
+By default the increments form **one linear `gt` stack** — each stacks on the previous, the shape
+`woostack-execute` runs. A plan **may** instead group increments under top-level **`## Track:`
+headings**; each track is an independent linear stack branched off the common base (the spec+plan
+PR). This is **author-driven and optional**: write tracks only when increments are genuinely
+independent and you intend an unattended overnight run to parallelize them. Do **not**
+auto-partition — default to one implicit track (no headings = today's behavior).
+
+Only [`woostack-execute-overnight`](../woostack-execute-overnight/SKILL.md) consumes tracks (it
+runs each track off the base and, on a blocker, ends only that track and advances to the next).
+[`woostack-execute`](../woostack-execute/SKILL.md) ignores the headings and runs every increment
+as one linear stack.
+
+## Bite-sized tasks (TDD)
+```
+
+- [ ] **Step 2: Verify the section exists and is author-driven (no auto-partition)**
+
+Run: `grep -c -E "^## Optional: parallel tracks" skills/woostack-plan/SKILL.md`
+Expected: `1`
+
+Run: `grep -c "author-driven and optional" skills/woostack-plan/SKILL.md`
+Expected: `1`
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "docs(woostack-plan): document the optional ## Track: grouping"
+```
+
+### Task 10: Note tree-stacked PRs in the status conventions
+
+**Files:**
+- Modify: `skills/woostack-status/references/conventions.md` (Invariant section, after the `spec.branch:` bullet)
+
+- [ ] **Step 1: Append the tree-stacked note to the invariant (Edit)**
+
+Find:
+```
+- `spec.branch:` names the active increment's branch.
+```
+Replace with:
+```
+- `spec.branch:` names the active increment's branch.
+- An overnight run ([`woostack-execute-overnight`](../../woostack-execute-overnight/SKILL.md)) may
+  produce **tree-stacked** increment PRs — multiple `## Track:`s branched off the common base, so a
+  spec can have several concurrent increment branches rather than one linear chain. The
+  `1 : 1 : N` count, the `**Source:**` join, and the `Spec:` PR trailer are unaffected, and this
+  adds **no** new phase-enum value; a blocked/partial overnight run is visible via its
+  `.woostack/overnight/` report.
+```
+
+- [ ] **Step 2: Verify the note exists and adds no enum value**
+
+Run: `grep -c "tree-stacked" skills/woostack-status/references/conventions.md`
+Expected: `1`
+
+Run: `grep -c -E "draft -> hardened -> approved -> planning -> executing -> in-review -> done" skills/woostack-status/references/conventions.md`
+Expected: `1` (the phase enum is unchanged — no new value added).
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "docs(conventions): note tree-stacked PRs from overnight track runs"
+```
+
+### Task 11: Final verification sweep
+
+**Files:** none (read-only checks)
+
+- [ ] **Step 1: Both new files exist**
+
+Run: `test -f skills/woostack-execute-overnight/SKILL.md && test -f skills/woostack-execute-overnight/references/report-template.md && echo OK`
+Expected: `OK`
+
+- [ ] **Step 2: No stale counts remain anywhere**
+
+Run: `grep -rn "twelve skills\|twelve-skill command surface\|fourteen \`SKILL.md\`" AGENTS.md README.md CONTRIBUTING.md`
+Expected: no output (exit 1) — every count was bumped.
+
+- [ ] **Step 3: The skill is registered in every surface**
+
+Run: `for f in AGENTS.md README.md CONTRIBUTING.md skills/using-woostack/SKILL.md skills/woostack-build/SKILL.md; do printf '%s ' "$f"; grep -c "woostack-execute-overnight" "$f"; done`
+Expected: `AGENTS.md 3`, `README.md 4`, `CONTRIBUTING.md 2`, `skills/using-woostack/SKILL.md 1`, `skills/woostack-build/SKILL.md 4`.
+
+- [ ] **Step 4: Cross-links in the new skill resolve to real paths**
+
+Run: `for p in skills/woostack-execute skills/woostack-commit skills/woostack-debug skills/woostack-address-comments skills/woostack-review skills/woostack-init skills/woostack-plan; do test -f "$p/SKILL.md" || echo "MISSING $p"; done; test -f skills/woostack-execute/references/inline-driver.md && test -f skills/woostack-execute/references/subagent-driver.md || echo "MISSING driver ref"`
+Expected: no output — every cross-linked target exists.
+
+- [ ] **Step 5: Report dir is gitignored**
+
+Run: `git check-ignore .woostack/overnight/probe.md`
+Expected: `.woostack/overnight/probe.md`
+
+- [ ] **Step 6: Track convention — documented in the producer, consumed only by overnight**
+
+Run: `grep -c "## Track:" skills/woostack-plan/SKILL.md skills/woostack-execute-overnight/SKILL.md`
+Expected: both files print `>= 1` (producer doc + consumer behavior).
+
+Run: `grep -c "## Track:" skills/woostack-execute/SKILL.md`
+Expected: `0` (execute is unchanged — does not consume tracks).
+
+- [ ] **Step 7: Status conventions note present and resolves**
+
+Run: `test -f skills/woostack-execute-overnight/SKILL.md && grep -q "tree-stacked" skills/woostack-status/references/conventions.md && echo OK`
+Expected: `OK`
+
+- [ ] **Step 8:** No separate commit — this task is read-only verification; the plan's checkboxes are ticked in place by `woostack-execute` as the live record.
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every spec section maps to a task:
+  - §4 Command & invocation, Pre-flight, Autonomy overrides (incl. driver-specific review split), Tracks & halt, Morning report, Report git handling → **Task 1** (SKILL.md) + **Task 2** (template) + **Task 3** (gitignore).
+  - §4 Wiring `woostack-build` (step 8 three-way, step 9, step 10, constraint) → **Task 4**.
+  - §4 Wiring the track convention (`woostack-plan` doc, status note) → **Tasks 9–10**.
+  - §5 edit set (using-woostack, AGENTS, README, CONTRIBUTING) → **Tasks 5–8**; (woostack-plan, status conventions, root .gitignore) → **Tasks 9, 10, 3**.
+  - §7 Testing (counts consistent, cross-links resolve, driver split documented, track doc, gitignore) → **Task 11**.
+- [ ] **No placeholders** — Tasks 1 & 2 carry the complete file content; every doc edit gives exact find/replace strings; every verification has an exact command and expected output. The `{{…}}` tokens inside the Task-2 code block are the *report template's own* fill-in slots (the artifact this skill ships), not plan placeholders.
+- [ ] **Type consistency** — skill name `woostack-execute-overnight`, command `/woostack-execute-overnight <plan-path> [--inline|--subagent]`, link path `../woostack-execute-overnight/SKILL.md` (and `../../` from `woostack-status/references/`), report path `.woostack/overnight/YYYY-MM-DD-<plan-basename>.md`, the four report sections, and the increment-status vocabulary (`done` / `done-with-findings` / `blocked` / `not-attempted`) are used identically across the skill, the template, the build wiring, and the docs.
+
+> woostack plan conventions (kept):
+> - Frontmatter-free; opens with the `**Source:**` line.
+> - Filename mirrors the spec basename: `.woostack/plans/2026-06-06-woostack-execute-overnight.md` (the spec's date).
+> - No required sub-skill banner — execution is `woostack-execute` / `woostack-execute-overnight`.
+> - This is a docs/skills repo: "failing test" steps are concrete verification commands (`grep`, `test -f`, `git check-ignore`) with exact expected output.

--- a/.woostack/specs/2026-06-06-woostack-execute-overnight.md
+++ b/.woostack/specs/2026-06-06-woostack-execute-overnight.md
@@ -1,0 +1,331 @@
+---
+name: woostack-execute-overnight
+type: spec
+status: planning
+date: 2026-06-06
+branch: feature/woostack-execute-overnight
+links:
+  - "[[2026-06-04-woostack-execute]]"
+  - "[[2026-06-04-build-execution-handoff-gate]]"
+---
+
+# woostack-execute-overnight: unattended autonomous plan execution — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+[`woostack-execute`](../../skills/woostack-execute/SKILL.md) drives an approved plan to a
+reviewed stack, but it is built for a **supervised** session: it stops and asks the user on
+every blocker — a failing verification `woostack-debug --auto` can't fix, a review that returns
+REQUEST_CHANGES, an ambiguous or unsafe plan step. That discipline is correct when a human is
+watching, and wrong when nobody is.
+
+The intended workflow is different: spend the day crafting and hardening a genuinely good plan
+through the normal gated build loop, then let a machine **execute the whole plan unattended
+overnight** so a human can manually test the result in the morning. Today there is no
+woostack-native way to do that. Running `woostack-execute` overnight would stall on the first
+blocker and waste the night; a person would wake up to a run halted at increment 1 with a
+question on screen and no progress behind it.
+
+We want an execution mode that trades *stop-and-ask* for *resolve-or-log-and-continue*, makes
+documented autonomous decisions, never relaxes safety, and leaves a single artifact a human
+reads first thing to know what to test and what needs attention.
+
+## 2. Goal
+
+Ship `skills/woostack-execute-overnight/SKILL.md`: a **public command** (the thirteenth) that
+takes one approved plan (**supplied as a required argument**) and drives **all** of its
+PR-sized stacked increments to completion **without any user input after launch**. It reuses
+`woostack-execute`'s machinery wholesale — the same per-increment cadence (branch → implement
+via the inline/subagent driver → tick checkboxes → `woostack-commit` → review → distill), the
+same drivers ([inline-driver.md](../../skills/woostack-execute/references/inline-driver.md) /
+[subagent-driver.md](../../skills/woostack-execute/references/subagent-driver.md)), the same
+smart-default driver selection, and the same hard safety invariants — and **overrides only the
+three points where execute would stop**, replacing each with an autonomous policy. It ends by
+writing a **morning report** to `.woostack/overnight/` and, like execute, **never merges**.
+
+Wire it into the collection two ways:
+
+1. As a direct command: `/woostack-execute-overnight <plan-path> [--inline | --subagent]`.
+2. As a third choice at [`woostack-build`](../../skills/woostack-build/SKILL.md)'s
+   **execution-handoff gate (step 8)**: **Go** (supervised execute) / **Hand off** (stop) /
+   **Run overnight** (this skill).
+
+The body stays **thin**: it documents only the deltas from execute and cross-links execute for
+everything shared, honoring the repo's "cross-link, do not duplicate" rule.
+
+## 3. Non-goals
+
+- **Not a planner.** Input is an already-approved plan under `.woostack/plans/`. It does not
+  ideate, write specs, or write plans. "Spend time making a good plan" happens by day, through
+  the normal gated loop; this skill only executes one. (Scope settled in ideate: pure execute
+  sibling, not plan+execute or full ideate→ship.)
+- **Does not auto-partition tracks.** The track convention (§4) is **author-driven**: the human
+  structures independent tracks deliberately when crafting the plan. `woostack-plan` only
+  *documents and allows* the `## Track:` grouping; it does not analyze the decomposition and
+  split tracks itself. Default plans have one implicit track.
+- **Does not change `woostack-execute`.** Tracks are an **overnight-only** optimization.
+  `woostack-execute` (supervised) ignores track headings and runs increments as one linear
+  stack, stopping and asking on any blocker — unchanged by this work.
+- **Does not merge.** Ends on a reviewed (or partially-reviewed) stack plus a morning report.
+  Merging is always a separate human action. No force-push.
+- **Does not relax safety for autonomy.** Destructive, secret-touching, auth-mutating, or
+  network plan steps are **never auto-approved** just because no human is present — they become
+  logged blockers. Autonomy removes *gates*, not *safety*.
+- **Adds no approval gate.** There is no human to gate at runtime. The pre-flight refuse-to-start
+  check (§4) is a safety check, not an approval gate. `woostack-build`'s upstream HARD GATES
+  (design, spec) are unchanged.
+- **Does not duplicate execute.** No copy of the drivers, cadence text, memory contract, or
+  safety rules — it references them. Only the autonomy overrides, halt policy, morning report,
+  and pre-flight refusal are authored here.
+- **Does not change the `1 : 1 : N` invariant.** One spec, one plan, N increment PRs. Tracks
+  make the N PRs **tree-stacked** (each track branches off the common base) instead of one
+  linear chain, but the count and the join contracts are unchanged.
+
+## 4. Approach
+
+Author one self-contained `SKILL.md` plus a single `references/report-template.md` (the morning
+report skeleton). Everything execute already owns is **referenced, not restated**.
+
+### Command & invocation
+- `/woostack-execute-overnight <plan-path> [--inline | --subagent]` — the plan path is a
+  **required argument**. Passing both mode flags is an error: stop and ask which.
+- `/woostack-execute-overnight` with no argument → ask which plan, list `.woostack/plans/`
+  candidates, and stop until one is named. A no-arg launch is the **only** moment user input is
+  solicited; an unattended run cannot start without a plan.
+- **Driver:** inherits execute's smart default (subagent where the host can spawn subagents,
+  else inline); explicit `--inline` / `--subagent` overrides. If `--subagent` is requested but
+  the host cannot spawn subagents, fall back to inline and say so — never pretend.
+
+### Pre-flight (the one check that still matters)
+Because nobody is watching mid-run, the skill validates *before* going dark and **refuses to
+start** rather than burning the night on a doomed run:
+- Load the plan and review it critically **once** (execute's "load and review the plan" step). A
+  plan with critical gaps that prevent a clean start → **do not launch**; write a short
+  refusal report to `.woostack/overnight/` naming the gaps and stop.
+- Confirm the current branch is not protected (`main`/`staging`/`beta`/`alpha`), `.woostack/`
+  exists, and (when invoked from build) the spec+plan PR base is present.
+- Create `.woostack/overnight/` if missing and open the morning-report file immediately, so the
+  report is written **incrementally** and a crash still leaves a partial record.
+
+If pre-flight is clean → go autonomous and solicit no further input.
+
+### Autonomous per-increment cadence
+Run execute's exact per-increment cadence in order, one increment per cycle. The only
+differences are the three stop-points, each replaced by an autonomous policy and a decision-log
+entry:
+
+| Where `woostack-execute` stops | `woostack-execute-overnight` instead |
+|---|---|
+| Verification fails repeatedly | Route to `woostack-debug --auto` (execute already does this autonomously). If debug returns its **3-fixes architectural stop**, there is no present user to escalate to → mark a **blocker** and apply the halt policy. |
+| Review is blocking | **Driver-specific** (see below): inline → bounded auto-address; subagent → the `BLOCKED` escalation is itself the blocker. |
+| Ambiguous or unsafe plan step | **Safety is not relaxed.** A destructive/secret/auth/network step, or a genuinely ambiguous instruction, is **never auto-approved** → **blocker** → halt policy. |
+
+**Review override is driver-specific** (grounded in how execute reviews per mode):
+- **inline** — `woostack-review --fast` runs on the increment PR and **posts a batched GitHub
+  Review**; a REQUEST_CHANGES leaves unresolved threads on the PR. Overnight attempts
+  [`woostack-address-comments --auto`](../../skills/woostack-address-comments/SKILL.md) (it
+  reads the PR's unresolved threads, fixes/replies/resolves/pushes autonomously — its
+  precondition of a clean tree + branch=PR head holds right after the increment commit), then
+  re-reviews, **up to 2 rounds**. Still blocking after the cap → **blocker** → halt policy.
+- **subagent** — there is no PR-level `woostack-review`; the per-task spec→quality reviewer
+  loops *are* the bounded review and a **`BLOCKED`** escalation is their terminal outcome. That
+  `BLOCKED` is treated directly as a **blocker** → halt policy (no separate auto-address pass —
+  the reviewer loop already was the iteration).
+
+Every autonomous action (a debug fix committed, a finding auto-addressed, a `BLOCKED`
+escalation, a blocker recorded, an increment not attempted) is appended to the decision log in
+the report **as it happens**.
+
+### Tracks & halt policy
+A plan may group its increments under **`## Track:` headings**; each track is its own linear
+`gt` stack branched off the **common base** (the spec+plan PR when invoked from build, else the
+current non-protected branch). A plan with no track headings has **one implicit track** — exactly
+today's linear behavior, fully backward-compatible. The convention is **author-driven**:
+`woostack-plan` documents and allows it (§Wiring), but does not auto-partition; only this skill
+consumes it.
+
+Overnight processes tracks **in order, sequentially** (it is a single session — no real
+concurrency); within a track, increments run in order. On a blocker:
+- **End the current track** at the blocker — do not stack new work on broken work; work already
+  committed stays committed (no rollback).
+- **Advance to the next track**, branching its first increment off the common base (unaffected
+  by the blocked track). The blocked track's remaining increments are recorded `not-attempted`.
+- A single-track (default) plan therefore halts the remainder at the blocker — expected and
+  reported, not an error. This rules out the "best-effort, never halt / force-build on broken
+  work" option from ideate.
+
+### Report git handling
+The morning report is a **per-run artifact, not shared knowledge** — like `.woostack/visuals/`
+and `metrics.json`, `.woostack/overnight/` is **gitignored**. It is never staged into an
+increment PR (and being gitignored, it does not dirty the working tree, so `woostack-review`
+and `woostack-address-comments` clean-tree preconditions still hold). The human reads it in
+place in the morning.
+
+### Morning report — the deliverable
+Written to `.woostack/overnight/YYYY-MM-DD-<plan-basename>.md` from
+`references/report-template.md`, populated incrementally:
+- **Top — needs you:** the blockers (if any) and a **morning test checklist** (what to manually
+  verify, where the stack is, which branch is HEAD).
+- **Run summary:** plan path, driver, start/end, overall outcome (clean stack / partial +
+  blockers / refused-to-start).
+- **Per-increment table:** status (`done` / `done-with-findings` / `blocked` / `not-attempted`),
+  branch + PR URL, review verdict, auto-address rounds used.
+- **Decision log:** every autonomous decision with its rationale.
+
+### Wiring `woostack-build`
+- **Step 8 (execution-handoff gate):** today a two-way **Go / Hand off** choice. Add a third:
+  **Run overnight** → invoke `woostack-execute-overnight` with the step-4 plan path. "Run
+  overnight" is an explicit go-ahead, so it does not violate "ambiguous or no answer is not a
+  go"; reword the gate to present three explicit options while keeping that guard.
+- **Step 10 (terminal state):** add a third terminal shape — **Overnight** → a reviewed (or
+  partially reviewed) Graphite stack plus a morning report under `.woostack/overnight/`,
+  possibly partial with logged blockers. Build still never merges.
+- **Overview / hard constraints:** reflect the three-way handoff; the "never auto-run execute"
+  constraint stays (overnight is a chosen option, not an inference).
+
+### Wiring the track convention (lightweight)
+- **`woostack-plan`:** document the **optional `## Track:` grouping** in the plan-format section
+  — increments may be grouped under track headings; default (no headings) is one implicit track.
+  Plans stay frontmatter-free. `woostack-plan` does **not** auto-partition; it only allows the
+  shape so a human can author parallel tracks for an overnight run.
+- **`woostack-status` conventions:** a one-line note that an overnight run may produce
+  **tree-stacked** increment PRs (tracks branched off the common base) rather than one linear
+  chain — so a spec can have several concurrent increment branches. The `1 : 1 : N` count and
+  the `Spec:`-trailer join are unaffected; no new phase-enum value.
+- **Root `.gitignore`:** add `.woostack/overnight/` alongside the existing
+  `.woostack/visuals/` and `.woostack/metrics.json` ignores.
+
+## 5. Components & data flow
+
+Edit set (decomposed into PR-sized increments in the plan):
+
+| File | Change |
+|---|---|
+| `skills/woostack-execute-overnight/SKILL.md` | **NEW** — the skill: scoped `description`, required `/woostack-execute-overnight <plan-path>` command + mode flags, pre-flight (refuse-to-start), the three autonomy overrides (incl. the inline/subagent review split), the `## Track:` consumption + per-track halt policy, morning-report write (incremental, gitignored), terminal state, gate boundary, hard constraints. Cross-links execute for drivers/cadence/safety/memory contract — does **not** restate them. |
+| `skills/woostack-execute-overnight/references/report-template.md` | **NEW** — morning-report skeleton (needs-you / run summary / per-increment table / decision log). |
+| `skills/woostack-build/SKILL.md` | Step 8: two-way → **three-way** handoff (Go / Hand off / Run overnight); step 10: add the overnight terminal shape; reword the "never auto-run execute" constraint to allow the explicit overnight choice. |
+| `skills/using-woostack/SKILL.md` | Add a Command Routing row: `/woostack-execute-overnight <plan-path>` → `woostack-execute-overnight`. |
+| `.claude/CLAUDE.md` (= `AGENTS.md`) | Public surface **twelve → thirteen**; add `woostack-execute-overnight` to the public-skill list and Quick file map; bump the "fourteen `SKILL.md` files (twelve public + two internal)" hard constraint to **fifteen (thirteen public + two internal)**; protect the new skill from deletion like the other shipped skills. |
+| `README.md` | Skill count twelve → thirteen; add `woostack-execute-overnight` to the public list; mention the overnight option in the build-loop prose if execute is described there. |
+| `CONTRIBUTING.md` | Add a "Change the overnight execute phase" pointer row → `skills/woostack-execute-overnight/SKILL.md`, parallel to the existing execute/ideate/harden rows. |
+| `skills/woostack-plan/SKILL.md` | Document the **optional `## Track:` grouping** in the plan-format section (increments may be grouped under track headings; default = one implicit track). No auto-partitioning; plans stay frontmatter-free. |
+| `skills/woostack-status/references/conventions.md` | Minimal note: an overnight run emits the same artifacts so the board reads it unchanged; a blocked/partial run is visible via its `.woostack/overnight/` report (not a new phase); track runs may yield **tree-stacked** increment PRs (several concurrent branches per spec) — `1 : 1 : N` count and `Spec:` join unaffected, no new enum value. |
+| `.gitignore` (root) | Add `.woostack/overnight/` next to the existing `.woostack/visuals/` and `.woostack/metrics.json` ignores — the morning report is a per-run artifact. |
+
+Data flow at runtime: `/woostack-execute-overnight <plan>` (or build step 8 → Run overnight) →
+pre-flight (load + critical review + safety checks; refuse + report if gappy) → open the
+(gitignored) morning report → for each track in order, branch its first increment off the
+common base, then for each increment run execute's cadence with the three overrides (debug
+--auto on repeated failure; inline auto-address ≤2 rounds / subagent `BLOCKED`-as-blocker on a
+blocking review; blocker on unsafe/ambiguous) → append decisions to the report live → on a
+blocker, end that track and advance to the next → terminal: a reviewed/partial Graphite stack
+(linear, or tree-stacked across tracks) + a complete morning report, never merged.
+
+## 6. Error handling
+
+- **No plan argument.** Required. No-arg → ask which plan, list candidates, stop. An unattended
+  run never starts without a named plan; never guess "the current plan."
+- **Gappy plan at pre-flight.** Critical gaps that prevent a clean start → refuse to launch,
+  write a short refusal report to `.woostack/overnight/`, stop. Better than failing all night.
+- **Verification fails repeatedly.** `woostack-debug --auto`; on debug's 3-fixes architectural
+  stop → blocker (no user to escalate to) → halt policy.
+- **Blocking review (inline).** `woostack-review --fast` posts REQUEST_CHANGES to the PR →
+  bounded auto-address via `woostack-address-comments --auto`, re-review, ≤2 rounds; still
+  blocking → blocker → halt policy. Never merges a finding away.
+- **Blocking review (subagent).** No PR-level review exists; a reviewer-loop `BLOCKED`
+  escalation is the bounded outcome → treated directly as a blocker → halt policy.
+- **Unsafe or ambiguous plan step.** Never auto-approved (untrusted-plan-step rule, unchanged
+  from execute) → blocker → halt policy.
+- **Memory store missing at distill.** Skip distillation (same contract as execute); distill
+  never blocks an increment.
+- **`.woostack/overnight/` missing.** Create it at pre-flight before opening the report; it is
+  gitignored, so it never dirties the tree for the review/address-comments clean-tree checks.
+- **Crash / interruption mid-run.** The report is written incrementally, so a partial report
+  names the last completed increment/track and the in-flight state — recoverable by the morning
+  human.
+- **Single-track plan halts at a blocker.** Expected, not an error: report it as "track halted
+  at increment K, no further tracks" with the blocker detail.
+- **No common base (standalone run).** When not invoked from build there may be no spec+plan
+  PR base; tracks branch off the current non-protected branch HEAD instead. Note it in the
+  report.
+- **Protected branch / host can't spawn subagents.** Never start on a protected branch; on a
+  `--subagent` request the host can't satisfy, fall back to inline and say so.
+- **Description over-trigger.** Scope the `description` to "execute an existing plan
+  autonomously / overnight, unattended" — distinct from supervised `woostack-execute` and not a
+  generic "write code" trigger, so `using-woostack` routes the two correctly.
+
+## 7. Testing
+
+No app/test harness in this repo (it is a skills collection). Verification is by inspection:
+
+- New `SKILL.md` has valid frontmatter (`name`, `description`), a required `<plan-path>`
+  argument, the pre-flight refusal, the three autonomy overrides, the halt policy, the morning
+  report, the gate-boundary + terminal-state + never-merge statements.
+- The body cross-links `woostack-execute` (drivers, cadence, safety, memory contract) rather
+  than duplicating them — grep shows references, not copied driver text.
+- `references/report-template.md` exists with the four sections.
+- `woostack-build` step 8 presents **three** options (Go / Hand off / Run overnight); step 10
+  lists the overnight terminal shape; the "never auto-run execute" constraint still holds for
+  ambiguous/no answer.
+- `using-woostack` has a `/woostack-execute-overnight` routing row.
+- Command-surface count is consistent everywhere — `AGENTS.md`, `README.md`, `using-woostack`,
+  CONTRIBUTING reflect **thirteen** public commands; the "do not rename" hard constraint reflects
+  **fifteen** `SKILL.md` files (thirteen public + two internal).
+- Cross-links resolve (`woostack-build` ↔ `woostack-execute-overnight`;
+  `woostack-execute-overnight` → `woostack-execute`, `woostack-debug`,
+  `woostack-address-comments`, `woostack-commit`, `woostack-review`).
+- `woostack-status` conventions note the overnight report + tree-stacked PRs without adding an
+  enum value.
+- The blocking-review override is documented **per driver** (inline `address-comments --auto`
+  ≤2 rounds; subagent `BLOCKED`-as-blocker), not as a single mode-blind rule.
+- `woostack-plan` documents the optional `## Track:` grouping (default one implicit track); it
+  does not auto-partition.
+- `.gitignore` (root) lists `.woostack/overnight/`; grep confirms it sits beside
+  `.woostack/visuals/` / `.woostack/metrics.json`.
+
+## 8. Open questions
+
+All resolved. Settled during ideate:
+
+- **Scope** → **pure execute sibling**: input is an approved plan path; runs all increments
+  unattended. Not plan+execute, not full ideate→ship.
+- **Blocker policy** → **halt the blocked chain, attempt independent tracks if the plan declares
+  them**; a linear plan halts at the blocker. Never force-build on broken work; never halt the
+  whole run pre-emptively when independent work remains.
+- **Review policy** → **bounded auto-address (≤2 rounds) then log + halt policy** — not
+  log-only, not hard-blocker-on-first-finding.
+- **Placement** → **thirteenth public command + a third build step-8 option** (Go / Hand off /
+  Run overnight). Fully wired (AGENTS.md, build, README, using-woostack, CONTRIBUTING, status
+  conventions).
+- **Driver** → **inherit execute's smart default** (subagent where possible, else inline) with
+  `--inline` / `--subagent` overrides.
+
+Settled as approved defaults during the design review:
+
+- **Morning-report path** → `.woostack/overnight/YYYY-MM-DD-<plan-basename>.md`, written
+  incrementally from `references/report-template.md`.
+- **Pre-flight on a gappy plan** → **refuse to start** and write a short refusal report, rather
+  than launching a doomed run.
+
+Settled during the spec harden pass:
+
+- **"Independent tracks" made real, but contained** → woostack plans are linearly stacked with
+  no independence marker, so the original "keep going elsewhere" needed a producer. Resolution:
+  an **author-driven, top-level `## Track:` convention** (depth-1) — each track is its own
+  linear `gt` stack off the common base; a blocker ends only its track. **Overnight is the only
+  consumer**; `woostack-plan` merely documents/allows the shape (no auto-partitioning);
+  `woostack-execute` ignores tracks (stays linear). Default = one implicit track = today's
+  behavior.
+- **Blocking-review override is driver-specific** → inline posts a GitHub review, so overnight
+  uses `woostack-address-comments --auto` (≤2 rounds) on the PR threads; subagent has no
+  PR-level review, so a reviewer-loop `BLOCKED` is the blocker directly (the loop was already the
+  bounded retry). No single mode-blind auto-address rule.
+- **Morning report is gitignored** → `.woostack/overnight/` joins `.woostack/visuals/` and
+  `.woostack/metrics.json` as a per-run artifact, keeping it out of increment PRs and out of the
+  clean-tree precondition for review/address-comments.
+- **Standalone runs without a base** → tracks branch off the current non-protected branch HEAD
+  when there is no spec+plan PR base; noted in the report.


### PR DESCRIPTION
## Goal

Capture the approved design and implementation plan for `woostack-execute-overnight` — a sibling of `woostack-execute` that drives an approved plan to a reviewed stack **unattended overnight**, so a human can manually test the result in the morning. This docs-only PR is the base of the stack; the implementation increment stacks on top.

## Summary

- **Spec** (`.woostack/specs/2026-06-06-woostack-execute-overnight.md`): pure execute-sibling that swaps execute's stop-and-ask gates for resolve-or-log-and-continue (debug `--auto` on stuck verifications; bounded auto-address on a blocking review, driver-specific; blocker-and-halt on anything unsafe/ambiguous — safety never relaxed), an author-driven optional `## Track:` parallelism, and an incremental gitignored morning report under `.woostack/overnight/`. Hardened: tracks contained to overnight-only, driver-specific review override, report gitignored.
- **Plan** (`.woostack/plans/2026-06-06-woostack-execute-overnight.md`): one PR-sized increment (~320 LOC) — new `SKILL.md` + `references/report-template.md`, root `.gitignore`, three-way build step-8 handoff (Go / Hand off / Run overnight), and registration across [AGENTS.md](http://AGENTS.md) (12→13), README, CONTRIBUTING, using-woostack, plus the `## Track:` convention in `woostack-plan` and a status-conventions note. Full file content + exact edits + grep verifications, no placeholders.
- Spec `status: planning`; `spec : plan : PRs = 1 : 1 : 1`.

## Test plan

### Manual

**Before merge**

- [x] Read the spec — confirm the autonomy overrides, the overnight-only track convention, and the gitignored morning report match intent.
- [x] Read the plan — confirm the single increment is reviewable and the grep/`test -f` verifications are runnable as written.

Spec: .woostack/specs/2026-06-06-woostack-execute-overnight.md