### PR TITLE
docs(woostack): structured §7 acceptance criteria — spec + plan

### DIFF
--- a/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
+++ b/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
@@ -1,0 +1,303 @@
+**Source:** .woostack/specs/2026-06-06-spec-acceptance-criteria.md
+
+# Structured Acceptance Criteria in the spec template — Implementation Plan
+
+**Goal:** Add a structured §7 Acceptance criteria section to the spec template (happy/error/edge per behavior) and wire plan self-review to gate that breadth into TDD tasks — fixed at the spec, gated at the plan, execute and harden untouched.
+
+**Architecture:** Two stacked increments. Increment 1 edits the spec template pair (`spec-template.md` + `spec-template.html`) to add §7 and renumber the trailing sections — independently shippable (authors get the section immediately). Increment 2 stacks on it and wires the plan self-review gate (`woostack-plan/SKILL.md` + `plan-template.md`) that references the new §7. No application code; this is a skills-collection docs change.
+
+**Tech Stack:** Markdown + HTML skill assets. No test runner (per AGENTS.md), so every "failing test" is a concrete `grep`/structural verification command with exact expected output.
+
+---
+
+## Increment 1: Spec template gains §7 Acceptance criteria
+
+> One independently shippable PR — its own Graphite-stacked branch on the spec+plan base. Adds §7 to the markdown template and its HTML mirror, renumbering Testing→§8 and Open questions→§9.
+
+### Task 1: Add §7 to `spec-template.md` and renumber
+
+**Files:**
+- Modify: `skills/woostack-build/references/spec-template.md:36-47`
+- Test: shell `grep` (no runner in this repo)
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+# Asserts §7 AC exists with all three slots, the instruction line, and that
+# Testing/Open questions are renumbered to §8/§9 (and the old §7 Testing is gone).
+test_md() {
+  f=skills/woostack-build/references/spec-template.md
+  grep -q '^## 7. Acceptance criteria$' "$f" \
+  && grep -q '^Each AC is a testable behavior' "$f" \
+  && grep -q '^  - happy: {{expected}}$' "$f" \
+  && grep -q '^  - error: {{expected}}$' "$f" \
+  && grep -q '^  - edge: {{expected}}$' "$f" \
+  && grep -q '^## 8. Testing$' "$f" \
+  && grep -q '^## 9. Open questions$' "$f" \
+  && ! grep -q '^## 7. Testing$' "$f" \
+  && ! grep -q '^## 8. Open questions$' "$f" \
+  && echo PASS || echo FAIL
+}
+test_md
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: paste and run the Step 1 block (it defines the check and calls it on the last line).
+Expected: FAIL — current file still has `## 7. Testing` / `## 8. Open questions` and no `## 7. Acceptance criteria`, so the block prints `FAIL`.
+
+- [ ] **Step 3: Minimal implementation**
+
+Replace the current sections 6–8 of `skills/woostack-build/references/spec-template.md`:
+
+```markdown
+## 6. Error handling
+
+{{ERRORS}}
+
+## 7. Testing
+
+{{TESTING}}
+
+## 8. Open questions
+
+{{OPEN_QUESTIONS}}
+```
+
+with:
+
+```markdown
+## 6. Error handling
+
+{{ERRORS}}
+
+## 7. Acceptance criteria
+
+Each AC is a testable behavior → ≥1 plan task. Fill every class or mark `N/A — <reason>`; mark the whole section `N/A — <why no testable behavior>` only when the spec has no testable behavior.
+
+- **AC1 — {{behavior}}**
+  - happy: {{expected}}
+  - error: {{expected}}
+  - edge: {{expected}}
+- **AC2 — {{behavior}}**
+  - happy: {{expected}}
+  - error: {{expected}}
+  - edge: {{expected}}
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+{{TESTING}}
+
+## 9. Open questions
+
+{{OPEN_QUESTIONS}}
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: re-run the Step 1 block (after the edit).
+Expected: PASS — prints `PASS`.
+
+### Task 2: Mirror §7 in `spec-template.html` and renumber
+
+**Files:**
+- Modify: `skills/woostack-build/references/spec-template.html:31-33`
+- Test: shell `grep` + a structural parity check against the markdown
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+# (a) HTML carries the §7 AC panel + renumbered §8/§9; (b) the ordered section
+# list of the HTML matches the markdown exactly (AC2: md/html stay 1:1).
+test_html() {
+  h=skills/woostack-build/references/spec-template.html
+  m=skills/woostack-build/references/spec-template.md
+  grep -q '<h2>7. Acceptance criteria</h2><div class="panel">{{ACCEPTANCE_CRITERIA}}</div>' "$h" \
+  && grep -q '<h2>8. Testing</h2>' "$h" \
+  && grep -q '<h2>9. Open questions</h2>' "$h" \
+  && ! grep -q '<h2>7. Testing</h2>' "$h" \
+  && diff <(grep -oE '<h2>[0-9]+\. [^<]+' "$h" | sed 's#<h2>##; s/&amp;/\&/g') \
+          <(grep -oE '^## [0-9]+\. .+' "$m" | sed 's/^## //') >/dev/null \
+  && echo PASS || echo FAIL
+}
+test_html
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: paste and run the Step 1 block.
+Expected: FAIL — HTML still has `<h2>7. Testing</h2>`, no AC panel, and its heading list differs from the (already-updated) markdown; prints `FAIL`.
+
+- [ ] **Step 3: Minimal implementation**
+
+Replace these three lines in `skills/woostack-build/references/spec-template.html`:
+
+```html
+  <h2>6. Error handling</h2><div class="panel">{{ERRORS}}</div>
+  <h2>7. Testing</h2><div class="panel">{{TESTING}}</div>
+  <h2>8. Open questions</h2><div class="panel">{{OPEN_QUESTIONS}}</div>
+```
+
+with:
+
+```html
+  <h2>6. Error handling</h2><div class="panel">{{ERRORS}}</div>
+  <h2>7. Acceptance criteria</h2><div class="panel">{{ACCEPTANCE_CRITERIA}}</div>
+  <h2>8. Testing</h2><div class="panel">{{TESTING}}</div>
+  <h2>9. Open questions</h2><div class="panel">{{OPEN_QUESTIONS}}</div>
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: re-run the Step 1 block (after the edit).
+Expected: PASS — the AC panel is present, §8/§9 renumbered, and the md/html heading lists are identical (empty `diff`); prints `PASS`.
+
+- [ ] **Step 5: Commit the increment**
+
+Single `woostack-commit` for Increment 1 (its own Graphite branch on the spec+plan base):
+
+```bash
+# first commit in this increment:
+gt create -m "feat(woostack-build): add §7 Acceptance criteria to the spec template"
+```
+
+---
+
+## Increment 2: Plan self-review gates AC → task → test breadth
+
+> One independently shippable PR, stacked on Increment 1 (it references the §7 the template now defines). Wires the plan-side gate: the self-review engine and the plan template's checklist.
+
+### Task 3: Wire AC coverage into `woostack-plan/SKILL.md`
+
+**Files:**
+- Modify: `skills/woostack-plan/SKILL.md:104` (cross-ref the banned phrase to §7)
+- Modify: `skills/woostack-plan/SKILL.md:131` (extend self-review step 1 with AC coverage + N/A sanity check)
+- Test: shell `grep`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+test_plan_skill() {
+  f=skills/woostack-plan/SKILL.md
+  grep -q '\*\*AC coverage:\*\*' "$f" \
+  && grep -q 'no behavioral requirement' "$f" \
+  && grep -q 'belong in the spec.s §7 Acceptance criteria' "$f" \
+  && echo PASS || echo FAIL
+}
+test_plan_skill
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: paste and run the Step 1 block.
+Expected: FAIL — none of the AC-coverage / N/A / §7 cross-ref strings exist yet; prints `FAIL`.
+
+- [ ] **Step 3: Minimal implementation**
+
+(a) Replace line 104 in `skills/woostack-plan/SKILL.md`:
+
+```markdown
+- "Add error handling" / "add validation" / "handle edge cases"
+```
+
+with:
+
+```markdown
+- "Add error handling" / "add validation" / "handle edge cases" — write the actual test instead; error and edge cases belong in the spec's §7 Acceptance criteria, enumerated there as happy/error/edge
+```
+
+(b) Replace the self-review step 1 (line 131):
+
+```markdown
+1. **Spec coverage** — every section/requirement maps to a task. List and fill any gap.
+```
+
+with:
+
+```markdown
+1. **Spec coverage** — every section/requirement maps to a task. List and fill any gap.
+   **AC coverage:** when the spec's §7 Acceptance criteria lists ACs, every AC — and each
+   filled (non-N/A) happy/error/edge case — maps to a task/test; when §7 is whole-section
+   `N/A`, confirm the spec body has no behavioral requirement (else flag the `N/A` as suspect).
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: re-run the Step 1 block (after the edits).
+Expected: PASS — all three strings present; prints `PASS`.
+
+### Task 4: Add the AC coverage line to `plan-template.md`
+
+**Files:**
+- Modify: `skills/woostack-plan/references/plan-template.md:61` (self-review checklist)
+- Test: shell `grep`
+
+- [ ] **Step 1: Write the failing test**
+
+```bash
+test_plan_template() {
+  f=skills/woostack-plan/references/plan-template.md
+  grep -q '^- \[ \] \*\*AC coverage\*\*' "$f" \
+  && grep -q 'happy/error/edge' "$f" \
+  && echo PASS || echo FAIL
+}
+test_plan_template
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: paste and run the Step 1 block.
+Expected: FAIL — no `AC coverage` checklist item yet; prints `FAIL`.
+
+- [ ] **Step 3: Minimal implementation**
+
+In `skills/woostack-plan/references/plan-template.md`, insert one checklist item after the **Spec coverage** line. Replace:
+
+```markdown
+- [ ] **Spec coverage** — every spec requirement maps to a task above.
+- [ ] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
+```
+
+with:
+
+```markdown
+- [ ] **Spec coverage** — every spec requirement maps to a task above.
+- [ ] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test; a whole-section `N/A` is sanity-checked against the spec body.
+- [ ] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: re-run the Step 1 block (after the edit).
+Expected: PASS — the `AC coverage` checklist item is present; prints `PASS`.
+
+- [ ] **Step 5: Commit the increment**
+
+Single `woostack-commit` for Increment 2 (stacked on Increment 1):
+
+```bash
+# first commit in this increment:
+gt create -m "feat(woostack-plan): gate §7 acceptance-criteria breadth in self-review"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every spec requirement maps to a task above.
+  - AC1 (template exposes §7 scaffold) → Task 1.
+  - AC2 (md/html 1:1) → Task 2 (incl. the `diff` parity check).
+  - AC3 (plan self-review gates breadth) → Tasks 3 + 4.
+  - AC4 (existing plan rules coherent) → Task 3 part (a), the `:104` cross-ref.
+- [ ] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test; a whole-section `N/A` is sanity-checked against the spec body.
+  - happy cases → the `grep`-PASS assertions in each task; edge (N/A handling, md/html parity) → the parity `diff` and the negated `! grep` renumber checks; error cases for AC1/AC4 are spec-marked N/A (static docs), so no test owed.
+- [ ] **No placeholders** — no TBD/TODO; every step has exact paths, complete before/after blocks, and exact expected output.
+- [ ] **Type consistency** — the token `{{ACCEPTANCE_CRITERIA}}` (html) and the section names §7/§8/§9 are used identically across both template files and both plan files.
+
+> woostack plan conventions (keep them):
+> - This file is **frontmatter-free** and **opens with** the `**Source:**` line.
+> - Filename mirrors the spec basename: `.woostack/plans/2026-06-06-spec-acceptance-criteria.md`.
+> - **No** required sub-skill banner — execution is `woostack-execute`'s (woostack-build step 8, or `/woostack-execute <plan>`).
+> - No test runner in this repo, so each "failing test" is a concrete `grep`/`diff` verification with exact expected output.

