### PR TITLE
docs(woostack): spec+plan to commit .woostack/memory changes unless gitignored

### DIFF
--- a/.woostack/plans/2026-06-06-commit-memory-changes.md
+++ b/.woostack/plans/2026-06-06-commit-memory-changes.md
@@ -1,0 +1,210 @@
+**Source:** .woostack/specs/2026-06-06-commit-memory-changes.md
+
+# Commit memory changes unless gitignored — Implementation Plan
+
+**Goal:** Make `woostack-commit` always stage non-gitignored `.woostack/memory/` changes, and make `woostack-execute` sweep pending memory whenever it hands control back, so distilled knowledge always reaches a PR.
+
+**Architecture:** Two skill-markdown edits, shipped as stacked PRs. Increment 1 adds an always-stage carve-out to `woostack-commit` step 4 (a directory-guarded `git add .woostack/memory/` that relies on `.gitignore` for the "unless gitignored" boundary). Increment 2 adds a single "memory sweep on handback" rule to `woostack-execute`, referenced from both the terminal state and the blocking-stop section; it invokes `woostack-commit`, so it depends on Increment 1 and stacks on top of it.
+
+**Tech Stack:** Markdown skill docs only. No application code, no test runner in this repo — verification is `grep`/`bash -n` with exact expected output.
+
+---
+
+## Increment 1: woostack-commit always-stages `.woostack/memory/`
+
+> One independently shippable PR — its own Graphite-stacked branch. Fixes the reported symptom on its own.
+
+### Task 1: Add the memory carve-out to `woostack-commit` step 4
+
+**Files:**
+- Modify: `skills/woostack-commit/SKILL.md` (§4 "Stage only session-relevant changes", around lines 117-131)
+
+- [ ] **Step 1: Write the failing test (verification command)**
+
+The marker text the edit introduces does not yet exist. Capture that as the failing check:
+
+```bash
+grep -c 'Always stage `.woostack/memory/` changes' skills/woostack-commit/SKILL.md
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `grep -c 'Always stage `.woostack/memory/` changes' skills/woostack-commit/SKILL.md`
+Expected: FAIL — prints `0` and exits non-zero (marker absent).
+
+- [ ] **Step 3: Minimal implementation**
+
+In `skills/woostack-commit/SKILL.md`, insert the carve-out into §4 immediately after the `git add -p <file>` fenced block and before the `Do not stage generated files…` line. Insert exactly:
+
+```markdown
+**Always stage `.woostack/memory/` changes.** Distilled memory notes are session work by
+definition in the woostack loop — never "unrelated dirty files." Stage every non-ignored
+change under `.woostack/memory/` (modifications, additions, and the note deletions distill's
+dedupe makes), folded into the same commit as the code, with no relevance check and no
+stop-and-ask:
+
+```bash
+[ -d .woostack/memory ] && git add .woostack/memory/
+```
+
+Plain `git add` (never `-f`) honors `.gitignore`, so ignored paths such as
+`.woostack/memory/metrics.json` and `*.local.*` are skipped automatically — "unless
+gitignored" needs no `git check-ignore` step. The `[ -d … ]` guard makes this a silent no-op
+outside a woostack repo, where a bare `git add` of an absent path would exit non-zero with
+`fatal: pathspec '.woostack/memory/' did not match any files`.
+```
+
+Then change the existing exclusion line so it no longer reads as excluding memory. Replace:
+
+```markdown
+Do not stage generated files, secrets, `.env*`, unrelated dirty files, or user work from outside this session.
+```
+
+with:
+
+```markdown
+Do not stage generated files, secrets, `.env*`, unrelated dirty files, or user work from outside this session — the `.woostack/memory/` rule above is the sole exception to "unrelated dirty files."
+```
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: `grep -c 'Always stage `.woostack/memory/` changes' skills/woostack-commit/SKILL.md`
+Expected: PASS — prints `1`.
+
+- [ ] **Step 5: Confirm the embedded command is syntactically valid and the exclusion carve-out landed**
+
+Run:
+```bash
+bash -nc '[ -d .woostack/memory ] && git add .woostack/memory/' && echo SYNTAX_OK
+grep -c 'sole exception to "unrelated dirty files"' skills/woostack-commit/SKILL.md
+```
+Expected: prints `SYNTAX_OK`, then `1`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+# first commit in this increment:
+gt create -m "fix(woostack-commit): always stage .woostack/memory/ unless gitignored"
+```
+
+---
+
+## Increment 2: woostack-execute sweeps memory on handback
+
+> Stacks on Increment 1 (the sweep calls `woostack-commit`, which now stages memory). One independently shippable PR.
+
+### Task 1: Add the "memory sweep on handback" rule to `woostack-execute`
+
+**Files:**
+- Modify: `skills/woostack-execute/SKILL.md` (new subsection after "Terminal state: a reviewed stack"; reference lines in that section and in "When to stop and ask")
+
+- [ ] **Step 1: Write the failing test (verification command)**
+
+```bash
+grep -c '## Memory sweep on handback' skills/woostack-execute/SKILL.md
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `grep -c '## Memory sweep on handback' skills/woostack-execute/SKILL.md`
+Expected: FAIL — prints `0` and exits non-zero.
+
+- [ ] **Step 3: Minimal implementation — add the dedicated rule section**
+
+In `skills/woostack-execute/SKILL.md`, insert this new section immediately after the "Terminal state: a reviewed stack" paragraph (the one ending `**Never merge.**`) and before `## When to stop and ask`. Insert exactly:
+
+```markdown
+## Memory sweep on handback
+
+Before this skill yields control back **for any reason** — the reviewed-stack terminal state
+above, or any blocking stop in [When to stop and ask](#when-to-stop-and-ask) — sweep any
+distilled memory so it is never stranded. If `.woostack/memory/` has non-ignored uncommitted
+changes, run one final [`woostack-commit`](../woostack-commit/SKILL.md) on the current
+increment's branch; it stages `.woostack/memory/` for you. This is necessarily a memory-only
+commit when the increment's code is already committed and reviewed. Skip it when memory is
+clean — never create an empty commit. Intermediate increments need nothing extra: increment
+N's distilled memory is swept by increment N+1's commit.
+```
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: `grep -c '## Memory sweep on handback' skills/woostack-execute/SKILL.md`
+Expected: PASS — prints `1`.
+
+### Task 2: Reference the sweep from the terminal state and the blocking-stop section
+
+**Files:**
+- Modify: `skills/woostack-execute/SKILL.md` ("Terminal state: a reviewed stack" paragraph; "When to stop and ask" section)
+
+- [ ] **Step 1: Write the failing test (verification command)**
+
+```bash
+grep -c '(#memory-sweep-on-handback)' skills/woostack-execute/SKILL.md
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: `grep -c '(#memory-sweep-on-handback)' skills/woostack-execute/SKILL.md`
+Expected: FAIL — prints `0` (only the heading exists so far; no in-text links to its anchor).
+
+- [ ] **Step 3: Minimal implementation — add the two reference pointers**
+
+In the "Terminal state: a reviewed stack" paragraph, replace (exact text, including the line break between `or` and `mode`):
+
+```markdown
+Report the branches/PRs and their review verdicts or
+mode. **Never merge.**
+```
+
+with:
+
+```markdown
+Run the [memory sweep on handback](#memory-sweep-on-handback) first, then report the
+branches/PRs and their review verdicts or mode. **Never merge.**
+```
+
+In the "When to stop and ask" section, replace the closing line:
+
+```markdown
+Return to the plan-review step if the plan is updated or the approach needs rethinking.
+```
+
+with:
+
+```markdown
+On every stop above, run the [memory sweep on handback](#memory-sweep-on-handback) before
+surfacing the stop, so a mid-run distill (e.g. a `woostack-debug` detour) is never stranded.
+
+Return to the plan-review step if the plan is updated or the approach needs rethinking.
+```
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: `grep -c '(#memory-sweep-on-handback)' skills/woostack-execute/SKILL.md`
+Expected: PASS — prints `2`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+# first commit in this increment (new branch stacked on Increment 1):
+gt create -m "fix(woostack-execute): sweep .woostack/memory/ on every handback"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every spec requirement maps to a task above.
+  - Fix 1 (commit carve-out, guarded `git add`, gitignore-free boundary, deletions staged, no-op when absent) → Increment 1, Task 1.
+  - Fix 2 (sweep on any handback — terminal + blocking stops, single rule referenced twice, memory-only commit, no empty commit) → Increment 2, Tasks 1-2.
+  - Non-goals (no distill change, no specs/plans staging change, no execute reorder) → not touched by any task. ✓
+  - Resolved Open Q1 (no foreign guard) → Increment 1 Step 3 wording "no relevance check and no stop-and-ask". ✓
+  - Resolved Open Q2 (any handback) → Increment 2 covers terminal + "When to stop and ask". ✓
+- [ ] **No placeholders** — every step has the exact edit text, exact command, and exact expected output. ✓
+- [ ] **Type consistency** — marker strings are consistent across find/replace and verification greps: ``Always stage `.woostack/memory/` changes`` (Inc 1), `## Memory sweep on handback` and `(#memory-sweep-on-handback)` (Inc 2). ✓
+
+> woostack plan conventions (kept):
+> - This file is **frontmatter-free** and **opens with** the `**Source:**` line.
+> - Filename mirrors the spec basename: `.woostack/plans/2026-06-06-commit-memory-changes.md`.
+> - **No** required sub-skill banner — execution is `woostack-execute`'s (woostack-build step 8, or `/woostack-execute <plan>`).
+> - Test runner absent → "failing test" steps are concrete `grep`/`bash -n` verification commands with exact expected output.

--- a/.woostack/specs/2026-06-06-commit-memory-changes.md
+++ b/.woostack/specs/2026-06-06-commit-memory-changes.md
@@ -1,0 +1,153 @@
+---
+name: commit-memory-changes
+type: spec
+status: planning
+date: 2026-06-06
+branch: feature/commit-memory-changes
+links:
+---
+
+# Commit memory changes unless gitignored — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
+## 1. Problem
+
+`woostack-commit` consistently leaves out `.woostack/memory/` changes. Its step 4
+("Stage only session-relevant changes") uses targeted staging plus the agent's judgment
+of relevance, and explicitly excludes "unrelated dirty files." Distilled memory notes get
+swept into that exclusion: the agent treats `.woostack/memory/*.md` edits as out-of-scope
+dirty work and never stages them. Result — durable knowledge distilled during a session
+never reaches the PR.
+
+`woostack-execute` compounds the symptom. Its per-increment cadence runs **commit at step 4
+but distill at step 7**, so the memory a given increment distills is written to the working
+tree *after* that increment's commit. With the relevance filter dropping memory, those
+changes then accumulate uncommitted: intermediate increments' memory could be picked up by
+the next increment's commit, but the **final** increment's distilled memory has no
+subsequent commit and is simply left behind when the stack finishes.
+
+## 2. Goal
+
+`/woostack-commit` always commits non-gitignored `.woostack/memory/` changes as part of the
+session, and `woostack-execute` never ends with the final increment's distilled memory left
+uncommitted.
+
+## 3. Non-goals
+
+- Not changing how memory is *distilled* (the reject-by-default distillation gate in the
+  [memory contract](../../woostack-init/references/memory.md) is untouched).
+- Not changing spec/plan staging: `.woostack/specs/` and `.woostack/plans/` are already
+  handled by the spec+plan PR and `woostack-commit`'s step 4.5 invariant check.
+- Not reordering `woostack-execute`'s per-increment cadence (distill stays at step 7, after
+  review — distilling before review would be premature). The fix is a terminal sweep, not a
+  reorder.
+- Not adding a per-increment dedicated memory commit; memory folds into the normal commit.
+- No `git add -f`, no force-staging of gitignored paths.
+
+## 4. Approach
+
+Two coordinated skill-markdown edits. No application code; this repo has no test harness.
+
+**Fix 1 — `woostack-commit` step 4 carve-out.** Add an explicit rule that changes under
+`.woostack/memory/` are session work by definition in the woostack loop and are **always
+staged unconditionally**, folded into the same commit as the code. They are never classified
+as "unrelated dirty files," and there is no relevance check or stop-and-ask for them
+(resolved Open Q1: no foreign-session guard — any guard would re-introduce the over-caution
+that caused the bug, and committing memory is the desired direction). Mechanism: a
+directory-guarded, path-scoped `git add .woostack/memory/`, e.g.
+`[ -d .woostack/memory ] && git add .woostack/memory/`. Two properties make this exactly
+right:
+
+- Plain (non-`-f`) `git add` honors `.gitignore`, so ignored paths such as
+  `.woostack/memory/metrics.json` and `*.local.*` are excluded automatically —
+  **"unless gitignored" is satisfied for free**, with no `git check-ignore` step and no `-f`.
+- `git add <dir>` stages modifications, additions, **and deletions** within the path (git
+  2.0+), so the note removals that distill's dedupe performs are committed too, not just
+  additions.
+
+The directory-existence guard is required: a bare `git add .woostack/memory/` against an
+absent directory exits non-zero with `fatal: pathspec '.woostack/memory/' did not match any
+files`. Guarding makes it a silent no-op in a non-woostack repo.
+
+**Fix 2 — `woostack-execute` memory sweep on handback.** Before `woostack-execute` yields
+control back **for any reason** — the clean terminal state *or* a blocking stop
+(REQUEST_CHANGES, a blocker, or woostack-debug's architectural stop) — if `.woostack/memory/`
+has pending non-ignored changes, run one final `/woostack-commit` on the current increment's
+branch to sweep them into that branch's PR (resolved Open Q2: any handback, not only the
+clean terminal — a mid-run woostack-debug detour can distill a gotcha before an early stop,
+and that memory must not be stranded). Intermediate increments need nothing extra: once Fix 1
+lands, increment N's distilled memory is swept by increment N+1's commit; the sweep covers
+the *last* committed point, which has no following commit.
+
+Two accepted consequences, both following from folding (Fix 1) without reordering execute:
+
+- **One-increment lag.** Because distill (execute step 7) runs after commit (step 4),
+  distilled memory lands in the *next* increment's commit; the final increment's memory lands
+  in the Fix 2 sweep. The user chose this over a larger reorder (distilling before review
+  would be premature).
+- **Sweep is a memory-only commit.** At handback the increment's code is already committed
+  (and, inline, reviewed), so the sweep necessarily produces a memory-only commit via
+  `/woostack-commit`. This does not contradict the "fold into the same commit" rule — folding
+  applies when code and memory are committed together in one invocation; the sweep is the
+  trailing case where only memory remains dirty.
+
+## 5. Components & data flow
+
+- **`skills/woostack-commit/SKILL.md` — §4 "Stage only session-relevant changes."** Add the
+  `.woostack/memory/` always-stage rule and the `git add .woostack/memory/` mechanism; keep
+  the existing exclusions (`.env*`, secrets, generated app files, unrelated dirty hunks)
+  intact. The new rule is an exception carved out of "unrelated dirty files," scoped strictly
+  to `.woostack/memory/`.
+- **`skills/woostack-execute/SKILL.md` — handback points.** Add the memory sweep at every
+  point execute yields control: the terminal "reviewed stack" state **and** the "When to stop
+  and ask" blocking stops. Phrase it as a single rule ("before handing control back, sweep
+  pending non-ignored `.woostack/memory/` via `/woostack-commit`") referenced from both
+  places, rather than duplicating mechanism. Cross-reference `woostack-commit`; do not restate
+  the staging mechanism.
+- **Data flow.** distill (execute §7) writes `.woostack/memory/*.md` + regenerates
+  `MEMORY.md` via `build-index.sh` → `git add .woostack/memory/` stages tracked notes +
+  index, skips gitignored `metrics.json` → commit folds them into the increment PR; the final
+  increment's memory rides the Fix 2 sweep commit.
+
+## 6. Error handling
+
+- **No `.woostack/memory/` directory** (non-woostack repo): the directory-existence guard
+  (`[ -d .woostack/memory ] && …`) makes the stage a silent no-op; commit proceeds normally.
+  An unguarded `git add` would instead exit non-zero with `fatal: pathspec … did not match`.
+- **Only gitignored memory changes dirty** (e.g. just `metrics.json`): `git add` stages
+  nothing, no empty memory commit is forced.
+- **Nothing to sweep at execute terminal** (memory clean after final distill): skip the
+  sweep commit; do not create an empty commit.
+- **Gitignored paths**: never force-added; `.gitignore` is the single source of the
+  "unless gitignored" boundary.
+
+## 7. Testing
+
+No automated test harness in this repo (skill-markdown change). Manual verification:
+
+- **Commit carve-out**: on a feature branch, dirty a `.woostack/memory/*.md` note and a
+  gitignored `metrics.json`; run `/woostack-commit`; confirm the note is staged and committed
+  and `metrics.json` is not.
+- **No-op safety**: run `/woostack-commit` in a repo with no `.woostack/memory/`; confirm it
+  proceeds with no error and no spurious staging.
+- **Execute sweep**: run `woostack-execute` to terminal state on a multi-increment plan;
+  confirm the final increment's distilled memory lands in a commit on the last branch rather
+  than being left dirty.
+
+## 8. Open questions
+
+Resolved during the harden phase (step 3):
+
+- **Foreign-session memory** → *No guard; stage all.* The always-stage rule is unconditional
+  (modulo `.gitignore`): every non-ignored `.woostack/memory/` change is staged, no relevance
+  check or stop-and-ask. A guard would re-introduce the over-caution that caused the bug, and
+  committing memory is the desired direction (it is shared knowledge). Folded into §4 Fix 1.
+- **Sweep on non-clean exit** → *Any handback.* The execute sweep fires whenever execute
+  yields control — clean terminal **and** blocking stops (REQUEST_CHANGES, blocker,
+  woostack-debug architectural stop) — so a mid-run distill is never stranded by an early
+  stop. Folded into §4 Fix 2 and §5.
+
+No open questions remain.


### PR DESCRIPTION
## Goal

woostack-commit consistently drops `.woostack/memory/` changes, so distilled knowledge never reaches a PR. This stack makes the build loop always commit memory unless it is gitignored.

## Summary

- Spec `.woostack/specs/2026-06-06-commit-memory-changes.md` (hardened, status `planning`): root-causes the drop and locks two fixes.
- Plan `.woostack/plans/2026-06-06-commit-memory-changes.md`: two PR-sized increments.
- **Increment 1** — woostack-commit §4 always-stages non-ignored `.woostack/memory/` via guarded `[ -d .woostack/memory ] && git add .woostack/memory/`; `.gitignore` supplies the "unless gitignored" boundary for free; stages deletions; no-op when absent.
- **Increment 2** — woostack-execute sweeps pending memory via `woostack-commit` on **every** handback (clean terminal or blocking stop), referenced from one rule section. Stacks on Increment 1.
- Resolved both open questions: no foreign-session guard; sweep fires on any handback.

## Test plan

### Manual

**Before merge**

- [ ] Read `.woostack/specs/2026-06-06-commit-memory-changes.md` — confirm root cause, two fixes, resolved open questions are accurate.
- [ ] Read `.woostack/plans/2026-06-06-commit-memory-changes.md` — confirm the two increments' find/replace strings match the live `woostack-commit`/`woostack-execute` SKILL.md text and the grep verifications are exact.

> Docs-only base of the stack (spec + plan). No code, no test harness in this repo. The skill edits and their `grep`/`bash -n` verifications land in the stacked increment PRs.

Spec: .woostack/specs/2026-06-06-commit-memory-changes.md
