### PR TITLE
docs: add spec and plan for address-comments commit integration

### DIFF
--- a/.woostack/plans/2026-06-08-address-comments-commit-integration.md
+++ b/.woostack/plans/2026-06-08-address-comments-commit-integration.md
@@ -1,0 +1,127 @@
+**Source:** .woostack/specs/2026-06-08-address-comments-commit-integration.md
+
+# woostack-address-comments: integrate the commit skill — Implementation Plan
+
+**Goal:** Integrate the `woostack-commit` skill into `woostack-address-comments` to handle committing, pushing, and updating PR metadata, while preserving the SHA capture for GitHub thread replies.
+
+**Architecture:** Edit `skills/woostack-address-comments/SKILL.md` and `skills/woostack-address-comments/prompts/address.md` to instruct the agent to use the `/woostack-commit` command instead of raw git commands, and then use `git rev-parse HEAD` to capture the SHA.
+
+**Tech Stack:** Markdown, Git, Bash
+
+---
+
+## Increment 1: Integrate woostack-commit into address-comments
+
+> One independently shippable PR containing the skill markdown changes.
+
+### Task 1: Update SKILL.md to use woostack-commit
+
+**Files:**
+- Modify: `skills/woostack-address-comments/SKILL.md`
+
+- [ ] **Step 1: Write the failing test**
+
+  Write a verification command that checks if the commit skill `woostack-commit` is referenced in the commit/push step of `SKILL.md`.
+  
+  Run: `grep -q "woostack-commit" skills/woostack-address-comments/SKILL.md`
+  Expected: FAIL (exit status 1)
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+  Run: `grep -q "woostack-commit" skills/woostack-address-comments/SKILL.md`
+  Expected: FAIL (exit code 1)
+
+- [ ] **Step 3: Minimal implementation**
+
+  Modify step 5 in `skills/woostack-address-comments/SKILL.md` to stage changes, run `/woostack-commit`, and capture the SHA:
+  
+  ```markdown
+  5. **Commit + push** — apply all final `FIX` edits to the working tree → stage the changes → invoke [`woostack-commit`](../woostack-commit/SKILL.md) with a message referencing the threads addressed (e.g. `/woostack-commit "fix: address review threads <ids>"`) to commit, run checks, push, and update the PR metadata → capture the commit `<sha>` (e.g., via `git rev-parse HEAD`) before any reply, so "Fixed in `<sha>`" is real. Never force-push.
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+  Run: `grep -q "woostack-commit" skills/woostack-address-comments/SKILL.md`
+  Expected: PASS (exit code 0)
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  gt create -m "docs: use commit skill in address-comments workflow"
+  ```
+
+### Task 2: Update prompts/address.md to run /woostack-commit
+
+**Files:**
+- Modify: `skills/woostack-address-comments/prompts/address.md`
+
+- [ ] **Step 1: Write the failing test**
+
+  Write a verification command that checks if the `/woostack-commit` command is referenced in `prompts/address.md`.
+  
+  Run: `grep -q "/woostack-commit" skills/woostack-address-comments/prompts/address.md`
+  Expected: FAIL (exit status 1)
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+  Run: `grep -q "/woostack-commit" skills/woostack-address-comments/prompts/address.md`
+  Expected: FAIL (exit code 1)
+
+- [ ] **Step 3: Minimal implementation**
+
+  Modify the instructions under "After the phases" Step 1 in `skills/woostack-address-comments/prompts/address.md` to use `/woostack-commit`:
+  
+  ```markdown
+  1. If any FIX edits were made, stage the changes and invoke the [`woostack-commit`](../woostack-commit/SKILL.md) skill to commit, push, and update the PR metadata:
+     ```bash
+     /woostack-commit "fix: address review threads <ids>"
+     ```
+     Then capture the commit `<sha>` (e.g., `git rev-parse HEAD`) before posting any replies. Never force-push.
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+  Run: `grep -q "/woostack-commit" skills/woostack-address-comments/prompts/address.md`
+  Expected: PASS (exit code 0)
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  gt modify -c -m "docs: instruct agent to invoke commit skill in address-comments prompt"
+  ```
+
+### Task 3: Verify existing address-comments tests
+
+**Files:**
+- None (verify scripts)
+
+- [ ] **Step 1: Write the verification command**
+
+  Run all tests in the `skills/woostack-address-comments/scripts/tests/` directory to ensure they all pass.
+  
+  Run:
+  ```bash
+  ./skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh && \
+  ./skills/woostack-address-comments/scripts/tests/test-address-comments-ownership.sh && \
+  ./skills/woostack-address-comments/scripts/tests/test-address-helper-scripts.sh
+  ```
+  Expected: PASS
+
+- [ ] **Step 2: Run the test, confirm it passes**
+
+  Run the command from Step 1 and verify all tests exit successfully.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  gt modify -c -m "test: verify all address-comments tests pass"
+  ```
+
+---
+
+## Self-review (run before handing back)
+
+- [x] **Spec coverage** — every spec requirement maps to a task above.
+- [x] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test.
+- [x] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
+- [x] **Type consistency** — types, signatures, and names match across tasks.

--- a/.woostack/specs/2026-06-08-address-comments-commit-integration.md
+++ b/.woostack/specs/2026-06-08-address-comments-commit-integration.md
@@ -1,0 +1,89 @@
+---
+name: address-comments-commit-integration
+type: spec
+status: planning
+date: 2026-06-08
+branch: feature/address-comments-commit-integration
+links:
+---
+
+# woostack-address-comments: integrate the commit skill — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+Currently, `woostack-address-comments` performs raw git commits and pushes directly when applying `FIX` edits to a PR. This duplicates commit logic, bypasses the user's `.woostack/config.json` pre-commit commands, bypasses Graphite integration (e.g. `gt submit` or branch stack management), and fails to update the PR body metadata (Goal, Summary, Test plan) that `woostack-commit` updates when new code is committed.
+
+At the same time, `woostack-address-comments` needs to know the exact commit SHA of the fix to post precise replies on GitHub (e.g., `"Fixed in <sha>"`). Simply calling `woostack-commit` must be done in a way that allows the orchestrator to capture this SHA.
+
+## 2. Goal
+
+Integrate the `woostack-commit` skill into `woostack-address-comments` for committing, pushing, and updating PR metadata, while ensuring the orchestrator can still capture the commit SHA.
+
+Concretely:
+- Replace raw git commit/push instructions in `SKILL.md` and `prompts/address.md` with instructions to invoke `/woostack-commit` with a message referencing the threads.
+- Instruct the agent to capture the resulting commit SHA using `git rev-parse HEAD` immediately after invoking `/woostack-commit`, using that SHA in GitHub thread replies.
+- Ensure all existing tests in `skills/woostack-address-comments/scripts/tests/` continue to pass.
+
+## 3. Non-goals
+
+- We do not modify `woostack-commit` itself.
+- We do not change other skills in the repository.
+- We do not merge branches.
+
+## 4. Approach
+
+1. **Modify SKILL.md**: Update Step 5 of the "Workflow" section to stage changes, invoke `woostack-commit` with a message referencing the addressed threads, and capture the commit SHA.
+2. **Modify prompts/address.md**: Update Step 1 under "After the phases" to explicitly command the agent to stage the changes and invoke `/woostack-commit "fix: address review threads <ids>"`, then run `git rev-parse HEAD` to capture the SHA.
+3. **Verify Tests**: Ensure the existing test suite passes and that the worker contract tests (asserting workers do not commit/push) are unaffected since only the parent orchestrator invokes the commit skill.
+
+## 5. Components & data flow
+
+No new scripts or components are created. The orchestration of git commits and pushes is routed through `/woostack-commit` instead of executing raw commands directly.
+
+```mermaid
+sequenceDiagram
+    participant Orchestrator
+    participant Worktree
+    participant CommitSkill as /woostack-commit
+    participant Git
+    participant GitHub
+
+    Orchestrator->>Worktree: Apply FIX edits
+    Orchestrator->>Git: git add <files>
+    Orchestrator->>CommitSkill: Run `/woostack-commit "fix: address review threads <ids>"`
+    CommitSkill->>Git: Commit, pre-commit checks, push/submit
+    CommitSkill-->>Orchestrator: Commit complete
+    Orchestrator->>Git: git rev-parse HEAD
+    Git-->>Orchestrator: Return SHA
+    Orchestrator->>GitHub: Resolve threads & reply with "Fixed in <sha>"
+```
+
+## 6. Error handling
+
+If the pre-commit hook or any check inside `/woostack-commit` fails, it exits non-zero. The orchestrator will halt immediately before posting any replies or resolving threads on GitHub, preventing the remote state from drifting.
+
+## 7. Acceptance criteria
+
+- **AC1 — SKILL.md updates**
+  - happy: `skills/woostack-address-comments/SKILL.md` instructs the orchestrator to stage changes and invoke the `woostack-commit` skill, then capture the SHA.
+- **AC2 — Prompt updates**
+  - happy: `skills/woostack-address-comments/prompts/address.md` instructs the agent to run `/woostack-commit "fix: address review threads <ids>"` and run `git rev-parse HEAD` to capture the SHA.
+- **AC3 — Test suite execution**
+  - happy: The test files in `skills/woostack-address-comments/scripts/tests/` pass successfully.
+
+## 8. Testing
+
+Run the local test scripts to ensure syntax and assertions pass:
+```bash
+./skills/woostack-address-comments/scripts/tests/test-address-helper-scripts.sh
+./skills/woostack-address-comments/scripts/tests/test-address-worker-contract.sh
+./skills/woostack-address-comments/scripts/tests/test-address-comments-ownership.sh
+```
+
+## 9. Open questions
+
+None.


### PR DESCRIPTION
## Goal

Add the design spec and implementation plan for integrating the commit skill into the `woostack-address-comments` workflow.

## Summary

- Added design spec: `.woostack/specs/2026-06-08-address-comments-commit-integration.md`
- Added implementation plan: `.woostack/plans/2026-06-08-address-comments-commit-integration.md`

## Test plan

### Automated

- [ ] Not run (spec and plan docs-only changes)

### Manual

**Before merge**

- [ ] Verify the spec and plan markdown files are valid and contain no placeholders.

Spec: .woostack/specs/2026-06-08-address-comments-commit-integration.md
