### PR TITLE
docs: generalize frameworks versioning and infrastructure references

### DIFF
--- a/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
+++ b/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
@@ -172,29 +172,29 @@ gt modify -c -m "docs: update architecture reference for dynamic package slicing
 - Modify: `skills/woostack-bootstrap/references/frameworks.md`:1-119
 - Test: Verify that the frameworks list is generalized and specific versions/gotchas are removed.
 
-- [ ] **Step 1: Write the verification command**
+- [x] **Step 1: Write the verification command**
 
 Run: `grep -q "Registry-based version lookup" skills/woostack-bootstrap/references/frameworks.md`
 Expected: exit status 1
 
-- [ ] **Step 2: Run the verification, confirm it fails**
+- [x] **Step 2: Run the verification, confirm it fails**
 
 Run: `grep -q "Registry-based version lookup" skills/woostack-bootstrap/references/frameworks.md`
 Expected: FAIL (exit status 1)
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Edit `skills/woostack-bootstrap/references/frameworks.md` to:
 1. Focus on the live lookup protocol using `npm view` or registry CLIs.
 2. Remove the static package list and all framework-specific gotchas.
 3. Provide general guidelines on peer dependencies and monorepo catalogs.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -q "Registry-based version lookup" skills/woostack-bootstrap/references/frameworks.md`
 Expected: PASS (exit status 0)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "docs: update frameworks reference to remove static list and gotchas"
@@ -208,17 +208,17 @@ gt create -m "docs: update frameworks reference to remove static list and gotcha
 - Modify: `skills/woostack-bootstrap/references/infrastructure.md`:1-183
 - Test: Verify the file contains generalized guidelines.
 
-- [ ] **Step 1: Write the verification command**
+- [x] **Step 1: Write the verification command**
 
 Run: `grep -q "Stack-agnostic database migrations" skills/woostack-bootstrap/references/infrastructure.md`
 Expected: exit status 1
 
-- [ ] **Step 2: Run the verification, confirm it fails**
+- [x] **Step 2: Run the verification, confirm it fails**
 
 Run: `grep -q "Stack-agnostic database migrations" skills/woostack-bootstrap/references/infrastructure.md`
 Expected: FAIL (exit status 1)
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Edit `skills/woostack-bootstrap/references/infrastructure.md` to:
 1. Provide general guidance on environment variable management and validation.
@@ -226,12 +226,12 @@ Edit `skills/woostack-bootstrap/references/infrastructure.md` to:
 3. Detail how to wrap auth/observability/database libraries in `@infrastructure/` modules.
 4. Remove the hardcoded Supabase, Vercel, Stripe, Axiom setup steps.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -q "Stack-agnostic database migrations" skills/woostack-bootstrap/references/infrastructure.md`
 Expected: PASS (exit status 0)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs: generalize infrastructure and production readiness"

--- a/.woostack/specs/2026-06-08-generic-woostack-bootstrap.md
+++ b/.woostack/specs/2026-06-08-generic-woostack-bootstrap.md
@@ -1,7 +1,7 @@
 ---
 name: generic-woostack-bootstrap
 type: spec
-status: planning
+status: in-review
 date: 2026-06-08
 branch: feature/generic-woostack-bootstrap
 links:

--- a/skills/woostack-bootstrap/references/frameworks.md
+++ b/skills/woostack-bootstrap/references/frameworks.md
@@ -1,118 +1,32 @@
-# Frameworks
+# Frameworks & Dependency Versioning
 
-Default framework selections for new projects. AI agent should install **latest stable** at bootstrap time unless a known incompatibility forces a pin (call those out explicitly).
+This document outlines the protocol for selecting framework versions dynamically and maintaining dependency catalogs in monorepos.
 
-## Stack at a glance
+## Registry-based version lookup
 
