### PR TITLE
feat(woostack-review): add silent-failure depth to observability angle

### DIFF
--- a/.woostack/memory/MEMORY.md
+++ b/.woostack/memory/MEMORY.md
@@ -4,6 +4,7 @@
 - [woostack-command-surface-bookkeeping](woostack-command-surface-bookkeeping.md) `convention` scope=`AGENTS.md` — Adding/removing a public command means updating the count + lists in five places
 - [woostack-feature-state-invariant](woostack-feature-state-invariant.md) `convention` scope=`.woostack/specs/**` — Specs, plans, and increment PRs are joined by Source and Spec trailers.
 - [gh-search-fuzzy-trailer-match](gh-search-fuzzy-trailer-match.md) `gotcha` scope=`skills/woostack-status/scripts/**` — `gh pr list --search` tokenizes paths and cross-matches; exact-match the trailer
+- [review-angle-trigger-precision](review-angle-trigger-precision.md) `gotcha` scope=`skills/woostack-review/**` — Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also match
 - [review-config-bool-jq-default](review-config-bool-jq-default.md) `gotcha` scope=`skills/woostack-review/scripts/**` — jq `// default` silently coerces an explicit `false` to the default — wrong for 
 - [review-prompt-self-contained-blob](review-prompt-self-contained-blob.md) `gotcha` scope=`skills/woostack-review/**` — woostack-review prompts ship as ONE self-contained blob to CI runners that follo
 - [skill-description-colon-space](skill-description-colon-space.md) `gotcha` scope=`skills/*/SKILL.md` — A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it

