### PR TITLE
feat(woostack-review): CI receipt gate, upload, one-retry, provider preflight

### DIFF
--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -120,7 +120,35 @@ jobs:
         with:
           name: review-artifacts
           path: /tmp/pr-review/
-      - uses: howarewoo/woostack@main
+      # One-retry wrapper: a transient angle failure (model timeout, rate limit) gets
+      # one re-run before the receipt gate fails the review, mirroring the local swarm's
+      # single retry. Dependency-free — a duplicated action step, no third-party retry action.
+      - name: Run angle review (attempt 1)
+        id: review1
+        continue-on-error: true
+        uses: howarewoo/woostack@main
+        with:
+          mode: review
+          angle: ${{ matrix.angle }}
+          chunk: ${{ matrix.chunk }}
+          provider: ${{ inputs.provider }}
+          model: ${{ inputs.model }}
+          force_tier: ${{ inputs.force_tier }}
+          anthropic_token: ${{ secrets.anthropic_token }}
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          openai_api_key: ${{ secrets.openai_api_key }}
+          google_api_key: ${{ secrets.google_api_key }}
+          gemini_api_key: ${{ secrets.gemini_api_key }}
+          openrouter_api_key: ${{ secrets.openrouter_api_key }}
+          trigger_phrase: ${{ inputs.trigger_phrase }}
+          max_turns: ${{ inputs.max_turns }}
+          skip_labels: ${{ inputs.skip_labels }}
+          prompt_override: ${{ inputs.prompt_override }}
+          react_doctor_version: ${{ inputs.react_doctor_version }}
+          impeccable_version: ${{ inputs.impeccable_version }}
+      - name: Run angle review (retry once)
+        if: steps.review1.outcome == 'failure'
+        uses: howarewoo/woostack@main
         with:
           mode: review
           angle: ${{ matrix.angle }}
@@ -146,7 +174,12 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: findings-${{ matrix.angle }}-${{ matrix.chunk || 'all' }}
-          path: /tmp/pr-review/findings.${{ matrix.angle }}*.json
+          # Receipts ride alongside findings in the same artifact so the validate
+          # job's `pattern: findings-*` + merge-multiple download picks them up,
+          # and verify-receipts.sh can prove each angle actually executed.
+          path: |
+            /tmp/pr-review/findings.${{ matrix.angle }}*.json
+            /tmp/pr-review/receipt.${{ matrix.angle }}*.json
           retention-days: 1
           if-no-files-found: ignore
 

--- a/.woostack/memory/MEMORY.md
+++ b/.woostack/memory/MEMORY.md
@@ -11,3 +11,4 @@
 - [review-config-bool-jq-default](review-config-bool-jq-default.md) `gotcha` scope=`skills/woostack-review/scripts/**` — jq `// default` silently coerces an explicit `false` to the default — wrong for 
 - [review-prompt-self-contained-blob](review-prompt-self-contained-blob.md) `gotcha` scope=`skills/woostack-review/**` — woostack-review prompts ship as ONE self-contained blob to CI runners that follo
 - [skill-description-colon-space](skill-description-colon-space.md) `gotcha` scope=`skills/*/SKILL.md` — A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it
+- [fanout-empty-needs-receipt](fanout-empty-needs-receipt.md) `pattern` scope=`skills/woostack-review/**` — An empty aggregate from a fan-out of workers is ambiguous (clean vs never-ran) —

--- a/.woostack/memory/fanout-empty-needs-receipt.md
+++ b/.woostack/memory/fanout-empty-needs-receipt.md
@@ -6,6 +6,8 @@ tags: receipt, false-pass, empty-findings, swarm, fan-out, gate, verify-receipts
 hook: An empty aggregate from a fan-out of workers is ambiguous (clean vs never-ran) — require a per-worker execution receipt to disambiguate.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-fail-fast-receipts.md
+recall_count: 1
+last_recalled: 2026-06-06
 ---
 
 When a flow fans work out to N workers and then aggregates their outputs, an