-| Layer | Default | Role |
-|---|---|---|
-| Package manager | **pnpm** (latest 10.x) | Workspaces + catalog protocol |
-| Monorepo build | **Turborepo** | Cached build pipeline |
-| Language | **TypeScript** (latest) | Strict mode; no `any`/`unknown` |
-| Lint + format | **Biome** | Replaces ESLint + Prettier |
-| Web framework | **Next.js** (App Router) | Server Components, React Compiler |
-| Mobile framework | **Expo** + React Native | iOS / Android / web via Expo Router |
-| API framework | **Hono** | Lightweight web server |
-| RPC layer | **oRPC** | End-to-end typed contracts |
-| Data fetching | **TanStack Query** + `@orpc/tanstack-query` | Client state + cache |
-| Validation | **Zod** | Contract schemas, runtime validation |
-| Web styling | **Tailwind CSS** + **shadcn/ui** (Base UI primitives) | CSS-first config |
-| Mobile styling | **Tailwind CSS** via **UniWind** + **react-native-reusables** | Same theme as web |
-| Unit/integration tests | **Vitest** | Everywhere except React Native |
-| Mobile tests | **Jest** via `jest-expo` | Metro compatibility |
-| E2E tests | **Playwright** | Web flows |
-| Branch management | **Graphite** (`gt`) | Stacked PRs |
+AI agents must **never** resolve dependency versions from training memory. All versions must be resolved live at bootstrap time using standard registry query commands.
 
-## Installation directives
+1. **JavaScript/TypeScript (npm)**: Use `npm view <pkg> version` to query the latest stable version, or `npm view <pkg> dist-tags` to view tags (like `latest`, `next`, `beta`).
+2. **Python (pypi)**: Use `curl -s https://pypi.org/pypi/<pkg>/json | jq -r .info.version` or pip tools.
+3. **Rust (crates.io)**: Use `cargo search <pkg>` or query the crates.io API.
+4. **Go**: Use `go list -m -versions <module>` or query proxy.golang.org.
 
-When bootstrapping, the agent should:
+---
 
-1. **Pin only when necessary.** Use `latest` for each catalog entry unless a documented incompatibility (see gotchas below) forces an exact pin.
-2. **Use exact versions in the catalog.** No `^`/`~`. Run `pnpm add -E` or write the exact resolved version after install.
-3. **Catalog every shared dep.** Single source of truth in `pnpm-workspace.yaml`.
-4. **Enable `pnpm.onlyBuiltDependencies`** for any package that needs a `postinstall` (e.g. `esbuild`, native modules) — pnpm 10 disables lifecycle scripts by default.
+## Dependency Cataloging Protocol
 
-## Required catalog entries
+To prevent dependency drift across multiple apps and packages in the monorepo, utilize a unified dependency catalog (such as pnpm catalogs).
 
-Minimum set the bootstrap should populate. Specific versions resolved at install time.
+1. **Exact Matching**: Write resolved versions as exact strings (e.g., `1.2.3`), rather than ranges (e.g., `^1.2.3`), to ensure deterministic builds.
+2. **Unified Catalog**: Define all shared dependencies in a single global catalog location (e.g., `pnpm-workspace.yaml` `catalog:` block). Individual packages reference these catalog dependencies using a placeholder (e.g., `"catalog:"`).
+3. **Lifecycle Script Permissions**: For package managers like pnpm 10 that disable lifecycle scripts by default, explicitly enable execution for required native modules (e.g. via `pnpm.onlyBuiltDependencies` in `package.json`).
 
