### PR TITLE
docs: generalize bootstrap procedure and adapt monorepo slice architecture

### DIFF
--- a/.woostack/memory/grep-c-counts-lines-not-occurrences.md
+++ b/.woostack/memory/grep-c-counts-lines-not-occurrences.md
@@ -6,7 +6,7 @@ tags: plans, verification, grep, counts
 hook: A plan's `grep -c` verification counts matching LINES, not occurrences — a phrase that line-wraps or two patterns sharing a line undercount.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-06-woostack-execute-overnight.md
-recall_count: 15
+recall_count: 16
 last_recalled: 2026-06-08
 ---
 When a woostack plan asserts an exact count with `grep -c -E "..."`, remember it counts

--- a/.woostack/memory/woostack-command-surface-bookkeeping.md
+++ b/.woostack/memory/woostack-command-surface-bookkeeping.md
@@ -6,7 +6,7 @@ tags: skills, docs, counts, surface
 hook: Adding/removing a public command means updating the count + lists in five places, which drift independently.
 updated: 2026-06-06
 source: .woostack/plans/2026-06-05-woostack-plan.md
-recall_count: 39
+recall_count: 40
 last_recalled: 2026-06-08
 ---
 The public-command count and skill lists are duplicated across several files and

--- a/.woostack/memory/woostack-feature-state-invariant.md
+++ b/.woostack/memory/woostack-feature-state-invariant.md
@@ -6,7 +6,7 @@ tags: status, specs, plans, prs
 hook: Specs, plans, and increment PRs are joined by Source and Spec trailers.
 updated: 2026-06-04
 source: .woostack/plans/2026-06-04-woostack-status.md
-recall_count: 62
+recall_count: 63
 last_recalled: 2026-06-08
 ---
 Feature state is derived from artifacts, not a committed status file: each spec

--- a/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
+++ b/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
@@ -96,29 +96,29 @@ gt modify -c -m "docs: rewrite decisions reference to use dynamic questionnaire"
 - Modify: `skills/woostack-bootstrap/references/bootstrap.md`:1-187
 - Test: Verify the file contains instructions for custom CLI generation.
 
-- [ ] **Step 1: Write the verification command**
+- [x] **Step 1: Write the verification command**
 
 Run: `grep -q "CLI bootstrap commands for the chosen stack" skills/woostack-bootstrap/references/bootstrap.md`
 Expected: exit status 1
 
-- [ ] **Step 2: Run the verification, confirm it fails**
+- [x] **Step 2: Run the verification, confirm it fails**
 
 Run: `grep -q "CLI bootstrap commands for the chosen stack" skills/woostack-bootstrap/references/bootstrap.md`
 Expected: FAIL (exit status 1)
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Edit `skills/woostack-bootstrap/references/bootstrap.md` to:
 1. Generalize inputs to include the chosen stack's specific services.
 2. Outline how to run arbitrary CLIs (Next.js, FastAPI, etc.) and clean their boilerplates.
 3. Detail how to initialize workspace files dynamically.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -q "CLI bootstrap commands for the chosen stack" skills/woostack-bootstrap/references/bootstrap.md`
 Expected: PASS (exit status 0)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "docs: generalize bootstrap procedure for arbitrary CLIs"
@@ -132,29 +132,29 @@ gt create -m "docs: generalize bootstrap procedure for arbitrary CLIs"
 - Modify: `skills/woostack-bootstrap/references/architecture.md`:1-103
 - Test: Verify the file details multi-language workspace boundaries.
 
-- [ ] **Step 1: Write the verification command**
+- [x] **Step 1: Write the verification command**
 
 Run: `grep -q "guidance for multi-language monorepos" skills/woostack-bootstrap/references/architecture.md`
 Expected: exit status 1
 
-- [ ] **Step 2: Run the verification, confirm it fails**
+- [x] **Step 2: Run the verification, confirm it fails**
 
 Run: `grep -q "guidance for multi-language monorepos" skills/woostack-bootstrap/references/architecture.md`
 Expected: FAIL (exit status 1)
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Edit `skills/woostack-bootstrap/references/architecture.md` to:
 1. Adapt the package tiers to generalize how non-JS/TS services (Python, Rust, etc.) reside in the structure.
 2. Explain how to manage dependencies natively (e.g. `cargo`, `uv`) and orchestrate build pipelines with Turborepo.
 3. Generalize `@infrastructure/` wrapper packages to be database/auth provider agnostic.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -q "guidance for multi-language monorepos" skills/woostack-bootstrap/references/architecture.md`
 Expected: PASS (exit status 0)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs: update architecture reference for dynamic package slicing"