--- a/.woostack/memory/fanout-empty-needs-receipt.md
+++ b/.woostack/memory/fanout-empty-needs-receipt.md
@@ -1,0 +1,38 @@
+---
+name: fanout-empty-needs-receipt
+type: pattern
+scope: skills/woostack-review/**
+tags: receipt, false-pass, empty-findings, swarm, fan-out, gate, verify-receipts
+hook: An empty aggregate from a fan-out of workers is ambiguous (clean vs never-ran) — require a per-worker execution receipt to disambiguate.
+updated: 2026-06-06
+source: .woostack/plans/2026-06-06-review-fail-fast-receipts.md
+---
+
+When a flow fans work out to N workers and then aggregates their outputs, an
+**empty aggregate is ambiguous**: it can mean "every worker ran and found nothing"
+(a true clean result) or "no worker actually ran" (runner/auth/bridge absent). If
+the aggregator pre-initializes each worker's output to a benign empty value (woostack-review
+pre-writes `findings.<angle>.json = []` for non-destructive failure) and swallows worker
+exit codes, the second case silently masquerades as the first — a **false PASS** (issue #237:
+review reported APPROVED with zero findings when no angle analysis ran).
+
+Fix pattern: each worker writes a **separate execution receipt** as its LAST action —
+proof-of-execution distinct from its result. woostack-review uses
+`receipt.<angle>[.<chunk>].json` = `{angle, chunk, runner, model, tier, ts}`, valid iff it is a
+JSON object with matching `angle`/`chunk` and **non-empty `runner`+`model`** (identity, not just
+file presence). Key rules learned:
+
+- **Do NOT pre-initialize the receipt** (unlike the result file). The receipt's *presence* is the
+  signal; pre-creating it defeats the mechanism.
+- A worker that dies *after* its pre-initialized empty result but *before* the receipt leaves a
+  *valid empty result + no receipt* — so the retry trigger must include "receipt missing", not
+  just "result invalid", or the one retry never fires.
+- One **single-authority** gate script owns the valid-receipt contract and the hard-fail
+  (`verify-receipts.sh`), exposing a non-failing `--list-missing` mode the swarm reuses for its
+  retry set so the contract never drifts between swarm and gate.
+- Ship the receipt-WRITE contract and the gate in **lockstep** — never the gate before workers
+  write receipts, or every run self-fails.
+
+This keeps the empty-result invariant honest: `findings.json == []` ⟺ every expected worker
+executed and found nothing. See [[review-angle-trigger-precision]] for the related
+detect-then-act wiring discipline in the same skill.

--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 6
+recall_count: 7
 last_recalled: 2026-06-06
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/review-add-angle-sites.md
+++ b/.woostack/memory/review-add-angle-sites.md
@@ -6,7 +6,7 @@ tags: angle, detect-angles, _header, load-config, anthropic, enumeration, add-an
 hook: Adding a woostack-review angle touches 11 sites — the easy-to-miss four are load-config VALID_ANGLES, the anthropic.md tier list, the _header footer whitelist, and the committed gating test.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 4
+recall_count: 5
 last_recalled: 2026-06-06
 ---
 Registering an angle so it is **fully** wired (runs, is config-addressable, renders its

--- a/.woostack/memory/review-angle-trigger-precision.md
+++ b/.woostack/memory/review-angle-trigger-precision.md
@@ -6,7 +6,7 @@ tags: detect-angles, angle, trigger, diff-gated, enrichment, tier, observability
 hook: Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also matches the new pattern — and never broaden a trigger on a common token.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 4
+recall_count: 5
 last_recalled: 2026-06-06
 ---
 Most review angles are **diff-gated**: `detect-angles.sh` decides whether the angle

--- a/.woostack/memory/review-config-bool-jq-default.md
+++ b/.woostack/memory/review-config-bool-jq-default.md
@@ -6,7 +6,7 @@ tags: jq, config, boolean, defaults, intersect-findings, load-config
 hook: jq `// default` silently coerces an explicit `false` to the default — wrong for any default-TRUE config bool.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-review-nit-comments.md
-recall_count: 8
+recall_count: 9
 last_recalled: 2026-06-06
 ---
 jq's `//` is the *alternative* operator: it returns the right-hand side when the

--- a/.woostack/memory/review-prompt-self-contained-blob.md
+++ b/.woostack/memory/review-prompt-self-contained-blob.md
@@ -6,7 +6,7 @@ tags: load-prompt, _header, ci-prompt, inline, cross-reference, model-tiers
 hook: woostack-review prompts ship as ONE self-contained blob to CI runners that follow no markdown links — shared content must be inlined, not just linked.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-execute-vary-subagent-model.md
-recall_count: 6
+recall_count: 7
 last_recalled: 2026-06-06
 ---
 `load-prompt.sh` concatenates `_header.md` + the provider body into a single

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 15
+recall_count: 16
 last_recalled: 2026-06-06
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/skill-test-assert-ascii-token.md
+++ b/.woostack/memory/skill-test-assert-ascii-token.md
@@ -6,7 +6,7 @@ tags: tests, grep, assertions, encoding, ascii, unicode
 hook: Grep-based skill tests should assert an ASCII token, not a unicode literal (e.g. a → arrow); keep the readable unicode in the prose and assert on an ASCII phrase that lives in the same text.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
-recall_count: 8
+recall_count: 9
 last_recalled: 2026-06-06
 ---
 woostack skills are documentation; their `scripts/tests/*.sh` guards are `rg -F`/`grep`

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 25
+recall_count: 26
 last_recalled: 2026-06-06
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 51
+recall_count: 52
 last_recalled: 2026-06-06
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
+++ b/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
@@ -784,7 +784,7 @@ gt modify -c -m "docs(woostack-review): orchestrator receipt gate + local prefli
 - Modify: `skills/woostack-review/scripts/detect-provider.sh:24-26`
 - Test: `skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh`:
 
@@ -808,12 +808,12 @@ assert_contains "$err" "install auth" "message names the auth remedy"
 finish
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `bash skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh`
 Expected: FAIL — current message lacks the new phrasing: `FAIL: actionable preflight message`.
 
-- [ ] **Step 3: Update the message**
+- [x] **Step 3: Update the message**
 
 In `skills/woostack-review/scripts/detect-provider.sh`, replace the empty-provider error line:
 
@@ -833,12 +833,12 @@ with:
     ;;
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `bash skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh`
 Expected: PASS — `  3 passed, 0 failed`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "feat(woostack-review): actionable provider/runner preflight error"
@@ -849,12 +849,12 @@ gt create -m "feat(woostack-review): actionable provider/runner preflight error"
 **Files:**
 - Modify: `action.yml` (insert a step before `Merge findings (validate modes)`, ~line 177)
 
-- [ ] **Step 1: Verification baseline**
+- [x] **Step 1: Verification baseline**
 
 Run: `grep -c "verify-receipts.sh" action.yml`
 Expected: `0`
 
-- [ ] **Step 2: Insert the gate step**
+- [x] **Step 2: Insert the gate step**
 
 In `action.yml`, immediately BEFORE the existing step:
 
@@ -878,7 +878,7 @@ insert:
       run: bash "${{ github.action_path }}/skills/woostack-review/scripts/verify-receipts.sh"
 ```
 
-- [ ] **Step 3: Confirm placement + YAML validity**
+- [x] **Step 3: Confirm placement + YAML validity**
 
 Run:
 ```bash
@@ -887,7 +887,7 @@ python3 -c "import yaml; yaml.safe_load(open('action.yml')); print('YAML-OK')"
 ```
 Expected: `OK` then `YAML-OK`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "feat(woostack-review): CI receipt gate before validate merge"
@@ -898,12 +898,12 @@ gt modify -c -m "feat(woostack-review): CI receipt gate before validate merge"
 **Files:**
 - Modify: `.github/workflows/reusable-review.yml` (review job: action step ~123-142, upload step ~146-151)
 
-- [ ] **Step 1: Verification baseline**
+- [x] **Step 1: Verification baseline**
 
 Run: `grep -c "receipt" .github/workflows/reusable-review.yml`
 Expected: `0`
 
-- [ ] **Step 2: Add the receipt glob to the upload step**
+- [x] **Step 2: Add the receipt glob to the upload step**
 
 In `.github/workflows/reusable-review.yml`, change the per-angle upload step's `path:`. Replace:
 
@@ -932,7 +932,7 @@ with:
           if-no-files-found: ignore
 ```
 
-- [ ] **Step 3: Add the one-retry wrapper to the review action step**
+- [x] **Step 3: Add the one-retry wrapper to the review action step**
 
 Replace the review job's single action invocation:
 
@@ -1009,7 +1009,7 @@ with two steps — a first attempt that tolerates failure, then a single retry t
           impeccable_version: ${{ inputs.impeccable_version }}
 ```
 
-- [ ] **Step 4: Confirm edits + YAML validity**
+- [x] **Step 4: Confirm edits + YAML validity**
 
 Run:
 ```bash
@@ -1019,7 +1019,7 @@ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/reusable-review.
 ```
 Expected: `OK1`, `OK2`, `YAML-OK`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(woostack-review): CI uploads receipts + one-retry per angle job"
@@ -1029,7 +1029,7 @@ gt modify -c -m "feat(woostack-review): CI uploads receipts + one-retry per angl
 
 **Files:** (none — verification only)
 
-- [ ] **Step 1: Run every woostack-review shell test**
+- [x] **Step 1: Run every woostack-review shell test**
 
 Run:
 ```bash
@@ -1040,7 +1040,7 @@ echo ALL-GREEN
 ```
 Expected: each test prints `  N passed, 0 failed`; final line `ALL-GREEN`.
 
-- [ ] **Step 2: Commit (only if the sweep surfaced a fixable nit)**
+- [x] **Step 2: Commit (only if the sweep surfaced a fixable nit)**
 
 ```bash
 gt modify -c -m "test(woostack-review): green full receipt + swarm test sweep"
@@ -1050,8 +1050,8 @@ gt modify -c -m "test(woostack-review): green full receipt + swarm test sweep"
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — receipt mechanism (Inc 1 contract + Inc 2 write), `verify-receipts.sh` single authority + `--list-missing` (Inc 1), strictness/every-angle + swarm hard-fail + retry-trigger extension + receipts-never-pre-initialized (Inc 3 Task 1), preflight light/local + GHA message (Inc 3 Task 3, Inc 4 Task 1), CI gate + receipt upload + one-retry + line-156 reversal (Inc 4 Tasks 2-3), all tests incl. updated `test-bounded-swarm.sh` (Inc 1-4). Non-goals respected: findings schema unchanged, validator-`degraded` axis untouched, no live API probe, merge/intersect unchanged.
-- [ ] **No placeholders** — every step has complete code/edit text + exact command + expected output.
-- [ ] **Type/contract consistency** — receipt object shape `{angle, chunk, runner, model, tier, ts}` identical across `_header.md`, the SKILL brief, every test stub, and `verify-receipts.sh`'s `is_valid_receipt` (matching `angle`/`chunk`, non-empty `runner`+`model`). Artifact paths `receipt.<angle>.json` / `receipt.<angle>.<chunk>.json` consistent everywhere. `verify-receipts.sh` invoked via `$SCRIPT_DIR/verify-receipts.sh` (swarm) and `${{ github.action_path }}/skills/woostack-review/scripts/verify-receipts.sh` (Action). Portable bash (no `mapfile`; `set -u`-safe array expansions).
+- [x] **Spec coverage** — receipt mechanism (Inc 1 contract + Inc 2 write), `verify-receipts.sh` single authority + `--list-missing` (Inc 1), strictness/every-angle + swarm hard-fail + retry-trigger extension + receipts-never-pre-initialized (Inc 3 Task 1), preflight light/local + GHA message (Inc 3 Task 3, Inc 4 Task 1), CI gate + receipt upload + one-retry + line-156 reversal (Inc 4 Tasks 2-3), all tests incl. updated `test-bounded-swarm.sh` (Inc 1-4). Non-goals respected: findings schema unchanged, validator-`degraded` axis untouched, no live API probe, merge/intersect unchanged.
+- [x] **No placeholders** — every step has complete code/edit text + exact command + expected output.
+- [x] **Type/contract consistency** — receipt object shape `{angle, chunk, runner, model, tier, ts}` identical across `_header.md`, the SKILL brief, every test stub, and `verify-receipts.sh`'s `is_valid_receipt` (matching `angle`/`chunk`, non-empty `runner`+`model`). Artifact paths `receipt.<angle>.json` / `receipt.<angle>.<chunk>.json` consistent everywhere. `verify-receipts.sh` invoked via `$SCRIPT_DIR/verify-receipts.sh` (swarm) and `${{ github.action_path }}/skills/woostack-review/scripts/verify-receipts.sh` (Action). Portable bash (no `mapfile`; `set -u`-safe array expansions).
 
 > woostack plan conventions: frontmatter-free; opens with the `**Source:**` line; filename mirrors the spec basename (`2026-06-06-review-fail-fast-receipts.md`); no required-sub-skill banner; in this skills repo a "failing test" is a shell test or a `grep`/`bash -n`/`python3 -c yaml` verification with exact expected output. Execution is `woostack-execute`'s job (woostack-build step 9, or `/woostack-execute <plan>`).

--- a/action.yml
+++ b/action.yml
@@ -174,6 +174,15 @@ runs:
           bash "${{ github.action_path }}/skills/woostack-review/scripts/detect-angles.sh"
         fi
 
+    - name: Verify angle receipts (validate modes)
+      # Hard-fail BEFORE merge/validate/post if any detected angle produced no valid
+      # execution receipt — i.e. a worker never ran. Prevents a false clean PASS when
+      # the runner/auth/bridge was absent. Reads angles.txt (× chunks.txt) and the
+      # receipt.*.json downloaded with the per-angle findings artifacts.
+      if: steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      shell: bash
+      run: bash "${{ github.action_path }}/skills/woostack-review/scripts/verify-receipts.sh"
+
     - name: Merge findings (validate modes)
       if: steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
       shell: bash

--- a/skills/woostack-review/scripts/detect-provider.sh
+++ b/skills/woostack-review/scripts/detect-provider.sh
@@ -22,7 +22,7 @@ fi
 case "$PROVIDER" in
   anthropic|openai|google|openrouter) ;;
   "")
-    echo "::error::No provider resolvable. Set 'provider' input or one of: anthropic_token, openai_api_key, google_api_key, openrouter_api_key."
+    echo "::error::woostack-review preflight: no model provider/runner resolvable, so no angle worker can execute. Configure a provider/model (set the 'provider' input), install auth (one of: anthropic_token, openai_api_key, google_api_key, openrouter_api_key), or set the correct runner override. Refusing to run a review that cannot analyze the diff."
     exit 1
     ;;
   *)

--- a/skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/detect-provider.sh"
+
+unset INPUT_PROVIDER INPUT_ANTHROPIC_TOKEN INPUT_ANTHROPIC_API_KEY \
+      INPUT_OPENAI_API_KEY INPUT_GOOGLE_API_KEY INPUT_GEMINI_API_KEY \
+      INPUT_OPENROUTER_API_KEY 2>/dev/null || true
+
+rc=0; err="$(bash "$SCRIPT" 2>&1)" || rc=$?
+assert_exit 1 "$rc" "no provider/runner → exit 1"
+assert_contains "$err" "no model provider/runner resolvable" "actionable preflight message"
+assert_contains "$err" "install auth" "message names the auth remedy"
+finish


### PR DESCRIPTION
## Goal

Increment 4 of [#237](https://github.com/howarewoo/woostack/issues/237): enforce the receipt gate on the **CI** path and harden the provider preflight, so a GitHub-Action review can't post a complete-looking result when angle jobs never ran. Final increment — stacks on Inc 1-3 (gate + receipts + local enforcement) per the lockstep.

## Summary

- `detect-provider.sh`: the no-provider preflight error is now actionable ("no model provider/runner resolvable … configure a provider/model, install auth, or set the runner override"). Stream unchanged (stdout).
- `action.yml`: new **Verify angle receipts** step in the validate modes, before `merge-findings.sh` — hard-fails the validate job (no post) if any detected angle lacks a valid receipt.
- `reusable-review.yml`: each matrix angle job uploads `receipt.${{ matrix.angle }}*.json` alongside findings (same artifact, picked up by the existing `pattern: findings-*` download), and gets a dependency-free **one-retry** wrapper (`continue-on-error` attempt 1 + `if: failure()` retry). This intentionally reverses the old "tolerate a failed angle" behavior — a persistent angle failure now fails the review.

## Test plan

### Automated

- [x] `test-detect-provider-preflight.sh` — 3 passed (no provider → exit 1, actionable message).
- [x] `python3 -c "yaml.safe_load(...)"` on `action.yml` and `reusable-review.yml` — both valid.
- [x] Full `skills/woostack-review/scripts/tests/test-*.sh` sweep — ALL-GREEN (18 files).

### Manual

**Before merge**

- [ ] Read the `reusable-review.yml` diff — confirm the one-retry wrapper (attempt 1 `continue-on-error` + `if: steps.review1.outcome == 'failure'` retry) and the receipt upload glob are correct.
- [ ] Read the `action.yml` gate step — confirm it runs before merge in both `validate` and `validate-prosecutor` modes.

**After merge**

- [ ] On a real PR review run, confirm a deliberately broken angle (bad/empty runner) fails the validate job with the receipt `::error` instead of posting an APPROVED review.

Spec: .woostack/specs/2026-06-06-review-fail-fast-receipts.md