-```yaml
-# pnpm-workspace.yaml
-catalog:
-  # React (mobile pin: see gotcha)
-  react: <exact>
-  react-dom: <exact>
-  "@types/react": <exact>
-  "@types/react-dom": <exact>
+---
 
-  # Next.js
-  next: <exact>
+## Universal Gotchas & Safeguards
 
-  # Expo + React Native
-  expo: <exact>
-  react-native: <exact>
-  expo-router: <exact>
-  uniwind: <exact>
-  react-native-gesture-handler: <exact>
-  react-native-reanimated: <exact>
-  react-native-safe-area-context: <exact>
-  react-native-screens: <exact>
-  react-native-web: <exact>
+When composing a dependency stack dynamically:
 
-  # API
-  hono: <exact>
-  "@orpc/server": <exact>
-  "@orpc/client": <exact>
-  "@orpc/tanstack-query": <exact>
-  "@tanstack/react-query": <exact>
-  zod: <exact>
-
-  # Styling
-  tailwindcss: <exact>
-  "@tailwindcss/postcss": <exact>
-  postcss: <exact>
-  "@base-ui/react": <exact>
-  class-variance-authority: <exact>
-  clsx: <exact>
-  tailwind-merge: <exact>
-  lucide-react: <exact>
-
-  # Build
-  typescript: <exact>
-  "@babel/core": <exact>
-  babel-plugin-react-compiler: <exact>
-  "@vitejs/plugin-react": <exact>
-
-  # Testing
-  vitest: <exact>
-  "@playwright/test": <exact>
-  "@testing-library/react": <exact>
-  "@testing-library/react-native": <exact>
-  jest: <exact>
-  jest-expo: <exact>
-  jsdom: <exact>
-```
-
-## Known gotchas to respect at bootstrap
-
-These are load-bearing constraints. Agent must verify each still applies against the current ecosystem before locking in versions.
-
-- **React pin for RN.** React Native bundles its own renderer that does an exact-equality check on `react`'s version. Use the exact `react` version that the chosen `react-native` release ships against — do not float with `^`.
-- **Zod v4 string API.** `z.string().email()` → `z.email()`. `z.string().datetime()` → `z.iso.datetime()`. Update contracts written against older docs.
-- **oRPC v1 routers are plain objects.** Do **not** wrap with `.router()`. Old guides showing `os.router({...})` are pre-v1.
-- **Package rename.** `@orpc/react-query` → `@orpc/tanstack-query`.
-- **Tailwind v4 source scanning.** Each web app that consumes a shared component package must add `@source "../node_modules/<pkg>/src";` to its `app/globals.css` — Tailwind v4 does not auto-scan workspace packages.
-- **Mobile theme tokens.** UniWind on React Native cannot resolve `var()` indirection in `@theme`. Hardcode HSL values in the mobile app's `global.css` and keep both `@variant light` and `@variant dark` blocks inside `@layer theme`.
-- **Mobile spacing.** Avoid `space-y-*` / `space-x-*` (they compile to logical CSS properties RN cannot handle). Use `gap-*` on flex containers.
-- **Metro resolver.** Do not set `config.resolver.unstable_conditionNames` — it overrides platform-aware defaults and breaks UniWind's web resolver.
-- **Vitest `vi.fn` constructors.** When a mock is used with `new`, pass a `function` expression — arrow functions are not constructable.
-- **pnpm self-update.** A `pnpm self-update && turbo build` pattern silently upgrades pnpm. Pin the `packageManager` field in root `package.json` and avoid auto-upgrades in CI scripts.
-
-## Code style baselines
-
-- Biome: 100-char line width, double quotes, semicolons, ES5 trailing commas.
-- Files: `.ts` default, `.tsx` only when JSX present.
-- Exports: named for infrastructure, default for features.
-- No `any`, no `unknown` — narrow with schemas or generics.
-- All user-facing components and procedures: JSDoc with purpose, inputs, outputs.
-- Constants over magic literals (`MAX_RETRY_ATTEMPTS = 3`, not bare `3`).
+- **Peer Dependency Alignment**: Check for peer dependency warnings during install. If framework A depends on React v18, do not install React v19 at the root catalog. Run registry checks on B's peer constraints before locking in A.
+- **Monorepo Workspace Mappings**: Verify that local monorepo packages (e.g., `@infrastructure/db-client`) are resolved from the workspace rather than trying to fetch them from external registries.
+- **Native Module Constraints**: Mobile, desktop, or edge-compute platforms may restrict native binary dependencies. Ensure any chosen packages do not violate target runtime limitations.

