### PR TITLE
feat(woostack-plan): gate §7 acceptance-criteria breadth in self-review

### DIFF
--- a/.woostack/memory/MEMORY.md
+++ b/.woostack/memory/MEMORY.md
@@ -10,6 +10,7 @@
 - [review-angle-trigger-precision](review-angle-trigger-precision.md) `gotcha` scope=`skills/woostack-review/**` — Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also match
 - [review-config-bool-jq-default](review-config-bool-jq-default.md) `gotcha` scope=`skills/woostack-review/scripts/**` — jq `// default` silently coerces an explicit `false` to the default — wrong for 
 - [review-prompt-self-contained-blob](review-prompt-self-contained-blob.md) `gotcha` scope=`skills/woostack-review/**` — woostack-review prompts ship as ONE self-contained blob to CI runners that follo
+- [review-skip-markdown-only-pr](review-skip-markdown-only-pr.md) `gotcha` scope=`skills/woostack-review/scripts/**` — prefetch.sh emits skip=true "no code files changed" on a markdown-only PR — a fa
 - [skill-description-colon-space](skill-description-colon-space.md) `gotcha` scope=`skills/*/SKILL.md` — A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it
 - [spec-template-md-html-mirror](spec-template-md-html-mirror.md) `gotcha` scope=`skills/woostack-build/references/**` — spec-template.html's {{tokens}} are illustrative, not a substitution engine — wo
 - [fanout-empty-needs-receipt](fanout-empty-needs-receipt.md) `pattern` scope=`skills/woostack-review/**` — An empty aggregate from a fan-out of workers is ambiguous (clean vs never-ran) —

--- a/.woostack/memory/MEMORY.md
+++ b/.woostack/memory/MEMORY.md
@@ -11,4 +11,5 @@
 - [review-config-bool-jq-default](review-config-bool-jq-default.md) `gotcha` scope=`skills/woostack-review/scripts/**` — jq `// default` silently coerces an explicit `false` to the default — wrong for 
 - [review-prompt-self-contained-blob](review-prompt-self-contained-blob.md) `gotcha` scope=`skills/woostack-review/**` — woostack-review prompts ship as ONE self-contained blob to CI runners that follo
 - [skill-description-colon-space](skill-description-colon-space.md) `gotcha` scope=`skills/*/SKILL.md` — A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it
+- [spec-template-md-html-mirror](spec-template-md-html-mirror.md) `gotcha` scope=`skills/woostack-build/references/**` — spec-template.html's {{tokens}} are illustrative, not a substitution engine — wo
 - [fanout-empty-needs-receipt](fanout-empty-needs-receipt.md) `pattern` scope=`skills/woostack-review/**` — An empty aggregate from a fan-out of workers is ambiguous (clean vs never-ran) —

