### PR TITLE
refactor(woostack-tdd): de-duplicate TDD doctrine references

### DIFF
--- a/.woostack/plans/2026-06-07-woostack-tdd.md
+++ b/.woostack/plans/2026-06-07-woostack-tdd.md
@@ -268,7 +268,7 @@ gt modify -c -m "feat(woostack-tdd): list woostack-tdd in AGENTS.md surface, cou
 **Files:**
 - Modify: `skills/woostack-bootstrap/references/patterns.md:129-148` (§7)
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 ```bash
 grep -q 'woostack-tdd' skills/woostack-bootstrap/references/patterns.md \
@@ -277,12 +277,12 @@ grep -q 'woostack-tdd' skills/woostack-bootstrap/references/patterns.md \
   && echo PATTERNS_OK
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: the command above.
 Expected: FAIL — no output (kernel workflow prose still present; no `woostack-tdd` link).
 
-- [ ] **Step 3: Replace the §7 body**
+- [x] **Step 3: Replace the §7 body**
 
 Replace lines 129-148 (the whole `## 7. Test-Driven Development` section through "A feature is **not complete** until all tests pass.") with:
 
@@ -300,7 +300,7 @@ E2E. Test files colocated with source as `*.test.ts(x)` or in `__tests__/`.
 A feature is **not complete** until all tests pass.
 ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: the Step 1 command.
 Expected: PASS — prints `PATTERNS_OK` (kernel linked; restated "minimum code to make it pass" workflow gone; project framework standard kept).
@@ -314,7 +314,7 @@ gt create -m "refactor(woostack-tdd): patterns.md §7 links the TDD kernel"
 **Files:**
 - Modify: `skills/woostack-plan/SKILL.md:85-93`
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 ```bash
 grep -q 'woostack-tdd' skills/woostack-plan/SKILL.md \
@@ -323,12 +323,12 @@ grep -q 'woostack-tdd' skills/woostack-plan/SKILL.md \
   && echo PLAN_OK
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: the command above.
 Expected: FAIL — no output (standalone no-runner paragraph still present; no kernel link).
 
-- [ ] **Step 3: Replace the second paragraph**
+- [x] **Step 3: Replace the second paragraph**
 
 Keep the first paragraph (lines 85-89, the step-decomposition / checkbox mechanics) unchanged.
 Replace the second paragraph (lines 91-93, currently:
@@ -343,7 +343,7 @@ no-runner→concrete-verification substitution — is the canonical kernel in
 
 > Note: `references/plan-template.md` is the literal task scaffold (mechanics) and keeps its own terse no-runner note — it is NOT edited here.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: the Step 1 command.
 Expected: PASS — prints `PLAN_OK` (kernel linked; the duplicated no-runner doctrine paragraph removed; step-shape sentence kept).
@@ -358,7 +358,7 @@ gt modify -c -m "refactor(woostack-tdd): woostack-plan links the TDD kernel"
 - Modify: `skills/woostack-execute/references/inline-driver.md:12-17`
 - Modify: `skills/woostack-execute/prompts/implementer.md:24-28`
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 ```bash
 grep -q 'woostack-tdd' skills/woostack-execute/references/inline-driver.md \
@@ -367,12 +367,12 @@ grep -q 'woostack-tdd' skills/woostack-execute/references/inline-driver.md \
   && echo EXEC_OK
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: the command above.
 Expected: FAIL — no output (full red-green-refactor restatement still in inline-driver; no kernel links).
 
-- [ ] **Step 3a: Replace inline-driver.md step 1**
+- [x] **Step 3a: Replace inline-driver.md step 1**
 
 Replace step 1 (lines 12-17) with:
 
@@ -383,7 +383,7 @@ Replace step 1 (lines 12-17) with:
    This is a principle, not a hard dependency: if the kernel isn't loaded, follow TDD by hand.
 ```
 
-- [ ] **Step 3b: Update implementer.md instruction 1 (keep self-contained)**
+- [x] **Step 3b: Update implementer.md instruction 1 (keep self-contained)**
 
 implementer.md is a prompt injected into a **fresh, context-free subagent**, so it keeps a
 **self-contained** inline TDD rule (it is not reduced to a bare link — same rationale that leaves
@@ -403,7 +403,7 @@ that also names the canonical source:
 > stays — a context-free subagent must not depend on following a link). Full phrase-removal
 > applies only to `inline-driver.md`, which the link-following main agent reads.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: the Step 1 command.
 Expected: PASS — prints `EXEC_OK` (both drivers link the kernel; the verbose red-green-refactor restatement removed; impl-loop framing kept).
@@ -417,7 +417,7 @@ gt modify -c -m "refactor(woostack-tdd): execute drivers link the TDD kernel"
 **Files:**
 - Modify: `skills/woostack-debug/SKILL.md:77-81` (Phase 4, step 1)
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 ```bash
 grep -q 'woostack-tdd' skills/woostack-debug/SKILL.md \
