### PR TITLE
docs(woostack-tdd): spec + plan for TDD doctrine-home + add-tests command

### DIFF
--- a/.woostack/plans/2026-06-07-woostack-tdd.md
+++ b/.woostack/plans/2026-06-07-woostack-tdd.md
@@ -1,0 +1,510 @@
+**Source:** .woostack/specs/2026-06-07-woostack-tdd.md
+
+# woostack-tdd Implementation Plan
+
+**Goal:** Add a public `woostack-tdd` skill that is the single canonical home for the TDD kernel and an on-demand `/woostack-tdd <target>` command that adds appropriate tests to a code block, PR, spec, or plan.
+
+**Architecture:** Increment 1 creates `skills/woostack-tdd/SKILL.md` (doctrine kernel + target-routed command) and wires it into the public surface (routing row + AGENTS.md counts/list/file-map) — a fully working new command on its own. Increment 2 stacks on top and de-duplicates the kernel: the 6 sites that currently restate TDD doctrine are repointed to *link* the new kernel while keeping their context-specific delta. No runtime delegation; no app build/CI (skills repo).
+
+**Tech Stack:** Markdown skill assets only. This repo has **no test runner** (AGENTS.md: "no application source code, app lockfile, build, or CI"), so every "failing test" is a concrete `grep`/link-check verification command with exact expected output (woostack convention, `woostack-plan/SKILL.md:91-93`). Source control via Graphite (`gt`).
+
+---
+
+## Increment 1: Create the woostack-tdd skill + wire the public surface
+
+> One independently shippable PR — a new, fully-routed `/woostack-tdd` command. Its own Graphite branch, stacked on the spec+plan PR.
+
+### Task 1: Author `skills/woostack-tdd/SKILL.md`
+
+**Files:**
+- Create: `skills/woostack-tdd/SKILL.md`
+
+- [ ] **Step 1: Write the failing verification**
+
+```bash
+# From repo root. Asserts the file exists with its load-bearing markers.
+test -f skills/woostack-tdd/SKILL.md \
+  && grep -q '^name: woostack-tdd$' skills/woostack-tdd/SKILL.md \
+  && grep -q '## The TDD kernel' skills/woostack-tdd/SKILL.md \
+  && grep -q 'CHARACTERIZATION-CARVE-OUT' skills/woostack-tdd/SKILL.md \
+  && grep -q '/woostack-tdd <target>' skills/woostack-tdd/SKILL.md \
+  && grep -q 'Never commits or merges' skills/woostack-tdd/SKILL.md \
+  && echo TDD_SKILL_OK
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: the command above.
+Expected: FAIL — no output / `No such file or directory` (file absent).
+
+- [ ] **Step 3: Create the file with this exact content**
+
+````markdown
+---
+name: woostack-tdd
+description: "woostack's canonical test-driven-development home and on-demand test-adder. The single source for the TDD kernel — Red→Green→Refactor, test-first, cover happy/error/edge/success+failure, framework-aware, no-runner→concrete verification — that woostack-plan, woostack-execute, woostack-debug, and bootstrap patterns.md §7 LINK instead of restating. Also the 14th public command: /woostack-tdd <target> adds appropriate tests to an existing code block, PR, spec, or plan — one verb, target-routed (code→colocated *.test files, PR→tests for the gh pr diff surface, spec→strengthen §7 acceptance criteria, plan→fill failing-test steps) — with a characterization carve-out for existing code (new code is red-first; existing code pins current behavior). Writes tests to the working tree and hands to woostack-commit; never commits, merges, or authors status:/branch:; owns no approval gate."
+---
+
+# woostack-tdd
+
+Two roles in one skill. **(1) The canonical TDD doctrine home** — the kernel below is stated
+once here and *linked*, never restated, by [woostack-plan](../woostack-plan/SKILL.md),
+[woostack-execute](../woostack-execute/SKILL.md), [woostack-debug](../woostack-debug/SKILL.md),
+and [bootstrap patterns.md §7](../woostack-bootstrap/references/patterns.md), honoring the repo's
+"cross-link, do not duplicate" rule. **(2) The 14th public command** — `/woostack-tdd <target>`
+adds the appropriate tests to an existing block of code, a PR, a spec, or a plan. It writes tests
+to the working tree and hands to [woostack-commit](../woostack-commit/SKILL.md); it never commits,
+merges, or touches a spec's `status:`/`branch:`, and owns no approval gate.
+
+## The TDD kernel
+
+The canonical test-driven-development discipline for all of woostack. Other skills **link** this
+section; they do not restate it.
+
+**Red → Green → Refactor.** For code woostack is *authoring*, the test comes first:
+
+1. **Red** — write a failing test describing the expected behavior; run it, watch it fail.
+2. **Green** — write the minimal code to make it pass; run it, watch it pass.
+3. **Refactor** — clean up names, duplication, and structure with the tests green; re-run to
+   confirm they stay green.
+
+**Coverage classes.** Appropriate tests span, per behavior: the **happy** path, every **error**
+path, **edge**/boundary conditions, and both **success and failure** outcomes — exactly what a
+spec's §7 Acceptance-criteria slots enumerate.
+
+**No-runner substitution.** In a target with no test runner (a docs/skills repo), "the failing
+test" becomes a concrete **verification command** — a `grep`, a `bash -n`, a link check, or an
+existing script's test — with exact expected output. Never a vague "verify it works."
+
+<CHARACTERIZATION-CARVE-OUT>
+Test-first applies to code being authored. When adding tests to code that ALREADY EXISTS (the
+`code` and `PR` command targets), you cannot write the test first — the code is already there.
+The one sanctioned departure: write CHARACTERIZATION tests that pin the code's CURRENT behavior,
+then use them as the regression safety net. New code is red-first; existing code is
+characterization. Forcing a red by mutating-then-restoring existing code is NOT required.
+</CHARACTERIZATION-CARVE-OUT>
+
+**Framework-aware.** Follow the project's runner and file conventions — Vitest everywhere except
+React Native (Jest via `jest-expo`), Playwright for E2E, tests colocated as `*.test.ts(x)` or in
+`__tests__/`. The project-specific standard lives in
+[patterns.md §7](../woostack-bootstrap/references/patterns.md).
+
+**Clarify before writing** when inputs, outputs, error contracts, or integration points are
+unclear — don't guess them.
+
+## `/woostack-tdd <target>` — add appropriate tests
+
+One verb — *add the appropriate tests* — applied to whatever the argument resolves to.
+Auto-detect the target by argument shape:
+
+| Target | Detected by | What it produces |
+|---|---|---|
+| **code** | a source path, or pasted code | colocated `*.test.ts(x)` per the project runner; **characterization** tests for existing code (see the carve-out) |
+| **PR** | a PR number or URL | tests covering the **diff surface only** — read it with `gh pr diff <n>` (read-only inspection; `git diff <base>...HEAD` for a local branch) |
+| **spec** | a path under `.woostack/specs/` | strengthen the testable **§7 Acceptance criteria** in place (happy/error/edge per behavior) |
+| **plan** | a path under `.woostack/plans/` | fill each task's **failing-test-first step** with the actual test and exact expected output |
+| **(none)** | no argument | **ask** what to test; never guess (mirrors [woostack-debug](../woostack-debug/SKILL.md)) |
+
+Apply the kernel to whichever target: real tests for code/PR, the artifact's test-equivalent for
+spec/plan. In a no-runner target, substitute the concrete verification command per the kernel. If
+the argument is ambiguous, **ask** — don't guess the target type.
+
+## Memory
+
+Recall testing `gotcha`/`pattern` notes for the target's working set before adding tests; distill
+**at most one** durable testing `pattern` at the end through the reject-by-default gate. The note
+schema, recall procedure, and distill gate are defined once in
+[memory.md](../woostack-init/references/memory.md) — link, never restate.
+
+## Hard constraints
+
+- **Single source for the kernel.** The kernel above is stated once; consumers link it. Adding a
+  duplicate restatement elsewhere is the anti-pattern this skill exists to remove.
+- **Never commits or merges.** Writes tests/edits to the working tree and hands to
+  [woostack-commit](../woostack-commit/SKILL.md).
+- **Gate-light.** Owns no approval gate (like `woostack-execute`/`woostack-harden`). For a
+  spec/plan edit, show the before/after diff; do not block.
+- **Authors no `status:`/`branch:`.** Spec/plan enrichment is content-only; never author a phase
+  transition or fork a second plan. The `spec : plan : PRs = 1 : 1 : N` invariant — defined in
+  [conventions.md](../woostack-status/references/conventions.md) — is untouched. When the target's
+  `status:` is ≥ `planning` (a plan already exists), surface that the plan may need re-derivation;
+  still edit content only.
+- **No runtime delegation.** `woostack-execute` and `woostack-debug` write their tests inline and
+  link this kernel for the "how"; they do not invoke this skill at runtime.
+- **Characterization for existing code only.** New code stays red-first; the carve-out is not a
+  license to skip test-first when authoring.
+- **No-runner → concrete verification.** Never a vague "verify it works."
+- **Distill durable knowledge only.** Reject-by-default; ≤1 testing `pattern` per run; never
+  feature-specific trivia.
+````
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: the Step 1 command.
+Expected: PASS — prints `TDD_SKILL_OK`.
+
+- [ ] **Step 5: Verify every cross-link resolves**
+
+```bash
+# Each linked path, resolved relative to skills/woostack-tdd/, must exist.
+cd skills/woostack-tdd && for p in \
+  ../woostack-plan/SKILL.md ../woostack-execute/SKILL.md ../woostack-debug/SKILL.md \
+  ../woostack-bootstrap/references/patterns.md ../woostack-commit/SKILL.md \
+  ../woostack-status/references/conventions.md ../woostack-init/references/memory.md; do
+  test -f "$p" || echo "BROKEN: $p"; done; echo LINKS_CHECKED
+```
+
+Expected: PASS — prints only `LINKS_CHECKED` (no `BROKEN:` lines). Then commit:
+
+```bash
+gt create -m "feat(woostack-tdd): canonical TDD kernel + /woostack-tdd add-tests command"
+```
+
+### Task 2: Add the Command-Routing row to `using-woostack`
+
+**Files:**
+- Modify: `skills/using-woostack/SKILL.md` (Command Routing table, after the `woostack-debug` row)
+
+- [ ] **Step 1: Write the failing verification**
+
+```bash
+grep -q '`/woostack-tdd <target>`.*`woostack-tdd`' skills/using-woostack/SKILL.md && echo ROUTE_OK
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: the command above.
+Expected: FAIL — no output (no routing row yet).
+
+- [ ] **Step 3: Insert the routing row**
+
+After the existing line:
+
+```
+| `/woostack-debug <target> [--auto]`, find a bug's root cause before fixing (gated; `--auto` for autonomous) | `woostack-debug` |
+```
+
+add:
+
+```
+| `/woostack-tdd <target>`, add appropriate tests to a code block, PR, spec, or plan (gate-light; TDD doctrine home) | `woostack-tdd` |
+```
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: the Step 1 command.
+Expected: PASS — prints `ROUTE_OK`. Then commit:
+
+```bash
+gt modify -c -m "feat(woostack-tdd): route /woostack-tdd in using-woostack"
+```
+
+### Task 3: Update `AGENTS.md` — surface list, counts, file map
+
+**Files:**
+- Modify: `AGENTS.md` (canonical; `.claude/CLAUDE.md` is a symlink to it)
+
+> Read the real strings first — the counts ("thirteen", "fifteen") and list are authoritative in the file, not in any cached copy. Apply each substitution exactly.
+
+- [ ] **Step 1: Write the failing verification**
+
+```bash
+grep -q 'fourteen skills' AGENTS.md \
+  && grep -q 'woostack-tdd' AGENTS.md \
+  && grep -q 'sixteen `SKILL.md` files' AGENTS.md \
+  && grep -q 'fourteen-skill command surface' AGENTS.md \
+  && ! grep -q 'thirteen' AGENTS.md \
+  && ! grep -q 'fifteen' AGENTS.md \
+  && echo AGENTS_OK
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: the command above.
+Expected: FAIL — no output (counts still say thirteen/fifteen; no `woostack-tdd`).
+
+- [ ] **Step 3: Apply the five edits**
+
+1. `The public command/adoption surface has thirteen skills:` → `... has fourteen skills:`
+2. In that bullet list, after the `woostack-debug` bullet add:
+   `` - [`woostack-tdd`](skills/woostack-tdd/SKILL.md) ``
+3. `they have no routing row and are absent from the thirteen-skill command` →
+   `... absent from the fourteen-skill command`
+4. `Do not move or rename any of the fifteen `SKILL.md` files (the thirteen public command/adoption skills plus the internal `woostack-ideate` and `woostack-harden`).`
+   → `... any of the sixteen `SKILL.md` files (the fourteen public command/adoption skills plus the internal `woostack-ideate` and `woostack-harden`).`
+5. In **Mode B**'s command enumeration (`... `/woostack-status`, `/woostack-visualize`, or `/woostack-debug`, including intent-equivalent wording.`) insert `/woostack-tdd` into the list:
+   `... `/woostack-visualize`, `/woostack-debug`, or `/woostack-tdd`, including intent-equivalent wording.`
+6. In **Quick file map**, after the `woostack-debug` entry add:
+   ```
+   - TDD doctrine home and add-tests command (public command):
+     [`skills/woostack-tdd/SKILL.md`](skills/woostack-tdd/SKILL.md)
+   ```
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: the Step 1 command.
+Expected: PASS — prints `AGENTS_OK`.
+
+- [ ] **Step 5: Confirm the symlink reflects the change**
+
+```bash
+grep -q 'fourteen skills' .claude/CLAUDE.md && echo SYMLINK_OK
+```
+
+Expected: PASS — prints `SYMLINK_OK` (symlink resolves to the edited `AGENTS.md`). Then commit:
+
+```bash
+gt modify -c -m "feat(woostack-tdd): list woostack-tdd in AGENTS.md surface, counts, file map"
+```
+
+---
+
+## Increment 2: Extract the kernel — de-dup the 6 consumer sites
+
+> One independently shippable refactor PR, stacked on Increment 1. Each site links the new kernel and drops its restated doctrine while keeping its context-specific delta. Its own Graphite branch.
+
+### Task 1: `patterns.md §7` — keep the project standard, link the kernel
+
+**Files:**
+- Modify: `skills/woostack-bootstrap/references/patterns.md:129-148` (§7)
+
+- [ ] **Step 1: Write the failing verification**
+
+```bash
+grep -q 'woostack-tdd' skills/woostack-bootstrap/references/patterns.md \
+  && ! grep -q 'minimum code to make it pass' skills/woostack-bootstrap/references/patterns.md \
+  && grep -q 'jest-expo' skills/woostack-bootstrap/references/patterns.md \
+  && echo PATTERNS_OK
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: the command above.
+Expected: FAIL — no output (kernel workflow prose still present; no `woostack-tdd` link).
+
+- [ ] **Step 3: Replace the §7 body**
+
+Replace lines 129-148 (the whole `## 7. Test-Driven Development` section through "A feature is **not complete** until all tests pass.") with:
+
+```markdown
+## 7. Test-Driven Development
+
+Red → Green → Refactor, test-first, non-negotiable. The canonical TDD kernel — the workflow,
+coverage classes, and no-runner substitution — lives once in
+[woostack-tdd](../../woostack-tdd/SKILL.md); follow it. This section records only the
+**project-specific** standard layered on top:
+
+**Frameworks:** Vitest everywhere except React Native (uses Jest via `jest-expo`). Playwright for
+E2E. Test files colocated with source as `*.test.ts(x)` or in `__tests__/`.
+
+A feature is **not complete** until all tests pass.
+```
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: the Step 1 command.
+Expected: PASS — prints `PATTERNS_OK` (kernel linked; restated "minimum code to make it pass" workflow gone; project framework standard kept).
+
+```bash
+gt create -m "refactor(woostack-tdd): patterns.md §7 links the TDD kernel"
+```
+
+### Task 2: `woostack-plan` §"Bite-sized tasks (TDD)" — keep step shape, link the kernel
+
+**Files:**
+- Modify: `skills/woostack-plan/SKILL.md:85-93`
+
+- [ ] **Step 1: Write the failing verification**
+
+```bash
+grep -q 'woostack-tdd' skills/woostack-plan/SKILL.md \
+  && ! grep -q 'Never a vague "verify it works."' skills/woostack-plan/SKILL.md \
+  && grep -q 'write the failing test → run it, confirm it fails' skills/woostack-plan/SKILL.md \
+  && echo PLAN_OK
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: the command above.
+Expected: FAIL — no output (standalone no-runner paragraph still present; no kernel link).
+
+- [ ] **Step 3: Replace the second paragraph**
+
+Keep the first paragraph (lines 85-89, the step-decomposition / checkbox mechanics) unchanged.
+Replace the second paragraph (lines 91-93, currently:
+`In a target without a test runner (e.g. a docs/skills repo), "the failing test" becomes a concrete **verification command** — a `grep`, a `bash -n`, a link check, or an existing script's test — with exact expected output. Never a vague "verify it works."`)
+with:
+
+```markdown
+The TDD discipline these steps embody — red→green→refactor, the coverage classes, and the
+no-runner→concrete-verification substitution — is the canonical kernel in
+[woostack-tdd](../woostack-tdd/SKILL.md); this section applies it to plan-task shape.
+```
+
+> Note: `references/plan-template.md` is the literal task scaffold (mechanics) and keeps its own terse no-runner note — it is NOT edited here.
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: the Step 1 command.
+Expected: PASS — prints `PLAN_OK` (kernel linked; the duplicated no-runner doctrine paragraph removed; step-shape sentence kept).
+
+```bash
+gt modify -c -m "refactor(woostack-tdd): woostack-plan links the TDD kernel"
+```
+
+### Task 3: `woostack-execute` drivers — keep impl-loop framing, link the kernel
+
+**Files:**
+- Modify: `skills/woostack-execute/references/inline-driver.md:12-17`
+- Modify: `skills/woostack-execute/prompts/implementer.md:24-28`
+
+- [ ] **Step 1: Write the failing verification**
+
+```bash
+grep -q 'woostack-tdd' skills/woostack-execute/references/inline-driver.md \
+  && grep -q 'woostack-tdd' skills/woostack-execute/prompts/implementer.md \
+  && ! grep -qF 'then **refactor** with the tests green' skills/woostack-execute/references/inline-driver.md \
+  && echo EXEC_OK
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: the command above.
+Expected: FAIL — no output (full red-green-refactor restatement still in inline-driver; no kernel links).
+
+- [ ] **Step 3a: Replace inline-driver.md step 1**
+
+Replace step 1 (lines 12-17) with:
+
+```markdown
+1. **Follow test-driven development** per the [woostack-tdd kernel](../../woostack-tdd/SKILL.md)
+   — red-first for new code, characterization for code that already exists; refactor with the
+   tests green; in a no-runner target substitute the concrete verification the plan specifies.
+   This is a principle, not a hard dependency: if the kernel isn't loaded, follow TDD by hand.
+```
+
+- [ ] **Step 3b: Update implementer.md instruction 1 (keep self-contained)**
+
+implementer.md is a prompt injected into a **fresh, context-free subagent**, so it keeps a
+**self-contained** inline TDD rule (it is not reduced to a bare link — same rationale that leaves
+`subagent-driver.md` alone). Replace instruction 1 (lines 24-28) with an aligned inline rule
+that also names the canonical source:
+
+```markdown
+1. Follow test-driven development (canonical: the woostack-tdd kernel,
+   `skills/woostack-tdd/SKILL.md`): for new code, write the failing test first, watch it fail,
+   write the minimal code, watch it pass, then refactor with the tests green; for code that
+   already exists, write characterization tests pinning current behavior. If the change has no
+   runnable test harness (e.g. a docs/skill edit), run the concrete verification the task
+   specifies instead (grep / link check / structural assertion).
+```
+
+> Note: for implementer.md the de-dup is **link-present only** (the inline rule legitimately
+> stays — a context-free subagent must not depend on following a link). Full phrase-removal
+> applies only to `inline-driver.md`, which the link-following main agent reads.
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: the Step 1 command.
+Expected: PASS — prints `EXEC_OK` (both drivers link the kernel; the verbose red-green-refactor restatement removed; impl-loop framing kept).
+
+```bash
+gt modify -c -m "refactor(woostack-tdd): execute drivers link the TDD kernel"
+```
+
+### Task 4: `woostack-debug` Phase 4 — keep failing-test-first, repoint to the kernel
+
+**Files:**
+- Modify: `skills/woostack-debug/SKILL.md:77-81` (Phase 4, step 1)
+
+- [ ] **Step 1: Write the failing verification**
+
+```bash
+grep -q 'woostack-tdd' skills/woostack-debug/SKILL.md \
+  && ! grep -q 'reusing the TDD discipline embodied in' skills/woostack-debug/SKILL.md \
+  && grep -q 'Write a failing test first' skills/woostack-debug/SKILL.md \
+  && echo DEBUG_OK
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: the command above.
+Expected: FAIL — no output (step still says "reusing the TDD discipline embodied in woostack-execute"; no woostack-tdd link).
+
+- [ ] **Step 3: Replace Phase 4 step 1**
+
+Replace step 1 (lines 77-81) with:
+
+```markdown
+1. **Write a failing test first.** The simplest reproduction of the bug, automated if a test
+   harness exists — per the [woostack-tdd kernel](../woostack-tdd/SKILL.md). In a target with no
+   test runner, the "failing test" is a concrete verification command (a `grep`, a `bash -n`, a
+   link check) with exact expected output — never a vague "verify it works". You must have this
+   before fixing.
+```
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: the Step 1 command.
+Expected: PASS — prints `DEBUG_OK` (kernel linked; the "embodied in woostack-execute" restatement gone; failing-test-first-before-a-fix kept).
+
+```bash
+gt modify -c -m "refactor(woostack-tdd): debug Phase 4 links the TDD kernel"
+```
+
+### Task 5: `woostack-build:105` — repoint the by-reference TDD mention
+
+**Files:**
+- Modify: `skills/woostack-build/SKILL.md` (the step-9 line: "each implemented with TDD, …")
+
+- [ ] **Step 1: Write the failing verification**
+
+```bash
+grep -q 'with TDD (the \[woostack-tdd kernel\](../woostack-tdd/SKILL.md))' skills/woostack-build/SKILL.md && echo BUILD_OK
+```
+
+- [ ] **Step 2: Run it, confirm it fails**
+
+Run: the command above.
+Expected: FAIL — no output (mention is by-reference only, unlinked).
+
+- [ ] **Step 3: Add the kernel link**
+
+The phrase wraps: line 104 ends with `each implemented`; line 105 begins `with TDD,`. On
+**line 105**, change `with TDD,` → `with TDD (the [woostack-tdd kernel](../woostack-tdd/SKILL.md)),`.
+Edit only the line-105 fragment; leave `each implemented` on line 104.
+
+- [ ] **Step 4: Run the verification, confirm it passes**
+
+Run: the Step 1 command.
+Expected: PASS — prints `BUILD_OK`.
+
+- [ ] **Step 5: Final de-dup link check**
+
+```bash
+# Every new kernel back-link resolves from its own file's directory.
+err=0
+check(){ ( cd "$1" && test -f "$2" ) || { echo "BROKEN: $1 -> $2"; err=1; }; }
+check skills/woostack-bootstrap/references ../../woostack-tdd/SKILL.md
+check skills/woostack-plan ../woostack-tdd/SKILL.md
+check skills/woostack-execute/references ../../woostack-tdd/SKILL.md
+check skills/woostack-execute/prompts ../../woostack-tdd/SKILL.md
+check skills/woostack-debug ../woostack-tdd/SKILL.md
+check skills/woostack-build ../woostack-tdd/SKILL.md
+[ $err -eq 0 ] && echo ALL_LINKS_OK
+```
+
+Expected: PASS — prints `ALL_LINKS_OK` (no `BROKEN:` lines). Then commit:
+
+```bash
+gt modify -c -m "refactor(woostack-tdd): woostack-build step 9 links the TDD kernel"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [x] **Spec coverage** — every spec section maps to a task. §4 Half-A (extract) → Inc 2 Tasks 1-5; §4 Half-B (command) → Inc 1 Task 1; §5 components → Inc 1 Tasks 1-3 + Inc 2 Tasks 1-5; §6 error handling → encoded in skill `## Hard constraints` (Inc 1 Task 1) + the link/grep checks.
+- [x] **AC coverage** — AC1 (doctrine home) → Inc 1 Task 1 (Steps 1/4 grep `## The TDD kernel`, frontmatter, carve-out). AC2 (4 targets + no-arg + framework) → Inc 1 Task 1 (target-router table + framework + no-runner + `(none)→ask`). AC3 (boundaries) → Inc 1 Task 1 (`## Hard constraints`: never commits/merges, gate-light, no status:/branch:, no runtime delegation). AC4 (extracted, not duplicated) → Inc 2 Tasks 1-5: full de-dup (link-present **and** phrase-absent) for the main-agent-read sites (`patterns.md`, `woostack-plan`, `inline-driver.md`, `woostack-debug`, `woostack-build`); **link-present only** for `implementer.md` (a context-free subagent prompt keeps its inline rule); `subagent-driver.md`/`plan-template.md` left untouched (not in the task list). AC5 (surface wired) → Inc 1 Tasks 2-3 (routing row; AGENTS.md counts thirteen→fourteen / fifteen→sixteen, list, file map) with the `! grep` guards catching one-count-but-not-the-other drift.
+- [x] **No placeholders** — full SKILL.md content inline; every edit gives exact old→new text and an exact grep with expected output.
+- [x] **Type consistency** — the kernel anchor name (`## The TDD kernel`), the link target (`woostack-tdd/SKILL.md`), and the carve-out marker (`CHARACTERIZATION-CARVE-OUT`) are used identically across all tasks; relative link depths verified per file location in Inc 1 Task 1 Step 5 and Inc 2 Task 5 Step 5.