--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 9
+recall_count: 10
 last_recalled: 2026-06-06
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 7
+recall_count: 9
 last_recalled: 2026-06-06
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/review-skip-markdown-only-pr.md
+++ b/.woostack/memory/review-skip-markdown-only-pr.md
@@ -1,0 +1,24 @@
+---
+name: review-skip-markdown-only-pr
+type: gotcha
+scope: skills/woostack-review/scripts/**
+tags: prefetch, skip, code-files, markdown, skills-repo, fast
+hook: prefetch.sh emits skip=true "no code files changed" on a markdown-only PR — a false-negative in this all-markdown skills repo; force the swarm on docs/skills angles instead of trusting the skip.
+updated: 2026-06-06
+source: .woostack/plans/2026-06-06-spec-acceptance-criteria.md
+---
+`prefetch.sh` counts "code files" in the diff and emits `skip=true` with reason
+**`no code files changed`** when the diff is entirely `.md` (and other non-code).
+In a normal app repo that is a sane low-risk skip. In **this** repo — a skills
+collection where every change is markdown and `SKILL.md` prose *is* the product —
+it is a false-negative: a real `woostack-plan/SKILL.md` semantic change reports
+"nothing to review."
+
+`detect-angles.sh` still resolves the right angles for markdown (`docs`, `skills`,
+plus always-on `bugs`/`security`), and the artifact tree (`diff.txt`, `meta.json`,
+`angles.txt`) is still written — so the skip is advisory, not fatal. When an
+execute increment is markdown-only, **don't lean on the skip**: run the bounded
+swarm on the resolved angles anyway (the `skills` angle is the one that actually
+reads SKILL.md against authoring best-practices) so the increment gets a real
+reviewed verdict. The Inc-1 sibling change reviewed normally only because its
+`.html` counted as a code file.

--- a/.woostack/memory/skill-description-angle-bracket-placeholders.md
+++ b/.woostack/memory/skill-description-angle-bracket-placeholders.md
@@ -6,7 +6,7 @@ tags: skill-description, frontmatter, review, skills-angle, false-positive, plac
 hook: Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are an accepted, shipped convention here — not an XML/HTML defect; the review `skills` angle must not flag them.
 updated: 2026-06-06
 source: pr-232
-recall_count: 1
+recall_count: 2
 last_recalled: 2026-06-06
 ---
 Angle-bracket usage placeholders in a `SKILL.md` `description:` field — e.g.

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 16
+recall_count: 17
 last_recalled: 2026-06-06
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/spec-template-md-html-mirror.md
+++ b/.woostack/memory/spec-template-md-html-mirror.md
@@ -1,0 +1,30 @@
+---
+name: spec-template-md-html-mirror
+type: gotcha
+scope: skills/woostack-build/references/**
+tags: spec-template, visualize, html-mirror, renumber, illustrative-tokens
+hook: spec-template.html's {{tokens}} are illustrative, not a substitution engine — woostack-visualize composes bespoke HTML; edit the .md and .html together and keep sections 1:1.
+updated: 2026-06-06
+source: .woostack/plans/2026-06-06-spec-acceptance-criteria.md
+---
+`woostack-build/references/spec-template.md` and `spec-template.html` are a
+**hand-maintained 1:1 pair** — same ordered section headings and numbers. There
+is **no template engine**: the `{{UPPER_SNAKE}}` tokens in the `.html` (and the
+`.md`) are *illustrative cues only*. `woostack-visualize` **composes bespoke
+HTML** per source/audience (`woostack-visualize/SKILL.md:32-38`) and reads none
+of the tokens; `/woostack-status` reads only frontmatter. So **nothing parses the
+section numbers** — renumbering is safe — but **nothing keeps the two files in
+sync either**: editing one without mirroring the other silently desyncs the
+render.
+
+When you add/remove/renumber a section, change **both** files and verify parity,
+e.g.:
+
+```bash
+diff <(grep -oE '<h2>[0-9]+\. [^<]+' spec-template.html | sed 's#<h2>##; s/&amp;/\&/g') \
+     <(grep -oE '^## [0-9]+\. .+'   spec-template.md   | sed 's/^## //')
+```
+
+Note the `&amp;`→`&` normalization: §"Components & data flow" is `&` in markdown
+but `&amp;` in HTML, so a naive diff false-positives. Same byte-vs-entity trap
+applies to any heading with a special char.

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 28
+recall_count: 29
 last_recalled: 2026-06-06
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 26
+recall_count: 28
 last_recalled: 2026-06-06
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 54
+recall_count: 55
 last_recalled: 2026-06-06
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 52
+recall_count: 54
 last_recalled: 2026-06-06
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
+++ b/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
@@ -176,7 +176,7 @@ gt create -m "feat(woostack-build): add §7 Acceptance criteria to the spec temp
 - Modify: `skills/woostack-plan/SKILL.md:131` (extend self-review step 1 with AC coverage + N/A sanity check)
 - Test: shell `grep`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```bash
 test_plan_skill() {
@@ -189,12 +189,12 @@ test_plan_skill() {
 test_plan_skill
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: paste and run the Step 1 block.
 Expected: FAIL — none of the AC-coverage / N/A / §7 cross-ref strings exist yet; prints `FAIL`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 (a) Replace line 104 in `skills/woostack-plan/SKILL.md`:
 
@@ -223,7 +223,7 @@ with:
    `N/A`, confirm the spec body has no behavioral requirement (else flag the `N/A` as suspect).
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: re-run the Step 1 block (after the edits).
 Expected: PASS — all three strings present; prints `PASS`.
@@ -234,7 +234,7 @@ Expected: PASS — all three strings present; prints `PASS`.
 - Modify: `skills/woostack-plan/references/plan-template.md:61` (self-review checklist)
 - Test: shell `grep`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```bash
 test_plan_template() {
@@ -246,34 +246,34 @@ test_plan_template() {
 test_plan_template
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: paste and run the Step 1 block.
 Expected: FAIL — no `AC coverage` checklist item yet; prints `FAIL`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 In `skills/woostack-plan/references/plan-template.md`, insert one checklist item after the **Spec coverage** line. Replace:
 
 ```markdown
-- [ ] **Spec coverage** — every spec requirement maps to a task above.
-- [ ] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
+- [x] **Spec coverage** — every spec requirement maps to a task above.
+- [x] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
 ```
 
 with:
 
 ```markdown
-- [ ] **Spec coverage** — every spec requirement maps to a task above.
-- [ ] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test; a whole-section `N/A` is sanity-checked against the spec body.
-- [ ] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
+- [x] **Spec coverage** — every spec requirement maps to a task above.
+- [x] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test; a whole-section `N/A` is sanity-checked against the spec body.
+- [x] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: re-run the Step 1 block (after the edit).
 Expected: PASS — the `AC coverage` checklist item is present; prints `PASS`.
 
-- [ ] **Step 5: Commit the increment**
+- [x] **Step 5: Commit the increment**
 
 Single `woostack-commit` for Increment 2 (stacked on Increment 1):
 
@@ -286,15 +286,15 @@ gt create -m "feat(woostack-plan): gate §7 acceptance-criteria breadth in self-
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — every spec requirement maps to a task above.
+- [x] **Spec coverage** — every spec requirement maps to a task above.
   - AC1 (template exposes §7 scaffold) → Task 1.
   - AC2 (md/html 1:1) → Task 2 (incl. the `diff` parity check).
   - AC3 (plan self-review gates breadth) → Tasks 3 + 4.
   - AC4 (existing plan rules coherent) → Task 3 part (a), the `:104` cross-ref.
-- [ ] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test; a whole-section `N/A` is sanity-checked against the spec body.
+- [x] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test; a whole-section `N/A` is sanity-checked against the spec body.
   - happy cases → the `grep`-PASS assertions in each task; edge (N/A handling, md/html parity) → the parity `diff` and the negated `! grep` renumber checks; error cases for AC1/AC4 are spec-marked N/A (static docs), so no test owed.
-- [ ] **No placeholders** — no TBD/TODO; every step has exact paths, complete before/after blocks, and exact expected output.
-- [ ] **Type consistency** — the token `{{ACCEPTANCE_CRITERIA}}` (html) and the section names §7/§8/§9 are used identically across both template files and both plan files.
+- [x] **No placeholders** — no TBD/TODO; every step has exact paths, complete before/after blocks, and exact expected output.
+- [x] **Type consistency** — the token `{{ACCEPTANCE_CRITERIA}}` (html) and the section names §7/§8/§9 are used identically across both template files and both plan files.
 
 > woostack plan conventions (keep them):
 > - This file is **frontmatter-free** and **opens with** the `**Source:**` line.

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -101,7 +101,7 @@ Every step carries the actual content an engineer needs. These are plan failures
 them:
 
 - "TBD", "TODO", "implement later", "fill in details"
-- "Add error handling" / "add validation" / "handle edge cases" — write the actual test instead; error and edge cases belong in the spec's §7 Acceptance criteria, enumerated there as happy/error/edge
+- "Add error handling" / "add validation" / "handle edge cases" — write the actual test instead; error and edge cases belong in the spec's §7 Acceptance criteria, enumerated there as happy/error/edge cases
 - "Write tests for the above" without the actual test
 - "Similar to Task N" — repeat the code; tasks may be read out of order
 - A step that says *what* without showing *how* (code/command blocks required)

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -101,7 +101,7 @@ Every step carries the actual content an engineer needs. These are plan failures
 them:
 
 - "TBD", "TODO", "implement later", "fill in details"
-- "Add error handling" / "add validation" / "handle edge cases"
+- "Add error handling" / "add validation" / "handle edge cases" — write the actual test instead; error and edge cases belong in the spec's §7 Acceptance criteria, enumerated there as happy/error/edge
 - "Write tests for the above" without the actual test
 - "Similar to Task N" — repeat the code; tasks may be read out of order
 - A step that says *what* without showing *how* (code/command blocks required)
@@ -129,6 +129,9 @@ After writing the plan, check it against the spec with fresh eyes — a checklis
 not a subagent dispatch:
 
 1. **Spec coverage** — every section/requirement maps to a task. List and fill any gap.
+   **AC coverage:** when the spec's §7 Acceptance criteria lists ACs, every AC — and each
+   filled (non-N/A) happy/error/edge case — maps to a task/test; when §7 is whole-section
+   `N/A`, confirm the spec body has no behavioral requirement (else flag the `N/A` as suspect).
 2. **Placeholder scan** — search for the red flags above; fix them.
 3. **Type consistency** — types, signatures, and property names match across tasks (a method
    called one name in Task 3 and another in Task 7 is a bug).

--- a/skills/woostack-plan/references/plan-template.md
+++ b/skills/woostack-plan/references/plan-template.md
@@ -59,6 +59,7 @@ gt modify -c -m "{{type}}: {{subject}}"
 ## Self-review (run before handing back)
 
 - [ ] **Spec coverage** — every spec requirement maps to a task above.
+- [ ] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test; a whole-section `N/A` is sanity-checked against the spec body.
 - [ ] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
 - [ ] **Type consistency** — types, signatures, and names match across tasks.
 


### PR DESCRIPTION
## Goal

Close the breadth loop opened by #247: make the plan engine *enforce* that the spec's §7 acceptance criteria — and their happy/error/edge cases — actually land as TDD tasks/tests, so structured breadth isn't just authored, it's gated. Increment 2 of 2.

## Summary

- `woostack-plan/SKILL.md` self-review step 1 now asserts **AC coverage**: every spec §7 AC (and each filled, non-N/A happy/error/edge case) maps to a task/test; a whole-section `N/A` is sanity-checked against the spec body (else flagged suspect).
- Cross-references the banned-placeholder rule ("handle edge cases") to §7 as the structured home for error/edge cases — keeps the ban, gives it a destination.
- `plan-template.md` self-review checklist gains a matching **AC coverage** line.
- Plan task mechanics unchanged — the gate checks test *existence*, not task count.

## Test plan

### Automated

- [x] `grep`: SKILL.md carries `**AC coverage:**`, the `no behavioral requirement` sanity-check, and the §7 cross-reference — **PASS**
- [x] `grep`: plan-template.md self-review checklist carries the `**AC coverage**` line — **PASS**
- [x] Both red→green transitions observed (assertions failed pre-edit, passed post-edit).

### Manual

**Before merge**

- [ ] Read the `woostack-plan/SKILL.md` self-review diff + `plan-template.md` checklist line — confirm the AC-coverage + N/A-sanity wording is clear and the §7 cross-ref reads right.

Spec: .woostack/specs/2026-06-06-spec-acceptance-criteria.md
