### PR TITLE
feat(fix): refine woostack-debug and create woostack-fix skill core

### DIFF
--- a/.woostack/memory/fanout-empty-needs-receipt.md
+++ b/.woostack/memory/fanout-empty-needs-receipt.md
@@ -6,8 +6,8 @@ tags: receipt, false-pass, empty-findings, swarm, fan-out, gate, verify-receipts
 hook: An empty aggregate from a fan-out of workers is ambiguous (clean vs never-ran) — require a per-worker execution receipt to disambiguate.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-fail-fast-receipts.md
-recall_count: 1
-last_recalled: 2026-06-06
+recall_count: 2
+last_recalled: 2026-06-08
 ---
 
 When a flow fans work out to N workers and then aggregates their outputs, an

--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 13
+recall_count: 14
 last_recalled: 2026-06-08
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 14
+recall_count: 15
 last_recalled: 2026-06-08
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/review-add-angle-sites.md
+++ b/.woostack/memory/review-add-angle-sites.md
@@ -6,8 +6,8 @@ tags: angle, detect-angles, _header, load-config, anthropic, enumeration, add-an
 hook: Adding a woostack-review angle touches 11 sites — the easy-to-miss four are load-config VALID_ANGLES, the anthropic.md tier list, the _header footer whitelist, and the committed gating test.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 5
-last_recalled: 2026-06-06
+recall_count: 6
+last_recalled: 2026-06-08
 ---
 Registering an angle so it is **fully** wired (runs, is config-addressable, renders its
 footer, routes to the right model, and is tested) touches **eleven** sites. Touch fewer and

--- a/.woostack/memory/review-angle-trigger-precision.md
+++ b/.woostack/memory/review-angle-trigger-precision.md
@@ -6,8 +6,8 @@ tags: detect-angles, angle, trigger, diff-gated, enrichment, tier, observability
 hook: Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also matches the new pattern — and never broaden a trigger on a common token.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-review-self-contained.md
