### PR TITLE
feat(woostack-review): hard-fail the bounded swarm + orchestrator on missing receipts

### DIFF
--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 5
+recall_count: 6
 last_recalled: 2026-06-06
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/review-add-angle-sites.md
+++ b/.woostack/memory/review-add-angle-sites.md
@@ -6,7 +6,7 @@ tags: angle, detect-angles, _header, load-config, anthropic, enumeration, add-an
 hook: Adding a woostack-review angle touches 11 sites — the easy-to-miss four are load-config VALID_ANGLES, the anthropic.md tier list, the _header footer whitelist, and the committed gating test.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 3
+recall_count: 4
 last_recalled: 2026-06-06
 ---
 Registering an angle so it is **fully** wired (runs, is config-addressable, renders its

--- a/.woostack/memory/review-angle-trigger-precision.md
+++ b/.woostack/memory/review-angle-trigger-precision.md
@@ -6,7 +6,7 @@ tags: detect-angles, angle, trigger, diff-gated, enrichment, tier, observability
 hook: Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also matches the new pattern — and never broaden a trigger on a common token.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 3
+recall_count: 4
 last_recalled: 2026-06-06
 ---
 Most review angles are **diff-gated**: `detect-angles.sh` decides whether the angle

--- a/.woostack/memory/review-config-bool-jq-default.md
+++ b/.woostack/memory/review-config-bool-jq-default.md
@@ -6,7 +6,7 @@ tags: jq, config, boolean, defaults, intersect-findings, load-config
 hook: jq `// default` silently coerces an explicit `false` to the default — wrong for any default-TRUE config bool.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-review-nit-comments.md
-recall_count: 7
+recall_count: 8
 last_recalled: 2026-06-06
 ---
 jq's `//` is the *alternative* operator: it returns the right-hand side when the

--- a/.woostack/memory/review-prompt-self-contained-blob.md
+++ b/.woostack/memory/review-prompt-self-contained-blob.md
@@ -6,7 +6,7 @@ tags: load-prompt, _header, ci-prompt, inline, cross-reference, model-tiers
 hook: woostack-review prompts ship as ONE self-contained blob to CI runners that follow no markdown links — shared content must be inlined, not just linked.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-execute-vary-subagent-model.md
-recall_count: 5
+recall_count: 6
 last_recalled: 2026-06-06
 ---
 `load-prompt.sh` concatenates `_header.md` + the provider body into a single

--- a/.woostack/memory/skill-description-angle-bracket-placeholders.md
+++ b/.woostack/memory/skill-description-angle-bracket-placeholders.md
@@ -6,6 +6,8 @@ tags: skill-description, frontmatter, review, skills-angle, false-positive, plac
 hook: Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are an accepted, shipped convention here — not an XML/HTML defect; the review `skills` angle must not flag them.
 updated: 2026-06-06
 source: pr-232
+recall_count: 1
+last_recalled: 2026-06-06
 ---
 Angle-bracket usage placeholders in a `SKILL.md` `description:` field — e.g.
 `/woostack-execute-overnight <plan-path> [--inline|--subagent]` — are an

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 14
+recall_count: 15
 last_recalled: 2026-06-06
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/skill-test-assert-ascii-token.md
+++ b/.woostack/memory/skill-test-assert-ascii-token.md
@@ -6,7 +6,7 @@ tags: tests, grep, assertions, encoding, ascii, unicode
 hook: Grep-based skill tests should assert an ASCII token, not a unicode literal (e.g. a → arrow); keep the readable unicode in the prose and assert on an ASCII phrase that lives in the same text.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
-recall_count: 7
+recall_count: 8
 last_recalled: 2026-06-06
 ---
 woostack skills are documentation; their `scripts/tests/*.sh` guards are `rg -F`/`grep`

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 24
+recall_count: 25
 last_recalled: 2026-06-06
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 50
+recall_count: 51
 last_recalled: 2026-06-06
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
+++ b/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
@@ -472,7 +472,7 @@ gt modify -c -m "docs(woostack-review): add receipt write to the Stage 3 sub-age
 **Files:**
 - Modify: `skills/woostack-review/scripts/run-bounded-swarm.sh` (retry computation ~lines 188-220; tail)
 
-- [ ] **Step 1: Write the failing test** (worker writes findings but no receipt → swarm hard-fails after retry)
+- [x] **Step 1: Write the failing test** (worker writes findings but no receipt → swarm hard-fails after retry)
 
 Create `skills/woostack-review/scripts/tests/test-bounded-swarm-receipts.sh`:
 
@@ -519,12 +519,12 @@ rm -rf "$work2"
 finish
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `bash skills/woostack-review/scripts/tests/test-bounded-swarm-receipts.sh`
 Expected: FAIL — Case A still exits 0 today (no gate), so `assert_exit 1` fails: `FAIL: missing receipts → swarm exits non-zero (expected exit 1, got 0)`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 In `skills/woostack-review/scripts/run-bounded-swarm.sh`, replace the first-pass-failed computation block (currently):
 
@@ -579,17 +579,17 @@ bash "$SCRIPT_DIR/verify-receipts.sh"
 
 (`set -euo pipefail` at the top propagates `verify-receipts.sh`'s non-zero exit as the swarm's exit code.)
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `bash skills/woostack-review/scripts/tests/test-bounded-swarm-receipts.sh`
 Expected: PASS — `  3 passed, 0 failed`
 
-- [ ] **Step 5: Syntax-check**
+- [x] **Step 5: Syntax-check**
 
 Run: `bash -n skills/woostack-review/scripts/run-bounded-swarm.sh && echo OK`
 Expected: `OK`
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 gt create -m "feat(woostack-review): hard-fail the bounded swarm on missing angle receipts"
@@ -600,12 +600,12 @@ gt create -m "feat(woostack-review): hard-fail the bounded swarm on missing angl
 **Files:**
 - Modify: `skills/woostack-review/scripts/tests/test-bounded-swarm.sh` (three inline worker heredocs)
 
-- [ ] **Step 1: Confirm the existing test now fails under the gate**
+- [x] **Step 1: Confirm the existing test now fails under the gate**
 
 Run: `bash skills/woostack-review/scripts/tests/test-bounded-swarm.sh`
 Expected: FAIL — the worker stubs write no receipts, so `run-bounded-swarm.sh` now exits non-zero at the first invocation (test line ~80), aborting under `set -e` before assertions (e.g. an error like `::error::woostack-review: … did not execute …` and a non-zero test exit).
 
-- [ ] **Step 2: Make the stubs write receipts**
+- [x] **Step 2: Make the stubs write receipts**
 
 In the FIRST worker heredoc (the `case "$WOO_REVIEW_ANGLE"` stub), add a receipt write for every angle. Replace the `case … esac` block:
 
@@ -691,12 +691,12 @@ printf '[]\n' > "$OUTDIR/findings.$WOO_REVIEW_ANGLE.$WOO_REVIEW_CHUNK.json"
 printf '{"angle":"%s","chunk":"%s","runner":"test","model":"test-model","tier":"standard","ts":"t"}\n' "$WOO_REVIEW_ANGLE" "$WOO_REVIEW_CHUNK" > "$OUTDIR/receipt.$WOO_REVIEW_ANGLE.$WOO_REVIEW_CHUNK.json"
 ```
 
-- [ ] **Step 3: Run the test, confirm it passes** (degraded/findings assertions intact; gate satisfied)
+- [x] **Step 3: Run the test, confirm it passes** (degraded/findings assertions intact; gate satisfied)
 
 Run: `bash skills/woostack-review/scripts/tests/test-bounded-swarm.sh`
 Expected: PASS — `  N passed, 0 failed` (all existing assertions, e.g. `degraded` is `true` for the `docs` findings case while the swarm still exits 0 because every angle wrote a receipt).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "test(woostack-review): swarm stubs write receipts; degraded path intact"
@@ -707,12 +707,12 @@ gt modify -c -m "test(woostack-review): swarm stubs write receipts; degraded pat
 **Files:**
 - Modify: `skills/woostack-review/SKILL.md` (Stage 3 bounded contract ~lines 284-292; after-swarm orchestration; Stage 2→3 boundary)
 
-- [ ] **Step 1: Verification baseline**
+- [x] **Step 1: Verification baseline**
 
 Run: `grep -c "verify-receipts.sh" skills/woostack-review/SKILL.md`
 Expected: `0`
 
-- [ ] **Step 2: Add the orchestrator gate after the swarm**
+- [x] **Step 2: Add the orchestrator gate after the swarm**
 
 In `skills/woostack-review/SKILL.md`, at the END of the Stage 3 section (immediately before the `### Stage 4 — Merge + Adversarial Validation` heading), add:
 
@@ -733,7 +733,7 @@ means that angle never ran, so an empty `findings.json` would be a false clean P
 both PR and local-no-PR modes.
 ```
 
-- [ ] **Step 3: Update bounded-contract step 6 + add the Stage 2→3 preflight note**
+- [x] **Step 3: Update bounded-contract step 6 + add the Stage 2→3 preflight note**
 
 In the bounded-execution numbered list, replace the step:
 
@@ -756,7 +756,7 @@ actionable error — do not dispatch a swarm that will produce no receipts and t
 gate. In the GitHub Action, `detect-provider.sh` performs the equivalent provider/runner preflight.
 ```
 
-- [ ] **Step 4: Confirm all three edits landed**
+- [x] **Step 4: Confirm all three edits landed**
 
 Run:
 ```bash
@@ -766,7 +766,7 @@ grep -q 'Preflight (local)' skills/woostack-review/SKILL.md && echo OK3
 ```
 Expected: `OK1`, `OK2`, `OK3`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs(woostack-review): orchestrator receipt gate + local preflight in SKILL"

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -281,6 +281,8 @@ Boundary precedence: workspace packages (`packages/<name>/`, `apps/<name>/`, `se
 
 **This is the local swarm step.** Local hosts MUST use bounded execution by default whenever more than one angle or `(angle, chunk)` pair is detected. The default concurrency limit is `6`, because several local hosts can spawn parallel sub-agents but cap active workers below the detected angle count. Set max concurrency to `1` for the sequential fallback.
 
+**Preflight (local).** Before dispatching workers, confirm your host can actually run review sub-agents (its `Task`/sub-agent primitive is available). If it cannot, stop now with an actionable error — do not dispatch a swarm that will produce no receipts and then hard-fail the gate. In the GitHub Action, `detect-provider.sh` performs the equivalent provider/runner preflight.
+
 Bounded execution means:
 
 1. read the expected work items from `$OUTDIR/angles.txt` and, when chunking is active, `$OUTDIR/chunks.txt`;
@@ -288,7 +290,7 @@ Bounded execution means:
 3. run at most `N` workers at once;
 4. drain the full first-pass queue;
 5. retry missing, empty, invalid-JSON, or non-array artifacts once after the queue drains;
-6. reset still-invalid artifacts to `[]`;
+6. reset still-invalid *findings* artifacts to `[]`, but treat a missing/invalid *receipt* as a worker that did not execute — after one retry, a still-missing receipt aborts the run (receipts are never pre-initialized; their presence is the proof of execution);
 7. write `$OUTDIR/swarm-metrics.json` so the summary can disclose bounded mode and degraded coverage.
 
 For unchunked reviews, the expected artifact is `$OUTDIR/findings.<angle>.json`. For chunked reviews, the expected artifact is `$OUTDIR/findings.<angle>.<chunk_id>.json`.
@@ -372,6 +374,14 @@ Per-provider resolution (full table in `_header.md`):
 - **Single model per session** (Codex Action, Gemini CLI): pin the run to a resolved run-tier (`fast` or `deep` via `FORCE_TIER`, otherwise `standard`). `tier:` becomes informational once the run tier resolves. Split into multiple jobs if you want per-angle fast/deep split behavior.
 
 Bounded runners MUST preserve the resolved tier/model context for every queued worker. In single-model hosts, pass the resolved run-tier (`FORCE_TIER` when set, otherwise the host's standard tier) to every worker. In per-call-routing hosts, apply each angle prompt's `tier:` while still preserving any explicit `FORCE_TIER` override. Bounded scheduling must not cause later queued angles to fall back to default model settings.
+
+**Receipt gate (hard fail).** After the swarm finishes — and before `merge-findings.sh` — run:
+
+```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/verify-receipts.sh"
+```
+
+This is the single authority on whether each expected angle actually executed: it hard-fails (non-zero) and prints an actionable `::error` if any angle in `angles.txt` (× `chunks.txt`) lacks a valid receipt (`receipt.<angle>[.<chunk>].json` — a JSON object with matching `angle`/`chunk` and non-empty `runner`+`model`). The shell helper `run-bounded-swarm.sh` already calls this as its final step; hosts that dispatch workers natively (no shell helper) MUST run it themselves. On non-zero, **abort the run and surface the error — do NOT proceed to merge/validate/post.** A missing receipt means that angle never ran, so an empty `findings.json` would be a false clean PASS. This applies in both PR and local-no-PR modes.
 
 ### Stage 4 — Merge + Adversarial Validation
 

--- a/skills/woostack-review/scripts/run-bounded-swarm.sh
+++ b/skills/woostack-review/scripts/run-bounded-swarm.sh
@@ -187,11 +187,25 @@ run_queue() {
 
 run_queue "${work_items[@]}"
 
+# Receipts still missing after pass 1 (verify-receipts.sh is the receipt authority).
+receipt_missing=()
+while IFS= read -r _lbl; do
+  [ -n "$_lbl" ] && receipt_missing+=("$_lbl")
+done < <(bash "$SCRIPT_DIR/verify-receipts.sh" --list-missing 2>/dev/null || true)
+
+in_list() { # needle list...
+  local needle="$1"; shift
+  local x
+  for x in "$@"; do [ "$x" = "$needle" ] && return 0; done
+  return 1
+}
+
 first_pass_failed=()
 for item in "${work_items[@]}"; do
   angle="${item%%|*}"
   chunk="${item#*|}"
-  if ! is_array_artifact "$angle" "$chunk"; then
+  lbl="$(item_label "$angle" "$chunk")"
+  if ! is_array_artifact "$angle" "$chunk" || in_list "$lbl" ${receipt_missing[@]+"${receipt_missing[@]}"}; then
     first_pass_failed+=("$item")
   fi
 done
@@ -290,3 +304,9 @@ jq -n \
 if [ "$degraded" = true ]; then
   echo "::warning::bounded swarm degraded; invalid angle artifacts after retry: $(label_list "${still_invalid[@]}")" >&2
 fi
+
+# Single-authority receipt gate. Findings degradation (above) is a soft warning;
+# a missing/invalid receipt means an angle never executed → hard-fail the swarm so
+# the orchestrator cannot proceed to merge a false-clean review. verify-receipts.sh
+# also folds executed_angles / expected_total / missing_receipts into swarm-metrics.json.
+bash "$SCRIPT_DIR/verify-receipts.sh"

--- a/skills/woostack-review/scripts/tests/test-bounded-swarm-receipts.sh
+++ b/skills/woostack-review/scripts/tests/test-bounded-swarm-receipts.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/run-bounded-swarm.sh"
+
+# Case A: worker writes findings but NEVER a receipt → swarm gate hard-fails.
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/out"
+printf '%s\n' bugs security > "$work/out/angles.txt"
+cat > "$work/worker.sh" <<'WORKER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '[]\n' > "$OUTDIR/findings.$WOO_REVIEW_ANGLE.json"
+# Intentionally writes NO receipt.
+WORKER
+chmod +x "$work/worker.sh"
+rc=0
+OUTDIR="$work/out" bash "$SCRIPT" --max-concurrency 2 -- "$work/worker.sh" >/dev/null 2>&1 || rc=$?
+assert_exit 1 "$rc" "missing receipts → swarm exits non-zero"
+
+# Case B: worker writes findings AND a valid receipt → swarm succeeds.
+work2="$(mktemp -d)"
+mkdir -p "$work2/out"
+printf '%s\n' bugs security > "$work2/out/angles.txt"
+cat > "$work2/worker.sh" <<'WORKER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '[]\n' > "$OUTDIR/findings.$WOO_REVIEW_ANGLE.json"
+printf '{"angle":"%s","chunk":null,"runner":"test","model":"test-model","tier":"standard","ts":"t"}\n' "$WOO_REVIEW_ANGLE" > "$OUTDIR/receipt.$WOO_REVIEW_ANGLE.json"
+WORKER
+chmod +x "$work2/worker.sh"
+rc=0
+OUTDIR="$work2/out" bash "$SCRIPT" --max-concurrency 2 -- "$work2/worker.sh" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "findings + receipts → swarm exits 0"
+assert_eq "$(jq -r '.executed_angles | length' "$work2/out/swarm-metrics.json")" "2" "metrics record executed angles"
+rm -rf "$work2"
+finish

--- a/skills/woostack-review/scripts/tests/test-bounded-swarm.sh
+++ b/skills/woostack-review/scripts/tests/test-bounded-swarm.sh
@@ -63,6 +63,8 @@ case "$WOO_REVIEW_ANGLE" in
     printf '[]\n' > "$OUTDIR/findings.%s.json" "$WOO_REVIEW_ANGLE"
     ;;
 esac
+printf '{"angle":"%s","chunk":null,"runner":"test","model":"test-model","tier":"%s","ts":"t"}\n' \
+  "$WOO_REVIEW_ANGLE" "${FORCE_TIER:-standard}" > "$OUTDIR/receipt.$WOO_REVIEW_ANGLE.json"
 
 while ! mkdir "$lock_dir" 2>/dev/null; do
   sleep 0.01
@@ -101,6 +103,7 @@ cat > "$work2/worker.sh" <<'WORKER'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '[]\n' > "$OUTDIR/findings.$WOO_REVIEW_ANGLE.json"
+printf '{"angle":"%s","chunk":null,"runner":"test","model":"test-model","tier":"standard","ts":"t"}\n' "$WOO_REVIEW_ANGLE" > "$OUTDIR/receipt.$WOO_REVIEW_ANGLE.json"
 WORKER
 chmod +x "$work2/worker.sh"
 OUTDIR="$work2/out" WOO_REVIEW_MAX_CONCURRENCY=1 bash "$SCRIPT" -- "$work2/worker.sh"
@@ -116,6 +119,7 @@ cat > "$work3/worker.sh" <<'WORKER'
 set -euo pipefail
 printf '%s\n' "$WOO_REVIEW_CHUNK" >> "$OUTDIR/chunks-seen.txt"
 printf '[]\n' > "$OUTDIR/findings.$WOO_REVIEW_ANGLE.$WOO_REVIEW_CHUNK.json"
+printf '{"angle":"%s","chunk":"%s","runner":"test","model":"test-model","tier":"standard","ts":"t"}\n' "$WOO_REVIEW_ANGLE" "$WOO_REVIEW_CHUNK" > "$OUTDIR/receipt.$WOO_REVIEW_ANGLE.$WOO_REVIEW_CHUNK.json"
 WORKER
 chmod +x "$work3/worker.sh"
 OUTDIR="$work3/out" bash "$SCRIPT" --max-concurrency 3 -- "$work3/worker.sh"


### PR DESCRIPTION
## Goal

Increment 3 of [#237](https://github.com/howarewoo/woostack/issues/237): wire the receipt gate into the **local** path so a swarm that produced no angle analysis hard-fails instead of reporting a false clean PASS. First enforcing increment — stacks on Inc 2 (receipts now written) per the lockstep.

## Summary

- `run-bounded-swarm.sh`: retry trigger extended to "findings invalid **OR** receipt missing" (reusing `verify-receipts.sh --list-missing` as the authority, so a worker that died after its first-action `[]` findings write still gets the one retry); appends `verify-receipts.sh` as the final hard gate → swarm exits non-zero if any receipt is still missing. Findings `degraded` stays a soft warning; only a missing receipt hard-fails.
- `SKILL.md`: orchestrator **Receipt gate (hard fail)** step before merge (for native-dispatch hosts), bounded-contract step 6 updated (receipts never pre-initialized; still-missing receipt aborts after one retry), and a local **Preflight** note at Stage 2→3.
- Tests: new `test-bounded-swarm-receipts.sh` (no receipt → swarm exits non-zero; findings+receipt → exits 0); `test-bounded-swarm.sh` stubs now write receipts so its `degraded`/retry assertions stay valid under the gate.

## Test plan

### Automated

- [x] `test-bounded-swarm.sh` — 24 passed (degraded/retry path intact; swarm exits 0 with receipts present).
- [x] `test-bounded-swarm-receipts.sh` — 3 passed (missing → non-zero; present → 0).
- [x] `test-verify-receipts-*.sh` (6) — all still green.
- [x] `bash -n run-bounded-swarm.sh` — OK; SKILL.md greps (gate block / contract note / preflight) — OK.

### Manual

**Before merge**

- [ ] Read the `run-bounded-swarm.sh` diff — confirm the retry union and the final gate placement (after metrics write + degraded warning) are correct, and that `degraded` findings remain a soft warning.

Spec: .woostack/specs/2026-06-06-review-fail-fast-receipts.md
