### PR TITLE
fix(woostack-execute): sweep .woostack/memory/ on every handback

### DIFF
--- a/.woostack/plans/2026-06-06-commit-memory-changes.md
+++ b/.woostack/plans/2026-06-06-commit-memory-changes.md
@@ -98,18 +98,18 @@ gt create -m "fix(woostack-commit): always stage .woostack/memory/ unless gitign
 **Files:**
 - Modify: `skills/woostack-execute/SKILL.md` (new subsection after "Terminal state: a reviewed stack"; reference lines in that section and in "When to stop and ask")
 
-- [ ] **Step 1: Write the failing test (verification command)**
+- [x] **Step 1: Write the failing test (verification command)**
 
 ```bash
 grep -c '## Memory sweep on handback' skills/woostack-execute/SKILL.md
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: `grep -c '## Memory sweep on handback' skills/woostack-execute/SKILL.md`
 Expected: FAIL — prints `0` and exits non-zero.
 
-- [ ] **Step 3: Minimal implementation — add the dedicated rule section**
+- [x] **Step 3: Minimal implementation — add the dedicated rule section**
 
 In `skills/woostack-execute/SKILL.md`, insert this new section immediately after the "Terminal state: a reviewed stack" paragraph (the one ending `**Never merge.**`) and before `## When to stop and ask`. Insert exactly:
 
@@ -126,7 +126,7 @@ clean — never create an empty commit. Intermediate increments need nothing ext
 N's distilled memory is swept by increment N+1's commit.
 ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -c '## Memory sweep on handback' skills/woostack-execute/SKILL.md`
 Expected: PASS — prints `1`.
@@ -136,18 +136,18 @@ Expected: PASS — prints `1`.
 **Files:**
 - Modify: `skills/woostack-execute/SKILL.md` ("Terminal state: a reviewed stack" paragraph; "When to stop and ask" section)
 
-- [ ] **Step 1: Write the failing test (verification command)**
+- [x] **Step 1: Write the failing test (verification command)**
 
 ```bash
 grep -c '(#memory-sweep-on-handback)' skills/woostack-execute/SKILL.md
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: `grep -c '(#memory-sweep-on-handback)' skills/woostack-execute/SKILL.md`
 Expected: FAIL — prints `0` (only the heading exists so far; no in-text links to its anchor).
 
-- [ ] **Step 3: Minimal implementation — add the two reference pointers**
+- [x] **Step 3: Minimal implementation — add the two reference pointers**
 
 In the "Terminal state: a reviewed stack" paragraph, replace (exact text, including the line break between `or` and `mode`):
 