@@ -426,12 +426,12 @@ grep -q 'woostack-tdd' skills/woostack-debug/SKILL.md \
   && echo DEBUG_OK
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: the command above.
 Expected: FAIL — no output (step still says "reusing the TDD discipline embodied in woostack-execute"; no woostack-tdd link).
 
-- [ ] **Step 3: Replace Phase 4 step 1**
+- [x] **Step 3: Replace Phase 4 step 1**
 
 Replace step 1 (lines 77-81) with:
 
@@ -443,7 +443,7 @@ Replace step 1 (lines 77-81) with:
    before fixing.
 ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: the Step 1 command.
 Expected: PASS — prints `DEBUG_OK` (kernel linked; the "embodied in woostack-execute" restatement gone; failing-test-first-before-a-fix kept).
@@ -457,29 +457,29 @@ gt modify -c -m "refactor(woostack-tdd): debug Phase 4 links the TDD kernel"
 **Files:**
 - Modify: `skills/woostack-build/SKILL.md` (the step-9 line: "each implemented with TDD, …")
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 ```bash
 grep -q 'with TDD (the \[woostack-tdd kernel\](../woostack-tdd/SKILL.md))' skills/woostack-build/SKILL.md && echo BUILD_OK
 ```
 
-- [ ] **Step 2: Run it, confirm it fails**
+- [x] **Step 2: Run it, confirm it fails**
 
 Run: the command above.
 Expected: FAIL — no output (mention is by-reference only, unlinked).
 
-- [ ] **Step 3: Add the kernel link**
+- [x] **Step 3: Add the kernel link**
 
 The phrase wraps: line 104 ends with `each implemented`; line 105 begins `with TDD,`. On
 **line 105**, change `with TDD,` → `with TDD (the [woostack-tdd kernel](../woostack-tdd/SKILL.md)),`.
 Edit only the line-105 fragment; leave `each implemented` on line 104.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: the Step 1 command.
 Expected: PASS — prints `BUILD_OK`.
 