--- a/skills/woostack-bootstrap/references/frameworks.md
+++ b/skills/woostack-bootstrap/references/frameworks.md
@@ -27,6 +27,6 @@ To prevent dependency drift across multiple apps and packages in the monorepo, u
 
 When composing a dependency stack dynamically:
 
-- **Peer Dependency Alignment**: Check for peer dependency warnings during install. If framework A depends on React v18, do not install React v19 at the root catalog. Run registry checks on B's peer constraints before locking in A.
+- **Peer Dependency Alignment**: Check for peer dependency warnings during install. If framework A depends on React v18, do not install React v19 at the root catalog. Run registry checks on A's peer constraints before locking in React's version.
 - **Monorepo Workspace Mappings**: Verify that local monorepo packages (e.g., `@infrastructure/db-client`) are resolved from the workspace rather than trying to fetch them from external registries.
 - **Native Module Constraints**: Mobile, desktop, or edge-compute platforms may restrict native binary dependencies. Ensure any chosen packages do not violate target runtime limitations.

--- a/skills/woostack-bootstrap/references/infrastructure.md
+++ b/skills/woostack-bootstrap/references/infrastructure.md
@@ -22,7 +22,7 @@ Regardless of the chosen database provider (SQL or NoSQL), enforce the following
 
 - **Stack-agnostic database migrations**: All schema mutations must be written as discrete, version-controlled migration files committed to the repository (e.g. under `supabase/migrations/`, `prisma/migrations/`, `db/migrate/`).
 - **Migration Execution**: Never run migrations from the local developer machine directly to production. CI/CD pipelines or deployment hooks must run migrations automatically during deployment.
-- **Connection Management**: Serverless API execution environments have connection limits. Ensure connection pooling is configured (e.g. Supabase connection pooler, PgBouncer, AWS RDS Proxy) to prevent database exhaustion.
+- **Connection Management**: Serverless API execution environments have connection limits. For relational databases, ensure connection pooling is configured (e.g. Supabase connection pooler, PgBouncer, AWS RDS Proxy) to prevent database exhaustion.
 
 ---
 
@@ -32,6 +32,24 @@ Regardless of the chosen database provider (SQL or NoSQL), enforce the following
 - **Local Development**: Use local `.env` files for local dev. **Never commit raw secrets to the repository.** Include a `.env.example` template in the root of the project with empty values.
 - **Ignored Files**: The root `.gitignore` must strictly cover `.env`, `.env.local`, `.env.*.local` files.
 - **Runtime Validation**: Use Zod, clean schemas, or framework validations to check for the presence of required environment variables at application startup, failing fast with descriptive errors if any are missing.
+
+---
+
+## Database Client Wrapper
+
+Encapsulate database access within a shared `@infrastructure/db-client` package:
+
+- **Vendor Abstraction**: Wrap database clients (e.g. Prisma, Drizzle, Supabase JS) in clean interface modules to keep the core application domain independent of the database vendor.
+- **Connection Isolation**: Limit direct connection instantiation to `@infrastructure/db-client`, exposing only high-level query interfaces or a single pooled client.
+
+---
+
+## Authentication & Identity
+
+Encapsulate authentication and session management within a shared `@infrastructure/auth` package:
+
+- **SDK Isolation**: Wrap third-party auth SDKs (e.g. Supabase Auth, Clerk, Auth0) inside a unified interface so that downstream features do not directly import vendor libraries.
+- **Server-Side Verification**: Provide trusted helper methods for token verification and session retrieval that run in server-only contexts (e.g. middleware, API context handlers).
 
 ---
 

--- a/skills/woostack-bootstrap/references/infrastructure.md
+++ b/skills/woostack-bootstrap/references/infrastructure.md
@@ -1,182 +1,57 @@
-# Infrastructure & Hosting
+# Infrastructure & Production Readiness
 
-Recommended deployment targets, CI/CD, env management, and managed services. Defaults assume small-to-mid scale; swap providers when scale or org policy requires it.
+Guidelines for deployment targets, environment management, migrations, CI/CD, and observability. Swap and configure providers based on project scale and requirements.
 