--- a/skills/woostack-bootstrap/references/architecture.md
+++ b/skills/woostack-bootstrap/references/architecture.md
@@ -1,102 +1,72 @@
-# Architecture
+# Architecture & Package Slicing
 
-Reference monorepo layout for new projects bootstrapped from this spec. AI agents should reproduce this structure unless the project explicitly diverges.
+Reference monorepo layout for new projects bootstrapped from this spec. AI agents must reproduce this structure.
 
 ## Layout
 
+Regardless of the chosen programming languages or frameworks, the project must follow a clean separation between **Apps** (deployable units), **Features** (business logic packages), and **Infrastructure** (shared libraries and vendor SDK wrappers).
+
 ```
 <project-root>/
-├── apps/                      Deployable units (unscoped names)
-│   ├── web/                   Next.js (App Router)
-│   ├── landing/               Next.js marketing site (optional)
-│   ├── mobile/                Expo + React Native
-│   └── api/                   Hono + oRPC
+├── apps/                      Deployable units (unscoped names, e.g., web, api, worker)
 ├── packages/
-│   ├── features/              Business logic packages (one per feature)
+│   ├── features/              Business logic packages (one package per feature slice)
 │   │   └── <feature>/
-│   │       ├── contracts/     Zod schemas (oRPC contracts)
-│   │       ├── routers/       oRPC routers
-│   │       ├── procedures/    Business logic called by handlers
-│   │       ├── components/    Internal UI
-│   │       ├── surfaces/      Public UI entry points (*Surface.tsx)
-│   │       ├── layouts/       Public layout components (*Layout.tsx)
-│   │       └── schemas/       Domain schemas
-│   └── infrastructure/        Shared utilities (scoped @infrastructure/*)
-│       ├── api-client/        oRPC client factories, shared base schemas
-│       ├── flags/             Vercel Flags SDK definitions + identify()
-│       ├── navigation/        Platform-agnostic Link + useNavigation
-│       ├── ui/                Design tokens, cn(), shared theme CSS
-│       ├── ui-web/            Shared shadcn/ui components
-│       ├── utils/             Cross-platform helpers
-│       └── typescript-config/ Shared tsconfig presets
-├── .github/workflows/         CI pipelines
-├── pnpm-workspace.yaml        Workspace + catalog
-├── turbo.json                 Turborepo pipeline
-├── biome.json                 Lint + format
-└── package.json               Root scripts only
+│   │       ├── src/
+│   │       │   ├── contracts/     Clean API contracts (Zod, Protobuf, OpenAPISchema)
+│   │       │   ├── services/      Business logic procedures and handlers
+│   │       │   ├── components/    Feature-specific internal UI components
+│   │       │   └── layouts/       Feature-specific layouts
+│   │       ├── package.json
+│   │       └── tsconfig.json
+│   └── infrastructure/        Shared libraries and SDK wrappers
+│       ├── db-client/         Database connector wrapper
+│       ├── auth/              Authentication client wrapper
+│       ├── observability/     Logging and error tracking
+│       ├── ui/                Design tokens and global styling
+│       └── utils/             Cross-platform helpers
 ```
 
-## Package tiers
+---
 
-Three tiers with strict import direction. Violations break the architecture.
+## Package Tiers
+
+The monorepo enforces three main tiers with strict import directions:
 
 ```
 Apps  →  Features  →  Infrastructure
 ```
 
