### PR TITLE
chore: update opus refs to 4.8

### DIFF
--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -13,7 +13,7 @@ implicitly `fast`.
 |---|---|---|---|---|---|
 | `fast` | rubric checklists, mechanical fully-specified 1–2-file tasks, context summaries | `claude-haiku-4-5` | `gpt-5.3-codex-spark` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
 | `standard` | reasoning workers, multi-file integration | `claude-sonnet-4-6` | `gpt-5.4` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
-| `deep` | skeptical validation, design/architecture judgment, code-quality review | `claude-opus-4-7` | `gpt-5.5` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
+| `deep` | skeptical validation, design/architecture judgment, code-quality review | `claude-opus-4-8` | `gpt-5.5` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
 
 > **Provider notes:**
 > - **Google** currently ships only `gemini-3-5-flash` in the 3.5 line; no Pro/Ultra/Thinking variant exists yet, so all tiers collapse onto flash (tier routing is effectively a no-op until Google releases a larger model).

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -148,7 +148,7 @@ Full schema (every key shown; all optional):
     "models": {
       "fast": "anthropic/claude-haiku-4-5",
       "standard": "openai/gpt-5.4",
-      "deep": "anthropic/claude-opus-4-7",
+        "deep": "anthropic/claude-opus-4-8",
       "openai": {
         "fast": "gpt-5.3-codex-spark",
         "standard": "gpt-5.4",
@@ -157,7 +157,7 @@ Full schema (every key shown; all optional):
       "anthropic": {
         "fast": "claude-haiku-4-5",
         "standard": "claude-sonnet-4-6",
-        "deep": "claude-opus-4-7"
+        "deep": "claude-opus-4-8"
       }
     },
     "force_tier": "deep",
@@ -362,7 +362,7 @@ Per-provider resolution (full table in `_header.md`):
 |---|---|---|---|---|
 | `fast` | `claude-haiku-4-5` | `gpt-5.3-codex-spark` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
 | `standard` | `claude-sonnet-4-6` | `gpt-5.4` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
-| `deep` | `claude-opus-4-7` | `gpt-5.5` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
+| `deep` | `claude-opus-4-8` | `gpt-5.5` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
 
 - **Google** currently exposes only `gemini-3-5-flash` — tier routing is a no-op on Gemini until a larger 3.5 model ships.
 - **OpenAI** GPT-5-family reasoning is a `reasoning_effort` parameter, not a slug suffix. Use `gpt-5.5` for the skeptical validator and complex review passes, `gpt-5.4` for everyday review work, and `gpt-5.3-codex-spark` for fast rubric workers and ultra-fast real-time coding checks. Use `gpt-5.4-mini` only as the non-Spark cost-sensitive fallback when Spark is unavailable. There is no `gpt-5-pro`.

--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -381,7 +381,7 @@ Field-by-field:
 
 - **`<host>`** — canonical slug for the host agent invoking this skill. Use one of: `claude-code`, `cursor`, `gemini-cli`, `codex`, `opencode`, or another stable identifier the host advertises. When a sub-agent profile or persona is identifiable (e.g. opencode running the `mimo-v2.5` agent), append it in parentheses: `opencode (mimo-v2.5)`. Detection hints: `CLAUDECODE=1` → `claude-code`; `OPENCODE*` env vars → `opencode`; `GEMINI_*` → `gemini-cli`; `CODEX_HOME` → `codex`; `CURSOR*` → `cursor`. Each orchestrator prompt declares a default host identifier near the top — prefer that only after the precedence above is exhausted.
 - **`<provider>`** — `anthropic` / `openai` / `google` / `openrouter` / `bedrock` / `vertex` / etc. Whatever the host is *actually* routing through. `opencode.md` is loaded for any OpenRouter-style orchestration shape, but OpenCode can route to any provider — do NOT assume `openrouter` just because this file was selected.
-- **`<model>`** — the actual validator model slug as the host sees it (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`, `gpt-5.5`, `gpt-5.3-codex-spark`, `gemini-3-pro`, `openrouter/deepseek/deepseek-v4-pro`). When `inputs.model`, `models.<provider>.<tier>`, or flat `models.<tier>` in `config.json` overrode the default, report the override value, not the table default.
+- **`<model>`** — the actual validator model slug as the host sees it (e.g. `claude-opus-4-8`, `claude-sonnet-4-6`, `gpt-5.5`, `gpt-5.3-codex-spark`, `gemini-3-pro`, `openrouter/deepseek/deepseek-v4-pro`). When `inputs.model`, `models.<provider>.<tier>`, or flat `models.<tier>` in `config.json` overrode the default, report the override value, not the table default.
 
 ## Findings Schema (`/tmp/pr-review/findings.json`)
 

--- a/skills/woostack-review/prompts/anthropic.md
+++ b/skills/woostack-review/prompts/anthropic.md
@@ -46,7 +46,7 @@ Claude Code's `Task` tool supports per-subagent model routing. Resolve each spaw
 Then resolve via the shared **Model Tiers** table — canonical at
 [`../../using-woostack/references/model-tiers.md`](../../using-woostack/references/model-tiers.md)
 and inlined into `_header.md` above (Anthropic column: `fast` → `claude-haiku-4-5`,
-`standard` → `claude-sonnet-4-6`, `deep` → `claude-opus-4-7`).
+`standard` → `claude-sonnet-4-6`, `deep` → `claude-opus-4-8`).
 
 **Every Task/Agent spawn MUST pass `model:` explicitly.** Omitting it makes the subagent inherit the parent session's model — typically Opus — which silently defeats tier routing and burns ~5x the tokens on rubric angles. The `tier:` frontmatter is informational unless the spawning call passes the resolved slug.
 
@@ -67,7 +67,7 @@ Resolution rule per spawn:
 3. **Per-repo override**: check `$OUTDIR/config.json` for `models.anthropic.<effective_tier>`, then flat `models.<effective_tier>` (e.g. when `run_tier=deep`: `jq -r '.models.anthropic.deep // .models.deep // empty' $OUTDIR/config.json`). If non-empty, use that slug instead of the table value.
 4. Pass the resolved slug as `model:` on the Task call.
 
-Do not default the validator to Sonnet — pass `model: "claude-opus-4-7"` explicitly. Opus's stricter false-positive filter pays for itself in review quality.
+Do not default the validator to Sonnet — pass `model: "claude-opus-4-8"` explicitly. Opus's stricter false-positive filter pays for itself in review quality.
 
 **OUTDIR handoff.** `$OUTDIR` defaults to a per-project `/tmp/pr-review-<hash>` (derived from the repo's git toplevel by `scripts/resolve-outdir.sh`) so concurrent reviews of different repos on one machine never share a tree. Resolve it ONCE in the orchestrator — `source "$WOO_REVIEW_ACTION_PATH/scripts/resolve-outdir.sh"` sets and exports `OUTDIR` — then export `OUTDIR` to **every** sub-agent you spawn. Sub-agents prefer the inherited `$OUTDIR`; if it is unset they re-derive via the same helper. Never fall back to a bare `/tmp/pr-review`.
 
@@ -108,11 +108,11 @@ For any path that (a) does not exist, OR (b) does not parse as a JSON array (`jq
 
 After recovery, run `bash $WOO_REVIEW_ACTION_PATH/scripts/merge-findings.sh` — it concatenates every `findings.<angle>*.json` into `raw_findings.json` and applies within-angle dedup so duplicates across chunks collapse to a single entry before validation.
 
-## Step 3 — Adversarial Validation (Opus 4.7, prosecutor + defender)
+## Step 3 — Adversarial Validation (Opus 4.8, prosecutor + defender)
 
 Skip if every per-angle file is empty / missing; status is `APPROVED`.
 
-Otherwise this step runs **two** sequential `claude-opus-4-7` validator subagents with opposing biases, then a deterministic intersection (issue #13). The intersection is the high-confidence set of findings the author sees.
+Otherwise this step runs **two** sequential `claude-opus-4-8` validator subagents with opposing biases, then a deterministic intersection (issue #13). The intersection is the high-confidence set of findings the author sees.
 
 Read `disable_adversarial` from `$OUTDIR/config.json`:
 
@@ -122,11 +122,11 @@ DISABLE_ADV="$(jq -r '.disable_adversarial // false' $OUTDIR/config.json 2>/dev/
 
 ### Step 3a — Prosecutor pass (skip if `DISABLE_ADV == true`)
 
-Launch one `claude-opus-4-7` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator-prosecutor.md` as its prompt. It assumes each finding is real and only drops the clearly-wrong ones. It writes `$OUTDIR/findings.prosecutor.json` and EXITS — it MUST NOT post a review.
+Launch one `claude-opus-4-8` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator-prosecutor.md` as its prompt. It assumes each finding is real and only drops the clearly-wrong ones. It writes `$OUTDIR/findings.prosecutor.json` and EXITS — it MUST NOT post a review.
 
 ### Step 3b — Defender pass
 
-Launch one `claude-opus-4-7` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` as its prompt. It applies the strict "defense attorney" filter — drops pedantic / lint-catchable / maybe-issues / placeholder-suggestion findings — and writes `$OUTDIR/findings.defender.json`. It writes `$OUTDIR/findings.defender.json` and EXITs — it does NOT run the intersect script or post (the orchestrator does that next). Apply only `validator.md`'s validation/filter rules (its Steps 1–2) to produce `findings.defender.json`; IGNORE validator.md's Step 3/3b/4 and its STOP-GATE — the orchestrator runs the intersect itself in the next step.
+Launch one `claude-opus-4-8` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` as its prompt. It applies the strict "defense attorney" filter — drops pedantic / lint-catchable / maybe-issues / placeholder-suggestion findings — and writes `$OUTDIR/findings.defender.json`. It writes `$OUTDIR/findings.defender.json` and EXITs — it does NOT run the intersect script or post (the orchestrator does that next). Apply only `validator.md`'s validation/filter rules (its Steps 1–2) to produce `findings.defender.json`; IGNORE validator.md's Step 3/3b/4 and its STOP-GATE — the orchestrator runs the intersect itself in the next step.
 
 The two passes MUST be sequential — the prosecutor's file must already exist before the defender runs when adversarial mode is on.
 

--- a/skills/woostack-review/scripts/load-prompt.sh
+++ b/skills/woostack-review/scripts/load-prompt.sh
@@ -62,7 +62,7 @@ default_model_for() {
       case "$tier" in
         fast) echo "claude-haiku-4-5" ;;
         standard) echo "claude-sonnet-4-6" ;;
-        deep) echo "claude-opus-4-7" ;;
+        deep) echo "claude-opus-4-8" ;;
       esac
       ;;
     openai)


### PR DESCRIPTION
## Goal

This change aligns woostack’s review and execution references on the Opus default model version so all deep-tier routes and prompts consistently target `claude-opus-4-8`.

## Summary

- Updated shared model-tier mapping and woostack-review defaults to use `claude-opus-4-8` for deep validation.
- Updated prompt and orchestration documentation examples to reflect the `4.8` model slug.
- Updated the runtime model resolver used by woostack-review to pass `claude-opus-4-8` for deep-tier execution.

## Test plan

### Manual

**Before merge**

- [ ] Confirm the five updated assets now all reference `claude-opus-4-8` and no longer `claude-opus-4-7`.
- [ ] Confirm the commit contains only the intended doc/script reference updates.
