### PR TITLE
docs: make woostack-bootstrap skill definition dynamic and rewrite decisions reference

### DIFF
--- a/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
+++ b/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
@@ -20,29 +20,29 @@
 - Modify: `skills/woostack-bootstrap/SKILL.md`:1-83
 - Test: Verify the file exists and contains the updated dynamic procedure.
 
-- [ ] **Step 1: Write the verification command**
+- [x] **Step 1: Write the verification command**
 
 Run: `grep -q "dynamic stack selection" skills/woostack-bootstrap/SKILL.md`
 Expected: exit status 1 (since the term is not yet present)
 
-- [ ] **Step 2: Run the verification, confirm it fails**
+- [x] **Step 2: Run the verification, confirm it fails**
 
 Run: `grep -q "dynamic stack selection" skills/woostack-bootstrap/SKILL.md`
 Expected: FAIL (exit status 1)
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Edit `skills/woostack-bootstrap/SKILL.md` to:
 1. Update the description to reflect a generic, requirements-driven bootstrap.
 2. Remove the hardcoded "Default stack" section.
 3. Update the "Procedure" section to outline the dynamic stack selection and requirements questionnaire steps.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -q "dynamic stack selection" skills/woostack-bootstrap/SKILL.md`
 Expected: PASS (exit status 0)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "docs: make woostack-bootstrap skill definition dynamic"
@@ -56,29 +56,29 @@ gt create -m "docs: make woostack-bootstrap skill definition dynamic"
 - Modify: `skills/woostack-bootstrap/references/decisions.md`:1-98
 - Test: Verify the file exists and contains the dynamic requirements questions.
 
-- [ ] **Step 1: Write the verification command**
+- [x] **Step 1: Write the verification command**
 
 Run: `grep -q "Requirements gathering questionnaire" skills/woostack-bootstrap/references/decisions.md`
 Expected: exit status 1
 
-- [ ] **Step 2: Run the verification, confirm it fails**
+- [x] **Step 2: Run the verification, confirm it fails**
 
 Run: `grep -q "Requirements gathering questionnaire" skills/woostack-bootstrap/references/decisions.md`
 Expected: FAIL (exit status 1)
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Edit `skills/woostack-bootstrap/references/decisions.md` to:
 1. Remove all hardcoded defaults (Supabase, Vercel, Stripe, Axiom, etc.).
 2. Define the requirements-gathering questionnaire (scale, database, hosting, compliance, budget, integrations).
 3. Outline the protocol for presenting 2-3 stack options with detailed pros/cons.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -q "Requirements gathering questionnaire" skills/woostack-bootstrap/references/decisions.md`
 Expected: PASS (exit status 0)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs: rewrite decisions reference to use dynamic questionnaire"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Not a template. It's the decisions and workflow an agent follows. For greenfield
 - [Quickstart](#quickstart): greenfield and brownfield entry points
 - [Concepts](#concepts): artifacts, branching, the review swarm
 - [Configuration](#configuration)
-- [Default stack](#default-stack)
 - [What it defines](#what-it-defines)
 - [Cloud / CI review](#cloud--ci-review)
 
@@ -49,7 +48,7 @@ An adoption skill for consumer repositories. Reference it from a project's root 
 
 ### `/woostack-bootstrap <goal>`: scaffold a new monorepo
 
-Walks you through the [decision catalog](skills/woostack-bootstrap/references/decisions.md) and gets explicit sign-off on every relevant choice, then scaffolds a web/mobile/API monorepo. Versions are resolved **live** at scaffold time (`npm view <pkg> version`), never hard-coded, and cross-checked against a known-gotchas list. After scaffolding it verifies the project boots: `pnpm install && typecheck && build && test && dev`. → [SKILL.md](skills/woostack-bootstrap/SKILL.md)
+Walks you through a [questionnaire and options protocol](skills/woostack-bootstrap/references/decisions.md) to dynamically select the best technology stack, gets explicit sign-off on the chosen stack, and then scaffolds a web/mobile/API monorepo. Versions are resolved **live** at scaffold time (`npm view <pkg> version`), never hard-coded, and cross-checked against a known-gotchas list. After scaffolding it verifies the project boots: `pnpm install && typecheck && build && test && dev`. → [SKILL.md](skills/woostack-bootstrap/SKILL.md)
 
 ### `/woostack-build <goal>`: feature loop, idea to PR
 
@@ -184,29 +183,13 @@ Minimal example:
 
 Use config for repository-specific review policy: widen or narrow the severity floor, force or skip optional angles, ignore generated files, add rule documents, customize bot/release auto-skips, opt into local metrics, or adjust diff chunking for large PRs. `bugs` and `security` always run and cannot be skipped. Invalid JSON or unknown keys inside `review` fail loudly so configuration mistakes do not silently change review behavior. → [Per-repo Configuration](skills/woostack-review/SKILL.md#per-repo-configuration-woostackconfigjson)
 
-## Default stack
-
-| Layer | Default |
-|---|---|
-| Web / Landing | Next.js (App Router) + React Compiler + shadcn/ui |
-| Mobile | Expo + React Native + react-native-reusables + UniWind |
-| API | Hono + oRPC |
-| Data | TanStack Query + Zod + Supabase (Postgres, Auth, Storage) |
-| Styling | Tailwind CSS (CSS-first) with a shared theme |
-| Build | Turborepo + pnpm catalog |
-| Lint/format | Biome |
-| Testing | Vitest, Jest (RN), Playwright |
-| Hosting | Vercel (web + api) + Expo EAS (mobile) |
-
-Defaults, not mandates. Bootstrap confirms each with you. Versions are resolved at bootstrap time. See [frameworks.md](skills/woostack-bootstrap/references/frameworks.md).
-
 ## What it defines
 
 The bootstrap skill's decisions live in reference files, loaded on demand:
 
 | Reference | What it defines |
 |---|---|
-| [decisions.md](skills/woostack-bootstrap/references/decisions.md) | Decision catalog the agent walks the user through before scaffolding |
+| [decisions.md](skills/woostack-bootstrap/references/decisions.md) | Questionnaire guide + confirmation protocol — the pre-scaffold gate |
 | [bootstrap.md](skills/woostack-bootstrap/references/bootstrap.md) | Step-by-step bootstrap procedure for AI agents |
 | [architecture.md](skills/woostack-bootstrap/references/architecture.md) | Monorepo layout, package tiers, import boundaries, naming |
 | [frameworks.md](skills/woostack-bootstrap/references/frameworks.md) | Recommended frameworks per layer, catalog protocol, known gotchas |

--- a/skills/woostack-bootstrap/SKILL.md
+++ b/skills/woostack-bootstrap/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: woostack-bootstrap
-description: Use when bootstrapping a new web, mobile, or API project from scratch — scaffolding a fresh monorepo, choosing which frameworks/hosting/data layer to use, or setting up architecture, CI, and conventions for a new full-stack app at current framework versions.
+description: Use when bootstrapping a new web, mobile, or API project from scratch — scaffolding a fresh monorepo, gathering requirements, dynamically researching industry-standard frameworks/services and their latest versions, and setting up the app/feature/infrastructure package slice architecture.
 ---
 
 # woostack-bootstrap
 
 ## Overview
 
-A spec — not a template — for bootstrapping AI-built web + mobile + API projects. It holds the *decisions* (frameworks, architecture, infrastructure, patterns) so an agent scaffolds a fresh repo at the latest framework versions without re-litigating choices every time. Templates rot; decisions don't.
+A spec — not a template — for bootstrapping AI-built full-stack projects. Instead of prescribing a hardcoded stack, this skill guides the agent to dynamically gather the project's requirements, look up the latest industry-standard solutions and versions, compare 2-3 options with pros/cons, and then bootstrap the chosen services using the app, feature, and infrastructure package slice architecture.
 
-**Core principle:** resolve versions live at bootstrap, never from memory.
+**Core principle:** resolve technologies and versions live based on project requirements, never from memory.
 
 ## Invocation
 
@@ -20,63 +20,53 @@ Invoke with `/woostack-bootstrap <goal>`, where the goal is a plain-language des
 /woostack-bootstrap a SaaS dashboard with a marketing site and a billing API
 ```
 
-From the goal, infer a *recommended* shape — surfaces, features, and provider choices — then walk the user through it (see Procedure). The goal seeds the recommendations; the user confirms or overrides every one.
+The goal seeds the initial requirements-gathering and recommendation phase.
 
 ## When to use
 
-- Standing up a new full-stack project (any subset of web / landing / mobile / api).
-- Deciding the stack: frameworks, hosting, data layer, CI, lint/test tooling.
-- Laying out a monorepo with shared packages and import boundaries.
+- Standing up a new full-stack project (any combination of web / mobile / desktop / api / daemon).
+- Determining the stack: cloud hosting, data layer, auth, libraries, CI/CD, linting, and testing tooling.
+- Laying out a monorepo with custom packages and import boundaries.
 
 **Not for:** adding features to an already-bootstrapped project (use that project's own conventions), or single-surface throwaway scripts.
 
-## Default stack
-
-| Layer | Default |
-|---|---|
-| Web / Landing | Next.js (App Router) + React Compiler + shadcn/ui |
-| Mobile | Expo + React Native + react-native-reusables + UniWind |
-| API | Hono + oRPC |
-| Data | TanStack Query + Zod + Supabase (Postgres, Auth, Storage) |
-| Styling | Tailwind CSS (CSS-first) + shared theme |
-| Build | Turborepo + pnpm catalog |
-| Lint/format | Biome |
-| Testing | Vitest, Jest (RN), Playwright |
-| Hosting | Vercel (web + api) + Expo EAS (mobile) |
-
-Defaults are overridable per project — record any deviation in the project's own README.
-
 ## Procedure
 
-1. **Interpret the goal** — from the plain-language goal, infer a recommended shape: a project name, the surfaces it implies, candidate features, and which capabilities it likely needs. (E.g. "mobile app for cataloging recipes" → `mobile` surface, probably an `api` for sync, a `recipes` feature, Supabase Postgres + Storage for images + Auth for accounts; no billing unless monetized.) These are *recommendations*, not decisions — they seed step 2.
-2. **Walk the user through every decision** — work through [references/decisions.md](references/decisions.md) before touching the filesystem. Present each relevant choice as a goal-aware recommendation with its default and alternatives, get an explicit answer (silence is not consent), resolve the genuine forks (e.g. API host), and treat capabilities (billing, email, flags, observability, …) as opt-in. **Do not scaffold any decision the user has not confirmed.**
-3. **Read the references in order** (below) — they are binding rules, not suggestions.
-4. **Follow [references/bootstrap.md](references/bootstrap.md) step by step** — it is the authoritative procedure.
-5. **Verify** before declaring done: `pnpm install && pnpm typecheck && pnpm build && pnpm test && pnpm dev` — every surface boots on its expected port.
+1. **Gather requirements** — Upon invocation, ask the user targeted questions about their goals to capture technical and business constraints (e.g. expected scale, deployment/cloud provider restrictions, compliance/security, external API integrations, budget).
+2. **Perform live industry research** — Use web search and registry lookup commands (e.g. `npm view`) to identify current industry-standard frameworks, libraries, databases, and services that satisfy the requirements, ensuring you ground your choices in the latest stable versions.
+3. **Present stack options** — Compile and present 2-3 cohesive stack options (e.g., Option A: Serverless Edge, Option B: Containerized VPS, Option C: Managed PaaS/BaaS) with a clear Pros/Cons breakdown, production-readiness evaluation, and cost implications for each. Get an explicit choice from the user before proceeding.
+4. **Walk through reference files** — Study and follow the generalized reference documents before writing code:
+   - [references/decisions.md](references/decisions.md)
+   - [references/bootstrap.md](references/bootstrap.md)
+   - [references/architecture.md](references/architecture.md)
+   - [references/frameworks.md](references/frameworks.md)
+   - [references/infrastructure.md](references/infrastructure.md)
+5. **Scaffold skeleton & run CLIs** — Create the monorepo structure. Run the appropriate CLI scaffolding tools for the chosen frameworks and clean up their generated boilerplates.
+6. **Verify** — Run the build, test, lint, and format pipelines defined for the stack to ensure every surface compiles and boots correctly.
 
 ## References (load on demand)
 
 | File | What it defines |
 |---|---|
-| [references/decisions.md](references/decisions.md) | Decision catalog + confirmation protocol — the pre-scaffold gate |
+| [references/decisions.md](references/decisions.md) | Questionnaire guide + confirmation protocol — the pre-scaffold gate |
 | [references/bootstrap.md](references/bootstrap.md) | Step-by-step bootstrap procedure — the spine |
 | [references/architecture.md](references/architecture.md) | Monorepo layout, package tiers, import boundaries, naming |
-| [references/frameworks.md](references/frameworks.md) | Recommended frameworks per layer, catalog protocol, **known gotchas** |
-| [references/infrastructure.md](references/infrastructure.md) | Hosting, CI/CD, env, observability, auth, data layer |
-| [references/patterns.md](references/patterns.md) | oRPC contracts, TanStack Query, RSC, navigation, TDD, feature exposure |
+| [references/frameworks.md](references/frameworks.md) | Version-resolution rules, workspace catalogs, and Gotchas |
+| [references/infrastructure.md](references/infrastructure.md) | Production-readiness patterns: hosting, CI/CD, env vars, migrations, observability |
+| [references/patterns.md](references/patterns.md) | Standard implementation and TDD guidelines |
 | [references/development.md](references/development.md) | Dev loop (ideate → approve spec → merge) and branching model |
 
 ## Hard constraints
 
 These are non-negotiable. Violating them produces a broken or drift-prone project.
 
-- **Confirm before scaffolding.** Walk the user through [references/decisions.md](references/decisions.md) and get explicit sign-off on every relevant decision first. Never scaffold a choice the user hasn't confirmed; never silently apply a default.
-- **Always resolve the latest versions before building.** Your training memory is stale — treat every version you "remember" as wrong. For every dependency, query the registry at bootstrap time (`npm view <pkg> version`, or `npm view <pkg> dist-tags` for channels) and write the resolved value. Never hard-code a version from memory.
-- **Cross-check the gotchas.** Reconcile every resolved version against [references/frameworks.md](references/frameworks.md#known-gotchas-to-respect-at-bootstrap) before writing it — some peers (notably `react` for RN) must match a pinned version.
-- **Match the layout exactly.** Follow [references/architecture.md](references/architecture.md); omit only folders for surfaces not requested.
-- **Don't ship unverified.** A bootstrap that fails `install / typecheck / build / test / dev` is not done. Fix every failure.
-- **Project docs reference, don't duplicate.** The generated project's README points back at this spec; record deviations explicitly.
+- **Confirm stack before scaffolding.** Present the pros/cons of the options and get explicit sign-off from the user before touching the filesystem. Never silently choose or scaffold a stack.
+- **Always resolve latest versions live.** Never use hardcoded versions from memory. Query the registry live (`npm view <pkg> version` or equivalent commands) during the research phase.
+- **Maintain package slice architecture.** Strictly follow [references/architecture.md](references/architecture.md) for package layering (`Apps -> Features -> Infrastructure`), regardless of the chosen technology stack.
+- **Don't ship unverified.** Running build, lint, and test scripts must succeed before declaring the bootstrap complete.
+- **Record decisions.** Write the finalized stack choices, versions, and rationale into the project's root `README.md` at hand-off.
 
 ## SPEC_VERSION
 
-`2.0.0` — first spec-only release. Bump on breaking changes so downstream projects can detect drift.
+`3.0.0` — Major breaking release moving to dynamic stack selection and dynamic lookup.
+

--- a/skills/woostack-bootstrap/references/decisions.md
+++ b/skills/woostack-bootstrap/references/decisions.md
@@ -1,97 +1,60 @@
-# Decisions
+# Decisions & Questionnaire Protocol
 
-Every choice a bootstrap makes. Walk the user through **all** of these before scaffolding — including the ones that have a default. The user confirms or overrides each; nothing gets scaffolded that the user has not signed off on.
+Every technology stack choice must be aligned with the user's specific project goals and constraints. Walk the user through this protocol **before** any files are created or scaffolded.
 
-## Confirmation protocol
+## Dynamic Stack Selection Protocol
 
 Run this gate **before** any scaffolding (it is step 0 of [bootstrap.md](bootstrap.md)).
 
-0. **Start from the goal.** The skill is invoked as `/woostack-bootstrap <goal>`. Read that goal first and infer a *recommended* shape — name, surfaces, candidate features, likely capabilities — then present each decision below pre-filled with that recommendation, not a blank default. Example: "mobile app for cataloging recipes" → recommend `mobile` (+ `api` for sync), a `recipes` feature, Supabase Postgres + Storage (images) + Auth (accounts), and *no* billing. The user still confirms or overrides every item; the goal just makes the recommendations specific instead of generic.
-1. **Surface only the relevant decisions.** Filter by the recommended/confirmed surfaces — don't ask mobile questions if there's no `mobile` surface, don't ask the API-host question if there's no `api`.
-2. **For every decision below, state the default and the alternatives, then get an explicit answer.** "Confirm everything" means the user actively accepts each default — silence is not consent. Group related decisions so the user answers in batches, not one popup at a time.
-3. **Capabilities are opt-in.** For billing, transactional email, webhooks, chat, observability, and realtime, first ask whether the project needs the capability at all. If no, skip its package and env entirely. If yes, confirm the provider. (`flags` is the exception — it is **not** opt-in: a standing package scaffolded empty in every project regardless of answer; see section 5 below.)
-4. **Never invent an unconfirmed value.** If a decision has neither a user answer nor a documented default, stop and ask. Do not guess.
-5. **Record the outcome.** Write the confirmed choices — and any deviation from a default — into the project's own README at hand-off (bootstrap step 11), so the next contributor sees what was decided and why.
+1. **Submit the Goal**: The user initiates bootstrap with a goal, e.g. `/woostack-bootstrap <goal>`.
+2. **Gather Requirements**: Ask the user 1-2 targeted questions to clarify:
+   - **Scale & Traffic Patterns**: Expected user base, read/write ratios, real-time requirements.
+   - **Hosting & Infrastructure restrictions**: Preferred cloud provider (AWS, GCP, Azure, Vercel, Cloudflare, Fly.io, self-hosted/VPS).
+   - **Database & Data Structure**: Relational vs. Document vs. Key-Value, blob storage requirements.
+   - **Auth & Compliance**: Need for SSO, social logins, RLS/database policies, GDPR/HIPAA compliance.
+   - **External Integrations**: Third-party APIs (e.g. Stripe for billing, Resend for email, flags).
+   - **Budget & Team constraints**: Familiarity with languages/tools, hosting budget limits.
+3. **Research & Lookup**: 
+   - Based on the requirements, look up the current industry-standard frameworks, libraries, databases, and services.
+   - Ground the research in **latest stable versions** using registry commands (`npm view <pkg> version` or equivalent tools for other platforms) or web searches.
+4. **Present 2-3 Stack Options**: Present the stack options clearly in a comparison table. For each option, specify:
+   - **Detailed Tech Stack**: Language, framework, database, auth, hosting, observability.
+   - **Pros & Cons**: Trade-offs around developer speed, complexity, scaling, cold starts, and lock-in.
+   - **Production Readiness**: Security baselines, disaster recovery, logging/monitoring backing.
+   - **Cost Estimation**: Free-tier availability and estimated operational costs.
+5. **Get Explicit Approval**: The user must explicitly select or customize one of the proposed stack options. **Do not scaffold any decision the user has not approved.**
+6. **Record the Stack**: Write the selected stack, resolved versions, and architectural decisions into the project's root `README.md` at hand-off.
 
-Do not proceed to scaffolding until every relevant decision below is confirmed.
+---
 
-## 1. Project basics — derive a recommendation from the goal, then confirm
+## Requirements gathering questionnaire
 
-Infer each of these from the `/woostack-bootstrap` goal and propose it; the user confirms or corrects.
+Below is a template of the requirements questionnaire the agent should present to the user:
 
-| Decision | Notes |
-|---|---|
-| Project name | Suggest one from the goal (e.g. "cataloging recipes" → `recipe-box`); confirm. Used for repo, root `package.json`, default app names. |
-| Surfaces | Infer from the goal ("mobile app" → `mobile`; "dashboard + marketing site" → `web` + `landing`). Any subset of `web`, `landing`, `mobile`, `api`. Drives every later filter. |
-| Initial features | Propose features the goal implies (e.g. `recipes`, `users`). May be empty. |
-| Repo host | Default **GitHub**. Confirm or override. |
-| Package manager | Default **pnpm** (catalog protocol assumes it). Override only with reason. |
+```markdown
+To bootstrap the best stack for your project, please answer the following questions (defaults will be recommended based on your goal):
 
-## 2. Core frameworks — defaults from [frameworks.md](frameworks.md)
+1. **Scale & Performance**: What are your traffic expectations? Does the project need real-time sync, edge compute, or heavy background workers?
+2. **Hosting/Cloud Preferences**: Do you have a preferred hosting target (e.g., Vercel, AWS, Cloudflare Workers, Fly.io, or a simple VPS)?
+3. **Data & Storage**: What kind of database is preferred (SQL/Postgres, NoSQL/Mongo, key-value)? Do you need object storage for files?
+4. **Auth & Security**: What type of authentication is required (e.g., social login, passwordless, email/password)? Any compliance constraints (HIPAA, GDPR)?
+5. **Additional Capabilities**: Do you need billing (Stripe), feature flags, email delivery, or structured observability?
+```
 
-Confirm per surface that's in scope.
+## Option Presentation Format
 
-| Layer | Default | Applies when |
-|---|---|---|
-| Web / Landing | Next.js (App Router) + React Compiler + shadcn/ui | `web` / `landing` |
-| Mobile | Expo + React Native + react-native-reusables + UniWind | `mobile` |
-| API | Hono + oRPC | `api` |
-| Styling | Tailwind CSS (CSS-first) + shared theme | any UI surface |
-| Build | Turborepo + pnpm catalog | always |
-| Lint / format | Biome | always |
-| Testing | Vitest, Jest (RN), Playwright | always |
+When presenting the researched options, structure them like this to keep evaluations scannable:
 
-Versions are resolved live at bootstrap — see [frameworks.md](frameworks.md). The *choice* of framework is confirmed here; the *version* is never invented.
+### Option 1: Edge-Native / Serverless (e.g., Next.js + Cloudflare Workers + Supabase)
+- **Use Case**: Best for global low latency, fast scaling, and low initial costs.
+- **Components**: Next.js (Frontend), Hono + Cloudflare Workers (API), Supabase (Postgres & Auth), Resend (Email).
+- **Pros**: Zero server maintenance, instant global distribution, low cold starts.
+- **Cons**: Vendor lock-in with Supabase/Cloudflare; database connection pooling limits.
+- **Production Readiness**: High; auto-scaling, managed SSL, and built-in edge caching.
 
-## 3. Hosting — defaults from [infrastructure.md#hosting](infrastructure.md#hosting)
-
-| Decision | Default | Alternatives | Applies when |
-|---|---|---|---|
-| Web / landing host | Vercel | — | `web` / `landing` |
-| **API host** | *no single default — a real fork* | Vercel Functions (Fluid Compute) **or** Cloudflare Workers | `api` |
-| Mobile build / submit | Expo EAS Build + Submit | — | `mobile` |
-| Domains / DNS | Vercel-managed (auto SSL) | external registrar | any web surface |
-
-The API-host question must always be asked when `api` is in scope — colocate on Vercel for shared env + preview URLs, or Cloudflare Workers for global edge + lower cold-start cost.
-
-## 4. Data & backend — defaults from [infrastructure.md#data-layer](infrastructure.md#data-layer)
-
-| Decision | Default | Alternatives |
-|---|---|---|
-| Relational DB | Supabase Postgres | Neon, RDS |
-| Auth | Supabase Auth | Auth0, custom (Hono + JWT) |
-| Object storage | Supabase Storage | S3, R2, Vercel Blob |
-| Key-value / cache | Upstash Redis (Vercel Marketplace) | Vercel KV |
-| Edge functions | Supabase Edge Functions (Deno) | Vercel Functions, Cloudflare Workers |
-
-The DB / auth / storage rows usually move together — picking Supabase answers all three. Only ask the **edge-functions** row if the project actually needs server-side compute beyond `apps/api`; otherwise skip it. Tie the choice to the data-layer provider you confirmed above.
-
-## 5. Capabilities — opt-in; ask "does this project need it?" first
-
-Every row here is opt-in **except `flags`** (see the note below the table). For the opt-in rows: if the user declines, skip the capability entirely.
-
-| Capability | Default provider | Alternatives | Package |
-|---|---|---|---|
-| Realtime | Supabase Realtime | Pusher, Ably | — |
-| Feature flags / experiments | Vercel Flags SDK + Edge Config backing store | Statsig, LaunchDarkly, GrowthBook adapters | `flags` — **not opt-in**: standing package, scaffolded empty even if no flags yet (see [bootstrap.md](bootstrap.md)); only the *backing store* is a choice |
-| Transactional email | Resend | — | consumed from `apps/api` |
-| Webhook delivery | Inngest or native Hono routes | — | — |
-| Chat / bot platforms | Vercel Chat SDK | — | — |
-| Billing / subscriptions | Stripe (Checkout + Customer Portal) | — | `packages/features/billing/` |
-| Observability | Axiom (errors, logs, vitals) | — | per-surface Axiom SDK |
-| AI code review | Vercel Agent | — | — |
-
-If a capability is declined, do not scaffold its package, SDK, or env vars. (Exception: `flags` is a standing package — scaffold it empty regardless, but only wire a backing store if flags are wanted.)
-
-## 6. Workflow & CI — defaults from [infrastructure.md#cicd](infrastructure.md#cicd) and [development.md](development.md)
-
-| Decision | Default | Notes |
-|---|---|---|
-| Branch tool | Graphite (`gt`) | — |
-| Trunk / integration | `main` trunk, optional `staging` | See branching model in [development.md](development.md). |
-| Node version | Latest LTS at bootstrap (resolve live) | Pin in CI via `actions/setup-node`. |
-| CI jobs | `biome ci`, `pnpm turbo build`, `pnpm test:changed` | No `typecheck` job — local-only. |
-
-## When the user defers
-
-If the user says "use the defaults" or "you decide," that **is** a confirmation — proceed with the documented defaults for the relevant surfaces, but still resolve the genuine forks that have no default (API host) and the opt-in capabilities (don't silently add Stripe/Resend/Axiom to a project that didn't ask for them). State the full set of defaults you're applying so the user can object before scaffolding starts.
+### Option 2: Containerized / Traditional VPS (e.g., Express/FastAPI + PostgreSQL + Docker)
+- **Use Case**: Best for complete control, predictability at scale, and avoiding serverless limits.
+- **Components**: React/Vite (Frontend), FastAPI (API), PostgreSQL (managed or Docker), Keycloak/Auth0 (Auth), Fly.io/AWS ECS (Hosting).
+- **Pros**: No serverless execution timeouts, complete language flexibility, portable container setup.
+- **Cons**: Requires setting up CI/CD pipelines, managing DB backups, higher maintenance overhead.
+- **Production Readiness**: High, provided health checks, migrations, and standard Docker configs are wired.


### PR DESCRIPTION
## Goal

Update the main `woostack-bootstrap` skill definition and its `decisions.md` reference to implement a dynamic, requirements-driven questionnaire and stack-selection protocol.

## Summary

- Remove hardcoded default stack from `skills/woostack-bootstrap/SKILL.md` and define the dynamic research/lookup procedure.
- Update `SPEC_VERSION` to `3.0.0` in `SKILL.md` to reflect a major breaking protocol change.
- Rewrite `skills/woostack-bootstrap/references/decisions.md` to establish a requirements-gathering questionnaire and dynamic options presentation template.

## Test plan

### Manual

**Before merge**

- [ ] Inspect the updated `skills/woostack-bootstrap/SKILL.md` file.
- [ ] Inspect the updated `skills/woostack-bootstrap/references/decisions.md` file.

Spec: .woostack/specs/2026-06-08-generic-woostack-bootstrap.md
