### PR TITLE
docs: wire woostack-dream command

### DIFF
--- a/.woostack/plans/2026-06-09-woostack-dream.md
+++ b/.woostack/plans/2026-06-09-woostack-dream.md
@@ -117,23 +117,23 @@ gt modify -c -m "test: verify woostack-dream skill structure"
 **Files:**
 - Modify: `skills/using-woostack/SKILL.md` (Command Routing table)
 
-- [ ] **Step 1: Red — assert no dream row yet**
+- [x] **Step 1: Red — assert no dream row yet**
 
 Run: `grep -c 'woostack-dream' skills/using-woostack/SKILL.md`
 Expected: `0`
 
-- [ ] **Step 2: Add the routing row** after the `/woostack-tdd` row in the Command Routing table:
+- [x] **Step 2: Add the routing row** after the `/woostack-tdd` row in the Command Routing table:
 
 ```markdown
 | `/woostack-dream [instructions]`, curate the memory store and recommend doc updates (gated) | `woostack-dream` |
 ```
 
-- [ ] **Step 3: Green — assert the row exists**
+- [x] **Step 3: Green — assert the row exists**
 
 Run: ``grep -c '| `/woostack-dream' skills/using-woostack/SKILL.md``
 Expected: `1`
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt create -m "docs: route woostack-dream in using-woostack"
@@ -146,28 +146,28 @@ gt create -m "docs: route woostack-dream in using-woostack"
 
 > Line numbers below are hints from the pre-edit file; match by the quoted content (inserts shift later lines). Edit `AGENTS.md` directly — the symlink follows.
 
-- [ ] **Step 1: Add the public-command bullet** after the `woostack-tdd` bullet (currently line 32):
+- [x] **Step 1: Add the public-command bullet** after the `woostack-tdd` bullet (currently line 32):
 
 ```markdown
 - [`woostack-dream`](skills/woostack-dream/SKILL.md)
 ```
 
-- [ ] **Step 2: Bump the surface count** — line 16, `has fifteen skills:` → `has sixteen skills:`.
+- [x] **Step 2: Bump the surface count** — line 16, `has fifteen skills:` → `has sixteen skills:`.
 
-- [ ] **Step 3: Bump the in-prose surface count** — line 38, `absent from the fifteen-skill command surface above` → `absent from the sixteen-skill command surface above`.
+- [x] **Step 3: Bump the in-prose surface count** — line 38, `absent from the fifteen-skill command surface above` → `absent from the sixteen-skill command surface above`.
 
-- [ ] **Step 4: Bump the SKILL.md-file count** — line 82, `any of the seventeen `SKILL.md` files (the fifteen public command/adoption` → `any of the eighteen `SKILL.md` files (the sixteen public command/adoption`.
+- [x] **Step 4: Bump the SKILL.md-file count** — line 82, `any of the seventeen `SKILL.md` files (the fifteen public command/adoption` → `any of the eighteen `SKILL.md` files (the sixteen public command/adoption`.
 
-- [ ] **Step 5: Add to the Mode B enumeration** — in the Mode B paragraph (lines 57-60), insert `` `/woostack-dream`, `` into the command list (after `/woostack-debug`).
+- [x] **Step 5: Add to the Mode B enumeration** — in the Mode B paragraph (lines 57-60), insert `` `/woostack-dream`, `` into the command list (after `/woostack-debug`).
 
-- [ ] **Step 6: Add a Quick file map entry** — after the visualize entry (lines 116-117):
+- [x] **Step 6: Add a Quick file map entry** — after the visualize entry (lines 116-117):
 
 ```markdown
 - Memory & docs curation engine (public command; agent-agnostic "dreams"):
   [`skills/woostack-dream/SKILL.md`](skills/woostack-dream/SKILL.md)
 ```
 
-- [ ] **Step 7: Green — counts consistent, no stale count remains**
+- [x] **Step 7: Green — counts consistent, no stale count remains**
 
 Run:
 ```bash
@@ -177,7 +177,7 @@ echo "stale seventeen: $(grep -ciE 'seventeen' AGENTS.md)"
 ```
 Expected: `dream refs:` ≥ `3`; `stale fifteen: 0`; `stale seventeen: 0`.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 gt modify -c -m "docs: register woostack-dream in AGENTS.md"
@@ -188,9 +188,9 @@ gt modify -c -m "docs: register woostack-dream in AGENTS.md"
 **Files:**
 - Modify: `README.md`
 
-- [ ] **Step 1: Update the surface sentence (line 28)** — `surface is fifteen skills:` → `surface is sixteen skills:`, and append `woostack-dream` to the comma list after `woostack-tdd` (e.g. `…woostack-debug, woostack-tdd, and woostack-dream.`).
+- [x] **Step 1: Update the surface sentence (line 28)** — `surface is fifteen skills:` → `surface is sixteen skills:`, and append `woostack-dream` to the comma list after `woostack-tdd` (e.g. `…woostack-debug, woostack-tdd, and woostack-dream.`).
 