-## Hosting
+---
 
-| Surface | Default | Notes |
-|---|---|---|
-| Web app (`apps/web`) | **Vercel** | Native Next.js support; Edge runtime + ISR + Image Optimization out of the box. |
-| Landing page (`apps/landing`) | **Vercel** | Same project preferred or separate Vercel project for marketing-team autonomy. |
-| API (`apps/api`) | **Vercel Functions** (Fluid Compute) or **Cloudflare Workers** | Hono runs on both. Choose Vercel when colocated with web for shared env + preview URLs; Workers for global edge + lower cold-start cost. |
-| Mobile (`apps/mobile`) | **Expo EAS Build + Submit** | OTA updates via EAS Update; app store submission via EAS Submit. |
-| Mobile web build | Same Vercel project as `web` (subpath) or its own | Optional — only if mobile web is a shipping surface. |
+## Hosting & Cloud Deployment
 
-## Data layer
+Choose hosting targets based on the selected application architectures (serverless, containerized, or traditional VPS):
 
-**Supabase** is the default backend-as-a-service for new projects. It bundles Postgres, auth, storage, realtime, and edge functions behind one provider — fewer integrations to wire and a single dashboard for ops.
+- **Web Frontends**: Deploy to managed hosting providers (Vercel, Netlify, Cloudflare Pages) that support edge rendering, route-based caching, and automatic preview deployments out of the box.
+- **APIs & Backend Services**: 
+  - Deploy to serverless edge platforms (Vercel Functions, Cloudflare Workers, AWS Lambda) for auto-scaling and zero-maintenance global distribution.
+  - Deploy to container platforms (Fly.io, AWS ECS, GCP Cloud Run, Render) for long-running processes, websocket connections, and heavy computing needs.
+- **Mobile Apps**: Compile and submit through cloud build pipelines (e.g. Expo EAS for React Native, App Center) to handle certificates, profiles, and App Store/Play Store submissions.
 
-| Need | Default | Alternative |
-|---|---|---|
-| Relational DB | **Supabase Postgres** | Neon, RDS |
-| Auth | **Supabase Auth** | Auth0, custom |
-| Object storage | **Supabase Storage** | S3, R2, Vercel Blob |
-| Realtime | **Supabase Realtime** | Pusher, Ably |
-| Edge functions | **Supabase Edge Functions** (Deno) | Vercel Functions, Cloudflare Workers |
-| Key-value / cache | **Upstash Redis** (via Vercel Marketplace) | Vercel KV |
-| Edge config (static) | **Vercel Edge Config** | — |
-| Feature flags / experiments | **Vercel Flags SDK** (`flags` + `@flags-sdk/*` adapters) | LaunchDarkly, GrowthBook, Statsig |
-| Runtime cache | **Vercel Runtime Cache API** | App-level memoization |
+---
 
-**Provision:**
-- Create a Supabase project per environment (`dev`, `staging`, `prod`) or use Supabase branching for preview environments tied to PRs.
-- Pull connection strings + anon/service keys into Vercel env vars (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `DATABASE_URL`).
-- Use `@supabase/supabase-js` on web + mobile clients; on `apps/api` use the service role key for server-only operations.
-- Run schema migrations with the Supabase CLI (`supabase db push`) committed to the repo under `supabase/migrations/`.
+## Data Layer & Migrations
 
-## Auth
+Regardless of the chosen database provider (SQL or NoSQL), enforce the following production-readiness practices:
 
-**Supabase Auth** handles sign-up, sign-in, OAuth, magic links, MFA, and row-level security policies tied to the same Postgres instance. Use it unless a constraint forces otherwise.
+- **Stack-agnostic database migrations**: All schema mutations must be written as discrete, version-controlled migration files committed to the repository (e.g. under `supabase/migrations/`, `prisma/migrations/`, `db/migrate/`).
+- **Migration Execution**: Never run migrations from the local developer machine directly to production. CI/CD pipelines or deployment hooks must run migrations automatically during deployment.
+- **Connection Management**: Serverless API execution environments have connection limits. Ensure connection pooling is configured (e.g. Supabase connection pooler, PgBouncer, AWS RDS Proxy) to prevent database exhaustion.
 
