### PR TITLE
docs: add spec and plan for woostack-fix

### DIFF
--- a/.woostack/plans/2026-06-08-woostack-fix.md
+++ b/.woostack/plans/2026-06-08-woostack-fix.md
@@ -1,0 +1,175 @@
+**Source:** .woostack/specs/2026-06-08-woostack-fix.md
+
+# woostack-fix Skill and woostack-debug Refinement Implementation Plan
+
+**Goal:** Create a new `woostack-fix` skill that uses `woostack-debug` to identify a root cause, writes a fix plan under `.woostack/fixes/`, hardens, executes, and commits, while refining `woostack-debug` to focus exclusively on root cause identification.
+
+**Architecture:** Split the implementation into three stacked Graphite increments:
+1. Refine `woostack-debug` to remove code modification/Phase 4, create `skills/woostack-fix/SKILL.md`, and add its command routing to `using-woostack`.
+2. Update `woostack-init` to initialize `.woostack/fixes/` and update `woostack-commit` to support fixes.
+3. Update `woostack-status` (`status.sh` and its SKILL.md) to scan, parse, and render fixes on the feature board, and update `AGENTS.md` / `README.md`.
+
+**Tech Stack:** Bash, Markdown, Git, Graphite, GitHub CLI (gh).
+
+---
+
+## Increment 1: Refine woostack-debug & Add woostack-fix Skill
+
+### Task 1: Refine `woostack-debug` to focus exclusively on root cause
+**Files:**
+- Modify: `skills/woostack-debug/SKILL.md`
+
+- [ ] **Step 1: Edit `skills/woostack-debug/SKILL.md`**
+  Remove Phase 4 (Implementation), count of attempts, and escalation rules for 3+ failed fixes. Update overview and behavior of `--auto` and standalone modes to focus purely on diagnosing the root cause.
+  
+  Replace lines 75-100 with a clean transition to returning findings:
+  ```markdown
+  ### Phase 4 — Handback
+  
+  1. **Summarize findings**: Clearly list the root cause, files/lines affected, and evidence gathered.
+  2. **Propose minimal fix**: Detail the exact logic change required. Do not apply it.
+  3. **TDD context**: Name the test file and exact test cases needed to reproduce the issue.
+  ```
+
+- [ ] **Step 2: Run verification**
+  Run: `grep -c "Phase 4 — Implementation" skills/woostack-debug/SKILL.md`
+  Expected: `0`
+
+### Task 2: Create the `woostack-fix` skill
+**Files:**
+- Create: `skills/woostack-fix/SKILL.md`
+
+- [ ] **Step 1: Write `skills/woostack-fix/SKILL.md`**
+  Define the unified execution loop (debug -> write fix plan -> harden -> approve -> execute -> commit) and provide the plan template.
+  
+  ```markdown
+  ---
+  name: woostack-fix
+  description: Create a fix plan under .woostack/fixes/ after identifying the root cause with woostack-debug, then harden, execute (TDD), and commit.
+  ---
+  
+  # woostack-fix
+  
+  ## Overview
+  ...
+  ```
+
+- [ ] **Step 2: Run verification**
+  Run: `test -f skills/woostack-fix/SKILL.md && echo "OK"`
+  Expected: `OK`
+
+### Task 3: Route `woostack-fix` in `using-woostack`
+**Files:**
+- Modify: `skills/using-woostack/SKILL.md`
+
+- [ ] **Step 1: Edit routing table in `skills/using-woostack/SKILL.md`**
+  Add a row for `/woostack-fix <target> [description]` to route it.
+  Update the public commands count if mentioned.
+
+- [ ] **Step 2: Run verification**
+  Run: `grep -q "woostack-fix" skills/using-woostack/SKILL.md && echo "OK"`
+  Expected: `OK`
+
+- [ ] **Step 3: Commit Increment 1**
+  Run:
+  ```bash
+  gt create feature/woostack-fix-core
+  git add skills/woostack-debug/SKILL.md skills/woostack-fix/SKILL.md skills/using-woostack/SKILL.md
+  gt modify -m "feat(fix): refine woostack-debug and create woostack-fix skill core"
+  ```
+
+---
+
+## Increment 2: Add Workspace Init Integration
+
+### Task 4: Update `woostack-init` to support `.woostack/fixes/`
+**Files:**
+- Modify: `skills/woostack-init/SKILL.md`
+- Create: `skills/woostack-init/templates/fixes/.gitkeep`
+
+- [ ] **Step 1: Create the template folder and `.gitkeep`**
+  Run: `mkdir -p skills/woostack-init/templates/fixes && touch skills/woostack-init/templates/fixes/.gitkeep`
+
+- [ ] **Step 2: Modify `skills/woostack-init/SKILL.md`**
+  Add the `.woostack/fixes/` directory and `.woostack/fixes/.gitkeep` to the list of items created/managed by `/woostack-init`.
+
+- [ ] **Step 3: Run verification**
+  Run: `test -f skills/woostack-init/templates/fixes/.gitkeep && echo "OK"`
+  Expected: `OK`
+
+### Task 5: Update `woostack-commit` to support fixes
+**Files:**
+- Modify: `skills/woostack-commit/SKILL.md`
+
+- [ ] **Step 1: Edit `skills/woostack-commit/SKILL.md`**
+  Update the PR trailer instructions and status conventions link to search for `.woostack/fixes/*.md` and write the trailer `Spec: .woostack/fixes/<file>.md` when working on a fix branch.
+
+- [ ] **Step 2: Run verification**
+  Run: `grep -q "woostack/fixes" skills/woostack-commit/SKILL.md && echo "OK"`
+  Expected: `OK`
+
+- [ ] **Step 3: Commit Increment 2**
+  Run:
+  ```bash
+  gt create feature/woostack-fix-init-commit
+  git add skills/woostack-init/ skills/woostack-commit/SKILL.md
+  gt modify -m "feat(fix): add fixes directory to woostack-init and support in woostack-commit"
+  ```
+
+---
+
+## Increment 3: Status Board Integration & Documentation
+
+### Task 6: Update `status.sh` script to parse and display fixes
+**Files:**
+- Modify: `skills/woostack-status/scripts/status.sh`
+- Modify: `skills/woostack-status/SKILL.md`
+
+- [ ] **Step 1: Modify `skills/woostack-status/scripts/status.sh`**
+  Update the script to scan `.woostack/fixes/*.md` in addition to specs, parse their status, checklist, and head PRs, and format them with `[FIX]` prefix.
+  
+  ```bash
+  # In status.sh, update specs definition:
+  specs=( "$SPEC_DIR"/*.md "$WOO_DIR"/fixes/*.md )
+  ```
+  And update plan_for / next_action / prs_for_spec logic to handle the fixes directory.
+
+- [ ] **Step 2: Modify `skills/woostack-status/SKILL.md`**
+  Document the status integration for fixes under `.woostack/fixes/`.
+
+- [ ] **Step 3: Run verification**
+  Run: `bash skills/woostack-status/scripts/status.sh`
+  Expected: Runs successfully and exits 0.
+
+### Task 7: Update AGENTS.md and README.md
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Edit `AGENTS.md`**
+  Add `woostack-fix` to the list of public skills (increasing count to 15).
+  Update file maps and descriptions.
+
+- [ ] **Step 2: Edit `README.md`**
+  Add `woostack-fix` documentation and update public command surface counts.
+
+- [ ] **Step 3: Run verification**
+  Run: `grep -q "woostack-fix" AGENTS.md && grep -q "woostack-fix" README.md && echo "OK"`
+  Expected: `OK`
+
+- [ ] **Step 4: Commit Increment 3**
+  Run:
+  ```bash
+  gt create feature/woostack-fix-status-docs
+  git add skills/woostack-status/ AGENTS.md README.md
+  gt modify -m "feat(fix): integrate fixes in status board and update documentation"
+  ```
+
+---
+
+## Self-review (run before handing back)
+
+- [x] **Spec coverage** — every spec requirement maps to a task above.
+- [x] **AC coverage** — each spec §7 acceptance criterion maps to a test.
+- [x] **No placeholders** — no TBD/TODO; complete details in every step.
+- [x] **Type consistency** — paths and formats match.