-- [ ] **Step 2: Add a command section** after the `/woostack-tdd` section (around line 111):
+- [x] **Step 2: Add a command section** after the `/woostack-tdd` section (around line 111):
 
 ```markdown
 ### `/woostack-dream [instructions]`: curate memory & recommend doc updates
@@ -198,7 +198,7 @@ gt modify -c -m "docs: register woostack-dream in AGENTS.md"
 The agent-agnostic version of managed "dreams": a reflection pass over your `.woostack/` knowledge store. It reads the memory store and docs (static — no session mining), then proposes a single gated changeset that merges duplicate notes, replaces stale or contradicted ones, drops dead/orphaned notes, resolves conflicts `doctor.sh` only flags, surfaces consolidated insights, and recommends **evidence-guarded** edits to your docs (promoting recurring conventions, fixing claims memory now contradicts). Nothing changes before you approve; it ends on a summary and lets you request changes. Memory edits are local-only; doc edits land in the working tree (offer to `woostack-commit`). Never commits or merges. → [SKILL.md](skills/woostack-dream/SKILL.md)
 ```
 
-- [ ] **Step 3: Green — README lists and documents the command**
+- [x] **Step 3: Green — README lists and documents the command**
 
 Run:
 ```bash
@@ -208,7 +208,7 @@ echo "stale: $(grep -c 'fifteen skills' README.md)"
 ```
 Expected: `sentence: 1`; `section: 1`; `stale: 0`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "docs: document woostack-dream in README"
@@ -219,7 +219,7 @@ gt modify -c -m "docs: document woostack-dream in README"
 **Files:**
 - Verify: `skills/using-woostack/SKILL.md`, `AGENTS.md`, `README.md`, `skills/woostack-dream/SKILL.md`
 
-- [ ] **Step 1: Assert the command is registered in every surface** (covers AC7)
+- [x] **Step 1: Assert the command is registered in every surface** (covers AC7)
 
 Run:
 ```bash
@@ -229,12 +229,12 @@ done
 ```
 Expected: four `OK:` lines, no `MISSING:`.
 
-- [ ] **Step 2: Assert no stale fifteen/seventeen count survives the wired surface**
+- [x] **Step 2: Assert no stale fifteen/seventeen count survives the wired surface**
 
 Run: `grep -rilE 'fifteen|seventeen' AGENTS.md README.md skills/using-woostack/SKILL.md | wc -l | tr -d ' '`
 Expected: `0`
 
