### PR TITLE
docs: add spec and plan for woostack-dream

### DIFF
--- a/.woostack/plans/2026-06-09-woostack-dream.md
+++ b/.woostack/plans/2026-06-09-woostack-dream.md
@@ -1,0 +1,257 @@
+**Source:** .woostack/specs/2026-06-09-woostack-dream.md
+
+# woostack-dream Skill Implementation Plan
+
+**Goal:** Create the `woostack-dream` skill — an agent-agnostic memory & docs curation pass over the `.woostack/` store — and wire it in as the sixteenth public command.
+
+**Architecture:** Two stacked Graphite increments. (1) Author `skills/woostack-dream/SKILL.md`: the self-contained five-phase skill (gather → synthesize → hard gate → apply → summarize/iterate) reusing the existing `woostack-init/scripts/` primitives; independently shippable and correct on its own. (2) Surface wiring: register the command in `using-woostack`, `AGENTS.md` (= `.claude/CLAUDE.md` symlink), and `README.md`, updating every fifteen→sixteen count for consistency. No new scripts, no memory-contract change.
+
+**Tech Stack:** Markdown, Bash (grep/test verification), Git, Graphite.
+
+> No test runner ships in this repo (skill markdown only). Per the [woostack-tdd](../../skills/woostack-tdd/SKILL.md) no-runner carve-out, each "failing test" step is a concrete `grep`/`test` verification with exact expected output: assert-it-fails (red) before authoring, assert-it-passes (green) after.
+
+---
+
+## Increment 1: Author the woostack-dream skill
+
+> One independently shippable PR — its own Graphite branch. The skill is complete and correct before any wiring; wiring is Increment 2.
+
+### Task 1: Create `skills/woostack-dream/SKILL.md`
+
+**Files:**
+- Create: `skills/woostack-dream/SKILL.md`
+
+- [ ] **Step 1: Red — assert the skill file is absent**
+
+Run: `test -f skills/woostack-dream/SKILL.md && echo EXISTS || echo MISSING`
+Expected: `MISSING`
+
+- [ ] **Step 2: Write `skills/woostack-dream/SKILL.md`**
+
+Author the file with this exact frontmatter:
+
+```markdown
+---
+name: woostack-dream
+description: Use to curate the .woostack/ knowledge store — an agent-agnostic version of managed "dreams". Reflects over the static memory store + docs (no session mining), then proposes a gated changeset that merges duplicate notes, replaces stale/contradicted ones, drops dead/orphaned notes, resolves conflicts, surfaces consolidated insights, and recommends evidence-guarded documentation edits. Nothing mutates before explicit approval; ends on a summary + iterate loop. Local-only memory (no commit); doc edits land in the working tree. Never commits or merges. Invoke via /woostack-dream [instructions].
+---
+```
+
+Then the body — write each section with complete prose (no placeholders):
+
+1. **Title + framing** — `# woostack-dream`, then: agent-agnostic, lo-fi analog of Anthropic's managed Dreams; reflects over the *static* store + docs (deterministic, repeatable), never session transcripts or the live conversation. Standalone maintenance command, **not** a `woostack-build` phase. It is the agentic synthesis + apply layer on top of `doctor.sh`'s mechanical lint.
+
+2. **`## Command`** — `/woostack-dream [instructions]`. The optional free-text `instructions` argument steers synthesis focus (e.g. `"focus on API conventions; ignore one-off gotchas"`), applied throughout — mirroring Dreams' `instructions`. No argument = curate the whole store.
+
+3. **`## Procedure`** — five `### Phase N — <name>` subsections:
+   - **Phase 1 — Gather (read-only).** If `.woostack/memory/` exists, run [`doctor.sh`](../woostack-init/scripts/doctor.sh) and capture its warnings (overlap clusters, stale provenance, orphaned scope, dead notes, missing provenance, non-glob trivia), then read `memory/MEMORY.md` + every note body. Always read the flat `.woostack/memory.md`. Enumerate the doc surface with `git ls-files '*.md'` (tracked-only — gitignored memory and `node_modules` excluded); exclude `.woostack/specs|plans|fixes/*.md` from the promotion-**target** set (provenance inputs, not promotion targets). Read recent `git log` and the spec/plan/fix a note's `source:` points at to ground stale-vs-current judgments. Honor the optional `instructions` steer. Cross-link the memory contract [`../woostack-init/references/memory.md`](../woostack-init/references/memory.md).
+   - **Phase 2 — Synthesize the "dream" (read-only).** Produce a changeset of discrete, labeled ops — enumerate **merge** (collapse duplicate/fuzzy-near-dupe notes; survivor keeps union of scopes + most specific provenance; rewrite inbound `[[wikilinks]]` via [`graph.sh`](../woostack-init/scripts/graph.sh) `--backlinks` to the survivor), **replace** (rewrite contradicted/stale note to latest value; preserve `source:`), **drop** (dead + orphaned-scope notes; rewrite/remove inbound links; **gitignored ⇒ unrecoverable**), **resolve** (adjudicate each `doctor.sh` overlap cluster; when you cannot confidently decide, **flag for the user — never guess**), **surface** (consolidate a recurring pattern into one new note; `source:` derived from contributing notes, never fabricated; must pass the memory-contract §7 distillation reject-by-default gate), and **doc recommendation** (promote a convention or fix a contradicted claim; **evidence guard:** cite the backing memory note — no note → no doc edit). State that the pass is **idempotent**.
+   - **Phase 3 — Review gate (HARD).** Present the complete changeset in conversation as before/after; each **drop shows the full note body** (unrecoverable once applied); each un-adjudicable conflict is **flagged for the user**; each doc edit shows a diff with its backing note cited. **Nothing has mutated.** Require explicit approval — silence/ambiguity is not approval (honor the project's approval-gate discipline). For a large changeset offer a [`woostack-visualize`](../woostack-visualize/SKILL.md) render (audience `engineer`) as a reading aid; the changeset still lives in conversation, not a separate artifact.
+   - **Phase 4 — Apply (on approval).** Memory: rewrite/delete the affected note files in place → run [`build-index.sh`](../woostack-init/scripts/build-index.sh) to regenerate `MEMORY.md` → re-run `doctor.sh` and confirm clean (report residual warnings, especially unresolved `[[wikilinks]]`). Docs: write the approved edits to the working tree (uncommitted).
+   - **Phase 5 — Summarize & iterate.** Report what changed (notes merged/replaced/dropped/added, conflicts resolved, doc edits applied). Invite change requests; on a request, return to Phase 3/4 and re-summarize. When done: memory changes are already local-only (no commit); for the working-tree doc edits, offer to hand off to [`woostack-commit`](../woostack-commit/SKILL.md). Never commit or merge here.
+
+4. **`## Degradation`** — scoped store → use the scripts; flat `memory.md` only → state the fallback and curate the flat file with bullet-level dedupe/replace/drop (no scope/index/doctor machinery); no `.woostack/` → stop, nothing to curate, do not scaffold (defer to `/woostack-init`); scripts missing (individual install) → announce manual fallback per memory-contract §10, do recall/lint by hand, never fail silently.
+
+5. **`## Hard constraints`** — bullets: non-destructive before the gate; explicit approval required (silence ≠ yes); memory local-only (no commit), doc edits working-tree only; never commits, pushes, or merges; doc edits evidence-guarded; dropped notes shown full-body at the gate; inbound-link integrity on merge/drop; idempotent; reuse existing scripts — add no new script, do not change the memory contract; not part of the gated build chain.
+
+Keep cross-links relative and correct: `../woostack-init/scripts/{doctor,build-index,graph,recall,scope-match}.sh`, `../woostack-init/references/memory.md`, `../woostack-visualize/SKILL.md`, `../woostack-commit/SKILL.md`.
+
+- [ ] **Step 3: Green — assert the file exists with valid frontmatter**
+
+Run: `test -f skills/woostack-dream/SKILL.md && head -3 skills/woostack-dream/SKILL.md | grep -c '^name: woostack-dream$'`
+Expected: `1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt create -m "feat: add woostack-dream skill"
+```
+
+### Task 2: Structural verification of the skill
+
+**Files:**
+- Verify: `skills/woostack-dream/SKILL.md`
+
+- [ ] **Step 1: Assert the five phases are present** (covers AC1)
+
+Run: `grep -cE '^### Phase [1-5] ' skills/woostack-dream/SKILL.md`
+Expected: `5`
+
+- [ ] **Step 2: Assert gate / non-destructive / no-commit / degradation / instructions language** (covers AC2, AC5, AC6, AC1-edge)
+
+Run:
+```bash
+for p in 'instructions' 'approval' 'evidence guard' 'doctor.sh' 'build-index.sh' 'never commit' 'local-only' 'Degradation' 'idempotent' 'unrecoverable'; do
+  grep -qi "$p" skills/woostack-dream/SKILL.md && echo "OK: $p" || echo "MISSING: $p"
+done
+```
+Expected: every line prints `OK: …` (no `MISSING:`).
+
+- [ ] **Step 3: Assert all relative cross-links resolve** (covers AC9 link-integrity intent — no dangling links)
+
+Run:
+```bash
+d=skills/woostack-dream
+grep -oE '\]\(\.\./[^)]+\)' "$d/SKILL.md" | sed -E 's/^\]\(//; s/\)$//' | while read -r rel; do
+  tgt="$d/${rel%%#*}"
+  [ -e "$tgt" ] && echo "OK: $rel" || echo "BROKEN: $rel"
+done
+```
+Expected: every referenced path prints `OK:` (no `BROKEN:`).
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+# only if Steps 1-3 surfaced a fix; otherwise skip
+gt modify -c -m "test: verify woostack-dream skill structure"
+```
+
+---
+
+## Increment 2: Wire woostack-dream as the sixteenth public command
+
+> One independently shippable PR, stacked on Increment 1. Pure documentation/routing edits; updates every fifteen→sixteen count (covers AC7).
+
+### Task 1: Add the routing row in `using-woostack`
+
+**Files:**
+- Modify: `skills/using-woostack/SKILL.md` (Command Routing table)
+
+- [ ] **Step 1: Red — assert no dream row yet**
+
+Run: `grep -c 'woostack-dream' skills/using-woostack/SKILL.md`
+Expected: `0`
+
+- [ ] **Step 2: Add the routing row** after the `/woostack-tdd` row in the Command Routing table:
+
+```markdown
+| `/woostack-dream [instructions]`, curate the memory store and recommend doc updates (gated) | `woostack-dream` |
+```
+
+- [ ] **Step 3: Green — assert the row exists**
+
+Run: ``grep -c '| `/woostack-dream' skills/using-woostack/SKILL.md``
+Expected: `1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt create -m "docs: route woostack-dream in using-woostack"
+```
+
+### Task 2: Update `AGENTS.md` (public list, counts, Mode B, file map)
+
+**Files:**
+- Modify: `AGENTS.md` (root; `.claude/CLAUDE.md` is a symlink to it — one edit updates both)
+
+> Line numbers below are hints from the pre-edit file; match by the quoted content (inserts shift later lines). Edit `AGENTS.md` directly — the symlink follows.
+
+- [ ] **Step 1: Add the public-command bullet** after the `woostack-tdd` bullet (currently line 32):
+
+```markdown
+- [`woostack-dream`](skills/woostack-dream/SKILL.md)
+```
+
+- [ ] **Step 2: Bump the surface count** — line 16, `has fifteen skills:` → `has sixteen skills:`.
+
+- [ ] **Step 3: Bump the in-prose surface count** — line 38, `absent from the fifteen-skill command surface above` → `absent from the sixteen-skill command surface above`.
+
+- [ ] **Step 4: Bump the SKILL.md-file count** — line 82, `any of the seventeen `SKILL.md` files (the fifteen public command/adoption` → `any of the eighteen `SKILL.md` files (the sixteen public command/adoption`.
+
+- [ ] **Step 5: Add to the Mode B enumeration** — in the Mode B paragraph (lines 57-60), insert `` `/woostack-dream`, `` into the command list (after `/woostack-debug`).
+
+- [ ] **Step 6: Add a Quick file map entry** — after the visualize entry (lines 116-117):
+
+```markdown
+- Memory & docs curation engine (public command; agent-agnostic "dreams"):
+  [`skills/woostack-dream/SKILL.md`](skills/woostack-dream/SKILL.md)
+```
+
+- [ ] **Step 7: Green — counts consistent, no stale count remains**
+
+Run:
+```bash
+echo "dream refs: $(grep -c 'woostack-dream' AGENTS.md)"
+echo "stale fifteen: $(grep -ciE 'fifteen' AGENTS.md)"
+echo "stale seventeen: $(grep -ciE 'seventeen' AGENTS.md)"
+```
+Expected: `dream refs:` ≥ `3`; `stale fifteen: 0`; `stale seventeen: 0`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+gt modify -c -m "docs: register woostack-dream in AGENTS.md"
+```
+
+### Task 3: Update `README.md` (surface sentence + command section)
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update the surface sentence (line 28)** — `surface is fifteen skills:` → `surface is sixteen skills:`, and append `woostack-dream` to the comma list after `woostack-tdd` (e.g. `…woostack-debug, woostack-tdd, and woostack-dream.`).
+
+- [ ] **Step 2: Add a command section** after the `/woostack-tdd` section (around line 111):
+
+```markdown
+### `/woostack-dream [instructions]`: curate memory & recommend doc updates
+
+The agent-agnostic version of managed "dreams": a reflection pass over your `.woostack/` knowledge store. It reads the memory store and docs (static — no session mining), then proposes a single gated changeset that merges duplicate notes, replaces stale or contradicted ones, drops dead/orphaned notes, resolves conflicts `doctor.sh` only flags, surfaces consolidated insights, and recommends **evidence-guarded** edits to your docs (promoting recurring conventions, fixing claims memory now contradicts). Nothing changes before you approve; it ends on a summary and lets you request changes. Memory edits are local-only; doc edits land in the working tree (offer to `woostack-commit`). Never commits or merges. → [SKILL.md](skills/woostack-dream/SKILL.md)
+```
+
+- [ ] **Step 3: Green — README lists and documents the command**
+
+Run:
+```bash
+echo "sentence: $(grep -c 'sixteen skills' README.md)"
+echo "section: $(grep -c '### `/woostack-dream' README.md)"
+echo "stale: $(grep -c 'fifteen skills' README.md)"
+```
+Expected: `sentence: 1`; `section: 1`; `stale: 0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt modify -c -m "docs: document woostack-dream in README"
+```
+
+### Task 4: Cross-file consistency check
+
+**Files:**
+- Verify: `skills/using-woostack/SKILL.md`, `AGENTS.md`, `README.md`, `skills/woostack-dream/SKILL.md`
+
+- [ ] **Step 1: Assert the command is registered in every surface** (covers AC7)
+
+Run:
+```bash
+for f in skills/woostack-dream/SKILL.md skills/using-woostack/SKILL.md AGENTS.md README.md; do
+  grep -q 'woostack-dream' "$f" && echo "OK: $f" || echo "MISSING: $f"
+done
+```
+Expected: four `OK:` lines, no `MISSING:`.
+
+- [ ] **Step 2: Assert no stale fifteen/seventeen count survives the wired surface**
+
+Run: `grep -rilE 'fifteen|seventeen' AGENTS.md README.md skills/using-woostack/SKILL.md | wc -l | tr -d ' '`
+Expected: `0`
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+# only if Steps 1-2 surfaced a fix; otherwise skip
+gt modify -c -m "docs: reconcile woostack-dream surface counts"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — AC1 (Inc1 T1 + T2 S1), AC2 (Inc1 T1 Phase 3 + T2 S2), AC3 (Inc1 T1 Phase 2/4 + T2 S2), AC4 (Phase 2 doc-recommendation + T2 S2 `evidence guard`), AC5 (Degradation + T2 S2), AC6 (Hard constraints + T2 S2), AC7 (Inc2 all tasks), AC8 (Phase 5), AC9 (Phase 2 merge/drop link rewrite + idempotent language + Inc1 T2 S3). All mapped.
+- [ ] **AC coverage** — each AC's happy/edge/error case maps to a grep/test assertion or an authored-section requirement above.
+- [ ] **No placeholders** — exact paths, exact commands, expected output in every step; SKILL.md content specified section-by-section.
+- [ ] **Type consistency** — phase names (Gather/Synthesize/Review gate/Apply/Summarize), op names (merge/replace/drop/resolve/surface/doc), and script names (`doctor.sh`/`build-index.sh`/`graph.sh`) are used identically across plan and skill.
+
+> woostack plan conventions (kept):
+> - Frontmatter-free; opens with the `**Source:**` line.
+> - Filename mirrors the spec basename: `.woostack/plans/2026-06-09-woostack-dream.md`.
+> - No required sub-skill banner — execution is `woostack-execute`'s.
+> - No test runner here → "failing test" steps are concrete `grep`/`test` verifications with exact expected output.

--- a/.woostack/specs/2026-06-09-woostack-dream.md
+++ b/.woostack/specs/2026-06-09-woostack-dream.md
@@ -1,0 +1,170 @@
+---
+name: woostack-dream
+type: spec
+status: planning
+date: 2026-06-09
+branch: feature/woostack-dream
+links:
+---
+
+# Create `woostack-dream` Skill — Agent-Agnostic Memory & Docs Curation — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+woostack agents write to the `.woostack/memory/` store incrementally as they work (distillation, accept-by-design review memory). Over many sessions that store accrues duplicates, near-duplicates phrased differently, stale entries scoped to deleted paths, and contradictory advice across overlapping scopes. `doctor.sh` already *detects* these structural signals (overlap clusters, stale provenance, orphaned scope, dead notes, missing provenance, trivia) but only **warns** — it never merges, rewrites, or drops anything, and it has no view into whether two co-loading notes actually contradict.
+
+Separately, durable conventions that recur across many memory notes often belong **promoted into documentation** (`AGENTS.md`, `README.md`, guides) where every contributor sees them, not buried in a local-only memory store. And docs drift: a doc can assert something the memory store has since contradicted. Nothing in woostack closes either loop.
+
+Anthropic's managed-agents "Dreams" feature solves the first half for hosted agents: it reads a memory store plus past session transcripts and produces a reorganized store (duplicates merged, stale entries replaced, new insights surfaced), non-destructively, for review. woostack has no agent-agnostic equivalent, and Dreams does not touch documentation.
+
+## 2. Goal
+
+Introduce a new public command skill, **`/woostack-dream [instructions]`**, that runs an agent-agnostic curation/reflection pass over the woostack knowledge store and:
+
+1. **Curates memory in place** — merges duplicates/near-duplicates, replaces stale or contradicted notes with the latest value, drops dead and orphaned-scope notes, resolves overlap-cluster conflicts, and surfaces consolidated cross-note insights.
+2. **Recommends documentation updates** — promotes recurring conventions from memory into repo docs and fixes doc claims the memory store now contradicts, scoped to **all repo markdown** but **gated on memory evidence** (a doc edit is proposed only where a specific memory note supports it).
+3. **Gates every mutation behind explicit user approval** — nothing changes before the user approves the proposed changeset (faithful to Dreams' "input never modified; review the output").
+4. **Ends with a summary and an iterate loop** — presents what changed and lets the user request further changes, applying adjustments until they are satisfied.
+
+The skill is the agent-agnostic, lo-fi analog of Dreams: no async API, no managed sessions — it reflects over the *static* store and docs, deterministically and repeatably.
+
+## 3. Non-goals
+
+- **No session-transcript mining.** Unlike Dreams, `woostack-dream` does not consume past session transcripts or the current live conversation. Inputs are the static store + docs + git history only. (Resolved fork; see §4.)
+- **No commit or merge.** Memory is local-only/gitignored (no commit). Doc edits land in the working tree only; `woostack-dream` offers `woostack-commit` but never commits, pushes, or merges itself.
+- **No new memory script.** `woostack-dream` reuses the existing `woostack-init/scripts/` primitives (`doctor.sh`, `build-index.sh`, `recall.sh`, `scope-match.sh`); it adds no new script and does not change the memory contract or note schema.
+- **No replacement of `doctor.sh`.** `doctor.sh` stays the mechanical lint; `woostack-dream` is the agentic synthesis + apply layer on top of its signals.
+- **No replacement of the incremental writers.** `woostack-dream` is periodic garbage-collection; it complements — does not replace — the incremental write paths (`woostack-execute` distillation, `woostack-address-comments` memory-record).
+- **No spec/plan/status reconciliation.** Drift between a spec's authored `status:` and its artifacts is `/woostack-status`'s job; `woostack-dream` touches only memory notes and docs.
+- **Not part of the gated build chain.** It is a standalone maintenance command, not a `woostack-build` phase.
+
+## 4. Approach
+
+A new self-contained skill at `skills/woostack-dream/SKILL.md` plus the surface wiring to register it as the **sixteenth public command**. The skill body defines a five-phase pipeline.
+
+### Phase 1 — Gather signals (read-only)
+- Resolve the memory store. If `.woostack/memory/` exists, run `doctor.sh` (capture its warnings) and read `memory/MEMORY.md` + all note bodies. Always read the flat `memory.md` global shard. If only the flat file exists (no scoped store), **state the degradation explicitly** and curate the flat file alone — bullet-level dedupe/replace/drop, no scope/index/doctor machinery (memory contract §10).
+- Read `AGENTS.md`/`CLAUDE.md` and enumerate the doc-recommendation surface as **tracked** markdown via `git ls-files '*.md'` (so gitignored memory and `node_modules` are never targets). Exclude `.woostack/specs|plans|fixes/*.md` from the *promotion-target* set — those are curation inputs (provenance), not docs to promote conventions into.
+- Read recent `git log` and the `.woostack/specs|plans|fixes/` artifacts a note's `source:` points at, to ground "stale vs. current" judgments in provenance.
+- Honor an optional free-text `instructions` argument that steers focus (e.g. `"focus on API conventions; ignore one-off gotchas"`) — applied throughout synthesis, like Dreams' `instructions`.
+
+### Phase 2 — Synthesize (the "dream", read-only)
+Agent judgment layered on doctor's signals, producing a proposed changeset of discrete, labeled ops:
+- **Merge** — duplicate or fuzzy-near-duplicate notes (matching hooks/bodies) collapse into one denser note; the survivor keeps the union of scopes and the most specific provenance. **Link integrity:** inbound `[[wikilinks]]` to a merged-away note (found via `graph.sh --backlinks`) are rewritten to the survivor in the same changeset, so `doctor.sh`'s unresolved-link check stays clean post-apply.
+- **Replace** — a note contradicted by a newer note or by current code/provenance is rewritten to the latest value, preserving `source:`.
+- **Drop** — dead notes (old + never recalled, per `doctor.sh`'s dead-note signal) and orphaned-scope notes (scope matches no tracked file) are proposed for deletion with the reason. Inbound links are rewritten or removed as for merge. **Because the memory store is gitignored, a dropped note is unrecoverable** — so the gate (Phase 3) must show the *full body* of every note proposed for deletion, giving the user a chance to salvage it.
+- **Resolve conflict** — for each `doctor.sh` overlap cluster, the agent judges whether the co-loading notes actually contradict; if so it picks the correct note and records why the other is superseded. **When the agent cannot confidently adjudicate** (genuine ambiguity needing domain knowledge), it does **not** guess — it surfaces the conflicting notes as a flagged decision for the user to resolve at the gate.
+- **Surface** — a recurring pattern spread across several notes is proposed as one new consolidated note. Its `source:` is **derived from the contributing notes' provenance, never fabricated**, and it must pass the distillation reject-by-default gate of memory contract §7 (glob scope, provenance, dedupe, `updated:` stamp).
+- **Doc recommendation** — where a memory note evidences a convention worth promoting, or contradicts a doc claim, propose the specific doc edit. **Evidence guard:** every proposed doc edit cites the memory note(s) backing it; no note → no doc edit. This keeps the broad "all repo markdown" scope high-signal.
+
+The pass is **idempotent**: run twice with no intervening work, the second run finds nothing to curate (no ghost merges, no re-proposed drops).
+
+### Phase 3 — Review gate (HARD)
+Present the complete changeset as a reviewable before/after: each memory op (merge/replace/drop/resolve/surface) with the affected note(s), each **drop showing the full note body** (unrecoverable once applied), each **un-adjudicated conflict flagged for the user to decide**, and each doc edit as a diff with its backing note cited. **Nothing has mutated yet.** Require explicit approval before applying. Honor `honor-approval-gates` — silence or ambiguity is not approval. For a large changeset, offer a `woostack-visualize` render (audience `engineer`) as a reading aid; the changeset still lives in the conversation, not a separate artifact.
+
+### Phase 4 — Apply (on approval)
+- Memory: rewrite/delete the affected note files in place, then run `build-index.sh` to regenerate `MEMORY.md`, then re-run `doctor.sh` and confirm it is clean (or report any residual warnings).
+- Docs: write the approved doc edits into the working tree (uncommitted).
+
+### Phase 5 — Summarize & iterate
+Present a final summary (notes merged/replaced/dropped/added, conflicts resolved, doc edits applied). Invite change requests; on a request, return to Phase 3/4 for the adjustment and re-summarize. When done: memory changes are already local-only (no commit needed); for the working-tree doc edits, offer to hand off to `woostack-commit`. `woostack-dream` never commits or merges itself.
+
+### Surface wiring
+- `skills/using-woostack/SKILL.md` — add the `/woostack-dream` Command Routing row.
+- `AGENTS.md` (= `.claude/CLAUDE.md` symlink) — add `woostack-dream` to the public command list (fifteen → sixteen), the Quick file map, and Mode B's command enumeration.
+- `README.md` — add `woostack-dream` wherever the public commands are listed, keeping any count consistent.
+
+## 5. Components & data flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Dream as /woostack-dream
+    participant Doctor as doctor.sh
+    participant Store as .woostack/memory/
+    participant Index as build-index.sh
+    participant Docs as repo *.md
+    participant Commit as /woostack-commit
+
+    User->>Dream: /woostack-dream [instructions]
+    Dream->>Doctor: run (capture warnings)
+    Dream->>Store: read MEMORY.md + note bodies + flat memory.md
+    Dream->>Docs: read AGENTS.md/CLAUDE.md + all *.md
+    Note over Dream: Phase 2 — synthesize changeset (read-only)
+    Dream-->>User: present full changeset (memory ops + doc diffs) — GATE
+    User->>Dream: approve
+    Dream->>Store: apply merge/replace/drop/resolve/surface
+    Dream->>Index: rebuild MEMORY.md
+    Dream->>Doctor: re-run, confirm clean
+    Dream->>Docs: write approved doc edits (working tree)
+    Dream-->>User: summary + invite change requests (iterate)
+    User->>Dream: (optional) request changes
+    Dream-->>User: offer woostack-commit for doc edits (never commits itself)
+```
+
+## 6. Error handling
+
+- **No `.woostack/` at all** — state that there is no memory store to curate and stop; do not scaffold (defer to `/woostack-init`).
+- **Scripts missing** (skill installed individually, not full collection) — follow the memory contract §10 degradation: announce manual fallback, do the recall/lint by hand, never fail silently.
+- **`doctor.sh` exits non-zero** (hard errors, not warnings) — surface the errors and continue the read; do not let a lint error abort the curation pass.
+- **Empty / clean store** — if synthesis finds nothing to change and no doc edits are warranted, report "nothing to curate" and stop without a gate.
+- **Post-apply `doctor.sh` still warns** — report the residual warnings in the summary rather than silently swallowing them. In particular, an unresolved-`[[wikilink]]` warning after apply means a merge/drop missed an inbound link — flag it for follow-up.
+- **No approval** — never apply. Re-present or exit on the user's choice.
+
+## 7. Acceptance criteria
+
+- **AC1 — Skill definition & pipeline**
+  - happy: `skills/woostack-dream/SKILL.md` exists with valid frontmatter (`name: woostack-dream`, a discovery-oriented `description`) and defines the five phases (gather → synthesize → gate → apply → summarize/iterate).
+  - edge: the optional `instructions` argument is documented as steering synthesis focus.
+- **AC2 — Hard gate / non-destructive**
+  - happy: the skill states no memory note or doc is mutated before explicit approval, and references `honor-approval-gates`.
+  - error: ambiguous/no answer is explicitly not treated as approval.
+- **AC3 — Memory curation ops**
+  - happy: the skill enumerates merge / replace / drop / resolve-conflict / surface, each tied to a `doctor.sh` signal where applicable.
+  - happy: after apply, the skill runs `build-index.sh` then re-runs `doctor.sh` to confirm clean.
+  - edge: new "surface" notes must pass the memory-contract §7 distillation reject-by-default gate (glob scope, provenance, dedupe, `updated:` stamp).
+- **AC4 — Doc recommendations (evidence-guarded)**
+  - happy: doc scope is all repo `*.md`; each proposed doc edit cites the backing memory note(s).
+  - error: a candidate doc edit with no backing memory note is not proposed.
+- **AC5 — Degradation**
+  - happy: with a scoped store, the skill uses `doctor.sh`/`build-index.sh`/`recall.sh`.
+  - edge: with only flat `memory.md` (no scoped store), the skill states the fallback and curates the flat file; with no `.woostack/` it stops without scaffolding.
+- **AC6 — No commit / no merge**
+  - happy: memory changes are described as local-only; doc edits land in the working tree only; the skill offers `woostack-commit` and never commits, pushes, or merges.
+- **AC7 — Surface wiring & consistent counts**
+  - happy: `using-woostack` has a `/woostack-dream` routing row; `AGENTS.md`/`CLAUDE.md` lists it in the public command list, Quick file map, and Mode B; `README.md` lists it.
+  - happy: every place that states the public-command count is updated from fifteen to sixteen and they agree.
+- **AC8 — Summary & iterate loop**
+  - happy: the skill ends by summarizing applied changes and inviting change requests, looping to apply adjustments before finishing.
+- **AC9 — Link integrity & idempotency**
+  - happy: merging or dropping a note rewrites/removes inbound `[[wikilinks]]` so post-apply `doctor.sh` reports no new unresolved links.
+  - edge: a second `woostack-dream` run with no intervening work finds nothing to curate (idempotent).
+  - edge: a note proposed for deletion is shown with its full body at the gate before it is removed.
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+This repo ships skill markdown, not application code, and has no app test runner or CI (per `AGENTS.md`). Per the `woostack-tdd` no-runner carve-out, verification is **concrete structural assertion** rather than red/green unit tests:
+
+- **Existence & frontmatter** — `skills/woostack-dream/SKILL.md` exists with a valid `name`/`description` frontmatter block.
+- **Cross-link integrity** — every relative link in the new SKILL.md (to `woostack-init` scripts, `woostack-commit`, the memory contract, `honor-approval-gates`, conventions.md) resolves to a real file.
+- **Surface consistency (grep)** — `grep` confirms the `/woostack-dream` row in `using-woostack`, the entry in `AGENTS.md`'s command list/file map/Mode B, and the `README.md` listing; a count check confirms no remaining "fifteen"/"15 public" references where "sixteen"/"16" is now correct.
+- **Live dry-run** — run `/woostack-dream` against this repo's own `.woostack/memory/` store and confirm: Phase 1 reads + `doctor.sh` runs, Phase 2 produces a labeled changeset, the gate halts before any mutation, and (on a test approval) `build-index.sh`/`doctor.sh` re-run clean. This doubles as the skill's own acceptance smoke test.
+
+## 9. Open questions
+
+**Settled during hardening:**
+- Inbound `[[wikilink]]` integrity on merge/drop → rewrite/remove in the same changeset; `doctor.sh` unresolved-link check verifies (§4 Merge/Drop, AC9).
+- Doc enumeration → `git ls-files '*.md'`, tracked-only; `.woostack/` spec/plan/fix markdown excluded as promotion *targets* (§4 Phase 1).
+- Un-adjudicable overlap conflicts → flagged for the user at the gate, never auto-guessed (§4 Resolve).
+- Dropped notes are unrecoverable (gitignored store) → gate shows full body before deletion (§3 Drop non-goal stake, §4 Phase 3, AC9).
+- "Surface" note provenance → derived from contributing notes, never fabricated (§4 Surface).
+- Idempotency → a re-run with no intervening work finds nothing (§4, AC9).
+- Changeset presentation → **in conversation** (consistent with the ideate/harden/fix gates), optionally rendered via `woostack-visualize`; no separate candidate-store artifact, so no `woostack-init` change.
+
+None open.


### PR DESCRIPTION
## Goal

Propose the specification and implementation plan for the `woostack-dream` skill, which provides agent-agnostic memory and documentation curation.

## Summary

- Add specification for `woostack-dream` under `.woostack/specs/2026-06-09-woostack-dream.md` detailing the five-phase pipeline.
- Add two-increment implementation plan under `.woostack/plans/2026-06-09-woostack-dream.md` defining how to build and integrate the skill.

## Test plan

### Manual

**Before merge**

- [ ] Verify that `.woostack/specs/2026-06-09-woostack-dream.md` exists and contains the approved specification.
- [ ] Verify that `.woostack/plans/2026-06-09-woostack-dream.md` exists, matches the plan structure, and defines concrete verification checks.

Spec: .woostack/specs/2026-06-09-woostack-dream.md