-- [ ] **Step 5: Final de-dup link check**
+- [x] **Step 5: Final de-dup link check**
 
 ```bash
 # Every new kernel back-link resolves from its own file's directory.

--- a/skills/woostack-bootstrap/references/patterns.md
+++ b/skills/woostack-bootstrap/references/patterns.md
@@ -128,20 +128,10 @@ import { findUserById } from "@features/users/src/procedures/findUserById";
 
 ## 7. Test-Driven Development
 
-Red → Green → Refactor. Tests are written **before** implementation. Non-negotiable.
-
-**Workflow:**
-1. **Red** — write a failing test that describes expected behavior.
-2. **Green** — minimum code to make it pass.
-3. **Refactor** — clean up, keep tests green.
-
-**Coverage required:**
-- All user scenarios.
-- Edge cases + boundary conditions.
-- All error conditions.
-- Success and failure paths both.
-
-**Clarify before writing tests** when requirements are unclear — don't guess inputs, outputs, error contracts, or integration points.
+Red → Green → Refactor, test-first, non-negotiable. The canonical TDD kernel — the workflow,
+coverage classes, and no-runner substitution — lives once in
+[woostack-tdd](../../woostack-tdd/SKILL.md); follow it. This section records only the
+**project-specific** standard layered on top:
 
 **Frameworks:** Vitest everywhere except React Native (uses Jest via `jest-expo`). Playwright for E2E. Test files colocated with source as `*.test.ts(x)` or in `__tests__/`.
 

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -102,7 +102,8 @@ sits after that PR. So the chain has exactly the three hard gates above.
    **Run overnight** at step 8, [`woostack-execute-overnight`](../woostack-execute-overnight/SKILL.md)
    (unattended) — with the plan path to
    work the plan as PR-sized stacked increments on top of the spec+plan PR — each implemented
-   with TDD, the plan's checkboxes ticked in place, committed via `woostack-commit`, reviewed per
+   with TDD (the [woostack-tdd kernel](../woostack-tdd/SKILL.md)), the plan's checkboxes
+   ticked in place, committed via `woostack-commit`, reviewed per
    the execution mode the active driver selects (`woostack-execute`: `woostack-review --fast` in
    inline mode, or the per-task spec+quality subagent loops in the default subagent mode;
    `woostack-execute-overnight` drives its own autonomous review policy), and distilled into

--- a/skills/woostack-debug/SKILL.md
+++ b/skills/woostack-debug/SKILL.md
@@ -75,11 +75,10 @@ Complete each phase before the next.
 ### Phase 4 — Implementation
 
 1. **Write a failing test first.** The simplest reproduction of the bug, automated if a test
-   harness exists — reusing the TDD discipline embodied in
-   [`woostack-execute`](../woostack-execute/SKILL.md). In a target with no test runner, the
-   "failing test" is a concrete verification command (a `grep`, a `bash -n`, a link check)
-   with exact expected output — never a vague "verify it works". You must have this before
-   fixing.
+   harness exists — per the [woostack-tdd kernel](../woostack-tdd/SKILL.md). In a target with no
+   test runner, the "failing test" is a concrete verification command (a `grep`, a `bash -n`, a
+   link check) with exact expected output — never a vague "verify it works". You must have this
+   before fixing.
 2. **Implement one minimal fix** at the root cause identified — one change, no "while I'm here"
    improvements, no bundled refactoring.
 3. **Verify the fix.** The test passes now, no other test broke, the issue is actually

--- a/skills/woostack-execute/prompts/implementer.md
+++ b/skills/woostack-execute/prompts/implementer.md
@@ -21,11 +21,12 @@ controller's session — everything you need is below.
 - Conventions to follow: <repo/test conventions, links to patterns>
 
 ## How to work
-1. Follow test-driven development: write the failing test, watch it fail, write the minimal code,
-   watch it pass, then refactor with the tests green (clean up names, duplication, and structure;
-   re-run the tests to confirm they stay green). If the change has no runnable test harness (e.g.
-   a docs/skill edit), run the concrete verification the task specifies instead (grep / link
-   check / structural assertion).
+1. Follow test-driven development (canonical: the woostack-tdd kernel,
+   `skills/woostack-tdd/SKILL.md`): for new code, write the failing test first, watch it fail,
+   write the minimal code, watch it pass, then refactor with the tests green; for code that
+   already exists, write characterization tests pinning current behavior. If the change has no
+   runnable test harness (e.g. a docs/skill edit), run the concrete verification the task
+   specifies instead (grep / link check / structural assertion).
 2. Implement exactly the task — no more (no extra flags, files, or features), no less.
 3. Self-review your diff before reporting. Fix what you find.
 4. Do NOT git-commit. Leave your changes in the working tree.

--- a/skills/woostack-execute/references/inline-driver.md
+++ b/skills/woostack-execute/references/inline-driver.md
@@ -9,12 +9,10 @@ subagents). See [subagent-driver.md](subagent-driver.md) for the other mode.
 
 For each task in the increment, in order:
 
-1. **Follow test-driven development** — write the failing test first, watch it
-   fail, write the minimal code, watch it pass, then **refactor** with the tests green (clean up
-   names, duplication, and structure; re-run the tests to confirm they stay green). This is a
-   principle, not a hard dependency: if no TDD skill is loaded, follow TDD by hand. For a change
-   with no runnable test harness (e.g. a docs/skill edit), substitute the concrete verification
-   the plan specifies (a `grep`, a link check, a structural assertion) for the test.
+1. **Follow test-driven development** per the [woostack-tdd kernel](../../woostack-tdd/SKILL.md)
+   — red-first for new code, characterization for code that already exists; refactor with the
+   tests green; in a no-runner target substitute the concrete verification the plan specifies.
+   This is a principle, not a hard dependency: if the kernel isn't loaded, follow TDD by hand.
 2. **Follow each safe plan step exactly** and run the verifications the plan names.
 3. **Tick the plan's checkboxes in place** (`[ ]` → `[x]`) as each step completes.
 

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -88,9 +88,9 @@ it, confirm it passes → commit. Use checkbox (`- [ ]`) syntax for every step s
 `woostack-execute` ticks them in place as the live progress record. DRY, YAGNI, TDD, frequent
 commits throughout.
 
-In a target without a test runner (e.g. a docs/skills repo), "the failing test" becomes a
-concrete **verification command** — a `grep`, a `bash -n`, a link check, or an existing script's
-test — with exact expected output. Never a vague "verify it works."
+The TDD discipline these steps embody — red→green→refactor, the coverage classes, and the
+no-runner→concrete-verification substitution — is the canonical kernel in
+[woostack-tdd](../woostack-tdd/SKILL.md); this section applies it to plan-task shape.
 
 The output shape (header, `**Source:**` line, task/step structure) is captured in
 [references/plan-template.md](references/plan-template.md) — populate it; don't reinvent it.


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