--- a/.woostack/specs/2026-06-06-spec-acceptance-criteria.md
+++ b/.woostack/specs/2026-06-06-spec-acceptance-criteria.md
@@ -1,0 +1,233 @@
+---
+name: spec-acceptance-criteria
+type: spec
+status: planning
+date: 2026-06-06
+branch: spec-acceptance-criteria
+links:
+---
+
+# Structured Acceptance Criteria in the spec template — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+woostack's TDD machinery guarantees test **cadence** but not test **breadth**. Each plan task
+runs a real failing test through red→green (`inline-driver.md:12-17`, `implementer.md:24-28`,
+`plan-template.md:24-44`), and plan self-review asserts "every requirement maps to a task"
+(`woostack-plan/SKILL.md:131`). But nothing requires that a requirement's tests span the
+**happy path, error path(s), and edge cases**. A task whose single assertion is a happy-path
+check passes every existing gate.
+
+The breadth gap originates at the **spec**, not at execute. The spec template
+([`spec-template.md`](../../skills/woostack-build/references/spec-template.md)) has eight
+sections; the only test-relevant ones — §6 Error handling and §7 Testing — are freeform
+`{{...}}` placeholders with no structure forcing per-behavior enumeration. There is no discrete,
+testable acceptance-criteria list for the plan to map 1:1 into tasks and tests. So whether
+error/edge cases get tested depends entirely on author diligence, enforced nowhere.
+
+`woostack-plan/SKILL.md:104` actively bans the vague phrase *"handle edge cases"* as a
+placeholder — anti-vagueness, but it also offers no structured slot where edge cases *should*
+be enumerated, so authors have nowhere to put them.
+
+## 2. Goal
+
+Add a structured **Acceptance Criteria** section to the spec template that enumerates testable
+behaviors, each carrying explicit happy / error / edge slots, and tighten plan self-review so
+that breadth flows mechanically into TDD tasks. After this change, a spec that lists a
+behavior's error and edge cases will have them carried — by the existing "every requirement →
+task → real failing test" plumbing — down into the executed test suite, with no change to how
+execute runs.
+
+## 3. Non-goals
+
+- **No change to TDD execution mechanics.** The drivers (`inline-driver.md`,
+  `subagent-driver.md`, `implementer.md`) and the per-task red→green cycle are untouched.
+  Execute runs whatever tests the plan names; it cannot know a feature's edge cases.
+- **No enforcement gate inside execute.** Breadth is a spec property; it is gated at plan, not
+  at execute.
+- **No new approval gate** in the build loop. The change is to artifacts and self-review
+  checklists only.
+- **No execution-receipt / proof-of-red mechanism.** Verifying that a red test was actually
+  observed (cf. `woostack-review`'s `verify-receipts.sh`) is a separate concern, out of scope
+  here.
+- **No change to `woostack-harden`.** Harden stays a generic interview engine (see §4).
+- **No change to the plan task shape.** A behavior's three cases may share one task or span
+  several — planner judgment, not a mechanical rule.
+- **No backfill of existing specs.** The change is forward-only: the 10 specs already in
+  `.woostack/specs/` keep their 8-section shape (their plans already exist, so retro-fitting §7
+  buys no test breadth). Only specs authored after this change carry §7.
+- **No template-substitution engine.** `spec-template.html`'s `{{...}}` tokens are illustrative
+  cues, not wired placeholders — `woostack-visualize` *composes bespoke HTML* and treats the
+  template as a starting point only (`woostack-visualize/SKILL.md:32-38`). This change adds no
+  rendering/substitution machinery.
+
+## 4. Approach
+
+Fix breadth at the layer that owns it (the spec), gate it at the layer that derives tasks from
+the spec (the plan), and leave the runner (execute) and the generic interviewer (harden)
+alone.
+
+- **Spec template** gains a dedicated, structured Acceptance Criteria section so behaviors are
+  enumerated as testable units with happy/error/edge slots. The markdown ships a **literal
+  scaffold** (instruction line + an example AC skeleton with `{{token}}` fills), not a bare
+  `{{ACCEPTANCE_CRITERIA}}` token — making the happy/error/edge structure visible to the author
+  is the feature. This matches `plan-template.md`'s scaffold style and deliberately diverges
+  from the sibling sections' bare-token style. The HTML mirror keeps a bare
+  `{{ACCEPTANCE_CRITERIA}}` panel, consistent with the other illustrative HTML panels.
+- **Coverage is opt-out, not mandatory.** A spec may mark §7 **whole-section N/A** when it has
+  no testable behavior (docs-only, pure refactor) — written as `N/A — <why no testable
+  behavior>`. When §7 carries real ACs, each filled (non-N/A) case must map to a test.
+- **Plan self-review** (the engine's checklist and the plan template's self-review block) gains
+  an AC-coverage check: when §7 has ACs, every AC — and each filled case — maps to a test; when
+  §7 is whole-section N/A, a one-line **sanity check** confirms the spec body genuinely has no
+  behavioral requirement (else flag), so the escape hatch cannot silently swallow breadth.
+- **Harden needs no edit.** It already "walks every branch of the decision tree" and grills
+  open questions one at a time. A spec AC section shipped with empty happy/error/edge cells —
+  or a dubious whole-section N/A — presents as open questions harden naturally surfaces:
+  emergent enforcement, without bloating a deliberately-generic skill with section-specific
+  rules.
+- **Execute needs no edit.** Once the plan names error/edge tests, the existing red→green
+  cadence runs them unchanged.
+
+The breadth chain end to end: spec AC (happy/error/edge) → harden grills blank cells / dubious
+N/A → plan self-review maps each filled case to a test (or sanity-checks a whole-section N/A) →
+plan task = a real failing test → execute drives it red→green.
+
+## 5. Components & data flow
+
+Four files change; two skills are deliberately left untouched.
+
+1. **`skills/woostack-build/references/spec-template.md`** — insert a new **§7 Acceptance
+   criteria** after §6 Error handling as a **literal scaffold** (instruction line allowing
+   per-slot N/A *and* whole-section `N/A — <why>`; an example AC skeleton with
+   `happy:`/`error:`/`edge:` sub-bullets and `{{behavior}}`/`{{expected}}` tokens); renumber
+   Testing → §8 and Open questions → §9; add a one-line scope note to §8 Testing.
+2. **`skills/woostack-build/references/spec-template.html`** — mirror the markdown 1:1: add a
+   `7. Acceptance criteria` heading + panel with a bare `{{ACCEPTANCE_CRITERIA}}` placeholder
+   (illustrative, like the sibling panels — no substitution engine reads it), and renumber the
+   following two sections. Heading text and numbers must match `spec-template.md` exactly.
+3. **`skills/woostack-plan/SKILL.md`** — extend self-review step 1 (spec coverage) to assert AC
+   → task → test mapping when §7 has ACs, **and** a whole-section-N/A sanity check (confirm the
+   spec body has no behavioral requirement, else flag); add a cross-reference reconciling the §7
+   AC slots with the existing `:104` ban on the vague *"handle edge cases"* phrase.
+4. **`skills/woostack-plan/references/plan-template.md`** — add an **AC coverage** line to the
+   self-review checklist; task/step mechanics unchanged.
+
+Untouched on purpose: `skills/woostack-harden/SKILL.md` (emergent coverage),
+`skills/woostack-execute/**` (runner), `skills/woostack-build/SKILL.md` (does not enumerate
+spec sections).
+
+Data flow (authoring time): author fills spec §7 → `woostack-harden` grills any blank cell as
+an open question → `woostack-plan` reads §7 and maps each AC + filled case to a task/test →
+`woostack-execute` runs those tests red→green. No runtime data structure; the "data" is the
+markdown propagating through the build phases.
+
+## 6. Error handling
+
+This is a docs/skills change with no runtime, so "errors" are authoring and consistency
+failures:
+
+- **Markdown ↔ HTML drift.** If only one of `spec-template.md` / `spec-template.html` is
+  edited, the render desynchronizes. Both must change together; section numbers and headings
+  must match exactly (§7 AC, §8 Testing, §9 Open questions).
+- **Inapplicable case classes.** Not every behavior has a meaningful error or edge case, and
+  not every spec has testable behavior at all. The template must explicitly allow **per-slot**
+  `N/A — <reason>` *and* **whole-section** `N/A — <why no testable behavior>`, so authors don't
+  fabricate cases or leave ambiguous blanks. A blank (unfilled) cell is a harden prompt; an
+  explicit `N/A — <why>` is a settled decision. A whole-section N/A is additionally sanity-checked
+  at plan self-review (confirm no behavioral requirement exists) so it cannot hide real breadth.
+- **Stale cross-references.** `woostack-plan/SKILL.md:104` and `:131` carry line-anchored
+  meaning; the edits must keep those references coherent and not orphan the banned-phrase rule.
+- **Over-prescription risk.** The AC section must stay lean (the repo values concision); an
+  over-heavy template would push authors to skip or under-fill it. Format is the
+  already-chosen per-AC bullet with three sub-slots, not a verbose BDD block.
+
+## 7. Acceptance criteria
+
+Each AC is a testable behavior → ≥1 plan task. Fill every class or mark N/A + why.
+
+- **AC1 — Spec template exposes a structured Acceptance Criteria scaffold**
+  - happy: `spec-template.md` contains a `## 7. Acceptance criteria` section shipped as a
+    literal scaffold — an instruction line plus an example AC skeleton with the per-AC bullet
+    format (behavior + `happy:`/`error:`/`edge:` sub-slots, `{{token}}` fills) — not a bare
+    `{{ACCEPTANCE_CRITERIA}}` token.
+  - error: N/A — a static template has no runtime error path; malformed authoring is caught by
+    AC2 (consistency) and by harden, not by the template itself.
+  - edge: The instruction line sanctions both **per-slot** `N/A — <reason>` (a behavior with no
+    meaningful error/edge case) and **whole-section** `N/A — <why no testable behavior>` (a
+    docs-only or pure-refactor spec), so §7 is never left ambiguously blank.
+
+- **AC2 — Markdown and HTML templates stay 1:1**
+  - happy: `spec-template.html` renders sections `1…9` with `7. Acceptance criteria`,
+    `8. Testing`, `9. Open questions`, including a bare `{{ACCEPTANCE_CRITERIA}}` panel, and
+    every heading/number matches `spec-template.md`.
+  - error: A numbering or heading mismatch between the two files is a defect — a structural diff
+    (compare the ordered section list of each file) must show them identical.
+  - edge: The `{{ACCEPTANCE_CRITERIA}}` token is illustrative only — `woostack-visualize`
+    composes bespoke HTML and reads no token — so it just follows the existing `{{UPPER_SNAKE}}`
+    panel convention; no substitution machinery is added or required.
+
+- **AC3 — Plan self-review gates AC → task → test breadth**
+  - happy: `woostack-plan/SKILL.md` self-review asserts every spec AC maps to a task and each
+    *filled* (non-N/A) happy/error/edge case maps to a test; `plan-template.md`'s self-review
+    checklist carries a matching **AC coverage** line.
+  - error: An AC (or a filled case within it) with no corresponding task/test is a self-review
+    failure the planner must fix before handing back — the checklist names this as a gap to
+    "list and fill," consistent with the existing spec-coverage step.
+  - edge: A case (or slot) marked `N/A — <reason>` is honored — no test required, not counted as
+    a gap. When §7 is **whole-section N/A**, the AC-mapping check is skipped but a one-line
+    sanity check confirms the spec body has no behavioral requirement (else the planner flags
+    the N/A as suspect), so the escape hatch cannot silently swallow breadth.
+
+- **AC4 — Existing plan rules stay coherent**
+  - happy: The `:104` ban on the vague phrase *"handle edge cases"* remains, now cross-referenced
+    to §7 as the structured place where edge cases are actually enumerated.
+  - error: N/A — no behavioral path; this is a documentation-consistency criterion verified by
+    reading the amended section.
+  - edge: Plan task/step mechanics (one real failing test per step) are unchanged — a behavior's
+    three cases may live in one task or span several, so the gate checks test *existence*, not
+    task count.
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+This repo is a skills collection with **no test runner** (see project AGENTS.md: "no
+application source code, app lockfile, build, or CI"). Per woostack convention
+(`woostack-plan/SKILL.md:91-93`), each "failing test" becomes a concrete **verification
+command** with exact expected output. Planned verifications:
+
+- `grep`/structural assertions that `spec-template.md` contains the `## 7. Acceptance criteria`
+  heading, the three sub-slots, and the instruction line; and that §8/§9 are renumbered.
+- A structural comparison that `spec-template.html`'s ordered section headings match
+  `spec-template.md`'s, and that `{{ACCEPTANCE_CRITERIA}}` is present.
+- `grep` that `woostack-plan/SKILL.md` self-review names AC→task→test mapping and that
+  `plan-template.md`'s self-review checklist carries the AC-coverage line.
+- A link/anchor check that the `:104` cross-reference to §7 is coherent.
+
+No automated harness, fixtures, or CI are added (forbidden by AGENTS.md "no hidden tools").
+
+## 9. Open questions
+
+_(none — all resolved. Settled decisions, in resolution order:)_
+
+- **AC format** (ideate) — per-AC bullet with `happy:`/`error:`/`edge:` sub-slots. Not a table,
+  not Given/When/Then.
+- **Enforcement layer** (ideate) — plan gate only; `woostack-harden` left untouched (emergent
+  coverage of blank cells / dubious N/A).
+- **Testing section** (ideate) — kept as §8 and scope-noted ("strategy only"), not absorbed into
+  AC.
+- **§7 in markdown** (harden) — literal scaffold (visible structure), diverging from sibling
+  bare-token sections; HTML keeps a bare `{{ACCEPTANCE_CRITERIA}}` panel.
+- **Renumbering** (harden) — safe: nothing parses spec section numbers (`/woostack-status` reads
+  frontmatter; `woostack-visualize` composes bespoke HTML).
+- **Backfill** (harden) — none; forward-only (see §3 Non-goals).
+- **AC required?** (harden) — no; §7 may be marked whole-section N/A when a spec has no testable
+  behavior. Coverage is opt-out, not mandatory.
+- **N/A guard** (harden) — whole-section N/A must carry a reason; harden grills a dubious N/A;
+  plan self-review sanity-checks an N/A §7 against the spec body. Three layers keep the opt-out
+  from swallowing real breadth.


### PR DESCRIPTION
## Goal

TDD in the woostack build loop guarantees test *cadence* (red→green per task) but not test *breadth* — nothing makes a behavior's tests span happy/error/edge, and the gap originates at the spec, which has no enumerated testable criteria. This PR ships the **spec + plan** (docs base of the stack) to fix breadth at the spec and gate it at the plan, leaving execute untouched.

## Summary

- Adds a structured **§7 Acceptance criteria** section to the spec template (`spec-template.md` + `spec-template.html`) — per-AC bullet with `happy:`/`error:`/`edge:` slots, shipped as a literal scaffold; renumbers Testing→§8 (scope-noted), Open questions→§9.
- Wires plan self-review (`woostack-plan/SKILL.md` + `plan-template.md`) to gate **AC → task → test** breadth, with a whole-section-`N/A` sanity check and a cross-reference from the `:104` banned "handle edge cases" phrase to §7.
- `woostack-harden` and `woostack-execute` deliberately untouched — breadth is fixed at the spec, gated at the plan, emergent in harden.
- This PR carries only the `.woostack/` spec and plan; the 2 implementation increments stack on top (not merged by build).

## Test plan

### Manual

**Before merge**

- [ ] Read `.woostack/specs/2026-06-06-spec-acceptance-criteria.md` §7 — confirm the AC scaffold + happy/error/edge model + N/A affordances read correctly.
- [ ] Read `.woostack/plans/2026-06-06-spec-acceptance-criteria.md` — confirm the 2 stacked increments (template, then gate) are independently shippable and the grep/diff verifications are exact.
- [ ] The implementation increments (stacked above) run the plan's verification blocks red→green.

Spec: .woostack/specs/2026-06-06-spec-acceptance-criteria.md