--- a/.woostack/specs/2026-06-07-woostack-tdd.md
+++ b/.woostack/specs/2026-06-07-woostack-tdd.md
@@ -1,0 +1,320 @@
+---
+name: woostack-tdd
+type: spec
+status: planning
+date: 2026-06-07
+branch: woostack-tdd
+links:
+---
+
+# woostack-tdd: TDD doctrine home + add-tests command — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+woostack's TDD doctrine is **scattered and restated** across five sites, with no canonical
+home — directly against this repo's "Cross-link, do not duplicate" ethos (project AGENTS.md):
+
+- `skills/woostack-bootstrap/references/patterns.md:129-148` (§7) — the kernel itself:
+  Red→Green→Refactor, "tests written before implementation", coverage classes (user
+  scenarios, edge/boundary, error conditions, success+failure), framework choices, "not
+  complete until tests pass".
+- `skills/woostack-plan/SKILL.md:83-94` (§"Bite-sized tasks (TDD)") + `references/plan-template.md`
+  — TDD as plan **steps** (write failing test → confirm fail → minimal impl → confirm pass →
+  commit), plus the no-runner→concrete-verification rule.
+- `skills/woostack-execute/references/inline-driver.md:10-17`, `prompts/implementer.md:23-27`,
+  `references/subagent-driver.md:37` — TDD as the **implement loop** (red → green → refactor;
+  no-runner substitution).
+- `skills/woostack-debug/SKILL.md:77-81` (Phase 4) — **failing-test-first** before a fix, with
+  the same no-runner substitution.
+- `skills/woostack-build/SKILL.md:105` — TDD by reference only.
+
+The kernel ("Red→Green→Refactor; test-first; cover happy/error/edge/success+failure;
+characterization for existing code; framework-aware; no-runner→concrete verification") is the
+same in every site, re-typed each time. There is no single source the others link.
+
+There is also a **capability gap**: every existing TDD touchpoint writes tests for code the
+loop is *currently authoring*. Nothing offers an on-demand "add the appropriate tests to *this*
+existing code / PR / spec / plan" entry point — the common brownfield need (untested existing
+code, a PR that shipped thin tests, a spec whose acceptance criteria are weak, a plan whose
+tasks lack concrete failing-test steps). Today that work has no skill.
+
+## 2. Goal
+
+Create a new **public** skill `woostack-tdd` that serves two coupled roles:
+
+1. **Canonical TDD doctrine home.** The kernel lives once in `woostack-tdd/SKILL.md`; the five
+   consumer sites keep only their **context-specific application** and **link** the kernel
+   instead of restating it — mirroring how `conventions.md` and `memory.md` are single sources
+   linked everywhere.
+2. **`/woostack-tdd <target>` command** that **adds appropriate tests** to a **code block / PR /
+   spec / plan**. One verb, target-specific output; framework-aware; in a no-runner target the
+   "test" is a concrete verification command. It writes tests/edits to the **working tree**,
+   hands off to `woostack-commit`, and **never commits or merges**.
+
+After this change, the kernel is stated once and reused by link; and a user with existing
+untested code (or a thin PR / weak spec / under-specified plan) has a single command that adds
+the right tests.
+
+## 3. Non-goals
+
+- **No runtime delegation.** `woostack-execute` (implementer) and `woostack-debug` (Phase 4)
+  keep writing tests **inline** in their own control flow. They link the kernel for the "how";
+  they do **not** invoke `woostack-tdd` as a sub-step. No skill hop inside hot loops.
+- **No new approval gate in the build loop.** The build chain's three hard gates are untouched.
+  `woostack-tdd` is **gate-light** — like `woostack-execute`/`woostack-harden`, it owns no
+  approval gate (it shows the diff for spec/plan edits but does not block).
+- **Never commits or merges.** Writes to the working tree; hands to `woostack-commit`.
+- **Authors no `status:`/`branch:` transitions.** Spec/plan edits are **content-only**; the
+  `spec : plan : PRs = 1 : 1 : N` invariant and the build loop's ownership of phase transitions
+  are untouched.
+- **No new test harness, CI, or package script** for this repo (AGENTS.md: "no hidden tools").
+- **No automatic backfill of existing specs/plans.** The command enriches a spec/plan **only
+  when explicitly pointed at one**; it does not sweep `.woostack/` retro-fitting §7 or task
+  steps.
+- **No coverage-percentage tooling.** It adds *appropriate* tests by behavior class, not a
+  numeric coverage gate or threshold.
+- **No template reshaping.** It uses the **existing** spec §7 Acceptance-criteria scaffold and
+  the existing plan-task step shape; it does not redesign either template.
+
+## 4. Approach
+
+Two halves, both pure skill-asset edits.
+
+**Half A — extract the kernel (de-dup).** `woostack-tdd/SKILL.md` carries the canonical TDD
+kernel as a named section. Each of the five consumer sites is edited to **keep its
+context-specific delta and link the kernel** rather than restate it:
+
+- `patterns.md §7` keeps the generated **project's** framework table + "not complete until
+  tests pass" standard; the Red→Green→Refactor/coverage-class prose links the kernel.
+- `woostack-plan` keeps the **plan-step** decomposition (one action per step, checkbox syntax);
+  the red→green rationale links the kernel.
+- `woostack-execute` (`inline-driver.md`, `implementer.md`, `subagent-driver.md`) keeps the
+  **implement-loop** wording; the red→green→refactor definition links the kernel.
+- `woostack-debug` Phase 4 keeps **failing-test-first-before-a-fix**; the TDD definition links
+  the kernel (it already half-links execute).
+- `woostack-build:105` keeps the by-reference mention, now pointing at the kernel.
+
+The test: the kernel sentences appear **once** (in `woostack-tdd`) and are **removed** from the
+consumers, which each gain a link.
+
+**Half B — the command.** `/woostack-tdd <target>` **auto-detects the target by argument
+shape** and applies one verb — "add appropriate tests" — with target-specific output:
+
+| Target | Detected by | Output |
+|---|---|---|
+| code block | a source path or pasted code | colocated `*.test.ts(x)`; **characterization** tests for existing code |
+| PR | a PR number / URL | tests covering the **diff surface** only |
+| spec | a path under `.woostack/specs/` | strengthen the testable **§7 Acceptance criteria** in place |
+| plan | a path under `.woostack/plans/` | fill each task's **failing-test-first step** with exact expected output |
+| (none) | no argument | **ask** what to test — never guess (mirrors `woostack-debug`) |
+
+**Test-first vs existing code (the kernel's central carve-out).** The kernel states test-first
+(red-first) as **the** discipline for code the loop is *authoring* (execute/debug/plan). But the
+command's headline job is adding tests to code that *already exists* — you cannot write the test
+"first". So the kernel sanctions **one** departure: for existing code (the code/PR targets), the
+command writes **characterization tests** that pin current behavior, explicitly named as the
+brownfield carve-out from literal red-first. New-code TDD stays red-first; existing-code
+test-adding is characterization. (Force-a-red — mutate code → watch fail → restore → watch pass —
+is **not** required; rejected as over-ceremony in harden.)
+
+Framework-aware: detect the runner (Vitest / Jest-expo / Playwright per `patterns.md §7`); in a
+**no-runner** target (e.g. this skills repo) the "failing test" becomes a **concrete
+verification command** (grep / `bash -n` / link check) with exact expected output — never a
+vague "verify it works". PR diff read via `gh pr diff <n>` (read-only inspection, per AGENTS.md;
+`git diff <base>...HEAD` for a local branch). Boundaries: write to the working tree, hand to
+`woostack-commit`, never commit/merge, leave `status:`/`branch:` alone, show the diff for
+spec/plan edits.
+
+**Memory** (light): recall testing `gotcha`/`pattern` notes for the target's working set at
+start; reject-by-default distill of **at most one** durable testing `pattern` at end. Schema and
+procedure are defined once in [memory.md](../../skills/woostack-init/references/memory.md) —
+link, never restate.
+
+## 5. Components & data flow
+
+**New file:**
+
+1. **`skills/woostack-tdd/SKILL.md`** — the skill. Sections: dense single-paragraph
+   `description` frontmatter; H1 lead (role: doctrine home + on-demand add-tests command, public
+   command #14, never commits/merges); a named **kernel** section (the canonical TDD doctrine
+   the consumers link); a **command** section with the target-router table + framework/no-runner
+   rule + no-arg→ask; a **boundaries** paragraph; a **memory** section (link memory.md); a
+   `## Hard constraints` list. House style: two-field frontmatter, named fenced block for any
+   load-bearing rule, cross-links relative.
+
+**Edited (de-dup, Half A):**
+
+2. `skills/woostack-bootstrap/references/patterns.md` (§7) — keep project framework/coverage
+   standard; link kernel for Red→Green→Refactor.
+3. `skills/woostack-plan/SKILL.md` (§"Bite-sized tasks (TDD)") — keep plan-step shape; link
+   kernel. `references/plan-template.md` is the **literal task scaffold** (mechanics, not
+   doctrine prose) → no kernel removal; the kernel link lives in the SKILL.md prose, not the
+   template.
+4. `skills/woostack-execute/references/inline-driver.md:12-17` + `prompts/implementer.md:23-27`
+   — both restate the full red→green→refactor kernel; keep the impl-loop framing, remove the
+   restated kernel, link it. `references/subagent-driver.md:36` only says "follows TDD"
+   (terse, no restatement) → **left untouched**.
+5. `skills/woostack-debug/SKILL.md` (Phase 4) — keep failing-test-first; relink the TDD
+   reference to the kernel.
+6. `skills/woostack-build/SKILL.md:105` — repoint the by-reference TDD mention at the kernel.
+
+**Edited (public-surface wiring, Half B):**
+
+7. `skills/using-woostack/SKILL.md` — add a Command-Routing row for `/woostack-tdd <target>`.
+8. `AGENTS.md` (= `.claude/CLAUDE.md` symlink) — add `woostack-tdd` to the public command
+   surface list; bump the count language (**thirteen→fourteen** public skills, **fifteen→sixteen**
+   `SKILL.md` files); add a Quick-file-map entry.
+
+No runtime data structure; the "data" is markdown/test files the command writes and the doctrine
+links propagating at authoring time.
+
+## 6. Error handling
+
+Authoring- and command-time failures (no runtime service):
+
+- **Ambiguous target.** If the argument doesn't clearly resolve to code/PR/spec/plan, **ask** —
+  never guess (mirrors `woostack-debug`'s no-target behavior).
+- **No test runner present.** Fall back to a concrete verification command with exact expected
+  output; never emit a vague "verify it works".
+- **Editing an in-flight spec/plan.** Enriching a spec's §7 or a plan's tasks while that artifact
+  is mid-build-loop can drift from its existing plan/PRs. The command edits **content only**,
+  **must not** author `status:`/`branch:`, and **surfaces** that the plan may need
+  re-derivation — it does not silently mutate phase state or the 1:1:N join.
+- **Over-removal during de-dup.** Stripping the kernel from a consumer must remove **only** the
+  restated kernel sentences, never the site's context-specific delta (plan-step shape, impl-loop
+  wording, failing-test-first rule, project framework table). Each consumer must still read
+  coherently and gain exactly one kernel link.
+- **Broken cross-link.** Every new kernel link must resolve (relative path + section anchor);
+  a dangling link is a defect caught by the link check.
+- **Doc-count drift.** AGENTS.md count strings ("thirteen", "fifteen"), the surface list, the
+  routing row, and the file map must update **together** and stay mutually consistent.
+- **Clobbering existing tests.** Characterization on existing code must **augment**, detecting
+  and not duplicating or overwriting tests already present.
+
+## 7. Acceptance criteria
+
+Each AC is a testable behavior → ≥1 plan task. Fill every class or mark N/A + why.
+
+- **AC1 — `woostack-tdd/SKILL.md` exists as the canonical doctrine home**
+  - happy: `skills/woostack-tdd/SKILL.md` exists with two-field frontmatter (`name: woostack-tdd`,
+    a dense `description`), an H1 lead naming it the doctrine home + add-tests command + public
+    command #14 that never commits/merges, and a named **kernel** section stating
+    Red→Green→Refactor, test-first, the coverage classes (happy/error/edge/success+failure),
+    characterization for existing code, framework-awareness, and no-runner→concrete-verification.
+  - error: N/A — a static skill file has no runtime error path; malformed authoring is caught by
+    AC4 (de-dup consistency) and the link checks, not by the file itself.
+  - edge: The kernel is stated **once** here; consumers link this section, so the doctrine has a
+    single anchor to point at.
+
+- **AC2 — `/woostack-tdd <target>` adds target-appropriate tests across all four targets**
+  - happy: The command section documents the target router — code→colocated `*.test` files
+    (characterization for existing code), PR→tests for the diff surface (`gh pr diff`),
+    spec→strengthen §7 ACs in place, plan→fill each task's failing-test-first step — plus
+    framework detection (Vitest/Jest-expo/Playwright), the no-runner→concrete-verification
+    fallback, and the **characterization carve-out** (existing code pins current behavior; only
+    new code is red-first).
+  - error: A target argument that doesn't resolve to one of the four types makes the command
+    **ask**, not guess; a missing test runner triggers the concrete-verification fallback, never
+    a vague "verify it works".
+  - edge: `/woostack-tdd` with **no argument** asks what to test (mirrors `woostack-debug`'s
+    no-target behavior) rather than defaulting to any target.
+
+- **AC3 — Boundaries are enforced**
+  - happy: `## Hard constraints` state: writes to the working tree and hands to `woostack-commit`;
+    **never commits or merges**; **gate-light** (owns no approval gate, shows the diff for
+    spec/plan edits); authors **no** `status:`/`branch:` transitions; leaves the
+    `spec : plan : PRs = 1 : 1 : N` invariant untouched.
+  - error: Spec/plan enrichment that would author `status:`/`branch:` or fork a second plan is a
+    constraint violation the skill text forbids; an in-flight-artifact edit surfaces the
+    re-derivation warning instead of mutating phase state.
+  - edge: No runtime delegation — execute/debug/plan are **not** invoked by or invoking this
+    skill at runtime (verified by AC4: they only gain a doctrine link).
+
+- **AC4 — Kernel is extracted, not duplicated**
+  - happy: Each of the five consumer sites (`patterns.md §7`, `woostack-plan`,
+    `woostack-execute` driver/implementer, `woostack-debug` Phase 4, `woostack-build:105`) gains
+    a link to the `woostack-tdd` kernel **and** has its restated kernel sentences removed, while
+    keeping its context-specific delta and reading coherently.
+  - error: A consumer that still restates the kernel **and** adds the link (duplication), or that
+    lost its context-specific delta during removal, is a de-dup defect a grep/read check flags.
+  - edge: De-dup depth varies by reader. Main-agent-read sites (`patterns.md`, `woostack-plan`,
+    `inline-driver.md`, `woostack-debug`, `woostack-build`) fully de-dup (link + phrase removed).
+    `implementer.md` is a **context-free subagent prompt** → keeps its inline rule and only
+    **adds** the canonical pointer (link-present, not phrase-absent). `subagent-driver.md`
+    ("follows TDD") and `plan-template.md` (literal scaffold) are untouched.
+
+- **AC5 — Public surface is wired consistently**
+  - happy: `using-woostack/SKILL.md` has a Command-Routing row for `/woostack-tdd <target>`;
+    AGENTS.md lists `woostack-tdd` in the public command surface, bumps the counts
+    (thirteen→fourteen public, fifteen→sixteen `SKILL.md`), and adds a Quick-file-map entry.
+  - error: A surface update that changes one count but not the other, or adds the routing row
+    without the surface-list entry (or vice-versa), is an inconsistency the doc-count checks
+    flag.
+  - edge: The `SKILL.md`-count change accounts for **one** new public skill (no new internal
+    sub-skill), so internal-sub-skill language (`woostack-ideate`/`woostack-harden`) is
+    unchanged.
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+This repo is a skills collection with **no test runner** (AGENTS.md: "no application source
+code, app lockfile, build, or CI"). Per woostack convention (`woostack-plan/SKILL.md:91-93`),
+each "failing test" is a concrete **verification command** with exact expected output. Planned
+verifications:
+
+- `grep`/structural assertions that `skills/woostack-tdd/SKILL.md` exists with the frontmatter,
+  the named kernel section (Red→Green→Refactor, the coverage classes, no-runner rule), the
+  target-router table, and the hard-constraints block.
+- `grep` that **each** consumer site links the `woostack-tdd` kernel **and** no longer restates
+  the kernel sentences (presence of link + absence of the duplicated phrase), while its
+  context-specific delta remains.
+- `grep` that `using-woostack/SKILL.md` carries the `/woostack-tdd` routing row, and that
+  AGENTS.md contains `woostack-tdd` in the surface list, the updated count strings, and the file-
+  map entry.
+- A link/anchor check that every new kernel cross-link resolves (relative path + section anchor).
+
+No automated harness, fixtures, or CI are added (forbidden by AGENTS.md "no hidden tools").
+
+## 9. Open questions
+
+_(Settled in ideate, in resolution order:)_
+
+- **Extract scope** (ideate) — full extract + de-dup: `woostack-tdd` is the canonical kernel;
+  the five consumers link it and keep only their delta.
+- **Spec/plan target semantics** (ideate) — enrich each artifact's test-shaped section in place
+  (spec §7 ACs; plan failing-test steps), one verb across all four targets.
+- **Runtime coupling** (ideate) — link doctrine only; no runtime skill hop in execute/debug hot
+  loops.
+- **Public vs internal** (lgtm) — public command #14: routing row + AGENTS.md surface/counts/file-
+  map.
+- **Gate posture** (lgtm) — gate-light (no build-loop gate); show the diff for spec/plan edits.
+- **Memory weight** (lgtm) — light: recall testing gotchas/conventions; ≤1 reject-by-default
+  testing `pattern` distilled.
+
+_(Settled in harden, in resolution order:)_
+
+- **Kernel location** (harden) — inline named section in `woostack-tdd/SKILL.md`; the skill
+  *is* the doctrine. Consumers link the **file** (`../woostack-tdd/SKILL.md`), matching the
+  repo's file-level link style (`inline-driver.md:3`) — **no** fragile in-file `#anchor`.
+- **De-dup precision** (harden) — `inline-driver.md:12-17` and `implementer.md:23-27` restate
+  the kernel (edit); `subagent-driver.md:36` ("follows TDD") and `plan-template.md` (literal
+  task scaffold) do **not** → left untouched.
+- **Test-first vs existing code** (harden) — characterization carve-out: new code is red-first;
+  existing code (code/PR targets) gets characterization tests pinning current behavior. Force-a-red
+  rejected as over-ceremony.
+- **PR-diff mechanics** (harden) — `gh pr diff <n>` (read-only inspection, AGENTS.md-sanctioned);
+  `git diff <base>...HEAD` for a local branch. No Graphite needed (read-only).
+- **No flags** (harden) — auto-detect target by arg shape + ask on ambiguity; no `--type` flag,
+  keeping the command surface minimal (house style for simple commands).
+- **In-flight-edit threshold** (harden) — when a spec/plan target's `status:` is ≥ `planning` (a
+  plan already exists), the content edit surfaces a "plan may need re-derivation" warning; it
+  still never authors `status:`/`branch:`.
+- **Prompt self-containment** (plan harden) — `implementer.md` (a context-free subagent prompt)
+  keeps its inline TDD rule and only adds the canonical pointer; it is **not** stripped to a bare
+  link, since a fresh subagent must not depend on following one. Full de-dup applies to the five
+  main-agent-read sites only.


### PR DESCRIPTION
## Goal

Establish a single canonical home for woostack's TDD doctrine and add an on-demand `/woostack-tdd <target>` command that adds appropriate tests to a code block, PR, spec, or plan. This PR ships the **spec and plan only** — the base of the build stack; implementation increments stack on top.

## Summary

- **Spec** `.woostack/specs/2026-06-07-woostack-tdd.md` — new public skill `woostack-tdd`: the canonical TDD kernel (Red→Green→Refactor, coverage classes, no-runner substitution) plus a target-routed add-tests command (code→`*.test` files, PR→`gh pr diff` surface, spec→§7 acceptance criteria, plan→failing-test steps). 5 acceptance criteria.
- **Plan** `.woostack/plans/2026-06-07-woostack-tdd.md` — 2 PR-sized increments: (1) create the skill + wire the public surface (routing row, AGENTS.md counts/list/file-map); (2) de-dup the kernel across 6 consumer sites (link, don't restate).
- **Hardened decisions** — characterization carve-out (new code red-first; existing code pins current behavior), gate-light (no build-loop gate), never commits/merges, leaves `status:`/`branch:`, and `implementer.md` kept self-contained (a context-free subagent prompt is not stripped to a bare link).

## Test plan

### Manual

**Before merge**

- [ ] Read spec §1–§9: confirm scope (doctrine home + 4-target command), the de-dup blast radius (6 sites), and public-command-#14 surface bumps.
- [ ] Read the plan's 2 increments: confirm each is independently shippable and its grep/link verifications carry exact expected output.

Spec: .woostack/specs/2026-06-07-woostack-tdd.md