-recall_count: 5
-last_recalled: 2026-06-06
+recall_count: 6
+last_recalled: 2026-06-08
 ---
 Most review angles are **diff-gated**: `detect-angles.sh` decides whether the angle
 runs at all by grepping the diff for trigger tokens (`has_<angle>_diff_token()` /

--- a/.woostack/memory/review-config-bool-jq-default.md
+++ b/.woostack/memory/review-config-bool-jq-default.md
@@ -6,8 +6,8 @@ tags: jq, config, boolean, defaults, intersect-findings, load-config
 hook: jq `// default` silently coerces an explicit `false` to the default — wrong for any default-TRUE config bool.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-review-nit-comments.md
-recall_count: 9
-last_recalled: 2026-06-06
+recall_count: 10
+last_recalled: 2026-06-08
 ---
 jq's `//` is the *alternative* operator: it returns the right-hand side when the
 left is `null` **or** `false`. So `jq -r '.key // true'` returns `true` for an

--- a/.woostack/memory/review-prompt-self-contained-blob.md
+++ b/.woostack/memory/review-prompt-self-contained-blob.md
@@ -6,8 +6,8 @@ tags: load-prompt, _header, ci-prompt, inline, cross-reference, model-tiers
 hook: woostack-review prompts ship as ONE self-contained blob to CI runners that follow no markdown links — shared content must be inlined, not just linked.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-05-execute-vary-subagent-model.md
-recall_count: 7
-last_recalled: 2026-06-06
+recall_count: 8
+last_recalled: 2026-06-08
 ---
 `load-prompt.sh` concatenates `_header.md` + the provider body into a single
 prompt string handed to external runners (`claude-code-action`, `codex-action`,

--- a/.woostack/memory/skill-description-angle-bracket-placeholders.md
+++ b/.woostack/memory/skill-description-angle-bracket-placeholders.md
@@ -6,7 +6,7 @@ tags: skill-description, frontmatter, review, skills-angle, false-positive, plac
 hook: Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are an accepted, shipped convention here — not an XML/HTML defect; the review `skills` angle must not flag them.
 updated: 2026-06-06
 source: pr-232
-recall_count: 6
+recall_count: 7
 last_recalled: 2026-06-08
 ---
 Angle-bracket usage placeholders in a `SKILL.md` `description:` field — e.g.

--- a/.woostack/memory/skill-description-angle-bracket-placeholders.md
+++ b/.woostack/memory/skill-description-angle-bracket-placeholders.md
@@ -6,7 +6,7 @@ tags: skill-description, frontmatter, review, skills-angle, false-positive, plac
 hook: Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are an accepted, shipped convention here — not an XML/HTML defect; the review `skills` angle must not flag them.
 updated: 2026-06-06
 source: pr-232
-recall_count: 5
+recall_count: 6
 last_recalled: 2026-06-08
 ---
 Angle-bracket usage placeholders in a `SKILL.md` `description:` field — e.g.

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 20
+recall_count: 21
 last_recalled: 2026-06-08
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 21
+recall_count: 22
 last_recalled: 2026-06-08
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 33
+recall_count: 34
 last_recalled: 2026-06-08
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 32
+recall_count: 33
 last_recalled: 2026-06-08
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 59
+recall_count: 60
 last_recalled: 2026-06-08
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 58
+recall_count: 59
 last_recalled: 2026-06-08
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,12 +13,13 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `npx skills add howarewoo/woostack`.
 
-The public command/adoption surface has fourteen skills:
+The public command/adoption surface has fifteen skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
 - [`woostack-bootstrap`](skills/woostack-bootstrap/SKILL.md)
 - [`woostack-build`](skills/woostack-build/SKILL.md)
+- [`woostack-fix`](skills/woostack-fix/SKILL.md)
 - [`woostack-plan`](skills/woostack-plan/SKILL.md)
 - [`woostack-execute`](skills/woostack-execute/SKILL.md)
 - [`woostack-execute-overnight`](skills/woostack-execute-overnight/SKILL.md)
@@ -34,7 +35,7 @@ The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the fourteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+`/woostack-*` commands: they have no routing row and are absent from the fifteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
 There is no application source code, app lockfile, build, or CI for this repo's own
@@ -54,7 +55,7 @@ docs, HTML templates, review scripts, prompts, or JSON config. Keep edits in ski
 do not add application code, app build configs, or app lockfiles.
 
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
-`/woostack-bootstrap`, `/woostack-build`, `/woostack-plan`, `/woostack-execute`, `/woostack-execute-overnight`, `/woostack-commit`,
+`/woostack-bootstrap`, `/woostack-build`, `/woostack-fix`, `/woostack-plan`, `/woostack-execute`, `/woostack-execute-overnight`, `/woostack-commit`,
 `/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, or
 `/woostack-tdd`, including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
@@ -78,7 +79,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the sixteen `SKILL.md` files (the fourteen public command/adoption
+- Do not move or rename any of the seventeen `SKILL.md` files (the fifteen public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -94,6 +95,8 @@ directory, not in this repo.
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/)
 - Build loop:
   [`skills/woostack-build/SKILL.md`](skills/woostack-build/SKILL.md)
+- Small-change fix loop (public command; diagnose → fix plan → approve → TDD → commit):
+  [`skills/woostack-fix/SKILL.md`](skills/woostack-fix/SKILL.md)
 - Plan-writing engine for the build loop (public command):
   [`skills/woostack-plan/SKILL.md`](skills/woostack-plan/SKILL.md)
 - Plan-execution engine for the build loop (public command):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, and `woostack-debug`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, `woostack-debug`, and `woostack-tdd`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 
@@ -19,6 +19,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Refine the bootstrap procedure | `skills/woostack-bootstrap/references/bootstrap.md` |
 | Change the bootstrap skill entry / discovery description | `skills/woostack-bootstrap/SKILL.md` |
 | Change the build loop (ideate→spec→harden→approve spec→plan→execute) | `skills/woostack-build/SKILL.md` |
+| Change the small-change fix loop (`/woostack-fix`) | `skills/woostack-fix/SKILL.md` |
 | Change the ideate phase (the build loop's first step) | `skills/woostack-ideate/SKILL.md` |
 | Change the harden phase (the build loop's stress-test step) | `skills/woostack-harden/SKILL.md` |
 | Change the plan phase (the build loop's planning step) | `skills/woostack-plan/SKILL.md` |
@@ -27,6 +28,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Change the commit / PR update workflow | `skills/woostack-commit/SKILL.md` |
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |
 | Change the systematic-debugging behavior (`/woostack-debug`) | `skills/woostack-debug/SKILL.md` |
+| Change the test-adder / TDD doctrine home (`/woostack-tdd`) | `skills/woostack-tdd/SKILL.md` |
 | Change the address-comments delegator | `skills/woostack-address-comments/SKILL.md` |
 | Change the status board / feature-state conventions | `skills/woostack-status/SKILL.md`, `skills/woostack-status/references/conventions.md`, `skills/woostack-status/scripts/` |
 | Update agent instructions (Claude or any) | `AGENTS.md` (`.claude/CLAUDE.md` is a symlink to it) |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is thirteen skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-plan, woostack-execute, woostack-execute-overnight, woostack-commit, woostack-review, woostack-address-comments, woostack-status, woostack-visualize, and woostack-debug. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is fifteen skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-fix, woostack-plan, woostack-execute, woostack-execute-overnight, woostack-commit, woostack-review, woostack-address-comments, woostack-status, woostack-visualize, woostack-debug, and woostack-tdd. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 
@@ -60,6 +60,16 @@ ideate → markdown spec → harden → approve spec → plan → execute (TDD) 
 ```
 
 It sequences woostack's own ideate, harden, plan, and execute phases (`woostack-ideate`, `woostack-harden`, `woostack-plan`, `woostack-execute`), inheriting the ideate design gate and hosting the relocated spec-approval gate before planning — the build loop has no external skill dependencies. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed (`woostack-review --fast`), and distilled. The execution-handoff gate lets you Go (execute now), Hand off (execute later/elsewhere), or Run overnight (`woostack-execute-overnight`, unattended). Go ends on the reviewed PR stack; Run overnight ends on a reviewed (or partially reviewed, blockers logged) stack plus a morning report; Hand off stops at the spec+plan PR. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
+
+### `/woostack-fix <target> [description]`: small-change fix loop
+
+The lightweight counterpart to `/woostack-build` for bugs, hotfixes, and small refactors:
+
+```
+diagnose root cause (woostack-debug) → fix plan (.woostack/fixes/ markdown) → harden → approve (GATE) → execute (TDD) → commit
+```
+
+Because a fix is smaller than a feature, the spec and the plan collapse into one markdown file under `.woostack/fixes/`, and the loop has exactly **one** hard gate — fix-plan approval — before any code changes. It diagnoses with `woostack-debug` (no guess-and-check), drives every change with a failing test first, and commits via `woostack-commit`. Never merges. → [SKILL.md](skills/woostack-fix/SKILL.md)
 
 ### `/woostack-plan <spec-path>`: write a plan from a spec
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Executes an approved markdown plan from `.woostack/plans/` as a sequence of PR-s
 
 ### `/woostack-execute-overnight <plan-path>`: run a plan unattended overnight
 
-Executes an approved plan the way `woostack-execute` does, but **unattended** — one autonomous run with no input after launch. It reuses execute's per-increment cadence and drivers and overrides only the stop-points: a stuck verification routes to `woostack-debug --auto`, a blocking review is auto-addressed (`woostack-address-comments --auto`, bounded) or escalated, and anything unsafe or ambiguous becomes a logged blocker — safety is never relaxed for autonomy. A blocker ends its track (plans may group increments under optional `## Track:` headings; default is one linear stack) and the run continues. It writes a **morning report** to `.woostack/overnight/` for a human to test in the morning. It is the third choice at `woostack-build`'s execution-handoff gate (Go / Hand off / Run overnight), and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute-overnight/SKILL.md)
+Executes an approved plan the way `woostack-execute` does, but **unattended** — one autonomous run with no input after launch. It reuses execute's per-increment cadence and drivers and overrides only the stop-points: a stuck verification routes to `woostack-debug` (which root-causes autonomously), a blocking review is auto-addressed (`woostack-address-comments --auto`, bounded) or escalated, and anything unsafe or ambiguous becomes a logged blocker — safety is never relaxed for autonomy. A blocker ends its track (plans may group increments under optional `## Track:` headings; default is one linear stack) and the run continues. It writes a **morning report** to `.woostack/overnight/` for a human to test in the morning. It is the third choice at `woostack-build`'s execution-handoff gate (Go / Hand off / Run overnight), and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute-overnight/SKILL.md)
 
 ### `/woostack-review [PR#]`: parallel review swarm
 