-| Tier | Path | Naming | Exports | May import |
-|---|---|---|---|---|
-| **Apps** | `apps/*` | unscoped (`web`, `api`) | n/a (deployables) | Features (via surfaces/layouts only), Infrastructure |
-| **Features** | `packages/features/*` | unscoped, default exports | Surfaces + Layouts only | Infrastructure |
-| **Infrastructure** | `packages/infrastructure/*` | `@infrastructure/*`, named exports | Anything intentionally public | Other infrastructure |
+- **Apps** may import **Features** and **Infrastructure**.
+- **Features** may import **Infrastructure** but *never* other Features or Apps.
+- **Infrastructure** may import other Infrastructure libraries, but *never* Features or Apps.
 
-**Exemption:** `apps/api` may import feature `contracts/` and `routers/` directly to compose the master oRPC router. This is the only app-level bypass of the Surfaces/Layouts rule.
+| Tier | Path | Role | May Import |
+|---|---|---|---|
+| **Apps** | `apps/*` | Deployable apps (e.g., frontends, APIs, workers). | Features, Infrastructure |
+| **Features** | `packages/features/*` | Core business logic separated by domain slice. | Infrastructure |
+| **Infrastructure** | `packages/infrastructure/*` | Technical wrappers (e.g., DB clients, Auth SDKs, loggers). | Other Infrastructure |
 
-## Naming
+---
 
-| Element | Convention | Example |
-|---|---|---|
-| Components | PascalCase, default export, one per file | `UserCard.tsx` |
-| Hooks | camelCase, `use` prefix | `useUserList.ts` |
-| Helpers | camelCase | `formatCurrency.ts` |
-| Constants | UPPER_SNAKE_CASE | `MAX_RETRY_ATTEMPTS` |
-| Types/Interfaces | PascalCase | `UserProfile` |
-| Schemas | PascalCase | `UserSchema` |
-| Procedures | camelCase verbs | `createUser.ts`, `listUsers.ts` |
-| oRPC contracts | `{feature}Contract.ts` | `usersContract.ts` |
-| oRPC routers | `{feature}ORPCRouter.ts` | `usersORPCRouter.ts` |
-| Surface components | `*Surface.tsx` suffix | `UserListSurface.tsx` |
-| Layout components | `*Layout.tsx` suffix | `DashboardLayout.tsx` |
+## Multi-Language Monorepos
 
-`.ts` by default. `.tsx` only when file contains JSX.
+If a project's requirements dictate using multiple programming languages (e.g., a Next.js TypeScript frontend and a Python or Go API), follow this guidance for multi-language monorepos to maintain package boundaries:
 
-## File organization inside a feature
+1. **Service Placement**: Place JS/TS apps in `apps/` and packages in `packages/`. Non-JS/TS apps and shared feature libraries should be located in `apps/<name>` or `packages/features/<name>` respectively.
+2. **Dependency Management**: Non-JS/TS folders manage their dependencies using their native package managers (e.g., `cargo` for Rust, `go mod` for Go, `uv` or `poetry` for Python). Do not try to force them into a single `package.json` catalog.
+3. **Build Orchestration**: The root `turbo.json` configures Turborepo to orchestrate tasks across all languages. Wrap native commands inside root `package.json` scripts that Turborepo can target:
+   - Example: A test task for a Python app runs `pytest`, which is invoked via a script in `apps/python-api/package.json` (`"test": "uv run pytest"`).
+4. **API Contracts**: Use language-agnostic contract specifications (e.g., OpenAPI JSON, Protocol Buffers, or JSON Schema) to share types between frontend and backend.
 
-Each feature package follows the same directory shape. Empty dirs are omitted; needed dirs match these names exactly.
+---
 
-```
-packages/features/<feature>/
-├── src/
-│   ├── contracts/        Zod schemas for oRPC i/o
-│   ├── routers/          oRPC router definitions
-│   ├── procedures/       Business logic
-│   ├── components/       Internal-only UI (not exported)
-│   ├── surfaces/         Public UI entry points
-│   ├── layouts/          Public layout components
-│   └── schemas/          Internal domain schemas
-├── package.json
-└── tsconfig.json
-```
+## Feature Internal Structure
 
-## Dependency catalog
+Each feature slice contains sub-directories grouping components by role. Empty directories are omitted.
 
