### PR TITLE
feat(woostack-tdd): route, AGENTS wiring, and canonical command

### DIFF
--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,8 +6,8 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 10
-last_recalled: 2026-06-06
+recall_count: 12
+last_recalled: 2026-06-07
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts
 matching **lines**, not matches. Two traps that made plan expectations wrong (twice in one

--- a/.woostack/memory/skill-description-angle-bracket-placeholders.md
+++ b/.woostack/memory/skill-description-angle-bracket-placeholders.md
@@ -6,8 +6,8 @@ tags: skill-description, frontmatter, review, skills-angle, false-positive, plac
 hook: Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are an accepted, shipped convention here — not an XML/HTML defect; the review `skills` angle must not flag them.
 updated: 2026-06-06
 source: pr-232
-recall_count: 2
-last_recalled: 2026-06-06
+recall_count: 4
+last_recalled: 2026-06-07
 ---
 Angle-bracket usage placeholders in a `SKILL.md` `description:` field — e.g.
 `/woostack-execute-overnight <plan-path> [--inline|--subagent]` — are an

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,8 +6,8 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 17
-last_recalled: 2026-06-06
+recall_count: 19
+last_recalled: 2026-06-07
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not
 contain `": "` (colon followed by space) — YAML reads it as a nested mapping-value indicator

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,8 +6,8 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 29
-last_recalled: 2026-06-06
+recall_count: 31
+last_recalled: 2026-06-07
 ---
 The public-command count and skill lists are duplicated across several files and
 drift independently (the `woostack-harden` internal-sub-skill mention in README

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,8 +6,8 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 55
-last_recalled: 2026-06-06
+recall_count: 57
+last_recalled: 2026-06-07
 ---
 Feature state is derived from artifacts, not a committed status file: each spec
 has exactly one plan via `**Source:** .woostack/specs/<file>.md`, and each

--- a/.woostack/plans/2026-06-07-woostack-tdd.md
+++ b/.woostack/plans/2026-06-07-woostack-tdd.md
@@ -19,7 +19,7 @@
 **Files:**
 - Create: `skills/woostack-tdd/SKILL.md`
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 ```bash
 # From repo root. Asserts the file exists with its load-bearing markers.
@@ -32,12 +32,12 @@ test -f skills/woostack-tdd/SKILL.md \
   && echo TDD_SKILL_OK
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: the command above.
 Expected: FAIL — no output / `No such file or directory` (file absent).
 
-- [ ] **Step 3: Create the file with this exact content**
+- [x] **Step 3: Create the file with this exact content**
 
 ````markdown
 ---
@@ -138,12 +138,12 @@ schema, recall procedure, and distill gate are defined once in
   feature-specific trivia.
 ````
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: the Step 1 command.
 Expected: PASS — prints `TDD_SKILL_OK`.
 
-- [ ] **Step 5: Verify every cross-link resolves**
+- [x] **Step 5: Verify every cross-link resolves**
 
 ```bash
 # Each linked path, resolved relative to skills/woostack-tdd/, must exist.
@@ -165,18 +165,18 @@ gt create -m "feat(woostack-tdd): canonical TDD kernel + /woostack-tdd add-tests
 **Files:**
 - Modify: `skills/using-woostack/SKILL.md` (Command Routing table, after the `woostack-debug` row)
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 ```bash
 grep -q '`/woostack-tdd <target>`.*`woostack-tdd`' skills/using-woostack/SKILL.md && echo ROUTE_OK
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: the command above.
 Expected: FAIL — no output (no routing row yet).
 
-- [ ] **Step 3: Insert the routing row**
+- [x] **Step 3: Insert the routing row**
 
 After the existing line:
 
@@ -190,7 +190,7 @@ add:
 | `/woostack-tdd <target>`, add appropriate tests to a code block, PR, spec, or plan (gate-light; TDD doctrine home) | `woostack-tdd` |
 ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: the Step 1 command.
 Expected: PASS — prints `ROUTE_OK`. Then commit:
@@ -206,7 +206,7 @@ gt modify -c -m "feat(woostack-tdd): route /woostack-tdd in using-woostack"
 
 > Read the real strings first — the counts ("thirteen", "fifteen") and list are authoritative in the file, not in any cached copy. Apply each substitution exactly.
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 ```bash
 grep -q 'fourteen skills' AGENTS.md \
@@ -218,12 +218,12 @@ grep -q 'fourteen skills' AGENTS.md \
   && echo AGENTS_OK
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: the command above.
 Expected: FAIL — no output (counts still say thirteen/fifteen; no `woostack-tdd`).
 
-- [ ] **Step 3: Apply the five edits**
+- [x] **Step 3: Apply the five edits**
 
 1. `The public command/adoption surface has thirteen skills:` → `... has fourteen skills:`
 2. In that bullet list, after the `woostack-debug` bullet add:
@@ -240,12 +240,12 @@ Expected: FAIL — no output (counts still say thirteen/fifteen; no `woostack-td
      [`skills/woostack-tdd/SKILL.md`](skills/woostack-tdd/SKILL.md)
    ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: the Step 1 command.
 Expected: PASS — prints `AGENTS_OK`.
 
-- [ ] **Step 5: Confirm the symlink reflects the change**
+- [x] **Step 5: Confirm the symlink reflects the change**
 
 ```bash
 grep -q 'fourteen skills' .claude/CLAUDE.md && echo SYMLINK_OK

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `npx skills add howarewoo/woostack`.
 
-The public command/adoption surface has thirteen skills:
+The public command/adoption surface has fourteen skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -28,13 +28,13 @@ The public command/adoption surface has thirteen skills:
 - [`woostack-status`](skills/woostack-status/SKILL.md)
 - [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
 - [`woostack-debug`](skills/woostack-debug/SKILL.md)
+- [`woostack-tdd`](skills/woostack-tdd/SKILL.md)
 
 The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the thirteen-skill command
-surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+`/woostack-*` commands: they have no routing row and are absent from the fourteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
 There is no application source code, app lockfile, build, or CI for this repo's own
@@ -55,8 +55,8 @@ do not add application code, app build configs, or app lockfiles.
 
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
 `/woostack-bootstrap`, `/woostack-build`, `/woostack-plan`, `/woostack-execute`, `/woostack-execute-overnight`, `/woostack-commit`,
-`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, or
-`/woostack-debug`, including intent-equivalent wording. Load the matching skill
+`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, or
+`/woostack-tdd`, including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
 directory, not in this repo.
 
@@ -78,7 +78,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the fifteen `SKILL.md` files (the thirteen public command/adoption
+- Do not move or rename any of the sixteen `SKILL.md` files (the fourteen public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -112,6 +112,8 @@ directory, not in this repo.
   [`skills/woostack-debug/SKILL.md`](skills/woostack-debug/SKILL.md)
 - Visualization engine (audience-tailored HTML renders):
   [`skills/woostack-visualize/SKILL.md`](skills/woostack-visualize/SKILL.md)
+- TDD doctrine home and add-tests command (public command):
+  [`skills/woostack-tdd/SKILL.md`](skills/woostack-tdd/SKILL.md)
 - Address-comments delegator:
   [`skills/woostack-address-comments/SKILL.md`](skills/woostack-address-comments/SKILL.md)
 - Derived feature board (status command) and its canonical feature-state conventions:

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -75,6 +75,7 @@ link it, never restate it.
 | `/woostack-status [--all] [--fetch]`, show the derived feature board (what's in flight, what to do next) | `woostack-status` |
 | `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |
 | `/woostack-debug <target> [--auto]`, find a bug's root cause before fixing (gated; `--auto` for autonomous) | `woostack-debug` |
+| `/woostack-tdd <target>`, add appropriate tests to a code block, PR, spec, or plan (gate-light; TDD doctrine home) | `woostack-tdd` |
 
 If the user asks for the behavior without using the exact command name, route by intent.
 For example, "use woostack to review this PR" means load `woostack-review`.

--- a/skills/woostack-tdd/SKILL.md
+++ b/skills/woostack-tdd/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: woostack-tdd
+description: "woostack's canonical test-driven-development home and on-demand test-adder. The single source for the TDD kernel — Red→Green→Refactor, test-first, cover happy/error/edge/success+failure, framework-aware, no-runner→concrete verification — that woostack-plan, woostack-execute, woostack-debug, and bootstrap patterns.md §7 should link to instead of restating. Also the 14th public command: /woostack-tdd <target> adds appropriate tests to an existing code block, PR, spec, or plan — one verb, target-routed (code→colocated *.test files, PR→tests for the gh pr diff surface, spec→strengthen §7 acceptance criteria, plan→fill failing-test steps) — with a characterization carve-out for existing code (new code is red-first; existing code pins current behavior). Writes tests to the working tree and hands to woostack-commit; never commits, merges, or authors status:/branch:; owns no approval gate."
+---
+
+# woostack-tdd
+
+Two roles in one skill. **(1) The canonical TDD doctrine home** — the kernel below is stated
+once here and *linked*, never restated, by [woostack-plan](../woostack-plan/SKILL.md),
+[woostack-execute](../woostack-execute/SKILL.md), [woostack-debug](../woostack-debug/SKILL.md),
+and [bootstrap patterns.md §7](../woostack-bootstrap/references/patterns.md), honoring the repo's
+"cross-link, do not duplicate" rule. **(2) The 14th public command** — `/woostack-tdd <target>`
+adds the appropriate tests to an existing block of code, a PR, a spec, or a plan. It writes tests
+to the working tree and hands to [woostack-commit](../woostack-commit/SKILL.md); it never commits,
+merges, or touches a spec's `status:`/`branch:`, and owns no approval gate.
+
+## The TDD kernel
+
+The canonical test-driven-development discipline for all of woostack. Other skills **link** this
+section; they do not restate it.
+
+**Red → Green → Refactor.** For code woostack is *authoring*, the test comes first:
+
+1. **Red** — write a failing test describing the expected behavior; run it, watch it fail.
+2. **Green** — write the minimal code to make it pass; run it, watch it pass.
+3. **Refactor** — clean up names, duplication, and structure with the tests green; re-run to
+   confirm they stay green.
+
+**Coverage classes.** Appropriate tests span, per behavior: the **happy** path, every **error**
+path, **edge**/boundary conditions, and both **success and failure** outcomes — exactly what a
+spec's §7 Acceptance-criteria slots enumerate.
+
+**No-runner substitution.** In a target with no test runner (a docs/skills repo), "the failing
+test" becomes a concrete **verification command** — a `grep`, a `bash -n`, a link check, or an
+existing script's test — with exact expected output. Never a vague "verify it works."
+
+<CHARACTERIZATION-CARVE-OUT>
+Test-first applies to code being authored. When adding tests to code that ALREADY EXISTS (the
+`code` and `PR` command targets), you cannot write the test first — the code is already there.
+The one sanctioned departure: write CHARACTERIZATION tests that pin the code's CURRENT behavior,
+then use them as the regression safety net. New code is red-first; existing code is
+characterization. Forcing a red by mutating-then-restoring existing code is NOT required.
+</CHARACTERIZATION-CARVE-OUT>
+
+**Framework-aware.** Follow the project's runner and file conventions — Vitest everywhere except
+React Native (Jest via `jest-expo`), Playwright for E2E, tests colocated as `*.test.ts(x)` or in
+`__tests__/`. The project-specific standard lives in
+[patterns.md §7](../woostack-bootstrap/references/patterns.md).
+
+**Clarify before writing** when inputs, outputs, error contracts, or integration points are
+unclear — don't guess them.
+
+## `/woostack-tdd <target>` — add appropriate tests
+
+One verb — *add the appropriate tests* — applied to whatever the argument resolves to.
+Auto-detect the target by argument shape:
+
+| Target | Detected by | What it produces |
+|---|---|---|
+| **code** | a source path, or pasted code | colocated `*.test.ts(x)` per the project runner; **characterization** tests for existing code (see the carve-out) |
+| **PR** | a PR number or URL | tests covering the **diff surface only** — read it with `gh pr diff <n>` (read-only inspection; `git diff <base>...HEAD` for a local branch) |
+| **spec** | a path under `.woostack/specs/` | strengthen the testable **§7 Acceptance criteria** in place (happy/error/edge per behavior) |
+| **plan** | a path under `.woostack/plans/` | fill each task's **failing-test-first step** with the actual test and exact expected output |
+| **(none)** | no argument | **ask** what to test; never guess (mirrors [woostack-debug](../woostack-debug/SKILL.md)) |
+
+Apply the kernel to whichever target: real tests for code/PR, the artifact's test-equivalent for
+spec/plan. In a no-runner target, substitute the concrete verification command per the kernel. If
+the argument is ambiguous, **ask** — don't guess the target type.
+
+## Memory
+
+Recall testing `gotcha`/`pattern` notes for the target's working set before adding tests; distill
+**at most one** durable testing `pattern` at the end through the reject-by-default gate. The note
+schema, recall procedure, and distill gate are defined once in
+[memory.md](../woostack-init/references/memory.md) — link, never restate.
+
+## Hard constraints
+
+- **Single source for the kernel.** The kernel above is stated once; consumers link it. Adding a
+  duplicate restatement elsewhere is the anti-pattern this skill exists to remove.
+- **Never commits or merges.** Writes tests/edits to the working tree and hands to
+  [woostack-commit](../woostack-commit/SKILL.md).
+- **Gate-light.** Owns no approval gate (like `woostack-execute`/`woostack-harden`). For a
+  spec/plan edit, show the before/after diff; do not block.
+- **Authors no `status:`/`branch:`.** Spec/plan enrichment is content-only; never author a phase
+  transition or fork a second plan. The `spec : plan : PRs = 1 : 1 : N` invariant — defined in
+  [conventions.md](../woostack-status/references/conventions.md) — is untouched. When the target's
+  `status:` is ≥ `planning` (a plan already exists), surface that the plan may need re-derivation;
+  still edit content only.
+- **No runtime delegation.** `woostack-execute` and `woostack-debug` write their tests inline and
+  link this kernel for the "how"; they do not invoke this skill at runtime.
+- **Characterization for existing code only.** New code stays red-first; the carve-out is not a
+  license to skip test-first when authoring.
+- **No-runner → concrete verification.** Never a vague "verify it works."
+- **Distill durable knowledge only.** Reject-by-default; ≤1 testing `pattern` per run; never
+  feature-specific trivia.


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