@@ -178,12 +178,12 @@ surfacing the stop, so a mid-run distill (e.g. a `woostack-debug` detour) is nev
 Return to the plan-review step if the plan is updated or the approach needs rethinking.
 ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -c '(#memory-sweep-on-handback)' skills/woostack-execute/SKILL.md`
 Expected: PASS — prints `2`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 # first commit in this increment (new branch stacked on Increment 1):
@@ -194,14 +194,14 @@ gt create -m "fix(woostack-execute): sweep .woostack/memory/ on every handback"
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — every spec requirement maps to a task above.
+- [x] **Spec coverage** — every spec requirement maps to a task above.
   - Fix 1 (commit carve-out, guarded `git add`, gitignore-free boundary, deletions staged, no-op when absent) → Increment 1, Task 1.
   - Fix 2 (sweep on any handback — terminal + blocking stops, single rule referenced twice, memory-only commit, no empty commit) → Increment 2, Tasks 1-2.
   - Non-goals (no distill change, no specs/plans staging change, no execute reorder) → not touched by any task. ✓
   - Resolved Open Q1 (no foreign guard) → Increment 1 Step 3 wording "no relevance check and no stop-and-ask". ✓
   - Resolved Open Q2 (any handback) → Increment 2 covers terminal + "When to stop and ask". ✓
-- [ ] **No placeholders** — every step has the exact edit text, exact command, and exact expected output. ✓
-- [ ] **Type consistency** — marker strings are consistent across find/replace and verification greps: ``Always stage `.woostack/memory/` changes`` (Inc 1), `## Memory sweep on handback` and `(#memory-sweep-on-handback)` (Inc 2). ✓
+- [x] **No placeholders** — every step has the exact edit text, exact command, and exact expected output. ✓
+- [x] **Type consistency** — marker strings are consistent across find/replace and verification greps: ``Always stage `.woostack/memory/` changes`` (Inc 1), `## Memory sweep on handback` and `(#memory-sweep-on-handback)` (Inc 2). ✓
 
 > woostack plan conventions (kept):
 > - This file is **frontmatter-free** and **opens with** the `**Source:**` line.

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -125,8 +125,19 @@ Then advance to the next increment.
 Stop when every increment is implemented, checked off, committed, reviewed, and distilled —
 leaving a Graphite stack of reviewed PRs. "Reviewed" is mode-dependent: by `woostack-review
 --fast` in inline mode, and by the per-task spec + quality subagent loops (plus the human's
-post-execution review) in subagent mode. Report the branches/PRs and their review verdicts or
-mode. **Never merge.**
+post-execution review) in subagent mode. Run the [memory sweep on handback](#memory-sweep-on-handback) first, then report the
+branches/PRs and their review verdicts or mode. **Never merge.**
+
+## Memory sweep on handback
+
+Before this skill yields control back **for any reason** — the reviewed-stack terminal state
+above, or any blocking stop in [When to stop and ask](#when-to-stop-and-ask) — sweep any
+distilled memory so it is never stranded. If `.woostack/memory/` has non-ignored uncommitted
+changes, run one final [`woostack-commit`](../woostack-commit/SKILL.md) on the current
+increment's branch; it stages `.woostack/memory/` for you. This is necessarily a memory-only
+commit when the increment's code is already committed and reviewed. Skip it when memory is
+clean — never create an empty commit. Intermediate increments need nothing extra: increment
+N's distilled memory is swept by increment N+1's commit.
 
 ## When to stop and ask
 
@@ -141,6 +152,9 @@ first and escalates to the user only on debug's 3-fixes architectural stop:
   architectural stop. Debug does not commit — execute commits the returned fix in its normal
   per-increment cadence. Applies to both the inline and subagent drivers.
 - A review returns REQUEST_CHANGES — handle the findings before continuing.
+
+On every stop above, run the [memory sweep on handback](#memory-sweep-on-handback) before
+surfacing the stop, so a mid-run distill (e.g. a `woostack-debug` detour) is never stranded.
 
 Return to the plan-review step if the plan is updated or the approach needs rethinking.
 


### PR DESCRIPTION
## Goal

woostack-execute distills memory (cadence step 7) *after* it commits (step 4), so an increment's distilled memory — the last increment's especially — could be left uncommitted. This guarantees pending memory is committed before execute ever hands control back.

## Summary

- New "Memory sweep on handback" section in woostack-execute: before yielding control **for any reason** (clean terminal state OR a blocking stop — REQUEST_CHANGES, blocker, woostack-debug architectural stop), commit pending non-ignored `.woostack/memory/` via `woostack-commit` on the current branch.
- Necessarily a memory-only commit (code already committed/reviewed); skipped when memory is clean (no empty commit); intermediate increments are swept by the next increment's commit.
- Referenced from both the "Terminal state" paragraph and the "When to stop and ask" section via the `#memory-sweep-on-handback` anchor — one rule, two pointers.
- Depends on #239 (the sweep invokes `woostack-commit`, which now stages `.woostack/memory/`).

## Test plan

### Automated

- [x] `grep -c '## Memory sweep on handback' skills/woostack-execute/SKILL.md` → `1` (rule section added; was `0`)
- [x] `grep -c '(#memory-sweep-on-handback)' skills/woostack-execute/SKILL.md` → `2` (both reference pointers added; was `0`)

### Manual

**Before merge**

- [ ] Read the diff — confirm the rule fires on any handback (terminal + blocking stops), is a memory-only commit, and skips when clean.
- [ ] Run `woostack-execute` to terminal state on a multi-increment plan; confirm the final increment's distilled memory lands in a commit rather than being left dirty.

Spec: .woostack/specs/2026-06-06-commit-memory-changes.md
