### PR TITLE
feat(fix): add fixes directory to woostack-init and support in woostack-commit

### DIFF
--- a/.woostack/memory/MEMORY.md
+++ b/.woostack/memory/MEMORY.md
@@ -4,6 +4,7 @@
 - [skill-description-angle-bracket-placeholders](skill-description-angle-bracket-placeholders.md) `convention` scope=`skills/**/SKILL.md` — Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are a
 - [skill-test-assert-ascii-token](skill-test-assert-ascii-token.md) `convention` scope=`skills/**/scripts/tests/*.sh` — Grep-based skill tests should assert an ASCII token, not a unicode literal (e.g.
 - [woostack-command-surface-bookkeeping](woostack-command-surface-bookkeeping.md) `convention` scope=`AGENTS.md` — Adding/removing a public command means updating the count + lists in five places
+- [woostack-commit-template-fence-trailer](woostack-commit-template-fence-trailer.md) `convention` scope=`skills/woostack-commit/SKILL.md` — woostack-commit PR-body template must keep ONLY the clean Spec: .woostack/specs/
 - [woostack-feature-state-invariant](woostack-feature-state-invariant.md) `convention` scope=`.woostack/specs/**` — Specs, plans, and increment PRs are joined by Source and Spec trailers.
 - [gh-search-fuzzy-trailer-match](gh-search-fuzzy-trailer-match.md) `gotcha` scope=`skills/woostack-status/scripts/**` — `gh pr list --search` tokenizes paths and cross-matches; exact-match the trailer
 - [grep-c-counts-lines-not-occurrences](grep-c-counts-lines-not-occurrences.md) `gotcha` scope=`.woostack/plans/**` — A plan's `grep -c` verification counts matching LINES, not occurrences — a phras

--- a/.woostack/memory/skill-description-angle-bracket-placeholders.md
+++ b/.woostack/memory/skill-description-angle-bracket-placeholders.md
@@ -6,7 +6,7 @@ tags: skill-description, frontmatter, review, skills-angle, false-positive, plac
 hook: Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are an accepted, shipped convention here — not an XML/HTML defect; the review `skills` angle must not flag them.
 updated: 2026-06-06
 source: pr-232
-recall_count: 9
+recall_count: 10
 last_recalled: 2026-06-08
 ---
 Angle-bracket usage placeholders in a `SKILL.md` `description:` field — e.g.

--- a/.woostack/memory/skill-description-angle-bracket-placeholders.md
+++ b/.woostack/memory/skill-description-angle-bracket-placeholders.md
@@ -6,7 +6,7 @@ tags: skill-description, frontmatter, review, skills-angle, false-positive, plac
 hook: Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are an accepted, shipped convention here — not an XML/HTML defect; the review `skills` angle must not flag them.
 updated: 2026-06-06
 source: pr-232
-recall_count: 7
+recall_count: 9
 last_recalled: 2026-06-08
 ---
 Angle-bracket usage placeholders in a `SKILL.md` `description:` field — e.g.

--- a/.woostack/memory/skill-description-angle-bracket-placeholders.md
+++ b/.woostack/memory/skill-description-angle-bracket-placeholders.md
@@ -6,7 +6,7 @@ tags: skill-description, frontmatter, review, skills-angle, false-positive, plac
 hook: Angle-bracket placeholders like `<plan-path>` in a SKILL.md `description:` are an accepted, shipped convention here — not an XML/HTML defect; the review `skills` angle must not flag them.
 updated: 2026-06-06
 source: pr-232
-recall_count: 10
+recall_count: 12
 last_recalled: 2026-06-08
 ---
 Angle-bracket usage placeholders in a `SKILL.md` `description:` field — e.g.

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 24
+recall_count: 25
 last_recalled: 2026-06-08
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 25
+recall_count: 27
 last_recalled: 2026-06-08
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/skill-description-colon-space.md
+++ b/.woostack/memory/skill-description-colon-space.md
@@ -6,7 +6,7 @@ tags: yaml, frontmatter, installer, skill-description
 hook: A `word: ` colon-space in a SKILL.md description is a YAML mapping indicator; it throws a ScannerError and the installer silently skips the skill.
 updated: 2026-06-05
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 22
+recall_count: 24
 last_recalled: 2026-06-08
 ---
 The SKILL.md frontmatter `description:` value is a YAML plain scalar. A plain scalar must not

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 37
+recall_count: 39
 last_recalled: 2026-06-08
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 36
+recall_count: 37
 last_recalled: 2026-06-08
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 34
+recall_count: 36
 last_recalled: 2026-06-08
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-commit-template-fence-trailer.md
+++ b/.woostack/memory/woostack-commit-template-fence-trailer.md
@@ -1,0 +1,8 @@
+---
+name: woostack-commit-template-fence-trailer
+type: convention
+scope: skills/woostack-commit/SKILL.md
+updated: 2026-06-08
+source: address-comments
+---
+woostack-commit PR-body template must keep ONLY the clean Spec: .woostack/specs/<file>.md line inside the fenced block; document the fixes/ trailer variant in prose outside the fence — agents emit the fence literally, so any parenthetical/annotation inside it breaks the status exact-match. Do not re-flag the template-vs-rules 'inconsistency'.

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 60
+recall_count: 62
 last_recalled: 2026-06-08
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -149,11 +149,11 @@ Do not stage generated files, secrets, `.env*`, unrelated dirty files, or user w
 
 ### 4.5 Invariant check (advisory)
 
-When the staged changes touch `.woostack/specs/*.md` or `.woostack/plans/*.md`, run the cheap feature-state invariant checks on every affected spec so the `/woostack-status` board stays honest. The affected set is every directly touched spec plus the spec named by each touched plan's `**Source:** .woostack/specs/<file>.md` line. These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
+When the staged changes touch `.woostack/specs/*.md`, `.woostack/plans/*.md`, or `.woostack/fixes/*.md`, run the cheap feature-state invariant checks on every affected spec/fix so the `/woostack-status` board stays honest. The affected set is every directly touched spec/fix plus the spec named by each touched plan's `**Source:** .woostack/specs/<file>.md` line. These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
 
-For each affected spec, check:
+For each affected spec/fix, check:
 
-- **1:1 plan** — exactly one plan resolves to it: a plan whose first lines carry `**Source:** .woostack/specs/<file>.md` (legacy same-slug match is the fallback). Zero or two-or-more resolved plans is a violation.
+- **1:1 plan** — exactly one plan resolves to it (for specs). (For fixes under `fixes/`, they are self-contained plans and this check is skipped).
 - **`branch:` present** — the frontmatter `branch:` is non-empty and not the literal `unknown`.
 - **`status:` in the enum** — the frontmatter `status:` is one of `draft｜hardened｜approved｜planning｜executing｜in-review｜done｜abandoned`.
 
@@ -244,12 +244,12 @@ Set or update the body with this structure:
 
 - [ ] <step only verifiable post-merge — deploy / migration / env-gated>
 
-Spec: .woostack/specs/<file>.md
+Spec: .woostack/specs/<file>.md  (OR .woostack/fixes/<file>.md for fixes)
 ```
 
 Rules:
 
-- End the body with a `Spec: .woostack/specs/<file>.md` **trailer line** naming the spec this PR's increments trace to — the spec whose `branch:` matches the current branch, or the spec under active work. The `/woostack-status` board enumerates a spec's increment PRs by searching this exact trailer (`gh pr list --search "Spec: <path>"`); the contract is defined in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md). Omit the trailer only when the change traces to no spec (for example a repo-meta or tooling edit).
+- End the body with a `Spec: .woostack/specs/<file>.md` or `Spec: .woostack/fixes/<file>.md` **trailer line** naming the spec/fix this PR's increments trace to — the spec/fix whose `branch:` matches the current branch, or the spec/fix under active work. The `/woostack-status` board enumerates a spec/fix's increment PRs by searching this exact trailer (`gh pr list --search "Spec: <path>"`); the contract is defined in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md). Omit the trailer only when the change traces to no spec/fix (for example a repo-meta or tooling edit).
 - State the **Goal** as intent or the problem solved in one or two sentences — not a change list. It is distinct from Summary, which lists *what* changed. Always present it.
 - Keep Summary bullets concise and specific. Include only changes in the committed diff.
 - Under **Automated**, list the commands/tests actually run, plus the configured `commit.pre_commit` command and result when it ran. Show this group whenever an automated check (test, lint, typecheck, `pre_commit`) could have run for the change: list results, or `Not run` with the reason when one was expected but skipped. Omit `### Automated` entirely when no automated check applies to the change (for example a doc-only edit in a repo with no test harness) rather than emitting a `Not run` placeholder.

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -244,7 +244,7 @@ Set or update the body with this structure:
 
 - [ ] <step only verifiable post-merge — deploy / migration / env-gated>
 
-Spec: .woostack/specs/<file>.md  (OR .woostack/fixes/<file>.md for fixes)
+Spec: .woostack/specs/<file>.md
 ```
 
 Rules:

--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -74,7 +74,7 @@ The skill has exactly **one** hard gate: **fix plan approval**. Because the plan
    ```
    /woostack-commit
    ```
-   Once the PR is open, update the fix plan's frontmatter to `status: in-review` (once merged, `status: done`). The fix file's frontmatter `status:` is the source of truth for the fix lifecycle — fixes are tracked by their `.woostack/fixes/` file, not the spec-centric `/woostack-status` board, which enumerates increment PRs only via the `Spec: .woostack/specs/<file>.md` trailer that [`woostack-commit`](../woostack-commit/SKILL.md) writes (it never emits a `fixes/` trailer).
+   Once the PR is open, update the fix plan's frontmatter to `status: in-review` (once merged, `status: done`). The fix file's frontmatter `status:` is the source of truth for the fix lifecycle — fixes are tracked by their `.woostack/fixes/` file, not the spec-centric `/woostack-status` board. [`woostack-commit`](../woostack-commit/SKILL.md) still writes a `Spec: .woostack/fixes/<file>.md` trailer on the fix PR (mirroring the `Spec: .woostack/specs/<file>.md` trailer it writes for spec increments), but that trailer attaches the PR to the fix file rather than to a spec — the fix file's frontmatter remains the lifecycle source of truth.
 
 7. **Distill Memory gotchas.**
    At the end of a successful execution, write **one** `gotcha` note to the `.woostack/memory/` store describing the root cause and the fix patterns learned. Dedupe, update `MEMORY.md`, and rebuild the index using `build-index.sh` and `doctor.sh` as required by the [memory contract](../woostack-init/references/memory.md).

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -39,6 +39,8 @@ Two callers:
    | `.woostack/memory.md` | (create empty — **never clobber an existing file**) |
    | `.woostack/specs/` directory | (create empty) |
    | `.woostack/plans/` directory | (create empty) |
+   | `.woostack/fixes/` directory | (create empty) |
+   | `.woostack/fixes/.gitkeep` | `templates/fixes/.gitkeep` |
    | `.woostack/config.json` | `templates/config.json` (`{ "review": {}, "status": { "staleDays": 14 } }`) |
    | `.woostack/.gitignore` | `templates/gitignore` |
 

--- a/skills/woostack-init/templates/fixes/.gitkeep
+++ b/skills/woostack-init/templates/fixes/.gitkeep
@@ -1,0 +1,1 @@
+# Keep empty directory in Git for fixes.

--- a/skills/woostack-init/templates/gitignore
+++ b/skills/woostack-init/templates/gitignore
@@ -1,6 +1,8 @@
 # Transient, per-clone — not shared knowledge.
 metrics.json
 *.local.*
+visuals/
+overnight/
 
 # Obsidian per-user UI state (the shared .obsidian/*.json config IS tracked).
 .obsidian/workspace*

--- a/skills/woostack-status/references/conventions.md
+++ b/skills/woostack-status/references/conventions.md
@@ -16,6 +16,12 @@ they do not restate these rules (cross-link, do not duplicate).
   body (`specs/<basename>`) — `gh --search` is fuzzy and would otherwise cross-match
   look-alike specs, so an untrailered or sibling PR never attaches to the wrong spec. When no
   trailered PR resolves, it falls back to the active `spec.branch:` head PR (marked partial).
+- fix PRs (from [`woostack-fix`](../../woostack-fix/SKILL.md)) carry a parallel
+  `Spec: .woostack/fixes/<file>.md` trailer (also written by woostack-commit), but a fix is
+  **not** a spec increment: that trailer attaches the PR to its fix file, and a fix's lifecycle
+  is tracked by the fix file's own frontmatter `status:`, not by attaching to a spec. The board
+  globs `.woostack/fixes/*.md` directly rather than resolving fixes through the spec trailer
+  search above, so the `specs/<basename>` exact-match never cross-matches a fix.
 - `spec.branch:` names the active increment's branch.
 - An overnight run ([`woostack-execute-overnight`](../../woostack-execute-overnight/SKILL.md)) may
   produce **tree-stacked** increment PRs — multiple `## Track:`s branched off the common base, so a

--- a/skills/woostack-status/references/conventions.md
+++ b/skills/woostack-status/references/conventions.md
@@ -19,9 +19,10 @@ they do not restate these rules (cross-link, do not duplicate).
 - fix PRs (from [`woostack-fix`](../../woostack-fix/SKILL.md)) carry a parallel
   `Spec: .woostack/fixes/<file>.md` trailer (also written by woostack-commit), but a fix is
   **not** a spec increment: that trailer attaches the PR to its fix file, and a fix's lifecycle
-  is tracked by the fix file's own frontmatter `status:`, not by attaching to a spec. The board
-  globs `.woostack/fixes/*.md` directly rather than resolving fixes through the spec trailer
-  search above, so the `specs/<basename>` exact-match never cross-matches a fix.
+  is tracked by the fix file's own frontmatter `status:`, not by attaching to a spec. Because the
+  spec trailer search exact-matches `specs/<basename>`, a `fixes/` trailer never cross-matches a
+  spec; surfacing fixes on the board from their `.woostack/fixes/*.md` files is owned by the
+  status board's fix integration, separate from this spec-trailer join.
 - `spec.branch:` names the active increment's branch.
 - An overnight run ([`woostack-execute-overnight`](../../woostack-execute-overnight/SKILL.md)) may
   produce **tree-stacked** increment PRs — multiple `## Track:`s branched off the common base, so a


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