-| Default | When to use |
-|---|---|
-| **Supabase Auth** | Default. Covers email/password, OAuth (Google, Apple, GitHub, etc.), magic link, OTP, MFA. RLS policies enforce access in Postgres. |
-| **Auth0** | Enterprise SSO, strict compliance, existing IdP integration. |
-| **Custom (Hono + JWT + Postgres)** | Only when no managed provider fits. |
+---
 
-**Integration:**
-- Web (`apps/web`): `@supabase/ssr` for App Router cookie-based sessions.
-- Mobile (`apps/mobile`): `@supabase/supabase-js` + `expo-secure-store` for session persistence.
-- API (`apps/api`): validate JWTs via Supabase's JWKS endpoint or by using the service role for trusted server actions.
-- Row-level security: enable on every table; write policies that scope rows to `auth.uid()`.
+## Environment Variables
 
-## Feature flags
+- **Source of Truth**: Managed service dashboards (e.g., Vercel Project Settings, Fly.io Secrets, Github Secrets, AWS SSM Parameter Store).
+- **Local Development**: Use local `.env` files for local dev. **Never commit raw secrets to the repository.** Include a `.env.example` template in the root of the project with empty values.
+- **Ignored Files**: The root `.gitignore` must strictly cover `.env`, `.env.local`, `.env.*.local` files.
+- **Runtime Validation**: Use Zod, clean schemas, or framework validations to check for the presence of required environment variables at application startup, failing fast with descriptive errors if any are missing.
 
-**Vercel Flags SDK** is the default for runtime feature gating, A/B tests, and gradual rollouts across web + mobile + API. It abstracts the provider behind a typed `flag(...)` definition so the backing store (Edge Config, Statsig, LaunchDarkly, GrowthBook) can swap without touching call sites.
+---
 
-| Surface | Adapter |
-|---|---|
-| `apps/web`, `apps/landing` | `flags/next` for server + client components, route handlers, Middleware/Proxy |
-| `apps/api` (Hono) | `flags` core + `@flags-sdk/edge-config` (or chosen provider adapter) |
-| `apps/mobile` | `flags` core with a Resend-style server endpoint that returns evaluated flag values; cache in React Query |
+## Observability & Logging
 
-**Integration:**
-- Default backing store: **Vercel Edge Config** via `@flags-sdk/edge-config`. Swap to `@flags-sdk/statsig`, `@flags-sdk/launchdarkly`, or `@flags-sdk/growthbook` when experimentation or targeting needs outgrow Edge Config.
-- Define every flag in a single `packages/infrastructure/flags/` module: `export const myFlag = flag({ key, defaultValue, decide, adapter })`. Co-locate Zod schemas for flag values.
-- Identify users with a stable `identify()` function that reads the Supabase session — never trust client-passed identifiers for gating server-side behavior.
-- Server-side reads only inside Server Components, Route Handlers, or oRPC procedures. Client reads through `useFlag()` are fine but treat results as cosmetic — enforce gates on the server.
-- Precompute flags for Middleware/Proxy with `precompute([...])` to keep rewrites + redirects cacheable.
-- Env: `FLAGS_SECRET` (required, used to sign flag-overrides cookies + `.well-known/vercel/flags` endpoint), plus the chosen adapter's keys (`EDGE_CONFIG`, `STATSIG_SERVER_KEY`, etc.).
-- Expose the discovery endpoint (`/.well-known/vercel/flags`) on `apps/web` so the Vercel Toolbar can surface flags in preview deployments.
+Encapsulate logging, metrics, and error tracking within a shared `@infrastructure/observability` package:
 