-All shared dependency versions live in `pnpm-workspace.yaml` `catalog:`. Package `package.json` files reference `catalog:` instead of literal versions. Catalog versions are **exact** (no `^` or `~`) for deterministic installs.
-
-See [frameworks.md](frameworks.md) for which dependencies belong in the catalog.
-
-## Size limits
-
-- Non-test source files: 500 lines max.
-- Test files (`*.test.*`, `*.spec.*`, `__tests__/`): exempt.
-
-Files approaching the limit signal a refactor opportunity; split before crossing.
+- `contracts/`: Typed interfaces and I/O validation schemas (e.g. Zod schemas or OpenAPI specs).
+- `services/`: Core business logic, database queries, and handlers (avoid putting raw DB queries directly in controllers/apps).
+- `components/`: UI components used internally by the feature.
+- `layouts/`: UI layouts used by the feature.
+- `schemas/`: Domain-specific internal validation schemas.

--- a/skills/woostack-bootstrap/references/architecture.md
+++ b/skills/woostack-bootstrap/references/architecture.md
@@ -16,7 +16,8 @@ Regardless of the chosen programming languages or frameworks, the project must f
 │   │       │   ├── contracts/     Clean API contracts (Zod, Protobuf, OpenAPISchema)
 │   │       │   ├── services/      Business logic procedures and handlers
 │   │       │   ├── components/    Feature-specific internal UI components
-│   │       │   └── layouts/       Feature-specific layouts
+│   │       │   ├── layouts/       Feature-specific layouts
+│   │       │   └── schemas/       Domain-specific internal validation schemas
 │   │       ├── package.json
 │   │       └── tsconfig.json
 │   └── infrastructure/        Shared libraries and SDK wrappers