--- a/.woostack/specs/2026-06-08-woostack-fix.md
+++ b/.woostack/specs/2026-06-08-woostack-fix.md
@@ -1,0 +1,118 @@
+---
+name: woostack-fix
+type: spec
+status: planning
+date: 2026-06-08
+branch: feature/woostack-fix
+links:
+---
+
+# Create `woostack-fix` Skill and Refine `woostack-debug` — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+Currently, resolving technical issues (bugs, small improvements) uses either `woostack-build` or `woostack-debug`. This has two major issues:
+1. **High Overhead**: The full `woostack-build` loop requires separate spec and plan files, multiple hardening rounds, a docs-only PR, and multiple execution branches. This is too heavy for small fixes.
+2. **Responsibility Bleed**: The `woostack-debug` skill mixes root cause diagnosis with code modification/implementation (Phase 4). This violates the single-responsibility principle. Debugging should focus purely on *identifying and reproducing* the root cause, whereas code changes should go through a plan-approve-execute flow.
+
+## 2. Goal
+
+Introduce a new `woostack-fix` skill that coordinates bug fixing, and refine the `woostack-debug` skill to focus exclusively on diagnosing root causes.
+
+Concretely:
+1. **Refine `woostack-debug`**: Remove Phase 4 (Implementation) and code-modifying steps. Limit its scope to Phase 1 (Investigation), Phase 2 (Pattern Analysis), and Phase 3 (Hypothesis & Test with minimal reproduction).
+2. **Create `woostack-fix`**: Implement a new public skill `/woostack-fix <target>` that:
+   - Uses `woostack-debug` to identify a root cause.
+   - Writes a unified "fix plan" under `.woostack/fixes/YYYY-MM-DD-<slug>.md`.
+   - Runs `woostack-harden` on the fix plan.
+   - Halts for explicit user approval before execution (the gate).
+   - Executes the fix steps using TDD (test-first).
+   - Commits the changes using `woostack-commit`.
+3. **Update `woostack-init`**: Ensure `.woostack/fixes/` directory and `.gitkeep` are created and managed.
+4. **Update `woostack-status`**: Scan `.woostack/fixes/*.md` and display active fixes on the feature board alongside features, prefixed with `[FIX]`.
+5. **Update Routing**: Register `woostack-fix` as the 15th public skill in `using-woostack`, `AGENTS.md`, and `README.md`.
+
+## 3. Non-goals
+
+- We do not modify the core TDD doctrine (`woostack-tdd`).
+- We do not change the core Obsidian memory/distillation scripts unless required.
+- We do not merge PRs automatically.
+
+## 4. Approach
+
+### A. Debug Skill Refinement
+- Edit `skills/woostack-debug/SKILL.md` to remove references to Phase 4 (Implementation), count of attempts, and escalation rules for 3+ failed fixes.
+- Adjust the `--auto` description: `--auto` mode in `woostack-debug` will run Phases 1–3 autonomously (reproducing and tracing data flow) and print the root cause hypothesis and evidence without prompting the user. Standalone mode (no `--auto`) will stop after Phase 1 or 2 and ask the user for guidance or verify findings interactively.
+- The Iron Law remains: **NO FIX WITHOUT ROOT CAUSE INVESTIGATION FIRST**.
+
+### B. Fix Skill Creation
+- Create `skills/woostack-fix/SKILL.md` defining the unified gated loop.
+- Define a template for the fix plan stored at `.woostack/fixes/YYYY-MM-DD-<slug>.md`.
+- Status enum transitions for fixes: `draft → hardened → approved → executing → in-review → done` (computed or written in frontmatter).
+
+### C. Workspace & Status Updates
+- Update `skills/woostack-init/SKILL.md` and templates to add `.woostack/fixes/`.
+- Update `skills/woostack-status/scripts/status.sh` to:
+  - Glob `.woostack/fixes/*.md` in addition to specs.
+  - Parse frontmatter (`type: fix`, `status:`, `branch:`) and checklist items.
+  - Render fixes in the status output with a `[FIX]` prefix.
+
+### D. Routing Updates
+- Update `skills/using-woostack/SKILL.md` Command Routing table.
+- Update `AGENTS.md` and `README.md`.
+
+## 5. Components & data flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant FixSkill as /woostack-fix
+    participant DebugSkill as /woostack-debug
+    participant HardenSkill as /woostack-harden
+    participant CommitSkill as /woostack-commit
+    participant Worktree
+    
+    User->>FixSkill: /woostack-fix <target>
+    FixSkill->>DebugSkill: run /woostack-debug <target> --auto
+    DebugSkill->>Worktree: Investigate, reproduce, trace data flow
+    DebugSkill-->>FixSkill: Root cause analysis + verification test details
+    FixSkill->>Worktree: Write .woostack/fixes/YYYY-MM-DD-<slug>.md
+    FixSkill->>HardenSkill: Run /woostack-harden on fix plan
+    HardenSkill-->>FixSkill: Hardened fix plan
+    FixSkill-->>User: Present plan & request approval (GATE)
+    User->>FixSkill: Approve
+    FixSkill->>Worktree: Execute (TDD: failing test -> implementation -> verify)
+    FixSkill->>CommitSkill: Run /woostack-commit
+```
+
+## 6. Error handling
+
+- If `woostack-debug` fails to identify a root cause, `woostack-fix` halts and prompts the user for manual investigation hints.
+- If execution verifications fail, the loop pauses and prompts the user or runs debug again on the new failure.
+
+## 7. Acceptance criteria
+
+- **AC1 — Debug skill refinement**
+  - happy: `skills/woostack-debug/SKILL.md` contains no implementation (Phase 4) details, focusing purely on Phases 1-3.
+- **AC2 — Fix skill definition**
+  - happy: `skills/woostack-fix/SKILL.md` exists and defines the unified execution loop using `woostack-debug`, `woostack-harden`, and `woostack-commit`.
+- **AC3 — Init integration**
+  - happy: Running `/woostack-init` ensures `.woostack/fixes/` and its `.gitkeep` exist.
+- **AC4 — Status integration**
+  - happy: `status.sh` scans `.woostack/fixes/*.md` and prints them with a `[FIX]` prefix, calculating progress from their checklists.
+- **AC5 — Workspace wiring**
+  - happy: `using-woostack`, `AGENTS.md`, and `README.md` all list `/woostack-fix` and have consistent counts (15 public skills).
+
+## 8. Testing
+
+- Run `woostack-init` and verify `.woostack/fixes/` exists.
+- Create a test fix plan at `.woostack/fixes/2026-06-08-test-fix.md` and check that `woostack-status` renders it correctly.
+- Verify that `woostack-status` shows correct checklist counts (`N/M`) for the test fix plan.
+
+## 9. Open questions
+
+None.


### PR DESCRIPTION
## Goal

Define the specification and implementation plan for introducing the new `woostack-fix` skill and refining the `woostack-debug` skill to focus exclusively on root cause identification.

## Summary

- Add design specification under `.woostack/specs/2026-06-08-woostack-fix.md` outlining the problem, goals, and approach.
- Add implementation plan under `.woostack/plans/2026-06-08-woostack-fix.md` decomposing the build into three Graphite-stacked increments.

## Test plan

### Manual

**Before merge**

- [ ] Verify spec contents match the approved design details.
- [ ] Verify plan covers refinement, init, status, and documentation tasks.

Spec: .woostack/specs/2026-06-08-woostack-fix.md
