### PR TITLE
fix(woostack-commit): always stage .woostack/memory/ unless gitignored

### DIFF
--- a/.woostack/plans/2026-06-06-commit-memory-changes.md
+++ b/.woostack/plans/2026-06-06-commit-memory-changes.md
@@ -19,7 +19,7 @@
 **Files:**
 - Modify: `skills/woostack-commit/SKILL.md` (§4 "Stage only session-relevant changes", around lines 117-131)
 
-- [ ] **Step 1: Write the failing test (verification command)**
+- [x] **Step 1: Write the failing test (verification command)**
 
 The marker text the edit introduces does not yet exist. Capture that as the failing check:
 
@@ -27,12 +27,12 @@ The marker text the edit introduces does not yet exist. Capture that as the fail
 grep -c 'Always stage `.woostack/memory/` changes' skills/woostack-commit/SKILL.md
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: `grep -c 'Always stage `.woostack/memory/` changes' skills/woostack-commit/SKILL.md`
 Expected: FAIL — prints `0` and exits non-zero (marker absent).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 In `skills/woostack-commit/SKILL.md`, insert the carve-out into §4 immediately after the `git add -p <file>` fenced block and before the `Do not stage generated files…` line. Insert exactly:
 
@@ -66,21 +66,21 @@ with:
 Do not stage generated files, secrets, `.env*`, unrelated dirty files, or user work from outside this session — the `.woostack/memory/` rule above is the sole exception to "unrelated dirty files."
 ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -c 'Always stage `.woostack/memory/` changes' skills/woostack-commit/SKILL.md`
 Expected: PASS — prints `1`.
 
-- [ ] **Step 5: Confirm the embedded command is syntactically valid and the exclusion carve-out landed**
+- [x] **Step 5: Confirm the embedded command is syntactically valid and the exclusion carve-out landed**
 
 Run:
 ```bash
 bash -nc '[ -d .woostack/memory ] && git add .woostack/memory/' && echo SYNTAX_OK
-grep -c 'sole exception to "unrelated dirty files"' skills/woostack-commit/SKILL.md
+grep -c 'sole exception to "unrelated dirty files' skills/woostack-commit/SKILL.md
 ```
-Expected: prints `SYNTAX_OK`, then `1`.
+Expected: prints `SYNTAX_OK`, then `1`. (The clause ends `files."` — period inside the closing quote — so the grep pattern omits the trailing `"`.)
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 # first commit in this increment:

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -128,7 +128,23 @@ When a file contains unrelated hunks, use interactive patch staging:
 git add -p <file>
 ```
 
-Do not stage generated files, secrets, `.env*`, unrelated dirty files, or user work from outside this session.
+**Always stage `.woostack/memory/` changes.** Distilled memory notes are session work by
+definition in the woostack loop — never "unrelated dirty files." Stage every non-ignored
+change under `.woostack/memory/` (modifications, additions, and the note deletions distill's
+dedupe makes), folded into the same commit as the code, with no relevance check and no
+stop-and-ask:
+
+```bash
+[ -d .woostack/memory ] && git add .woostack/memory/
+```
+
+Plain `git add` (never `-f`) honors `.gitignore`, so ignored paths such as
+`.woostack/memory/metrics.json` and `*.local.*` are skipped automatically — "unless
+gitignored" needs no `git check-ignore` step. The `[ -d … ]` guard makes this a silent no-op
+outside a woostack repo, where a bare `git add` of an absent path would exit non-zero with
+`fatal: pathspec '.woostack/memory/' did not match any files`.
+
+Do not stage generated files, secrets, `.env*`, unrelated dirty files, or user work from outside this session — the `.woostack/memory/` rule above is the sole exception to "unrelated dirty files."
 
 ### 4.5 Invariant check (advisory)
 


### PR DESCRIPTION
## Goal

`woostack-commit` consistently left `.woostack/memory/` changes out of commits — its step-4 relevance filter treated distilled notes as "unrelated dirty files." This makes the skill always commit non-gitignored memory.

## Summary

- woostack-commit §4: new "Always stage `.woostack/memory/` changes" rule — distilled notes are session work by definition, staged unconditionally (no relevance check, no stop-and-ask), folded into the same commit.
- Mechanism: `[ -d .woostack/memory ] && git add .woostack/memory/`. Plain `git add` honors `.gitignore`, so `metrics.json`/`*.local.*` are skipped automatically — "unless gitignored" with no extra check; deletions are staged too; the `[ -d … ]` guard is a no-op outside a woostack repo.
- The existing exclusion line now names this as the sole exception to "unrelated dirty files."

## Test plan

### Automated

- [x] `grep -c 'Always stage \`.woostack/memory/\` changes' skills/woostack-commit/SKILL.md` → `1` (marker present; was `0` before the edit)
- [x] `bash -nc '[ -d .woostack/memory ] && git add .woostack/memory/'` → `SYNTAX_OK` (embedded command is valid shell)
- [x] `grep -c 'sole exception to "unrelated dirty files' skills/woostack-commit/SKILL.md` → `1` (exclusion carve-out landed)

### Manual

**Before merge**

- [ ] Read the diff — confirm the carve-out is scoped to `.woostack/memory/` and existing exclusions (`.env*`, secrets, generated files) are intact.
- [ ] On a feature branch, dirty a `.woostack/memory/*.md` note and a gitignored `metrics.json`, run `/woostack-commit`, confirm the note is committed and `metrics.json` is not.

Spec: .woostack/specs/2026-06-06-commit-memory-changes.md