--- a/skills/woostack-bootstrap/references/bootstrap.md
+++ b/skills/woostack-bootstrap/references/bootstrap.md
@@ -67,7 +67,7 @@ Determine the exact CLI bootstrap commands for the chosen stack (e.g., `npx crea
 
 ### 7. Scaffold features (if any)
 For each initial feature in the inputs, create a directory under `packages/features/<feature>/`. 
-Organize code into clean sub-layers representing contracts, procedures/services, schemas, layouts, and components. Wire feature entry points into the main routing/API app.
+Organize code into clean sub-layers representing contracts, services, schemas, layouts, and components. Wire feature entry points into the main routing/API app.
 
 ### 8. Configure CI/CD
 Write a generalized GitHub Actions configuration `.github/workflows/ci.yml` that triggers on pull requests targeting the integration branches. The workflow should checkout the code, install dependencies, run lints/formatters, run tests, and verify the build pipeline.

--- a/skills/woostack-bootstrap/references/bootstrap.md
+++ b/skills/woostack-bootstrap/references/bootstrap.md
@@ -1,186 +1,90 @@
-# Bootstrap
+# Bootstrap Procedure
 
-How an AI agent (or human) uses this spec to spin up a new project. The spec is the source of truth; the agent fills in the latest framework versions.
+How an AI agent (or human) uses this spec to spin up a new project. The agent dynamically gathers requirements, researches the stack, and fills in the latest framework versions.
 
 ## Inputs the agent needs
 
-The skill is invoked as `/woostack-bootstrap <goal>` — a plain-language description of what to build. Derive the following from the goal and confirm them in step 0; don't require the user to spell them out:
+The skill is invoked as `/woostack-bootstrap <goal>` — a plain-language description of what to build. Derive the project name and potential surfaces from the goal, then run the requirements questionnaire (defined in [decisions.md](decisions.md)) to finalize:
 
-1. **Project name** (used for repo, root `package.json`, default app names).
-2. **Surfaces required** — any subset of: `web`, `landing`, `mobile`, `api`.
-3. **Initial features** — list of feature names to scaffold (e.g. `recipes`, `users`). Can be empty.
+1. **Project name** (used for repo, root config, default app names).
+2. **Surfaces required** — e.g. frontend web, backend API, mobile app, background processing worker.
+3. **Selected Stack Option** — the chosen frameworks, databases, auth, and hosting providers.
+4. **Initial features** — list of feature names to scaffold (e.g. `recipes`, `users`). Can be empty.
 
-Everything else — hosting, data layer, auth, capabilities, repo host — is resolved with the user in step 0, not assumed.
+---
 
 ## Steps
 
 ### 0. Interpret the goal, then confirm decisions with the user
+Follow the protocol in [decisions.md](decisions.md) to gather requirements, perform live lookup, present options, and get explicit user approval. **Do not scaffold any decision the user has not confirmed.**
 
-Read the `/woostack-bootstrap` goal and infer a recommended shape — name, surfaces, candidate features, likely capabilities. Then walk the user through [decisions.md](decisions.md), presenting every relevant decision **pre-filled with the goal-aware recommendation** alongside its default and alternatives. Get explicit sign-off, resolve the genuine forks (e.g. API host), and treat capabilities (billing, email, flags, observability, …) as opt-in. **Do not scaffold any decision the user has not confirmed**, and do not silently apply a default. If the user defers ("use the defaults"), state the full set you'll apply so they can object first.
-
-### 1. Read the spec
-
+### 1. Read the reference files
 Load these files into context first:
-
 - [architecture.md](architecture.md)
 - [frameworks.md](frameworks.md)
 - [infrastructure.md](infrastructure.md)
 - [patterns.md](patterns.md)
 - [development.md](development.md)
 
-These define the binding rules. Do not deviate without a documented reason.
-
 ### 2. Resolve framework versions
-
-**Always query the registry — never use a version from memory.** Your training data is stale by the time you run; every version you "remember" is a guess that will drift the project from current releases. Resolve live, every time.
-
-For each catalog entry in [frameworks.md](frameworks.md):
-
-1. Query the latest version from the registry (`npm view <pkg> version` for latest stable; `npm view <pkg> dist-tags` when you need a specific channel). Do not skip this for packages you think you know.
-2. Cross-check against the **known gotchas** list — some packages (notably `react` for RN compatibility) must match a specific peer version.
-3. Write the resolved versions into `pnpm-workspace.yaml` `catalog:` as exact strings.
+**Always query the registry live — never use a version from memory.** 
+For every dependency needed for the selected stack:
+1. Query the latest version from the registry (e.g., `npm view <pkg> version` for Node, or equivalent commands for other runtimes).
+2. Write the exact resolved versions into the monorepo's shared catalog/workspace configuration.
 
 ### 3. Create repo skeleton
-
+Create a standard monorepo folder layout matching [architecture.md](architecture.md), omitting folders for surfaces not requested:
 ```
 <project>/
 ├── apps/                     # only the surfaces requested
 ├── packages/
 │   ├── features/             # one dir per requested feature
-│   └── infrastructure/
-│       ├── api-client/
-│       ├── navigation/
-│       ├── ui/
-│       ├── ui-web/           # only if web or landing requested
-│       ├── utils/
-│       └── typescript-config/
+│   └── infrastructure/       # wrapper packages for DB, auth, logging, client, etc.
 ├── .github/workflows/ci.yml
 ├── .gitignore
-├── biome.json
 ├── package.json              # root scripts only
-├── pnpm-workspace.yaml       # workspaces + catalog
-├── tsconfig.json             # extends infrastructure/typescript-config
+├── pnpm-workspace.yaml       # workspaces + catalog (or language equivalent)
 └── turbo.json
 ```
 
-Match the layout in [architecture.md](architecture.md) exactly. Omit folders for surfaces not requested.
-
 ### 4. Configure root tooling
-
-- `package.json` — `packageManager: "pnpm@<exact>"`, root scripts: `dev`, `build`, `test`, `test:changed`, `test:e2e`, `typecheck`, `lint`, `format`.
-- `pnpm-workspace.yaml` — workspaces `apps/*` and `packages/**/*`, catalog populated.
-- `turbo.json` — pipelines for `build`, `test`, `dev` (no cache for `dev`).
-- `biome.json` — 100-char width, double quotes, semicolons, ES5 trailing commas.
-- `tsconfig.json` — extends `@infrastructure/typescript-config/base.json`.
-- `.gitignore` — covers `node_modules`, `.next`, `.expo`, `.turbo`, `dist`, `.env*` (except `.env.example`).
+Set up workspace configuration files based on the chosen technologies:
+- **Build Orchestrator**: Configure `turbo.json` with pipeline tasks (`build`, `test`, `lint`, etc.).
+- **Formatting/Linting**: Install and configure Biome (or equivalent for other language ecosystems) at the root level.
+- **Gitignore**: Add a `.gitignore` that covers dependencies, caches, builds, and local `.env` files.
 
 ### 5. Scaffold infrastructure packages
-
-For each `@infrastructure/*` package:
-
-1. `package.json` with `name`, `private: true`, `exports`, `main` pointing at `src/index.ts`.
-2. `tsconfig.json` extending the relevant preset (`library`, `nextjs`, or `react-native`).
-3. `src/index.ts` re-exporting public surface.
-
-**Required infrastructure contents:**
-
-- `api-client` — `createApiClient<Router>(baseUrl)`, `createOrpcUtils(client)`, shared base Zod schemas.
-- `flags` — every `flag(...)` definition (Vercel Flags SDK), the shared `identify()` reading Supabase session, and the chosen adapter wiring. See [infrastructure.md#feature-flags](infrastructure.md#feature-flags). Scaffold this for every project regardless of surface mix — it is a standing package; leave the definitions empty (just `identify()` + adapter wiring) until the first flag is added.
-- `navigation` — `<Link>`, `useNavigation()`, `NavigationProvider`, platform-agnostic types.
-- `ui` — design tokens (`tokens.ts`), `cn()` helper, shared `globals.css` with theme.
-- `ui-web` — shadcn components shared across web apps; barrel exports.
-- `utils` — cross-platform helpers (no React, no Node-only APIs).
-- `typescript-config` — `base.json`, `library.json`, `nextjs.json`, `react-native.json`.
+For each required capability (Database client, Auth client, API client, Observability logger, Feature flags), create a wrapper package under `packages/infrastructure/` (e.g., `@infrastructure/db-client`, `@infrastructure/auth`). This encapsulates the vendor-specific SDK so features do not import them directly.
+Each package should contain:
+1. Native package manifest with `name`, exports, and entry point.
+2. Code wrapping the chosen SDK, exposing clean interfaces to features.
 
 ### 6. Scaffold apps
-
-Run framework CLIs for the requested surfaces. Then **strip generated boilerplate** that conflicts with the spec (e.g. default Next.js `app/page.tsx`, default Expo welcome screen) and replace with minimal placeholders.
-
-| App | Bootstrap command | Post-bootstrap edits |
-|---|---|---|
-| `web` | `pnpx create-next-app@latest --ts --app --tailwind --src-dir false` | Wire `<NavigationProvider>`, add `@source` for `ui-web`, enable React Compiler in `next.config.ts`. |
-| `landing` | Same as `web` | Same. |
-| `mobile` | `pnpx create-expo-app@latest` then add UniWind | Configure Metro for UniWind, hardcode theme HSL in `global.css`, add `<NavigationProvider>`. |
-| `api` | Manual: Hono + oRPC scaffold | `src/router.ts` exporting `Router`, `src/index.ts` running Hono on port `3001`. |
-
-Each app `package.json` references shared deps as `"catalog:"`.
+Determine the exact CLI bootstrap commands for the chosen stack (e.g., `npx create-next-app` for Next.js, `cargo new --bin` for Rust, `django-admin startproject` for Django, `uv init` for Python). 
+- Run the CLI tools in non-interactive mode inside the `apps/` subdirectories.
+- Strip away generated visual boilerplates, replacing them with minimal landing/health-check entry points.
+- Map the apps to the root workspace config.
 
 ### 7. Scaffold features (if any)
+For each initial feature in the inputs, create a directory under `packages/features/<feature>/`. 
+Organize code into clean sub-layers representing contracts, procedures/services, schemas, layouts, and components. Wire feature entry points into the main routing/API app.
 
-For each feature in the input:
-
-```
-packages/features/<feature>/
-├── src/
-│   ├── contracts/<feature>Contract.ts     # empty Zod schema stub
-│   ├── routers/<feature>ORPCRouter.ts     # empty router stub
-│   ├── procedures/                        # empty
-│   ├── components/                        # empty
-│   ├── surfaces/                          # empty
-│   ├── layouts/                           # empty
-│   └── schemas/                           # empty (internal domain schemas)
-├── package.json
-└── tsconfig.json
-```
-
-Wire the router into `apps/api/src/router.ts` if `api` is in the surfaces list.
-
-### 8. CI workflow
-
-Write `.github/workflows/ci.yml` per [infrastructure.md](infrastructure.md#cicd). Jobs: `biome ci`, `pnpm turbo build`, `pnpm test:changed`. Pin Node + pnpm versions. Do **not** add a `typecheck` job — it is a local-only script (step 4); CI relies on `build` to catch type errors. See [infrastructure.md](infrastructure.md#cicd).
+### 8. Configure CI/CD
+Write a generalized GitHub Actions configuration `.github/workflows/ci.yml` that triggers on pull requests targeting the integration branches. The workflow should checkout the code, install dependencies, run lints/formatters, run tests, and verify the build pipeline.
 
 ### 9. Verify
+Run the validation scripts to confirm the workspace is operational:
+- Install all dependencies.
+- Run typecheckers, formatters, and linters.
+- Build the entire monorepo.
+- Run tests.
+- Boot the applications in development mode and verify health checks/ports.
 
-Before declaring done:
-
-```bash
-pnpm install
-pnpm typecheck
-pnpm build
-pnpm test
-pnpm dev   # spot-check each app boots on its expected port
-```
-
-Fix every failure. A bootstrap that doesn't pass these isn't done.
-
-### 10. Initialize repo
-
-Run `/woostack-init` after `git init` so the project ships with a `.woostack/` workspace
-(memory store + index, `specs/`, `plans/`, `config.json`, `.gitignore`) committed from the
-start — the same workspace the build/review/address skills use.
-
-```bash
-git init
-```
-
-Then **invoke the `/woostack-init` skill** to scaffold the `.woostack/` workspace
-(memory/specs/plans/config). It is a skill, not a shell command — run it as an explicit
-step here, not as a line inside the block above. It is non-interactive on a fresh repo, so
-there are no conflicts to resolve. Once it has written `.woostack/`, finish the commit:
-
-```bash
-git add .
-git commit -m "chore: initial bootstrap from spec"
-gh repo create <project> --private --source=. --push
-```
-
-Add Vercel project link (`vercel link`) for any web/api surfaces. Pull initial env scaffold (`vercel env pull`).
+### 10. Initialize workspace
+Initialize git, run `/woostack-init` to set up the `.woostack/` workspace (memory store, specs, plans, config) so that subsequent agent sessions can run status, execute, and review tasks seamlessly. Commit the initial skeleton and push to the remote host.
 
 ### 11. Hand off
-
-Write a project-local `README.md` documenting:
-
-- Which surfaces were scaffolded
-- Any spec deviations and why
-- Run/build/test commands
-- Hosting + env setup status
-
-The project-local docs should **reference**, not duplicate, the spec. If a rule moves into the project's own context (e.g. an organization-wide override), document the divergence explicitly.
-
-## Maintenance
-
-When this spec changes:
-
-- New projects pick up changes at their next bootstrap.
-- Existing projects do **not** auto-update — treat spec changes as advisory upgrades they opt into.
-- Breaking changes to the spec (e.g. removing a required pattern) should bump the `SPEC_VERSION` recorded in [SKILL.md](../SKILL.md) so downstream projects can detect drift.
+Write a project-local `README.md` recording:
+- Scaffolded apps and packages.
+- Final stack decisions and why they were chosen.
+- Verification commands and dev instructions.

--- a/skills/woostack-bootstrap/references/patterns.md
+++ b/skills/woostack-bootstrap/references/patterns.md
@@ -8,20 +8,19 @@ Recommended patterns for projects bootstrapped from this spec. Each pattern is *
 
 **Structure:**
 - Contracts: `packages/features/<feature>/src/contracts/{feature}Contract.ts` — Zod schemas
-- Routers: `packages/features/<feature>/src/routers/{feature}ORPCRouter.ts` — oRPC router
-- Procedures: `packages/features/<feature>/src/procedures/` — business logic
-- Composition: `apps/api/src/router.ts` — imports feature routers, exports `Router` type
+- Services: `packages/features/<feature>/src/services/` — business logic and API handlers
+- Composition: `apps/api/src/router.ts` — imports feature services/handlers, exports `Router` type
 - Client utils: `@infrastructure/api-client` — `createApiClient`, `createOrpcUtils`
 
 **Example:**
 
 ```typescript
-// contracts/usersContract.ts
+// src/contracts/usersContract.ts
 import { z } from "zod";
 export const UserSchema = z.object({ id: z.string(), name: z.string() });
 export const CreateUserSchema = z.object({ name: z.string().min(1) });
 
-// routers/usersORPCRouter.ts
+// src/services/usersRouter.ts
 import { os } from "@orpc/server";
 import { UserSchema, CreateUserSchema } from "../contracts/usersContract";
 
@@ -36,7 +35,7 @@ export const usersRouter = {
 };
 
 // apps/api/src/router.ts
-import { usersRouter } from "@features/users/src/routers/usersORPCRouter";
+import { usersRouter } from "@features/users/src/services/usersRouter";
 export const router = { users: usersRouter };
 export type Router = typeof router;
 ```
@@ -106,24 +105,24 @@ Both consume the same theme from `@infrastructure/ui` (design tokens, `cn()` hel
 
 **Theme changes:** edit `@infrastructure/ui` (web tokens) and `apps/mobile/global.css` (mobile mirror). Keep both in sync — UniWind can't resolve `var()` indirection in `@theme`.
 
-## 6. Surface + Layout export pattern
+## 6. Component + Layout export pattern
 
 Features expose a public API through two folders only:
 
-- `surfaces/` — `*Surface.tsx` components (UI entry points)
-- `layouts/` — `*Layout.tsx` components (layout shells)
+- components/ — UI components (UI entry points)
+- layouts/ — Layout components (layout shells)
 
-Apps consume only these. Other folders (`components/`, `procedures/`, `schemas/`) are package-internal.
+Apps consume only these. Other folders (services/, schemas/) are package-internal.
 
-**Exemption:** `apps/api` may import a feature's `contracts/` and `routers/` for router composition.
+Exemption: apps/api may import a feature's contracts/ for router composition.
 
 ```typescript
 // apps/web/app/users/page.tsx
-import { UserListSurface } from "@features/users/src/surfaces/UserListSurface";
+import { UserList } from "@features/users/src/components/UserList";
 // ✓ allowed
 
-import { findUserById } from "@features/users/src/procedures/findUserById";
-// ✗ forbidden — procedures are internal
+import { findUserById } from "@features/users/src/services/findUserById";
+// ✗ forbidden — services are internal
 ```
 
 ## 7. Test-Driven Development


### PR DESCRIPTION
## Goal

Generalize the step-by-step bootstrap procedure and the monorepo slice architecture to accommodate any arbitrary technology stack.

## Summary

- Rewrite `skills/woostack-bootstrap/references/bootstrap.md` to use dynamic, stack-agnostic inputs, CLI commands, and root configs.
- Rewrite `skills/woostack-bootstrap/references/architecture.md` to define package layering (`Apps -> Features -> Infrastructure`) generically.
- Add specific guidance for structuring and orchestrating multi-language monorepos (e.g. using `cargo`/`uv` alongside Turborepo) in `architecture.md`.

## Test plan

### Manual

**Before merge**

- [ ] Inspect the updated `skills/woostack-bootstrap/references/bootstrap.md` file.
- [ ] Inspect the updated `skills/woostack-bootstrap/references/architecture.md` file.

Spec: .woostack/specs/2026-06-08-generic-woostack-bootstrap.md