@@ -103,9 +103,9 @@ A read-only, on-demand board derived fresh from your `.woostack/` artifacts: for
 
 A discovery command for rendering source material as an audience-tailored HTML view while keeping the source authoritative. → [SKILL.md](skills/woostack-visualize/SKILL.md)
 
-### `/woostack-debug <target> [--auto]`: find the root cause before fixing
+### `/woostack-debug <target>`: find the root cause before fixing
 
-Runs woostack's systematic-debugging method on a bug, test failure, or unexpected behavior: root-cause investigation → pattern analysis → hypothesis/test → a minimal fix with a failing test first, under the Iron Law (no fix without a root cause) and a 3-fixes-→-question-the-architecture escalation. It recalls known `gotcha`s from `.woostack/memory/` at the start and distills one at the end. Standalone it gates on the root cause before fixing (the gated form `woostack-review` points you at for a confirmed bug); `--auto` runs autonomously (how `woostack-execute` calls it on a stuck verification). Never commits or merges. → [SKILL.md](skills/woostack-debug/SKILL.md)
+Runs woostack's systematic-debugging method on a bug, test failure, or unexpected behavior: root-cause investigation → pattern analysis → hypothesis/test → handback, under the Iron Law (no fix without a root cause). It recalls known `gotcha`s from `.woostack/memory/` at the start. Running it performs the analysis autonomously and hands back the root cause, a proposed minimal fix, and the TDD context — it is investigative only and never writes code (the caller implements the fix: `woostack-fix`, or `woostack-execute` on a stuck verification). `woostack-review` points you at it for a confirmed bug. Never commits or merges. → [SKILL.md](skills/woostack-debug/SKILL.md)
 
 ### Growing scope
 

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -66,6 +66,7 @@ link it, never restate it.
 | `/woostack-init [path]`, initialize or repair the `.woostack/` workspace | `woostack-init` |
 | `/woostack-bootstrap <goal>`, scaffold a new web/mobile/API project | `woostack-bootstrap` |
 | `/woostack-build <goal>`, build a feature through the woostack loop | `woostack-build` |
