### PR TITLE
fix(review): keep doc-only diffs reviewable and place OUTDIR in workspace tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,7 @@ pnpm-debug.log*
 .woostack/visuals/
 # woostack: per-run overnight execution reports (regenerated each run)
 .woostack/overnight/
+# woostack: temporary review artifacts
+.woostack/tmp/
 # Claude Code scheduling runtime lock (generated, not source)
 .claude/scheduled_tasks.lock

--- a/skills/woostack-review/scripts/prefetch.sh
+++ b/skills/woostack-review/scripts/prefetch.sh
@@ -432,7 +432,8 @@ if [ -n "$INCREMENTAL_USED" ] && [ "$DIFF_BYTES" -lt 50 ]; then
   emit_skip "no new commits since last review ($INCREMENTAL_USED)"
 fi
 
-if [ "$CODE_FILES" -eq 0 ]; then
+HAS_SKILL_OR_DOC=$(jq -r '.files[].path' "$OUTDIR/meta.json" 2>/dev/null | grep -E '\.md$' | wc -l || echo 0)
+if [ "$CODE_FILES" -eq 0 ] && [ "$HAS_SKILL_OR_DOC" -eq 0 ]; then
   emit_skip "no code files changed"
 fi
 

--- a/skills/woostack-review/scripts/resolve-outdir.sh
+++ b/skills/woostack-review/scripts/resolve-outdir.sh
@@ -15,7 +15,13 @@
 if [ -z "${OUTDIR:-}" ]; then
   _wr_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   _wr_hash="$(printf '%s' "$_wr_root" | { sha1sum 2>/dev/null || shasum; } | cut -c1-12)"
-  OUTDIR="/tmp/pr-review-${_wr_hash}"
+  # Place inside the workspace's .woostack/tmp/ directory to leverage pre-approved
+  # workspace permissions and avoid sandbox permission prompt loops locally.
+  if [ -d "${_wr_root}/.woostack" ]; then
+    OUTDIR="${_wr_root}/.woostack/tmp/pr-review-${_wr_hash}"
+  else
+    OUTDIR="/tmp/pr-review-${_wr_hash}"
+  fi
   unset _wr_root _wr_hash
 fi
 export OUTDIR


### PR DESCRIPTION
## Goal

Make `woostack-review` usable on this skills-collection repo: doc-only/SKILL.md diffs were being skipped as "no code files," and the `/tmp` OUTDIR triggered sandbox permission prompt loops locally.

## Summary

- `prefetch.sh`: don't emit "no code files changed" when the diff contains Markdown (`*.md`, including `SKILL.md`) files, so doc/skill-only PRs still get reviewed
- `resolve-outdir.sh`: when a `.woostack/` workspace exists, place OUTDIR under `.woostack/tmp/pr-review-<hash>` to reuse pre-approved workspace permissions; fall back to `/tmp` otherwise
- `.gitignore`: ignore `.woostack/tmp/` (regenerated review artifacts)

## Test plan

### Automated

- [ ] `bash -n skills/woostack-review/scripts/prefetch.sh` — passed (syntax OK)

### Manual

**Before merge**

- [ ] Run `/woostack-review` on a branch whose diff is Markdown-only and confirm it is NOT skipped with "no code files changed"
- [ ] Confirm OUTDIR resolves to `<repo>/.woostack/tmp/pr-review-<hash>` inside a woostack workspace and to `/tmp/pr-review-<hash>` outside one
- [ ] Confirm `.woostack/tmp/` is git-ignored (`git status` stays clean after a review run)
