### PR TITLE
feat(woostack-review): add verify-receipts.sh execution gate + tests

### DIFF
--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 4
+recall_count: 5
 last_recalled: 2026-06-06
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 2
+recall_count: 4
 last_recalled: 2026-06-06
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/review-add-angle-sites.md
+++ b/.woostack/memory/review-add-angle-sites.md
@@ -6,7 +6,7 @@ tags: angle, detect-angles, _header, load-config, anthropic, enumeration, add-an
 hook: Adding a woostack-review angle touches 11 sites — the easy-to-miss four are load-config VALID_ANGLES, the anthropic.md tier list, the _header footer whitelist, and the committed gating test.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 2
+recall_count: 3
 last_recalled: 2026-06-06
 ---
 Registering an angle so it is **fully** wired (runs, is config-addressable, renders its

--- a/.woostack/memory/review-add-angle-sites.md
+++ b/.woostack/memory/review-add-angle-sites.md
@@ -6,7 +6,8 @@ tags: angle, detect-angles, _header, load-config, anthropic, enumeration, add-an
 hook: Adding a woostack-review angle touches 11 sites — the easy-to-miss four are load-config VALID_ANGLES, the anthropic.md tier list, the _header footer whitelist, and the committed gating test.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 0
+recall_count: 2
+last_recalled: 2026-06-06
 ---
 Registering an angle so it is **fully** wired (runs, is config-addressable, renders its
 footer, routes to the right model, and is tested) touches **eleven** sites. Touch fewer and

--- a/.woostack/memory/review-angle-trigger-precision.md
+++ b/.woostack/memory/review-angle-trigger-precision.md
@@ -6,7 +6,8 @@ tags: detect-angles, angle, trigger, diff-gated, enrichment, tier, observability
 hook: Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also matches the new pattern — and never broaden a trigger on a common token.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 0
+recall_count: 2
+last_recalled: 2026-06-06
 ---
 Most review angles are **diff-gated**: `detect-angles.sh` decides whether the angle
 runs at all by grepping the diff for trigger tokens (`has_<angle>_diff_token()` /

--- a/.woostack/memory/review-angle-trigger-precision.md
+++ b/.woostack/memory/review-angle-trigger-precision.md
@@ -6,7 +6,7 @@ tags: detect-angles, angle, trigger, diff-gated, enrichment, tier, observability
 hook: Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also matches the new pattern — and never broaden a trigger on a common token.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 2
+recall_count: 3
 last_recalled: 2026-06-06
 ---
 Most review angles are **diff-gated**: `detect-angles.sh` decides whether the angle

--- a/.woostack/memory/review-config-bool-jq-default.md
+++ b/.woostack/memory/review-config-bool-jq-default.md
@@ -6,8 +6,8 @@ tags: jq, config, boolean, defaults, intersect-findings, load-config
 hook: jq `// default` silently coerces an explicit `false` to the default — wrong for any default-TRUE config bool.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-review-nit-comments.md
-recall_count: 4
-last_recalled: 2026-06-05
+recall_count: 6
+last_recalled: 2026-06-06
 ---
 jq's `//` is the *alternative* operator: it returns the right-hand side when the
 left is `null` **or** `false`. So `jq -r '.key // true'` returns `true` for an

--- a/.woostack/memory/review-config-bool-jq-default.md
+++ b/.woostack/memory/review-config-bool-jq-default.md
@@ -6,7 +6,7 @@ tags: jq, config, boolean, defaults, intersect-findings, load-config
 hook: jq `// default` silently coerces an explicit `false` to the default — wrong for any default-TRUE config bool.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-review-nit-comments.md
-recall_count: 6
+recall_count: 7
 last_recalled: 2026-06-06
 ---
 jq's `//` is the *alternative* operator: it returns the right-hand side when the

--- a/.woostack/memory/review-prompt-self-contained-blob.md
+++ b/.woostack/memory/review-prompt-self-contained-blob.md
@@ -6,7 +6,7 @@ tags: load-prompt, _header, ci-prompt, inline, cross-reference, model-tiers
 hook: woostack-review prompts ship as ONE self-contained blob to CI runners that follow no markdown links — shared content must be inlined, not just linked.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-execute-vary-subagent-model.md
-recall_count: 4
+recall_count: 5
 last_recalled: 2026-06-06
 ---
 `load-prompt.sh` concatenates `_header.md` + the provider body into a single

--- a/.woostack/memory/review-prompt-self-contained-blob.md
+++ b/.woostack/memory/review-prompt-self-contained-blob.md
@@ -6,8 +6,8 @@ tags: load-prompt, _header, ci-prompt, inline, cross-reference, model-tiers
 hook: woostack-review prompts ship as ONE self-contained blob to CI runners that follow no markdown links — shared content must be inlined, not just linked.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-execute-vary-subagent-model.md
-recall_count: 2
-last_recalled: 2026-06-05
+recall_count: 4
+last_recalled: 2026-06-06
 ---
 `load-prompt.sh` concatenates `_header.md` + the provider body into a single
 prompt string handed to external runners (`claude-code-action`, `codex-action`,

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 13
+recall_count: 14
 last_recalled: 2026-06-06
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 11
+recall_count: 13
 last_recalled: 2026-06-06
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/skill-test-assert-ascii-token.md
+++ b/.woostack/memory/skill-test-assert-ascii-token.md
@@ -6,7 +6,7 @@ tags: tests, grep, assertions, encoding, ascii, unicode
 hook: Grep-based skill tests should assert an ASCII token, not a unicode literal (e.g. a → arrow); keep the readable unicode in the prose and assert on an ASCII phrase that lives in the same text.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
-recall_count: 6
+recall_count: 7
 last_recalled: 2026-06-06
 ---
 woostack skills are documentation; their `scripts/tests/*.sh` guards are `rg -F`/`grep`

--- a/.woostack/memory/skill-test-assert-ascii-token.md
+++ b/.woostack/memory/skill-test-assert-ascii-token.md
@@ -6,7 +6,7 @@ tags: tests, grep, assertions, encoding, ascii, unicode
 hook: Grep-based skill tests should assert an ASCII token, not a unicode literal (e.g. a → arrow); keep the readable unicode in the prose and assert on an ASCII phrase that lives in the same text.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
-recall_count: 4
+recall_count: 6
 last_recalled: 2026-06-06
 ---
 woostack skills are documentation; their `scripts/tests/*.sh` guards are `rg -F`/`grep`

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 23
+recall_count: 24
 last_recalled: 2026-06-06
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 21
+recall_count: 23
 last_recalled: 2026-06-06
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 47
+recall_count: 49
 last_recalled: 2026-06-06
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 49
+recall_count: 50
 last_recalled: 2026-06-06
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
+++ b/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
@@ -24,7 +24,7 @@
 - Create: `skills/woostack-review/scripts/verify-receipts.sh`
 - Test: `skills/woostack-review/scripts/tests/test-verify-receipts-pass.sh`
 
-- [ ] **Step 1: Write the failing test** (happy path: all receipts valid → exit 0, metrics recorded)
+- [x] **Step 1: Write the failing test** (happy path: all receipts valid → exit 0, metrics recorded)
 
 Create `skills/woostack-review/scripts/tests/test-verify-receipts-pass.sh`:
 
@@ -51,12 +51,12 @@ assert_eq "$(jq -r '.expected_total' "$OUTDIR/swarm-metrics.json")" "2" "metrics
 finish
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `bash skills/woostack-review/scripts/tests/test-verify-receipts-pass.sh`
 Expected: FAIL — script missing, e.g. `bash: .../verify-receipts.sh: No such file or directory`, non-zero exit.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Create `skills/woostack-review/scripts/verify-receipts.sh`:
 
@@ -167,7 +167,7 @@ fi
 if [ "${#missing[@]}" -gt 0 ]; then
   miss_csv="$(IFS=', '; echo "${missing[*]}")"
   if [ "${#executed[@]}" -eq 0 ]; then
-    echo "::error::woostack-review: no angle analysis executed (0 of ${expected_total} angle workers produced a valid receipt). The review did NOT run. Configure a provider/model, install auth, or set the correct runner override, then re-run." >&2
+    echo "::error::woostack-review: no angle analysis executed (0 of ${expected_total} angle workers produced a valid receipt): ${miss_csv}. The review did NOT run. Configure a provider/model, install auth, or set the correct runner override, then re-run." >&2
   else
     echo "::error::woostack-review: ${#missing[@]} of ${expected_total} angle worker(s) did not execute (no valid receipt): ${miss_csv}. No angle analysis ran for these, so the review is NOT complete. Configure a provider/model, install auth, or set the correct runner override, then re-run." >&2
   fi
@@ -177,17 +177,17 @@ fi
 echo "verify-receipts: all ${expected_total} angle receipt(s) valid."
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `bash skills/woostack-review/scripts/tests/test-verify-receipts-pass.sh`
 Expected: PASS — `  3 passed, 0 failed`
 
-- [ ] **Step 5: Syntax-check the script**
+- [x] **Step 5: Syntax-check the script**
 
 Run: `bash -n skills/woostack-review/scripts/verify-receipts.sh && echo OK`
 Expected: `OK`
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 # first commit in this increment:
@@ -201,7 +201,7 @@ gt create -m "feat(woostack-review): add verify-receipts.sh execution gate"
 - Test: `skills/woostack-review/scripts/tests/test-verify-receipts-none.sh`
 - Test: `skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Create `skills/woostack-review/scripts/tests/test-verify-receipts-missing.sh`:
 
@@ -280,7 +280,7 @@ assert_exit 1 "$rc" "empty runner → invalid receipt → exit 1"
 finish
 ```
 
-- [ ] **Step 2: Run the tests, confirm they pass** (script already exists from Task 1)
+- [x] **Step 2: Run the tests, confirm they pass** (script already exists from Task 1)
 
 Run:
 ```bash
@@ -290,7 +290,7 @@ bash skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh
 ```
 Expected: each prints `  N passed, 0 failed` and exits 0 (`4 passed`, `2 passed`, `3 passed` respectively).
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 gt modify -c -m "test(woostack-review): cover verify-receipts missing/none/identity paths"
@@ -302,7 +302,7 @@ gt modify -c -m "test(woostack-review): cover verify-receipts missing/none/ident
 - Test: `skills/woostack-review/scripts/tests/test-verify-receipts-list-missing.sh`
 - Test: `skills/woostack-review/scripts/tests/test-verify-receipts-chunked.sh`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Create `skills/woostack-review/scripts/tests/test-verify-receipts-list-missing.sh`:
 
@@ -358,7 +358,7 @@ assert_exit 0 "$rc" "all chunk receipts valid → exit 0"
 finish
 ```
 
-- [ ] **Step 2: Run the tests, confirm they pass**
+- [x] **Step 2: Run the tests, confirm they pass**
 
 Run:
 ```bash
@@ -367,7 +367,7 @@ bash skills/woostack-review/scripts/tests/test-verify-receipts-chunked.sh
 ```
 Expected: `  4 passed, 0 failed` and `  3 passed, 0 failed`.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 gt modify -c -m "test(woostack-review): cover verify-receipts list-missing + chunked"

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-chunked.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-chunked.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+printf '%s\n' bugs > "$OUTDIR/angles.txt"
+printf '%s\n' chunk-0 chunk-1 > "$OUTDIR/chunks.txt"
+# chunk-0 executed, chunk-1 missing.
+printf '{"angle":"bugs","chunk":"chunk-0","runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.chunk-0.json"
+
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "missing (angle,chunk) receipt → exit 1"
+assert_contains "$err" "bugs.chunk-1" "names the missing angle.chunk"
+
+# Add the missing chunk receipt → now passes.
+printf '{"angle":"bugs","chunk":"chunk-1","runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.chunk-1.json"
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "all chunk receipts valid → exit 0"
+finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-chunked.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-chunked.sh
@@ -21,4 +21,9 @@ assert_contains "$err" "bugs.chunk-1" "names the missing angle.chunk"
 printf '{"angle":"bugs","chunk":"chunk-1","runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.chunk-1.json"
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
 assert_exit 0 "$rc" "all chunk receipts valid → exit 0"
+# Verify the chunked arithmetic: expected_total = 1 angle x 2 chunks, and both
+# (angle,chunk) pairs are recorded as executed. This is the only multiplication
+# path in the script and the only place the dotted label set is counted.
+assert_eq "$(jq -r '.expected_total' "$OUTDIR/swarm-metrics.json")" "2" "expected_total = 1 angle x 2 chunks"
+assert_eq "$(jq -r '.executed_angles | length' "$OUTDIR/swarm-metrics.json")" "2" "both (angle,chunk) pairs recorded as executed"
 finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+printf '%s\n' bugs > "$OUTDIR/angles.txt"
+# Receipt file present + valid JSON object + matching angle, but model is empty.
+printf '{"angle":"bugs","chunk":null,"runner":"claude-code","model":"","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "empty model → invalid receipt → exit 1"
+assert_contains "$err" "bugs" "names the angle whose identity is incomplete"
+
+# Empty runner is likewise invalid.
+printf '{"angle":"bugs","chunk":null,"runner":"","model":"m","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 1 "$rc" "empty runner → invalid receipt → exit 1"
+finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh
@@ -16,8 +16,11 @@ rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
 assert_exit 1 "$rc" "empty model → invalid receipt → exit 1"
 assert_contains "$err" "bugs" "names the angle whose identity is incomplete"
 
-# Empty runner is likewise invalid.
+# Empty runner is likewise invalid. Capture stderr and assert the error names the
+# angle, mirroring the empty-model sub-case — a silent or mis-named error path
+# would otherwise pass this check.
 printf '{"angle":"bugs","chunk":null,"runner":"","model":"m","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
 assert_exit 1 "$rc" "empty runner → invalid receipt → exit 1"
+assert_contains "$err" "bugs" "names the angle whose identity is incomplete"
 finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-list-missing.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-list-missing.sh
@@ -17,4 +17,17 @@ assert_exit 0 "$rc" "--list-missing exits 0 (non-failing)"
 assert_contains "$out" "security" "lists missing security"
 assert_contains "$out" "types" "lists missing types"
 assert_not_contains "$out" "bugs" "valid receipt not listed as missing"
+
+# Scenario 2: under chunking, missing labels take the dotted <angle>.<chunk>
+# form. --list-missing shares the same missing[] array as gate mode, so the
+# chunked label format must surface here too.
+export OUTDIR="$work/out2"; mkdir -p "$OUTDIR"
+printf '%s\n' bugs > "$OUTDIR/angles.txt"
+printf '%s\n' chunk-0 chunk-1 > "$OUTDIR/chunks.txt"
+printf '{"angle":"bugs","chunk":"chunk-0","runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.chunk-0.json"
+# bugs.chunk-1 missing.
+rc=0; out="$(bash "$SCRIPT" --list-missing)" || rc=$?
+assert_exit 0 "$rc" "--list-missing exits 0 under chunking"
+assert_contains "$out" "bugs.chunk-1" "lists missing dotted <angle>.<chunk> label"
+assert_not_contains "$out" "bugs.chunk-0" "present chunk receipt not listed as missing"
 finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-list-missing.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-list-missing.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+printf '%s\n' bugs security types > "$OUTDIR/angles.txt"
+printf '{"angle":"bugs","chunk":null,"runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.json"
+# security + types missing.
+
+rc=0; out="$(bash "$SCRIPT" --list-missing)" || rc=$?
+assert_exit 0 "$rc" "--list-missing exits 0 (non-failing)"
+assert_contains "$out" "security" "lists missing security"
+assert_contains "$out" "types" "lists missing types"
+assert_not_contains "$out" "bugs" "valid receipt not listed as missing"
+finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-missing.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-missing.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+printf '%s\n' bugs security types > "$OUTDIR/angles.txt"
+# bugs + security executed; types produced NO receipt.
+for a in bugs security; do
+  printf '{"angle":"%s","chunk":null,"runner":"claude-code","model":"m","tier":"standard","ts":"t"}\n' "$a" > "$OUTDIR/receipt.$a.json"
+done
+
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "missing receipt → exit 1"
+assert_contains "$err" "did not execute" "error states workers did not execute"
+assert_contains "$err" "types" "error names the non-executing angle"
+assert_not_contains "$err" "no angle analysis executed" "partial failure uses the partial message"
+finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-none.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-none.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+printf '%s\n' bugs security > "$OUTDIR/angles.txt"
+# No receipts at all.
+
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "zero receipts → exit 1"
+assert_contains "$err" "no angle analysis executed" "zero-receipt message fires"
+finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-pass.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-pass.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+printf '%s\n' bugs security > "$OUTDIR/angles.txt"
+for a in bugs security; do
+  printf '{"angle":"%s","chunk":null,"runner":"claude-code","model":"claude-sonnet-4-6","tier":"standard","ts":"2026-06-06T00:00:00Z"}\n' "$a" > "$OUTDIR/receipt.$a.json"
+done
+
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "all receipts valid → exit 0"
+assert_eq "$(jq -r '.executed_angles | length' "$OUTDIR/swarm-metrics.json")" "2" "metrics record 2 executed angles"
+assert_eq "$(jq -r '.expected_total' "$OUTDIR/swarm-metrics.json")" "2" "metrics record expected total"
+finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-wrong-angle.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-wrong-angle.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+printf '%s\n' bugs > "$OUTDIR/angles.txt"
+# Receipt is present, valid JSON, non-empty runner/model — but its .angle field
+# says "security" while it occupies the bugs slot. The is_valid_receipt
+# `.angle == $a` guard must reject it (a worker writing the wrong angle label is
+# a realistic failure mode and exercises a distinct jq branch).
+printf '{"angle":"security","chunk":null,"runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.json"
+
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "mismatched .angle field → invalid receipt → exit 1"
+assert_contains "$err" "bugs" "names the angle whose receipt is invalid"
+finish

--- a/skills/woostack-review/scripts/verify-receipts.sh
+++ b/skills/woostack-review/scripts/verify-receipts.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Postflight gate: assert every expected angle (from angles.txt × chunks.txt) wrote
+# a VALID execution receipt. A valid receipt is a JSON object whose `angle` (and
+# `chunk`, when chunking is active) matches and whose `runner` and `model` are both
+# non-empty. This is the single authority on "did the angle worker actually execute":
+# empty findings are an honest clean review ONLY when the receipt proves the worker ran.
+#
+# Modes:
+#   (default)       gate: emit ::error and exit 1 if any expected receipt is missing/invalid.
+#   --list-missing  print the missing/invalid "<angle>" or "<angle>.<chunk>" labels, exit 0.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=skills/woostack-review/scripts/resolve-outdir.sh
+source "$SCRIPT_DIR/resolve-outdir.sh"
+
+mode="gate"
+case "${1:-}" in
+  --list-missing) mode="list" ;;
+  "") ;;
+  -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+  *) echo "::error::unknown argument: $1" >&2; exit 2 ;;
+esac
+
+angles_file="$OUTDIR/angles.txt"
+if [ ! -s "$angles_file" ]; then
+  echo "::error::missing or empty angles file: $angles_file" >&2
+  exit 2
+fi
+
+angles=()
+while IFS= read -r a; do [ -n "$a" ] && angles+=("$a"); done < "$angles_file"
+if [ "${#angles[@]}" -eq 0 ]; then
+  echo "::error::no angles found in $angles_file" >&2
+  exit 2
+fi
+
+chunks=("")
+chunks_file="$OUTDIR/chunks.txt"
+if [ -s "$chunks_file" ]; then
+  chunks=()
+  while IFS= read -r c; do [ -n "$c" ] && chunks+=("$c"); done < "$chunks_file"
+  [ "${#chunks[@]}" -eq 0 ] && chunks=("")
+fi
+
+receipt_path() { # angle chunk
+  if [ -n "$2" ]; then printf '%s/receipt.%s.%s.json' "$OUTDIR" "$1" "$2"
+  else printf '%s/receipt.%s.json' "$OUTDIR" "$1"; fi
+}
+label() { # angle chunk
+  if [ -n "$2" ]; then printf '%s.%s' "$1" "$2"; else printf '%s' "$1"; fi
+}
+
+# Valid iff: JSON object; .angle == angle; (.chunk matches, or both empty/null);
+# .runner and .model are non-empty.
+is_valid_receipt() { # angle chunk file
+  local angle="$1" chunk="$2" f="$3"
+  [ -s "$f" ] || return 1
+  jq -e --arg a "$angle" --arg c "$chunk" '
+    (type == "object")
+    and (.angle == $a)
+    and ( (($c == "") and ((.chunk == null) or (.chunk == ""))) or (.chunk == $c) )
+    and (((.runner // "") | tostring | length) > 0)
+    and (((.model  // "") | tostring | length) > 0)
+  ' "$f" >/dev/null 2>&1
+}
+
+missing=()
+executed=()
+for angle in "${angles[@]}"; do
+  for chunk in "${chunks[@]}"; do
+    f="$(receipt_path "$angle" "$chunk")"
+    if is_valid_receipt "$angle" "$chunk" "$f"; then
+      executed+=("$(label "$angle" "$chunk")")
+    else
+      missing+=("$(label "$angle" "$chunk")")
+    fi
+  done
+done
+
+if [ "$mode" = "list" ]; then
+  for m in ${missing[@]+"${missing[@]}"}; do printf '%s\n' "$m"; done
+  exit 0
+fi
+
+# Gate mode: record executed/expected/missing into swarm-metrics.json (best-effort).
+expected_total=$(( ${#angles[@]} * ${#chunks[@]} ))
+metrics="$OUTDIR/swarm-metrics.json"
+to_json_array() { # items...
+  if [ "$#" -eq 0 ]; then printf '[]'; return; fi
+  printf '%s\n' "$@" | jq -R . | jq -s .
+}
+exec_json="$(to_json_array ${executed[@]+"${executed[@]}"})"
+miss_json="$(to_json_array ${missing[@]+"${missing[@]}"})"
+if [ -s "$metrics" ] && jq -e . "$metrics" >/dev/null 2>&1; then
+  tmp="$(mktemp)"
+  jq --argjson ex "$exec_json" --argjson mi "$miss_json" --argjson et "$expected_total" \
+    '.executed_angles=$ex | .expected_total=$et | .missing_receipts=$mi' "$metrics" > "$tmp" && mv "$tmp" "$metrics"
+else
+  jq -n --argjson ex "$exec_json" --argjson mi "$miss_json" --argjson et "$expected_total" \
+    '{schema_version:1, executed_angles:$ex, expected_total:$et, missing_receipts:$mi}' > "$metrics"
+fi
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  miss_csv="$(IFS=', '; echo "${missing[*]}")"
+  if [ "${#executed[@]}" -eq 0 ]; then
+    echo "::error::woostack-review: no angle analysis executed (0 of ${expected_total} angle workers produced a valid receipt): ${miss_csv}. The review did NOT run. Configure a provider/model, install auth, or set the correct runner override, then re-run." >&2
+  else
+    echo "::error::woostack-review: ${#missing[@]} of ${expected_total} angle worker(s) did not execute (no valid receipt): ${miss_csv}. No angle analysis ran for these, so the review is NOT complete. Configure a provider/model, install auth, or set the correct runner override, then re-run." >&2
+  fi
+  exit 1
+fi
+
+echo "verify-receipts: all ${expected_total} angle receipt(s) valid."


### PR DESCRIPTION
## Goal

Increment 1 of [#237](https://github.com/howarewoo/woostack/issues/237): add the standalone receipt gate that proves an angle worker actually executed. Inert on its own — nothing calls it yet — so it ships with zero behavior change.

## Summary

- New `skills/woostack-review/scripts/verify-receipts.sh` — the single authority on "did this angle execute". Valid receipt = JSON object, matching `angle`/`chunk`, non-empty `runner`+`model`. Default mode hard-fails (`::error` + exit 1) when any expected angle (from `angles.txt` × `chunks.txt`) lacks a valid receipt; `--list-missing` prints the missing labels and exits 0 (for the swarm's retry set).
- Records `executed_angles` / `expected_total` / `missing_receipts` into `swarm-metrics.json` (best-effort).
- 6 shell tests: pass, missing, none (zero receipts), identity (empty runner/model), list-missing, chunked.

## Test plan

### Automated

- [x] `test-verify-receipts-{pass,missing,none,identity,list-missing,chunked}.sh` — all green (3/4/2/3/4/3 assertions).
- [x] `bash -n verify-receipts.sh` — OK.

### Manual

**Before merge**

- [ ] Read `verify-receipts.sh` — confirm the valid-receipt contract (object + angle/chunk match + non-empty runner/model) and the two error messages (partial vs zero-executed) are right.

Spec: .woostack/specs/2026-06-06-review-fail-fast-receipts.md