--- a/.woostack/memory/review-angle-trigger-precision.md
+++ b/.woostack/memory/review-angle-trigger-precision.md
@@ -1,0 +1,31 @@
+---
+name: review-angle-trigger-precision
+type: gotcha
+scope: skills/woostack-review/**
+tags: detect-angles, angle, trigger, diff-gated, enrichment, tier, observability
+hook: Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also matches the new pattern — and never broaden a trigger on a common token.
+updated: 2026-06-06
+source: .woostack/plans/2026-06-06-review-self-contained.md
+recall_count: 0
+---
+Most review angles are **diff-gated**: `detect-angles.sh` decides whether the angle
+runs at all by grepping the diff for trigger tokens (`has_<angle>_diff_token()` /
+`has_<angle>_file()`). Adding a new check to an angle **prompt** does NOTHING on a PR
+unless that PR also trips the angle's existing trigger — so enriching a prompt usually
+requires extending the matching trigger too. Skip this and the new guidance silently
+never fires.
+
+The inverse trap: do **not** broaden a trigger on a token that is common in normal code.
+Firing `observability` on any added `?.`/`??` would run the angle on nearly every TS PR
+(cost blowup + noise), and `observability` is now `standard`-tier and can block. The rule:
+extend the trigger only for **high-signal** tokens (e.g. production `Mock|Fake|Stub`
+fallback construction), and let a common-token check ride on the **prompt** — evaluated
+only when the angle already fires for another reason. The `?.`/`??` suppressor co-occurs
+with the `catch` / `.catch` / logging changes that already trigger the angle, so the
+relevant PRs are in scope anyway; accept the rare miss (a lone common-token case with no
+other trigger) over universal firing.
+
+Tier follows reasoning load: when an angle gains design-judgment checks (silent-failure
+depth, invariant design), bump `fast → standard` in **both** the prompt frontmatter and
+the `SKILL.md` routing table — they are two separate sites. See
+[[review-prompt-self-contained-blob]].

--- a/.woostack/plans/2026-06-06-review-self-contained.md
+++ b/.woostack/plans/2026-06-06-review-self-contained.md
@@ -19,16 +19,16 @@
 **Files:**
 - Modify: `skills/woostack-review/prompts/angles/observability.md`
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `grep -c 'null-coalescing\|mock / stub / fake\|unrelated.*error' skills/woostack-review/prompts/angles/observability.md`
 Expected: FAIL — prints `0` (none of the new patterns are present yet).
 
-- [ ] **Step 2: Confirm it fails**
+- [x] **Step 2: Confirm it fails**
 
 Run the command above. Expected output: `0`.
 
-- [ ] **Step 3: Add the three new bullets to the "Swallowed errors" block and tighten retry-exhaustion**
+- [x] **Step 3: Add the three new bullets to the "Swallowed errors" block and tighten retry-exhaustion**
 
 In `observability.md`, the **Swallowed errors** list currently ends at the `void asyncFn()` bullet. Append these three bullets immediately after it:
 
@@ -60,9 +60,9 @@ with:
     caller silently proceeds as if the operation succeeded.
 ```
 
-- [ ] **Step 4: Confirm it passes**
+- [x] **Step 4: Confirm it passes**
 
-Run: `grep -c 'null-coalescing\|mock / stub / fake\|unrelated' skills/woostack-review/prompts/angles/observability.md`
+Run: `grep -ic 'null-coalescing\|mock / stub / fake\|unrelated' skills/woostack-review/prompts/angles/observability.md`
 Expected: PASS — prints `3` or more.
 
 ### Task 2: Bump the observability angle tier `fast → standard`
@@ -70,20 +70,20 @@ Expected: PASS — prints `3` or more.
 **Files:**
 - Modify: `skills/woostack-review/prompts/angles/observability.md` (frontmatter)
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `sed -n '1,3p' skills/woostack-review/prompts/angles/observability.md`
 Expected: FAIL — shows `tier: fast`.
 
-- [ ] **Step 2: Confirm it fails**
+- [x] **Step 2: Confirm it fails**
 
 Run the command above. Expected: the frontmatter reads `tier: fast`.
 
-- [ ] **Step 3: Edit the frontmatter**
+- [x] **Step 3: Edit the frontmatter**
 
 Change line 2 of `observability.md` from `tier: fast` to `tier: standard`.
 
-- [ ] **Step 4: Confirm it passes**
+- [x] **Step 4: Confirm it passes**
 
 Run: `head -3 skills/woostack-review/prompts/angles/observability.md | grep -q 'tier: standard' && echo PASS`
 Expected: PASS.
@@ -97,7 +97,7 @@ Expected: PASS.
 >
 > Hardened note: the mock/stub/fake grep is deliberately coarse — it also matches a `Mock` constructed in a *test* file. The prompt scopes findings to **production** paths, so a test-only mock costs at most one extra `standard`-tier worker slot and yields no finding. This is the established coarse-trigger / precise-prompt split; the bounded false-fire cost is accepted.
 
-- [ ] **Step 1: Write the failing fixture test**
+- [x] **Step 1: Write the failing fixture test**
 
 ```bash
 export OUTDIR=/tmp/woo-detect-test-mock
@@ -112,11 +112,11 @@ bash skills/woostack-review/scripts/detect-angles.sh >/dev/null 2>&1
 grep -qx observability "$OUTDIR/angles.txt" && echo "OBSERVABILITY-FIRED" || echo "NOT-FIRED"
 ```
 
-- [ ] **Step 2: Confirm it fails**
+- [x] **Step 2: Confirm it fails**
 
 Run the block above. Expected: `NOT-FIRED` (the mock fallback token is not yet a trigger; the diff has no logging/catch token).
 
-- [ ] **Step 3: Add the mock/stub/fake grep to `has_observability_diff_token()`**
+- [x] **Step 3: Add the mock/stub/fake grep to `has_observability_diff_token()`**
 
 In `detect-angles.sh`, inside `has_observability_diff_token()` (currently two `grep … && return 0` lines then `return 1`), insert a third detection line **before** `return 1`:
 
@@ -130,7 +130,7 @@ In `detect-angles.sh`, inside `has_observability_diff_token()` (currently two `g
 
 Also update the angle-gating doc header (the `#   observability —` block near the top, lines ~47-50) to append: `, production Mock/Fake/Stub fallback construction`.
 
-- [ ] **Step 4: Confirm syntax + the fixture now fires**
+- [x] **Step 4: Confirm syntax + the fixture now fires**
 
 ```bash
 bash -n skills/woostack-review/scripts/detect-angles.sh && echo "SYNTAX-OK"
@@ -139,7 +139,7 @@ grep -qx observability "$OUTDIR/angles.txt" && echo "OBSERVABILITY-FIRED"
 ```
 Expected: `SYNTAX-OK` then `OBSERVABILITY-FIRED`.
 
-- [ ] **Step 5: Control test — confirm raw `?.`/`??` does NOT broaden the trigger**
+- [x] **Step 5: Control test — confirm raw `?.`/`??` does NOT broaden the trigger**
 
 ```bash
 export OUTDIR=/tmp/woo-detect-test-optchain
@@ -160,17 +160,17 @@ Expected: `CORRECTLY-SILENT` (proves we did not broaden on `?.`/`??`). Note: `ty
 **Files:**
 - Modify: `skills/woostack-review/SKILL.md` (Model-routing tier table, ~line 349)
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `grep -n '`observability`, `types`, `i18n`, `docs`, `deps` workers | `fast`' skills/woostack-review/SKILL.md`
 Expected: FAIL to be absent — the line is still present (observability/types not yet moved).
 
-- [ ] **Step 2: Confirm it fails**
+- [x] **Step 2: Confirm it fails**
 
 Run: `grep -q 'observability\`, \`types\`, \`i18n\`, \`docs\`, \`deps\` workers | \`fast\`' skills/woostack-review/SKILL.md && echo "STILL-FAST"`
 Expected: `STILL-FAST`.
 
-- [ ] **Step 3: Edit the tier table**
+- [x] **Step 3: Edit the tier table**
 
 In the tier table, change the `fast` row from:
 
@@ -185,12 +185,12 @@ to (drop `observability`, and add a new `standard` row above it — note `types`
 | `types`, `i18n`, `docs`, `deps` workers | `fast` | Pattern matching + diff-anchored hygiene checks. |
 ```
 
-- [ ] **Step 4: Confirm it passes**
+- [x] **Step 4: Confirm it passes**
 
 Run: `grep -q '`observability` worker | `standard`' skills/woostack-review/SKILL.md && echo PASS`
 Expected: PASS.
 
-- [ ] **Step 5: Commit increment 1**
+- [x] **Step 5: Commit increment 1**
 
 ```bash
 gt create -m "feat(woostack-review): add silent-failure depth to observability angle"

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -346,7 +346,8 @@ Sub-agents MUST NOT post comments, edit the PR, touch other angles' files, run `
 | `tests`, `api`, `infra` workers | `standard` | Coverage/contract/IaC reasoning. |
 | `skills` worker | `standard` | Skill-authoring judgment against the best-practices guide. |
 | `seo`, `aeo` workers | `fast` | Rubric checklists; no novel reasoning. |
-| `observability`, `types`, `i18n`, `docs`, `deps` workers | `fast` | Pattern matching + diff-anchored hygiene checks. |
+| `observability` worker | `standard` | Silent-failure depth: error-suppression + swallow-path reasoning. |
+| `types`, `i18n`, `docs`, `deps` workers | `fast` | Pattern matching + diff-anchored hygiene checks. |
 | Skeptical Validator | `deep` | Highest-leverage step — strictest false-positive filter pays for itself. |
 
 Per-provider resolution (full table in `_header.md`):

--- a/skills/woostack-review/prompts/angles/observability.md
+++ b/skills/woostack-review/prompts/angles/observability.md
@@ -1,5 +1,5 @@
 ---
-tier: fast
+tier: standard
 ---
 
 # Angle: Observability
@@ -16,13 +16,26 @@ tier: fast
   - `catch {}` with no log, no rethrow, no fallback (new in diff).
   - `.catch(() => null)` / `.catch(() => undefined)` on a non-trivial async call that silently hides failure.
   - Promise rejection ignored (`void asyncFn()` without `.catch`).
+  - `?.` optional chaining / `??` null-coalescing used to silently skip an operation that
+    *should* surface a failure — e.g. `user?.save()` where a missing `user` means the write
+    never happens and nobody is told, or `primary() ?? fallback()` that masks a failed primary
+    call. A legitimate optional *read* (`user?.name`) is fine — flag only when the skipped
+    operation has a side effect or a failure that should be observed.
+  - Broad, **non-empty** `catch (e) { log; continue }` that can swallow *unrelated* error
+    classes. In the finding's `description`, enumerate which unexpected error types this catch
+    could hide (e.g. a `TypeError` from a later refactor, an `AbortError`, an out-of-memory) —
+    not just the expected one.
+  - Mock / stub / fake fallback reached on a **production** code path (e.g. `return
+    mockClient()` / `new FakeRepo()` in a non-test file when the real dependency is
+    unavailable). This hides an outage behind synthetic data — flag as an architectural defect.
 - **Log-level abuse:**
   - `error` used for expected control flow (e.g. validation rejections, 404s).
   - `info` / `log` inside a hot loop with no rate limit or sampling.
   - `debug` left in a path that runs in production (no env gating).
 - **Missing signals on new paths:**
   - New endpoint / job / consumer with no log on entry, no log on failure, no metric / counter.
-  - New retry loop with no log on retry-exhaustion.
+  - New retry loop that exhausts its attempts with no log **and no user-facing signal** — the
+    caller silently proceeds as if the operation succeeded.
   - New external call (HTTP / DB / queue) with no timing / span / error-rate signal.
 - **Tracing hygiene:**
   - New async boundary without context propagation (lost `traceparent`, lost AsyncLocalStorage).

--- a/skills/woostack-review/scripts/detect-angles.sh
+++ b/skills/woostack-review/scripts/detect-angles.sh
@@ -47,7 +47,8 @@
 #   observability — logging / error-handling tokens in diff body:
 #               console.log/error, logger./log., print(, fmt.Println, Sentry.,
 #               OpenTelemetry / span. / metrics., bare `catch {}` swallow,
-#               `.catch(() => null|undefined)`.
+#               `.catch(() => null|undefined)`, production Mock/Fake/Stub fallback
+#               construction.
 #   types     — *.ts / *.tsx / *.cts / *.mts in diff. TypeScript-only.
 #   i18n      — locales/, messages/, i18n/, translations/ directory trees,
 #               *.po / *.pot files, or `i18n.t(` / `useTranslations(` /
@@ -186,6 +187,11 @@ has_observability_diff_token() {
   # doesn't fire the angle.
   grep -qE "^\+.*\b(console\.(log|warn|error|info|debug)|logger\.|log\.(info|warn|error|debug|trace)|fmt\.(Println|Printf|Fprintln)|Sentry\.|OpenTelemetry|otel\.|opentelemetry|tracer\.startSpan|span\.(end|recordException)|metrics\.(counter|histogram|gauge)|\.catch\([[:space:]]*\([^)]*\)[[:space:]]*=>[[:space:]]*(null|undefined))" "$DIFF" && return 0
   grep -qE "^\+[[:space:]]*}[[:space:]]*catch[[:space:]]*(\([^)]*\))?[[:space:]]*\{[[:space:]]*\}" "$DIFF" && return 0
+  # Production mock/stub/fake fallback that hides an outage behind synthetic data.
+  # NOT raw ?./?? (too common — would fire on nearly every TS PR; that suppressor
+  # check rides on the prompt when the angle already fires). Broad non-empty catch
+  # blocks that log already fire via the logger./console. tokens above.
+  grep -qE "^\+[^/]*\b(return|=>|:?=)[[:space:]]*(new[[:space:]]+)?(Mock|Fake|Stub)[A-Za-z0-9_]*\(" "$DIFF" && return 0
   return 1
 }
 


### PR DESCRIPTION
## Goal

Fold `silent-failure-hunter`'s review value into woostack-review's `observability` angle so the toolkit's error-handling auditor is no longer needed.

## Summary

- **observability prompt** — added `?.`/`??` error-suppression detection, broad non-empty `catch` enumeration (list what unrelated errors it could hide), and production Mock/Fake/Stub fallback detection; tightened the retry-exhaustion bullet to cover user-facing silence.
- **detect-angles.sh** — extended `has_observability_diff_token()` to fire on production mock/stub/fake fallback tokens only; raw `?.`/`??` is deliberately **not** a trigger (it would fire on nearly every TS PR — that check rides on the prompt when the angle already fires).
- **tier `fast → standard`** — in the prompt frontmatter and the `SKILL.md` routing table, reflecting the heavier silent-failure reasoning.

## Test plan

### Automated

- [x] `bash -n skills/woostack-review/scripts/detect-angles.sh` → SYNTAX-OK
- [x] Mock-fallback fixture diff → `observability` fires
- [x] `?.`/`??` control fixture → `observability` stays silent (trigger not broadened)
- [x] `grep -ic` the three new patterns in `observability.md` → `3`

### Manual

**Before merge**

- [ ] Read the `observability` diff; confirm the `?.`/`??` guidance flags only side-effecting / failure-bearing operations, not legitimate optional reads.
- [ ] Confirm the tier bump to `standard` appears in both the prompt frontmatter and the `SKILL.md` routing table.

Spec: .woostack/specs/2026-06-06-review-self-contained.md