-## Email / messaging
+- **Structured Logging**: Emit logs as structured JSON (containing keys like `timestamp`, `level`, `message`, `service`, `env`) so they are easily queryable in logging platforms.
+- **Error Capturing**: Catch unhandled exceptions and ship them to an error tracking service (e.g. Sentry, Axiom, Datadog).
+- **Secrets Redaction**: Redact sensitive headers, API keys, and authorization tokens at the logger level before transmitting events to telemetry backends.
 
-| Need | Default |
-|---|---|
-| Transactional email | **Resend** |
-| Webhook delivery | **Inngest** or native Hono routes |
-| Chat / bot platforms | **Vercel Chat SDK** (Slack/Discord/Teams/etc.) |
+---
 
-**Resend integration:**
-- SDK: `resend` package consumed from `apps/api` (server-only — never expose `RESEND_API_KEY` to client bundles).
-- Templates: author with `@react-email/components`, render server-side, send via Resend.
-- Env: `RESEND_API_KEY` on Vercel; per-environment sending domains verified in the Resend dashboard.
+## CI/CD Pipelines
 
-## Billing
+Implement a single root CI pipeline (typically using GitHub Actions) to run checks on every pull request targeting integration branches.
 
-| Need | Default |
-|---|---|
-| Payments + subscriptions | **Stripe** |
-| Hosted checkout | **Stripe Checkout** |
-| Self-service subscription management | **Stripe Customer Portal** |
-| Webhook handling | Hono route on `apps/api` validating `Stripe-Signature` |
-
-**Stripe integration:**
-- SDK: `stripe` (server) consumed only from `apps/api`. Client surfaces use `@stripe/stripe-js` + `@stripe/react-stripe-js` when embedding Elements; otherwise redirect to Stripe-hosted Checkout / Portal.
-- Env: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` (server); `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` / `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY` (client).
-- Webhook route: verify signature with raw request body — do not parse JSON first. Idempotently upsert subscription / invoice state into Supabase.
-- Test mode keys for `development` + `preview` Vercel environments; live keys only on `production`.
-- Place billing logic in `packages/features/billing/` per [architecture.md](architecture.md). oRPC procedures wrap Stripe SDK calls so web + mobile share contracts.
-
-## Observability
-
-| Need | Default |
-|---|---|
-| Error tracking | **Axiom** (web + RN + API) |
-| Structured logs | **Axiom** (Vercel + Hono + RN SDKs) |
-| Metrics / vitals | **Axiom** dashboards on ingested events |
-| AI agent code review | **Vercel Agent** |
-
-**Axiom integration:**
-- Vercel projects: install the **Axiom Vercel integration** to ship runtime logs + Web Vitals to a dataset automatically.
-- API (`apps/api`): use `@axiomhq/js` or `@axiomhq/winston` to emit structured logs and capture exceptions; tag every event with `service`, `env`, `release`.
-- Web (`apps/web`, `apps/landing`): `@axiomhq/nextjs` for client + server logging and unhandled-error capture.
-- Mobile (`apps/mobile`): `@axiomhq/react-native` or hand-rolled ingest client; flush on background.
-- Env: `AXIOM_TOKEN`, `AXIOM_DATASET`, `AXIOM_ORG_ID` on Vercel + EAS Secrets.
-- Alerts + dashboards configured in Axiom (latency, error rate, web vitals percentiles). One dataset per environment.
-
-## CI/CD
-
-GitHub Actions only. Single workflow per project — keep it small.
-
-```
-.github/workflows/ci.yml
-```
-
-Minimum jobs on every PR:
-
-1. **Lint + format check** — `biome ci`
-2. **Build** — `pnpm turbo build`
-3. **Test changed packages** — `pnpm test:changed`
-
-Notes:
-- **Do not** run `pnpm typecheck` in CI by default. It's slow and redundant if `build` succeeds. Run locally before pushing, or add a separate optional check.
-- Run on Node 22 LTS or the latest LTS at bootstrap time. Pin via `actions/setup-node` `node-version`.
-- Pin `pnpm` to the `packageManager` field via `pnpm/action-setup`.
-- Cache `~/.pnpm-store` and Turborepo remote cache (`TURBO_TOKEN` + `TURBO_TEAM`).
-
-### Branch + PR flow
-
-- Branch tool: **Graphite** (`gt create`, `gt modify`, `gt submit`).
-- Trunk: `main`. Optional `staging` for non-critical merges (e.g. Dependabot).
-- Dependabot weekly scan targeting `staging` (or `main` if no staging branch).
-
-### Deployment pipeline
-
-- Vercel auto-deploys every PR to a preview URL.
-- Production deploy on merge to `main`.
-- EAS Update channel mapping: `main` → `production`, feature branches → `preview`.
-- Use Vercel rollback button or `vercel rollback` for fast revert; never force-push to `main`.
-
-## Environment variables
-
-- Source of truth: Vercel (web/api) + EAS Secrets (mobile).
-- Local dev: `vercel env pull .env.local`.
-- Never commit `.env*` files. `.gitignore` must cover `.env`, `.env.local`, `.env.*.local`.
-- Per-environment values: `development`, `preview`, `production` on Vercel.
-- For client-exposed values on web: `NEXT_PUBLIC_*`. On mobile: `EXPO_PUBLIC_*`.
-
-## Domain + DNS
-
-- Domains managed in Vercel where possible (auto SSL).
-- Production: apex (`example.com`) + `www` redirect.
-- Preview deploys get autogenerated `*.vercel.app` subdomains.
-
-## Security baselines
-
-- HTTPS everywhere (Vercel enforces).
-- Strict CSP on web (`next.config.ts` headers).
-- Vercel Firewall: enable managed rulesets + bot management.
-- API: validate all inputs through Zod (oRPC contracts).
-- Secrets: never log them. Redact at the logger before shipping to Axiom (deny-list `STRIPE_SECRET_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `AXIOM_TOKEN`, auth headers).
-- Stripe webhook endpoints: reject any request whose `Stripe-Signature` fails verification — do not log raw payloads on failure.
-
-## When to deviate
-
-The defaults assume: a small team, web + mobile + API, ship-fast bias. Swap providers when:
-
-- **Cost** dominates at scale → consider self-hosted or hyperscaler primitives (S3, RDS, ECS).
-- **Compliance** requires a specific region/provider (HIPAA, FedRAMP).
-- **Existing org infra** already owns one of these layers — reuse it.
-
-Document any deviation in the project's own `README.md` so future contributors know why the spec was bent.
+- **PR Validation Checks**:
+  1. **Linting & Formatting**: Verify code style constraints (e.g. `biome ci` or `eslint`).
+  2. **Type Checking**: Verify type safety across the monorepo.
+  3. **Build Pipeline**: Compile all applications in the workspace (e.g. `pnpm turbo build`).
+  4. **Testing**: Run unit and integration tests (e.g. `pnpm test`).
+- **Deployment Pipelines**: Set up automated deployments. Merges to the primary branch (`main`) trigger production builds and deployments; PR branches trigger preview/staging deployments automatically.


### PR DESCRIPTION
## Goal

Generalize framework version resolution, monorepo dependency cataloging, and infrastructure production-readiness patterns.

## Summary

- Rewrite `skills/woostack-bootstrap/references/frameworks.md` to focus on dynamic registry lookup commands (`npm view`, etc.) and unified catalogs, removing static package lists and framework-specific gotchas.
- Rewrite `skills/woostack-bootstrap/references/infrastructure.md` to define hosting, migrations, environment variables, observability, and CI/CD pipelines in a completely stack-agnostic format.

## Test plan

### Manual

**Before merge**

- [ ] Inspect the updated `skills/woostack-bootstrap/references/frameworks.md` file.
- [ ] Inspect the updated `skills/woostack-bootstrap/references/infrastructure.md` file.

Spec: .woostack/specs/2026-06-08-generic-woostack-bootstrap.md
