### PR TITLE
feat(woostack-review): add type-design/invariant depth to types angle

### DIFF
--- a/.woostack/plans/2026-06-06-review-self-contained.md
+++ b/.woostack/plans/2026-06-06-review-self-contained.md
@@ -207,16 +207,16 @@ gt create -m "feat(woostack-review): add silent-failure depth to observability a
 **Files:**
 - Modify: `skills/woostack-review/prompts/angles/types.md`
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `grep -c 'Anemic domain model\|unrepresentable\|Mutable internals' skills/woostack-review/prompts/angles/types.md`
 Expected: FAIL — prints `0`.
 
-- [ ] **Step 2: Confirm it fails**
+- [x] **Step 2: Confirm it fails**
 
 Run the command above. Expected: `0`.
 
-- [ ] **Step 3: Insert the new section before the `**Skip:**` block**
+- [x] **Step 3: Insert the new section before the `**Skip:**` block**
 
 In `types.md`, immediately before the `**Skip:**` line, insert:
 
@@ -233,7 +233,7 @@ In `types.md`, immediately before the `**Skip:**` line, insert:
     `status: string` instead of `'active' | 'archived'`; a raw `string` id instead of `UserId`).
 ```
 
-- [ ] **Step 4: Confirm it passes**
+- [x] **Step 4: Confirm it passes**
 
 Run: `grep -c 'Anemic domain model\|unrepresentable\|Mutable internals' skills/woostack-review/prompts/angles/types.md`
 Expected: PASS — prints `3`.
@@ -244,16 +244,16 @@ Expected: PASS — prints `3`.
 - Modify: `skills/woostack-review/prompts/angles/types.md` (frontmatter)
 - Modify: `skills/woostack-review/SKILL.md` (tier table — the `fast` row left by Increment 1)
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `head -3 skills/woostack-review/prompts/angles/types.md | grep -q 'tier: fast' && echo "STILL-FAST"`
 Expected: FAIL-state present — prints `STILL-FAST`.
 
-- [ ] **Step 2: Confirm it fails**
+- [x] **Step 2: Confirm it fails**
 
 Run the command above. Expected: `STILL-FAST`.
 
-- [ ] **Step 3: Edit both files**
+- [x] **Step 3: Edit both files**
 
 (a) In `types.md`, change line 2 from `tier: fast` to `tier: standard`.
 
@@ -271,7 +271,7 @@ to:
 | `i18n`, `docs`, `deps` workers | `fast` | Pattern matching + diff-anchored hygiene checks. |
 ```
 
-- [ ] **Step 4: Confirm it passes**
+- [x] **Step 4: Confirm it passes**
 
 ```bash
 head -3 skills/woostack-review/prompts/angles/types.md | grep -q 'tier: standard' && echo "PROMPT-OK"
@@ -279,7 +279,7 @@ grep -q '`observability`, `types` workers | `standard`' skills/woostack-review/S
 ```
 Expected: `PROMPT-OK` then `SKILL-OK`.
 
-- [ ] **Step 5: Commit increment 2**
+- [x] **Step 5: Commit increment 2**
 
 ```bash
 gt create -m "feat(woostack-review): add type-design/invariant depth to types angle"

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -346,8 +346,8 @@ Sub-agents MUST NOT post comments, edit the PR, touch other angles' files, run `
 | `tests`, `api`, `infra` workers | `standard` | Coverage/contract/IaC reasoning. |
 | `skills` worker | `standard` | Skill-authoring judgment against the best-practices guide. |
 | `seo`, `aeo` workers | `fast` | Rubric checklists; no novel reasoning. |
-| `observability` worker | `standard` | Silent-failure depth: error-suppression + swallow-path reasoning. |
-| `types`, `i18n`, `docs`, `deps` workers | `fast` | Pattern matching + diff-anchored hygiene checks. |
+| `observability`, `types` workers | `standard` | Silent-failure depth + type-design/invariant reasoning. |
+| `i18n`, `docs`, `deps` workers | `fast` | Pattern matching + diff-anchored hygiene checks. |
 | Skeptical Validator | `deep` | Highest-leverage step — strictest false-positive filter pays for itself. |
 
 Per-provider resolution (full table in `_header.md`):

--- a/skills/woostack-review/prompts/angles/types.md
+++ b/skills/woostack-review/prompts/angles/types.md
@@ -1,5 +1,5 @@
 ---
-tier: fast
+tier: standard
 ---
 
 # Angle: Types
@@ -31,6 +31,16 @@ tier: fast
   - `enum` numeric default values relied on by serialization.
 - **React-specific (only if the `react` angle is NOT enabled — otherwise defer):**
   - `props: any`, `useState<any>()`, event handler typed as `Function`.
+- **Type design & invariants:**
+  - Anemic domain model: a new type that is a bag of public, independently-settable primitives
+    whose invariants are enforced nowhere — or only in a prose comment (e.g.
+    `{ startDate: string; endDate: string }` with "endDate must be after startDate" written in a
+    comment instead of the type).
+  - Mutable internals leaking an invariant: a public mutable field / array / map callers can
+    mutate to violate the type's contract (no `readonly`, no encapsulation, an exposed setter).
+  - Invariant left to runtime/docs that the type system could enforce: `string` where a branded
+    type, template-literal type, or union would make the illegal state unrepresentable (e.g.
+    `status: string` instead of `'active' | 'archived'`; a raw `string` id instead of `UserId`).
 
 **Skip:**
 


### PR DESCRIPTION
## Goal

Fold `type-design-analyzer`'s review value into woostack-review's `types` angle so the toolkit's type auditor is no longer needed.

## Summary

- **types prompt** — added a "Type design & invariants" section: anemic domain models (invariants enforced nowhere or only in comments), mutable internals leaking an invariant, and invariants left to runtime/docs that the type system could make unrepresentable (branded types, unions). Complements the existing type-*hole* checks (`any`, unsafe casts, untyped boundaries) rather than duplicating them.
- **tier `fast → standard`** — prompt frontmatter + `SKILL.md` routing table, reflecting the heavier invariant-design judgment.

## Test plan

### Automated

- [x] `grep -c` the three invariant patterns in `types.md` → `3`
- [x] Prompt frontmatter reads `tier: standard`
- [x] `SKILL.md` routes `observability`, `types` at `standard`; `types` no longer in the `fast` row

### Manual

**Before merge**

- [ ] Read the `types` diff; confirm the invariant checks complement the existing type-hole checks and don't double-flag the same issue.

Spec: .woostack/specs/2026-06-06-review-self-contained.md