-- [ ] **Step 3: Commit any fixes**
+- [x] **Step 3: Commit any fixes**
 
 ```bash
 # only if Steps 1-2 surfaced a fix; otherwise skip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `npx skills add howarewoo/woostack`.
 
-The public command/adoption surface has fifteen skills:
+The public command/adoption surface has sixteen skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -30,12 +30,13 @@ The public command/adoption surface has fifteen skills:
 - [`woostack-visualize`](skills/woostack-visualize/SKILL.md)
 - [`woostack-debug`](skills/woostack-debug/SKILL.md)
 - [`woostack-tdd`](skills/woostack-tdd/SKILL.md)
+- [`woostack-dream`](skills/woostack-dream/SKILL.md)
 
 The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the fifteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+`/woostack-*` commands: they have no routing row and are absent from the sixteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
 There is no application source code, app lockfile, build, or CI for this repo's own
@@ -56,7 +57,7 @@ do not add application code, app build configs, or app lockfiles.
 
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
 `/woostack-bootstrap`, `/woostack-build`, `/woostack-fix`, `/woostack-plan`, `/woostack-execute`, `/woostack-execute-overnight`, `/woostack-commit`,
-`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, or
+`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, `/woostack-dream`, or
 `/woostack-tdd`, including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
 directory, not in this repo.
@@ -79,7 +80,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the seventeen `SKILL.md` files (the fifteen public command/adoption
+- Do not move or rename any of the eighteen `SKILL.md` files (the sixteen public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -115,6 +116,8 @@ directory, not in this repo.
   [`skills/woostack-debug/SKILL.md`](skills/woostack-debug/SKILL.md)
 - Visualization engine (audience-tailored HTML renders):
   [`skills/woostack-visualize/SKILL.md`](skills/woostack-visualize/SKILL.md)
+- Memory & docs curation engine (public command; agent-agnostic "dreams"):
+  [`skills/woostack-dream/SKILL.md`](skills/woostack-dream/SKILL.md)
 - TDD doctrine home and add-tests command (public command):
   [`skills/woostack-tdd/SKILL.md`](skills/woostack-tdd/SKILL.md)
 - Address-comments delegator:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, `woostack-debug`, and `woostack-tdd`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, `woostack-debug`, `woostack-tdd`, and `woostack-dream`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 
@@ -29,6 +29,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |
 | Change the systematic-debugging behavior (`/woostack-debug`) | `skills/woostack-debug/SKILL.md` |
 | Change the test-adder / TDD doctrine home (`/woostack-tdd`) | `skills/woostack-tdd/SKILL.md` |
+| Change the memory/docs curation engine (`/woostack-dream`) | `skills/woostack-dream/SKILL.md` |
 | Change the address-comments delegator | `skills/woostack-address-comments/SKILL.md` |
 | Change the status board / feature-state conventions | `skills/woostack-status/SKILL.md`, `skills/woostack-status/references/conventions.md`, `skills/woostack-status/scripts/` |
 | Update agent instructions (Claude or any) | `AGENTS.md` (`.claude/CLAUDE.md` is a symlink to it) |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Templates rot. Dependencies drift, breaking changes pile up, and every new proje
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is fifteen skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-fix, woostack-plan, woostack-execute, woostack-execute-overnight, woostack-commit, woostack-review, woostack-address-comments, woostack-status, woostack-visualize, woostack-debug, and woostack-tdd. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is sixteen skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-fix, woostack-plan, woostack-execute, woostack-execute-overnight, woostack-commit, woostack-review, woostack-address-comments, woostack-status, woostack-visualize, woostack-debug, woostack-tdd, and woostack-dream. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
 
 > **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
 
@@ -109,6 +109,10 @@ Runs woostack's systematic-debugging method on a bug, test failure, or unexpecte
 ### `/woostack-tdd <target>`: test-driven development engine
 
 Applies the TDD kernel (Red → Green → Refactor) to add appropriate tests to an existing code block, PR, spec, or plan. New code requires tests first, while existing code characterization tests pin current behavior. → [SKILL.md](skills/woostack-tdd/SKILL.md)
+
+### `/woostack-dream [instructions]`: curate memory & recommend doc updates
+
+The agent-agnostic version of managed "dreams": a reflection pass over your `.woostack/` knowledge store. It reads the memory store and docs (static — no session mining), then proposes a single gated changeset that merges duplicate notes, replaces stale or contradicted ones, drops dead/orphaned notes, resolves conflicts `doctor.sh` only flags, surfaces consolidated insights, and recommends **evidence-guarded** edits to your docs (promoting recurring conventions, fixing claims memory now contradicts). Nothing changes before you approve; it ends on a summary and lets you request changes. Memory edits are local-only; doc edits land in the working tree (offer to `woostack-commit`). Never commits or merges. → [SKILL.md](skills/woostack-dream/SKILL.md)
 
 ### Growing scope
 

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -77,6 +77,8 @@ link it, never restate it.
 | `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |
 | `/woostack-debug <target>`, run an autonomous root-cause analysis before fixing (investigative only — hands back the root cause and a proposed fix) | `woostack-debug` |
 | `/woostack-tdd <target>`, add appropriate tests to a code block, PR, spec, or plan (gate-light; TDD doctrine home) | `woostack-tdd` |
+| `/woostack-dream [instructions]`, curate the memory store and recommend doc updates (gated) | `woostack-dream` |
+
 
 If the user asks for the behavior without using the exact command name, route by intent.
 For example, "use woostack to review this PR" means load `woostack-review`.


### PR DESCRIPTION
## Goal

This PR wires the new `woostack-dream` skill into the public command surface, routing table, and documentation.

## Summary

- Registered `/woostack-dream` command in the `using-woostack` Command Routing table.
- Added the public command bullet to `AGENTS.md` and bumped all surface counts from fifteen to sixteen skills, and `SKILL.md` file counts from seventeen to eighteen.
- Updated `README.md` to document the new command details and updated its command count to sixteen.
- Ran consistency checks to verify no stale counts remain.

## Test plan

### Automated

- [x] Verified `woostack-dream` is registered in every relevant file: `skills/woostack-dream/SKILL.md`, `skills/using-woostack/SKILL.md`, `AGENTS.md`, and `README.md`.
- [x] Verified no stale "fifteen" or "seventeen" count keywords remain in the wired files.

### Manual

**Before merge**

- [ ] Inspect the documentation changes in [AGENTS.md](file:///Users/adamwoo/Documents/GitHub/woostack/AGENTS.md) and [README.md](file:///Users/adamwoo/Documents/GitHub/woostack/README.md) to confirm counts and references are accurate.

Spec: .woostack/specs/2026-06-09-woostack-dream.md