+| `/woostack-fix <target> [description]`, resolve a bug/issue through the unified fix loop | `woostack-fix` |
 | `/woostack-plan <spec-path>`, write the implementation plan for an approved spec as PR-sized increments | `woostack-plan` |
 | `/woostack-execute <plan-path> [--inline\|--subagent]`, execute an approved plan as PR-sized stacked increments (inline or subagent-driven) | `woostack-execute` |
 | `/woostack-execute-overnight <plan-path> [--inline\|--subagent]`, execute an approved plan unattended overnight (autonomous, morning report) | `woostack-execute-overnight` |

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -75,7 +75,7 @@ link it, never restate it.
 | `/woostack-address-comments [PR#]`, address unresolved review threads | `woostack-address-comments` |
 | `/woostack-status [--all] [--fetch]`, show the derived feature board (what's in flight, what to do next) | `woostack-status` |
 | `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |
-| `/woostack-debug <target> [--auto]`, find a bug's root cause before fixing (gated; `--auto` for autonomous) | `woostack-debug` |
+| `/woostack-debug <target>`, run an autonomous root-cause analysis before fixing (investigative only — hands back the root cause and a proposed fix) | `woostack-debug` |
 | `/woostack-tdd <target>`, add appropriate tests to a code block, PR, spec, or plan (gate-light; TDD doctrine home) | `woostack-tdd` |
 
 If the user asks for the behavior without using the exact command name, route by intent.

--- a/skills/woostack-bootstrap/references/development.md
+++ b/skills/woostack-bootstrap/references/development.md
@@ -10,6 +10,7 @@ for each phase:
 | Phase | Skill |
 |---|---|
 | Build a feature, idea → implementation (gated chain — the skill owns the steps) | `woostack-build` |
+| Fix a small issue, diagnosis → implementation (gated fix loop) | `woostack-fix` |
 | Review | `woostack-review` |
 | Address review feedback | `woostack-address-comments` |
 

--- a/skills/woostack-debug/SKILL.md
+++ b/skills/woostack-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-debug
-description: "Use as woostack's systematic-debugging phase — find the root cause of a bug, test failure, or unexpected behavior before any fix. Retells the four-phase method (root-cause investigation → pattern analysis → hypothesis/test → handback) with the Iron Law (no fix without root cause), wired to the .woostack/memory store (recall known gotchas at start). Invoke via /woostack-debug <target> for interactive root cause analysis, or with --auto for autonomous operation. Owns no spec/plan/status, never writes code, never commits, and never merges — it hands the root cause findings back."
+description: "Use as woostack's systematic-debugging phase — find the root cause of a bug, test failure, or unexpected behavior before any fix. Retells the four-phase method (root-cause investigation → pattern analysis → hypothesis/test → handback) with the Iron Law (no fix without root cause), wired to the .woostack/memory store (recall known gotchas at start). Invoke via /woostack-debug <target>; it runs the four-phase root-cause analysis automatically and hands the findings back. Investigative only — autonomous is its sole mode (no flag), and it never writes code, commits, or merges."
 ---
 
 # woostack-debug
@@ -10,18 +10,20 @@ fix. This is woostack's own systematic-debugging phase: a place every woostack s
 a stuck verification or a confirmed bug instead of falling back to guess-and-check. It owns no
 approval gate, never writes code, never commits, and never merges — it hands the diagnosed root cause back.
 
-It is both the 12th public command (`/woostack-debug <target> [--auto]`) and an internal hook:
-[`woostack-execute`](../woostack-execute/SKILL.md) dispatches it autonomously when a
-verification fails repeatedly to diagnose the root cause, and [`woostack-review`](../woostack-review/SKILL.md) suggests it
-for a confirmed bug.
+It is a public command — `/woostack-debug <target>` — and an internal hook:
+[`woostack-execute`](../woostack-execute/SKILL.md) and
+[`woostack-execute-overnight`](../woostack-execute-overnight/SKILL.md) dispatch it on a
+repeatedly-failing verification, and [`woostack-review`](../woostack-review/SKILL.md) points the
+author at it for a confirmed bug. It always runs autonomously — there is no interactive mode and
+no flag; running it performs a full root-cause analysis and hands the findings back.
 
 <IRON-LAW>
 NO FIX WITHOUT ROOT CAUSE INVESTIGATION FIRST.
 
 A symptom fix is a failure. If you have not completed Phase 1 (root-cause investigation), you
 may not propose or apply a fix. This holds for EVERY issue regardless of perceived simplicity
-and ESPECIALLY under time pressure — systematic debugging is faster than thrashing. Even in
-`--auto` mode the root cause is narrated before any fix, so the "why" is always visible.
+and ESPECIALLY under time pressure — systematic debugging is faster than thrashing. The root
+cause is always narrated before any fix is proposed, so the "why" is always visible.
 </IRON-LAW>
 
 ## When to use
@@ -80,15 +82,15 @@ Complete each phase before the next.
 For timing-dependent or flaky failures, recommend replacing arbitrary timeouts with **condition-based
 waiting** (poll for the condition) rather than sleeping a fixed interval.
 
-## Mode: `--auto` vs standalone
+## Operation
 
-Mode is selected by an explicit `--auto` flag — mirroring
-[`woostack-execute`](../woostack-execute/SKILL.md)'s explicit `--inline/--subagent` precedent —
-never by context-sniffing.
+woostack-debug always runs autonomously. Running `/woostack-debug <target>` works through
+Phases 1–4 end to end — no per-hypothesis approval gate — and hands back the Phase 4 result: the
+root-cause summary, the proposed minimal fix, and the TDD context. There is no interactive mode
+and no `--auto` flag; autonomous is the only mode. The Iron Law still forces narrating the root
+cause before any fix is proposed, so the "why" is always visible. It is investigative only — it
+hands the findings back and never applies the fix itself.
 
-- **`--auto` (autonomous).** Run Phases 1–4 end to end autonomously to identify the root cause and hand it back. No per-hypothesis approval gate. The Iron Law still forces narrating the root cause findings. At the end, output the Phase 4 handback — the summary, recommended minimal fix, and verification steps — then stop. `woostack-execute` dispatches this mode on a repeatedly-failing verification.
-- **No `--auto` (standalone — the default).** Work through Phases 1–4 interactively with the user. Present findings, verify hypotheses, align on the proposed fix plan, and hand back.
-- **Fail-safe.** Absence or an unrecognized flag ⇒ the standalone mode.
 - **No target given.** `/woostack-debug` with no argument → ask what's broken; do not guess
   (mirror `woostack-execute`'s no-argument behavior).
 
@@ -136,4 +138,4 @@ external: document what you investigated and log findings for future investigati
 - **Iron Law.** No fix proposed or applied before Phase 1 is complete. Keep this prominent so it survives summarization.
 - **Owns no spec/plan/status.** Never writes a `.woostack/specs/`, `.woostack/plans/`, or `.woostack/fixes/` file. The phase enum and join contracts live in [conventions.md](../woostack-status/references/conventions.md) — link, never restate.
 - **Never writes code, commits, or merges.** Hands the findings back; does not touch repository code files.
-- **Mode is explicit.** `--auto` ⇒ autonomous; its absence ⇒ interactive standalone mode.
+- **Always autonomous.** Runs the four phases end to end without a user gate and hands back; owns no `--auto` flag (autonomous is the only mode) and never runs interactively. Investigative only — it never applies the fix.

--- a/skills/woostack-debug/SKILL.md
+++ b/skills/woostack-debug/SKILL.md
@@ -1,19 +1,18 @@
 ---
 name: woostack-debug
-description: "Use as woostack's systematic-debugging phase — find the root cause of a bug, test failure, or unexpected behavior before any fix, then fix it minimally with a failing test first. Retells the four-phase method (root-cause investigation → pattern analysis → hypothesis/test → implementation) with the Iron Law (no fix without root cause) and the 3-fixes-→-question-architecture escalation, wired to the .woostack/memory store (recall known gotchas at start, distill one gotcha at end). Invoke via /woostack-debug <target> for a look-before-fix gate, or with --auto for autonomous operation (woostack-execute dispatches --auto on a repeatedly-failing verification; woostack-review suggests the gated command for a confirmed bug). Owns no spec/plan/status, never commits or merges."
+description: "Use as woostack's systematic-debugging phase — find the root cause of a bug, test failure, or unexpected behavior before any fix. Retells the four-phase method (root-cause investigation → pattern analysis → hypothesis/test → handback) with the Iron Law (no fix without root cause), wired to the .woostack/memory store (recall known gotchas at start). Invoke via /woostack-debug <target> for interactive root cause analysis, or with --auto for autonomous operation. Owns no spec/plan/status, never writes code, never commits, and never merges — it hands the root cause findings back."
 ---
 
 # woostack-debug
 
 Find the root cause of any bug, test failure, or unexpected behavior **before** attempting a
-fix, then fix the root cause minimally with a failing test first. This is woostack's own
-systematic-debugging phase: a place every woostack skill can route a stuck verification or a
-confirmed bug instead of falling back to guess-and-check. It owns no approval gate beyond its
-standalone look-before-fix mode, never commits, and never merges — it hands the fix back.
+fix. This is woostack's own systematic-debugging phase: a place every woostack skill can route
+a stuck verification or a confirmed bug instead of falling back to guess-and-check. It owns no
+approval gate, never writes code, never commits, and never merges — it hands the diagnosed root cause back.
 
 It is both the 12th public command (`/woostack-debug <target> [--auto]`) and an internal hook:
 [`woostack-execute`](../woostack-execute/SKILL.md) dispatches it autonomously when a
-verification fails repeatedly, and [`woostack-review`](../woostack-review/SKILL.md) suggests it
+verification fails repeatedly to diagnose the root cause, and [`woostack-review`](../woostack-review/SKILL.md) suggests it
 for a confirmed bug.
 
 <IRON-LAW>
@@ -72,31 +71,14 @@ Complete each phase before the next.
    don't stack more fixes on top.
 4. **When you don't know,** say "I don't understand X" and research or ask — don't pretend.
 
-### Phase 4 — Implementation
+### Phase 4 — Handback
 
-1. **Write a failing test first.** The simplest reproduction of the bug, automated if a test
-   harness exists — per the [woostack-tdd kernel](../woostack-tdd/SKILL.md). In a target with no
-   test runner, the "failing test" is a concrete verification command (a `grep`, a `bash -n`, a
-   link check) with exact expected output — never a vague "verify it works". You must have this
-   before fixing.
-2. **Implement one minimal fix** at the root cause identified — one change, no "while I'm here"
-   improvements, no bundled refactoring.
-3. **Verify the fix.** The test passes now, no other test broke, the issue is actually
-   resolved. Optionally add **defense-in-depth** validation at the relevant layer boundaries so
-   the same class of bad value is caught earlier next time.
-4. **If the fix doesn't work,** count attempts: `< 3` → return to Phase 1 with the new
-   evidence; `≥ 3` → STOP (see the escalation block).
+1. **Summarize findings**: Clearly list the root cause, files/lines affected, and evidence gathered.
+2. **Propose minimal fix**: Detail the exact logic change required. Do not apply it.
+3. **TDD context**: Name the test file and exact test cases needed to reproduce the issue (the failing test description) so the caller or fix flow can implement it.
 
-For timing-dependent or flaky failures, replace arbitrary timeouts with **condition-based
+For timing-dependent or flaky failures, recommend replacing arbitrary timeouts with **condition-based
 waiting** (poll for the condition) rather than sleeping a fixed interval.
-
-<ESCALATION>
-If 3+ fixes have failed, STOP. This is not a failed hypothesis — it is a wrong-architecture
-signal: each fix reveals new coupling or shared state somewhere else, fixes start needing
-"massive refactoring", and each fix creates new symptoms. Question the fundamentals with the
-user: is this pattern sound, or are we continuing through inertia? Do NOT attempt fix #4 before
-that discussion. When invoked with `--auto`, this stop is the handback signal to the caller.
-</ESCALATION>
 
 ## Mode: `--auto` vs standalone
 
@@ -104,17 +86,9 @@ Mode is selected by an explicit `--auto` flag — mirroring
 [`woostack-execute`](../woostack-execute/SKILL.md)'s explicit `--inline/--subagent` precedent —
 never by context-sniffing.
 
-- **`--auto` (autonomous).** Run Phases 1–4 end to end. No per-fix approval gate (consistent
-  with `woostack-execute` / `woostack-harden` owning none). The Iron Law still forces narrating
-  the root cause before any fix. The only hard stop is the ≥3-fixes escalation, which doubles
-  as the handback to the caller. `woostack-execute` dispatches this mode on a repeatedly-failing
-  verification.
-- **No `--auto` (standalone — the default).** After Phases 1–3 (root cause found, hypothesis
-  confirmed), **stop and present the root cause plus the proposed minimal fix, and wait for an
-  explicit go-ahead** before Phase 4. When the fix is applied, name
-  [`woostack-commit`](../woostack-commit/SKILL.md) as the next step — debug does not commit.
-- **Fail-safe.** Absence or an unrecognized flag ⇒ the gated standalone mode. An unrequested
-  fix is never silently applied.
+- **`--auto` (autonomous).** Run Phases 1–4 end to end autonomously to identify the root cause and hand it back. No per-hypothesis approval gate. The Iron Law still forces narrating the root cause findings. At the end, output the Phase 4 handback — the summary, recommended minimal fix, and verification steps — then stop. `woostack-execute` dispatches this mode on a repeatedly-failing verification.
+- **No `--auto` (standalone — the default).** Work through Phases 1–4 interactively with the user. Present findings, verify hypotheses, align on the proposed fix plan, and hand back.
+- **Fail-safe.** Absence or an unrecognized flag ⇒ the standalone mode.
 - **No target given.** `/woostack-debug` with no argument → ask what's broken; do not guess
   (mirror `woostack-execute`'s no-argument behavior).
 
@@ -131,13 +105,7 @@ debugging uses them.
   match, one-hop link expand) otherwise. Surface matching `gotcha`/`hotspot`/`pattern` notes
   before investigating — a matching note may already name the root cause. State whether recall
   was script-assisted or manual; never fail silently.
-- **Distill (end, on a confirmed fix).** Write **one** `gotcha` note through the reject-by-
-  default gate: a narrow glob `scope:` covering the touched files (a single-literal-path scope
-  is trivia and is rejected), `source:` set to the owning spec/plan or `pr-N`, a terse body
-  with `[[wikilinks]]` to related notes, and `updated:` stamped today. Dedupe against
-  `MEMORY.md` first — update an existing note rather than adding a near-duplicate. Then run
-  `build-index.sh` and `doctor.sh`. The note records the **root cause and its fix**, not the
-  symptom.
+- **Distill (end).** `woostack-debug` does not write code, so it does not distill gotcha notes directly. Memory note distillation is owned by the caller (such as `woostack-fix` or `woostack-execute`) once the minimal fix has been implemented and verified.
 
 ## Red flags — stop and return to Phase 1
 
@@ -145,14 +113,10 @@ If you catch yourself thinking any of these, stop and restart at Phase 1:
 
 - "Quick fix for now, investigate later."
 - "Just try changing X and see if it works."
-- "Add multiple changes, run the tests."
-- "Skip the test, I'll manually verify."
-- "It's probably X, let me fix that."
+- "Proposing fixes before tracing data flow."
+- "Skip the test/reproduction, I'll manually verify."
+- "It's probably X, let me write code for that."
 - "I don't fully understand but this might work."
-- Proposing fixes before tracing data flow.
-- "One more fix attempt" (when you have already tried 2+).
-- Each fix reveals a new problem in a different place. → That is the ≥3-fixes architectural
-  signal: question the architecture, don't fix again.
 
 ## Common rationalizations
 
@@ -160,29 +124,16 @@ If you catch yourself thinking any of these, stop and restart at Phase 1:
 |---|---|
 | "Issue is simple, no process needed." | Simple issues have root causes too; the process is fast for them. |
 | "Emergency, no time for process." | Systematic debugging is faster than guess-and-check thrashing. |
-| "I'll write the test after the fix works." | Untested fixes don't stick. The failing test first proves the fix. |
-| "Multiple fixes at once saves time." | You can't isolate what worked, and it causes new bugs. |
-| "I see the problem, let me fix it." | Seeing symptoms is not understanding the root cause. |
+| "I see the symptom, let me fix it." | Seeing symptoms is not understanding the root cause. |
 
 ## When investigation reveals no root cause
 
 If a genuine investigation shows the issue is truly environmental, timing-dependent, or
-external: document what you investigated, implement appropriate handling (retry, timeout,
-condition-based wait, a clear error message) plus logging for future investigation, and say so.
-But treat this as rare — most "no root cause" outcomes are incomplete investigation.
+external: document what you investigated and log findings for future investigation. But treat this as rare — most "no root cause" outcomes are incomplete investigation.
 
 ## Hard constraints
 
-- **Iron Law.** No fix proposed or applied before Phase 1 is complete. It and the ≥3-fixes
-  ESCALATION are load-bearing blocks — keep them prominent so they survive summarization.
-- **Owns no spec/plan/status.** Never writes a `.woostack/specs/` or `.woostack/plans/` file
-  and never touches a spec's `status:`/`branch:`. The `spec : plan : PRs = 1 : 1 : N` invariant
-  is untouched. The phase enum and join contracts live in
-  [conventions.md](../woostack-status/references/conventions.md) — link, never restate.
-- **Never commits or merges.** Hands the fix back: standalone names `woostack-commit`; `--auto`
-  lets the caller commit in its own cadence.
-- **Mode is explicit.** `--auto` ⇒ autonomous; its absence ⇒ the look-before-fix gate. Fail-
-  safe to gated; never apply an unrequested fix.
-- **One minimal fix at a time.** No bundled refactoring, no "while I'm here" changes.
-- **Distill durable knowledge only.** Reject-by-default; dedupe; one `gotcha` per confirmed
-  fix; never feature-specific trivia.
+- **Iron Law.** No fix proposed or applied before Phase 1 is complete. Keep this prominent so it survives summarization.
+- **Owns no spec/plan/status.** Never writes a `.woostack/specs/`, `.woostack/plans/`, or `.woostack/fixes/` file. The phase enum and join contracts live in [conventions.md](../woostack-status/references/conventions.md) — link, never restate.
+- **Never writes code, commits, or merges.** Hands the findings back; does not touch repository code files.
+- **Mode is explicit.** `--auto` ⇒ autonomous; its absence ⇒ interactive standalone mode.

--- a/skills/woostack-debug/SKILL.md
+++ b/skills/woostack-debug/SKILL.md
@@ -67,8 +67,9 @@ Complete each phase before the next.
 ### Phase 3 — Hypothesis and test
 
 1. **Form one hypothesis.** State it: "X is the root cause because Y." Be specific.
-2. **Test minimally.** Make the smallest possible change to test it; change one variable at a
-   time; don't fix several things at once.
+2. **Test minimally.** Probe the hypothesis with the smallest non-destructive check — read the
+   relevant source, trace the call path, or run an existing test/command; isolate one variable at
+   a time. Make no persistent code change (revert any temporary probe before handback).
 3. **Verify before continuing.** Worked → Phase 4. Didn't work → form a **new** hypothesis;
    don't stack more fixes on top.
 4. **When you don't know,** say "I don't understand X" and research or ask — don't pretend.

--- a/skills/woostack-execute-overnight/SKILL.md
+++ b/skills/woostack-execute-overnight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-execute-overnight
-description: Use to execute an approved woostack plan UNATTENDED overnight — one autonomous run with no user input after launch that drives every increment to a reviewed stack, swapping woostack-execute's stop-and-ask gates for resolve-or-log-and-continue (woostack-debug --auto on stuck verifications; bounded auto-address on a blocking review; halt-the-track on anything unsafe or ambiguous), honoring optional `## Track:` grouping in the plan (independent, fault-isolated tracks run sequentially), and writing a morning report under .woostack/overnight/ for a human to test in the morning. It is the third choice at woostack-build's execution-handoff gate (Go / Hand off / Run overnight); also usable standalone via /woostack-execute-overnight <plan-path> [--inline|--subagent]. One plan per spec, multiple PRs per plan. Never merges; never relaxes safety for autonomy.
+description: Use to execute an approved woostack plan UNATTENDED overnight — one autonomous run with no user input after launch that drives every increment to a reviewed stack, swapping woostack-execute's stop-and-ask gates for resolve-or-log-and-continue (woostack-debug on stuck verifications; bounded auto-address on a blocking review; halt-the-track on anything unsafe or ambiguous), honoring optional `## Track:` grouping in the plan (independent, fault-isolated tracks run sequentially), and writing a morning report under .woostack/overnight/ for a human to test in the morning. It is the third choice at woostack-build's execution-handoff gate (Go / Hand off / Run overnight); also usable standalone via /woostack-execute-overnight <plan-path> [--inline|--subagent]. One plan per spec, multiple PRs per plan. Never merges; never relaxes safety for autonomy.
 ---
 
 # woostack-execute-overnight
@@ -69,9 +69,10 @@ stop. Each becomes an autonomous policy, and **every decision is appended to the
 log as it happens**.
 
 1. **Verification fails repeatedly** → route to
-   [`woostack-debug --auto`](../woostack-debug/SKILL.md) (execute already does this
-   autonomously). If debug returns its **3-fixes architectural stop**, there is no present user to
-   escalate to → record a **blocker** and apply the halt policy.
+   [`/woostack-debug <target>`](../woostack-debug/SKILL.md), which runs its root-cause analysis
+   autonomously and hands back a proposed minimal fix (execute already does this); execute
+   implements and commits the fix. If debug **cannot establish a root cause**, there is no
+   present user to escalate to → record a **blocker** and apply the halt policy.
 2. **Blocking review** — driver-specific:
    - **inline**: `woostack-review --fast` posts a batched GitHub Review on the increment PR. On
      REQUEST_CHANGES, run
@@ -140,7 +141,7 @@ an inference. It never merges and never relaxes safety for autonomy.
   running, solicit nothing.
 - **Refuse a doomed run.** A plan with critical gaps → refuse at pre-flight with a report; don't
   start.
-- **Resolve-or-log-and-continue, never relax safety.** debug --auto / bounded auto-address /
+- **Resolve-or-log-and-continue, never relax safety.** debug / bounded auto-address /
   blocker-and-halt as above; destructive/secret/auth/network/ambiguous steps are never
   auto-approved.
 - **Tracks: author-driven, overnight-only.** Honor `## Track:` headings (default one implicit

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -143,14 +143,15 @@ N's distilled memory is swept by increment N+1's commit.
 
 Stop — never guess — when one of these hits. Most surface to the user immediately; a
 repeatedly-failing verification instead routes to [`woostack-debug`](../woostack-debug/SKILL.md)
-first and escalates to the user only on debug's 3-fixes architectural stop:
+and escalates to the user only when debug cannot establish a root cause:
 
 - A blocker hits (missing dependency, failing verification, unclear instruction).
 - The plan has critical gaps preventing a start.
-- A verification fails repeatedly — route it to `woostack-debug <target> --auto` (autonomous)
-  to find and fix the root cause; escalate to the user only if debug returns its 3-fixes
-  architectural stop. Debug does not commit — execute commits the returned fix in its normal
-  per-increment cadence. Applies to both the inline and subagent drivers.
+- A verification fails repeatedly — route it to `/woostack-debug <target>`, which runs its
+  root-cause analysis autonomously and hands back the root cause and a proposed minimal fix.
+  `woostack-debug` is investigative only and never commits — execute implements and commits the
+  returned fix in its normal per-increment cadence. Escalate to the user only when debug cannot
+  establish a root cause. Applies to both the inline and subagent drivers.
 - A review returns REQUEST_CHANGES — handle the findings before continuing.
 
 On every stop above, run the [memory sweep on handback](#memory-sweep-on-handback) before

--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: woostack-fix
+description: Use to resolve small technical issues (bugs, hotfixes, refactors) through a unified execution loop — diagnose root cause with woostack-debug, author a fix plan under .woostack/fixes/, harden, get explicit user approval, execute via TDD, and commit via woostack-commit.
+---
+
+# woostack-fix
+
+## Overview
+
+Drives a bug fix or a small technical change from diagnosis to implementation through a lightweight, unified loop. Fixes are smaller than features and combine the spec and the plan into a single markdown file under `.woostack/fixes/`.
+
+```
+diagnose root cause (woostack-debug) → write fix plan (fixes/ markdown) → harden fix plan 
+  → approve fix plan (GATE) → execute (TDD: failing test → minimal fix → verify) 
+  → commit (woostack-commit)
+```
+
+The skill has exactly **one** hard gate: **fix plan approval**. Because the plan contains both the diagnosis (the spec part) and the steps (the plan part), a single approval stop protects the codebase from wrong fixes or poor plans before implementation begins.
+
+## Procedure
+
+1. **Diagnose the root cause.**
+   Run the systematic-debugging skill to find the root cause before proposing any code edits.
+   ```
+   /woostack-debug <target> --auto
+   ```
+   Let it run its autonomous Phase 1-3. It will investigate the symptoms, trace data flow backward, and output a clear root-cause hypothesis and the necessary test case description. If it cannot find a root cause, do not guess: stop and ask the user for hints.
+
+2. **Write the fix plan as markdown.**
+   Create a markdown file under `.woostack/fixes/YYYY-MM-DD-<slug>.md`, using the current date and a short slug based on the target (e.g. `.woostack/fixes/2026-06-08-status-parsing.md`).
+   
+   The file must follow this structure:
+   ```markdown
+   ---
+   type: fix
+   status: draft
+   branch: fix/<target-slug>
+   ---
+
+   # Fix: <Short description of the bug/symptom>
+
+   ## 1. Root Cause
+   *Summarize the findings from woostack-debug. Where does the bad value originate? What is the evidence?*
+
+   ## 2. Proposed Fix
+   *Describe the minimal, targeted code changes to resolve the root cause.*
+
+   ## 3. Implementation Plan
+   - [ ] **Step 1: Reproduce with a failing test**
+     - Add test case verifying...
+   - [ ] **Step 2: Apply the minimal fix**
+     - Implement...
+   - [ ] **Step 3: Verification**
+     - Run verification command...
+   ```
+   Set the frontmatter `status: draft` and set the `branch:` to the branch name you will use.
+
+3. **Harden the fix plan.**
+   Invoke [`woostack-harden`](../woostack-harden/SKILL.md) on the fix plan file. Resolve open questions one at a time and refine the implementation steps in place. Once hardening produces no new questions, set the frontmatter `status: hardened`.
+
+4. **Get explicit approval (GATE).**
+   **Always present the written fix plan to the user and get explicit approval before executing** — this is a hard gate. Point the user at the file path, wait for a clear yes, and make any requested changes. When approved, set the frontmatter `status: approved`.
+
+5. **Execute.**
+   Create the feature branch named in the frontmatter (`git switch -c fix/<slug>` or `gt create fix/<slug>`). Set the frontmatter `status: executing` on the fix file.
+   Work through the implementation plan tasks in order using TDD:
+   - Implement the failing test first (confirm it fails).
+   - Apply the minimal fix (no bundled refactoring, no "while I'm here" edits).
+   - Run the tests and verify they pass.
+   - Tick the checkboxes (`- [x]`) in the fix plan file as you complete each task.
+
+6. **Commit and PR.**
+   Stage the code changes, tests, and the modified fix plan. Invoke the commit skill:
+   ```
+   /woostack-commit
+   ```
+   Once the PR is open, update the fix plan's frontmatter to `status: in-review` (once merged, `status: done`). The fix file's frontmatter `status:` is the source of truth for the fix lifecycle — fixes are tracked by their `.woostack/fixes/` file, not the spec-centric `/woostack-status` board, which enumerates increment PRs only via the `Spec: .woostack/specs/<file>.md` trailer that [`woostack-commit`](../woostack-commit/SKILL.md) writes (it never emits a `fixes/` trailer).
+
+7. **Distill Memory gotchas.**
+   At the end of a successful execution, write **one** `gotcha` note to the `.woostack/memory/` store describing the root cause and the fix patterns learned. Dedupe, update `MEMORY.md`, and rebuild the index using `build-index.sh` and `doctor.sh` as required by the [memory contract](../woostack-init/references/memory.md).
+
+## Hard constraints
+
+- **No guess-and-check.** Always run `woostack-debug` to trace the data flow and confirm the root cause before writing the fix plan.
+- **One combined markdown file under `.woostack/fixes/`.** Fixes are specified and planned in a single file under `.woostack/fixes/` (not `.woostack/specs/` or `.woostack/plans/`).
+- **Wait for explicit approval.** Never execute a fix plan on inferred or assumed approval. Silence is not a yes.
+- **TDD Kernel.** Every fix must be driven by a failing test first.
+- **Never merge.** The skill commits and opens/updates stacked PRs; it never merges.

--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -22,9 +22,9 @@ The skill has exactly **one** hard gate: **fix plan approval**. Because the plan
 1. **Diagnose the root cause.**
    Run the systematic-debugging skill to find the root cause before proposing any code edits.
    ```
-   /woostack-debug <target> --auto
+   /woostack-debug <target>
    ```
-   Let it run its autonomous Phase 1-3. It will investigate the symptoms, trace data flow backward, and output a clear root-cause hypothesis and the necessary test case description. If it cannot find a root cause, do not guess: stop and ask the user for hints.
+   It runs its four-phase root-cause analysis automatically — investigating the symptoms, tracing data flow backward, identifying the root cause — and hands back the Phase 4 result: the root-cause summary, the proposed minimal fix, and the TDD context (the failing-test description). Carry the proposed fix forward into the fix plan's Proposed Fix section below. If it cannot find a root cause, do not guess: stop and ask the user for hints.
 
 2. **Write the fix plan as markdown.**
    Create a markdown file under `.woostack/fixes/YYYY-MM-DD-<slug>.md`, using the current date and a short slug based on the target (e.g. `.woostack/fixes/2026-06-08-status-parsing.md`).

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -550,7 +550,7 @@ The `if:` gate restricts comment-triggered runs to the repo owner / members / co
 - Trust the Skeptical Validator. Disabling it produces noisy reviews.
 - Honor angle-prompt tiers (`fast`/`standard`/`deep`) when the host supports per-call model routing. Hosts that run one model per session should pin `gpt-5.5` for maximum validator quality, or `gpt-5.4` when cost matters more than deep validation.
 - Pass `disable_angles` to skip optional angles when scope is narrow (e.g. backend-only PR → `disable_angles: "seo,aeo,design,react,i18n"`).
-- For a confirmed bug (not a style nit) that the author wants to fix, suggest investigating it with [`woostack-debug`](../woostack-debug/SKILL.md): `/woostack-debug <target>` (gated — it finds the root cause before any fix). Review never dispatches `woostack-debug --auto`: it owns no fix behavior and never auto-addresses findings, so it only points the author at the gated command.
+- For a confirmed bug (not a style nit) that the author wants to fix, suggest investigating it with [`woostack-debug`](../woostack-debug/SKILL.md): `/woostack-debug <target>` (it runs an autonomous root-cause analysis and hands back the root cause and a proposed fix). Review never dispatches `woostack-debug` itself: it owns no fix behavior and never auto-addresses findings, so it only points the author at the command.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
