### PR TITLE
feat(woostack-build): spec template §7 Acceptance criteria

### DIFF
--- a/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
+++ b/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
@@ -20,7 +20,7 @@
 - Modify: `skills/woostack-build/references/spec-template.md:36-47`
 - Test: shell `grep` (no runner in this repo)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```bash
 # Asserts §7 AC exists with all three slots, the instruction line, and that
@@ -41,12 +41,12 @@ test_md() {
 test_md
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: paste and run the Step 1 block (it defines the check and calls it on the last line).
 Expected: FAIL — current file still has `## 7. Testing` / `## 8. Open questions` and no `## 7. Acceptance criteria`, so the block prints `FAIL`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Replace the current sections 6–8 of `skills/woostack-build/references/spec-template.md`:
 
@@ -95,7 +95,7 @@ Each AC is a testable behavior → ≥1 plan task. Fill every class or mark `N/A
 {{OPEN_QUESTIONS}}
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: re-run the Step 1 block (after the edit).
 Expected: PASS — prints `PASS`.
@@ -106,7 +106,7 @@ Expected: PASS — prints `PASS`.
 - Modify: `skills/woostack-build/references/spec-template.html:31-33`
 - Test: shell `grep` + a structural parity check against the markdown
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```bash
 # (a) HTML carries the §7 AC panel + renumbered §8/§9; (b) the ordered section
@@ -125,12 +125,12 @@ test_html() {
 test_html
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: paste and run the Step 1 block.
 Expected: FAIL — HTML still has `<h2>7. Testing</h2>`, no AC panel, and its heading list differs from the (already-updated) markdown; prints `FAIL`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Replace these three lines in `skills/woostack-build/references/spec-template.html`:
 
@@ -149,12 +149,12 @@ with:
   <h2>9. Open questions</h2><div class="panel">{{OPEN_QUESTIONS}}</div>
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: re-run the Step 1 block (after the edit).
 Expected: PASS — the AC panel is present, §8/§9 renumbered, and the md/html heading lists are identical (empty `diff`); prints `PASS`.
 
-- [ ] **Step 5: Commit the increment**
+- [x] **Step 5: Commit the increment**
 
 Single `woostack-commit` for Increment 1 (its own Graphite branch on the spec+plan base):
 

--- a/skills/woostack-build/references/spec-template.html
+++ b/skills/woostack-build/references/spec-template.html
@@ -29,7 +29,8 @@
   <h2>4. Approach</h2><div class="panel">{{APPROACH}}</div>
   <h2>5. Components &amp; data flow</h2><div class="panel">{{COMPONENTS}}</div>
   <h2>6. Error handling</h2><div class="panel">{{ERRORS}}</div>
-  <h2>7. Testing</h2><div class="panel">{{TESTING}}</div>
-  <h2>8. Open questions</h2><div class="panel">{{OPEN_QUESTIONS}}</div>
+  <h2>7. Acceptance criteria</h2><div class="panel">{{ACCEPTANCE_CRITERIA}}</div>
+  <h2>8. Testing</h2><div class="panel">{{TESTING}}</div>
+  <h2>9. Open questions</h2><div class="panel">{{OPEN_QUESTIONS}}</div>
 </div></body>
 </html>

--- a/skills/woostack-build/references/spec-template.md
+++ b/skills/woostack-build/references/spec-template.md
@@ -37,10 +37,25 @@ links:
 
 {{ERRORS}}
 
-## 7. Testing
+## 7. Acceptance criteria
+
+Each AC is a testable behavior → ≥1 plan task. Fill every class or mark `N/A — <reason>`; mark the whole section `N/A — <why no testable behavior>` only when the spec has no testable behavior.
+
+- **AC1 — {{behavior}}**
+  - happy: {{expected}}
+  - error: {{expected}}
+  - edge: {{expected}}
+- **AC2 — {{behavior}}**
+  - happy: {{expected}}
+  - error: {{expected}}
+  - edge: {{expected}}
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
 
 {{TESTING}}
 
-## 8. Open questions
+## 9. Open questions
 
 {{OPEN_QUESTIONS}}


### PR DESCRIPTION
## Goal

Give spec authors a structured place to enumerate testable behaviors (happy / error / edge) so test breadth originates at the spec, not the executor. Increment 1 of 2 (the template; the plan-side gate follows in the next PR).

## Summary

- Adds **§7 Acceptance criteria** to `spec-template.md` — per-AC bullet with `happy:`/`error:`/`edge:` slots, shipped as a literal scaffold; instruction line sanctions per-slot `N/A — <reason>` and whole-section `N/A — <why>`.
- Mirrors §7 in `spec-template.html` (`{{ACCEPTANCE_CRITERIA}}` panel); renumbers Testing→**§8** (scope-noted "strategy only — cases live in §7"), Open questions→**§9**.
- Verified the two templates stay 1:1 (ordered section headings identical, §1–9).

## Test plan

### Automated

- [x] `grep` assertions: §7 present with all three slots + instruction line; §8/§9 renumbered; old `## 7. Testing` / `## 8. Open questions` gone — **PASS**
- [x] structural `diff`: markdown vs HTML ordered headings identical (1–9, entity-normalized) — **PASS**

### Manual

**Before merge**

- [ ] Skim `spec-template.md` §7 + `spec-template.html` — confirm headings/numbers match and the scaffold reads cleanly.

Spec: .woostack/specs/2026-06-06-spec-acceptance-criteria.md
