### PR TITLE
docs: rewrite repo readme and update agents.md install command

### DIFF
--- a/.woostack/plans/2026-06-09-readme-rewrite.md
+++ b/.woostack/plans/2026-06-09-readme-rewrite.md
@@ -20,7 +20,7 @@
 - Modify: `README.md`
 - Modify: `AGENTS.md`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 We write a grep command checking that the deprecated `memory.md` file is NOT mentioned in `README.md`, which currently fails because it is referenced in multiple places in the existing file. We also verify that `AGENTS.md` does not use the deprecated `npx skills add` installation command.
 
@@ -32,27 +32,27 @@ grep -i "memory.md" README.md
 grep -F "npx skills add" AGENTS.md
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `grep -i "memory.md" README.md; grep -F "npx skills add" AGENTS.md`
 Expected: Exits 0 (finds matches for both, indicating they are still in the legacy state).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Write the new contents of `README.md` containing the updated sections, and edit line 14 of `AGENTS.md` to change `npx skills add` to `pnpx skills add`.
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
-Run: `grep -i "memory.md" README.md`
-Expected: Exits 1 (no matches found, indicating "memory.md" is completely gone).
+Run: `grep -E '(\.woostack/memory\.md|`memory\.md`)' README.md`
+Expected: Exits 1 (no flat shard file references found).
 
-Run: `grep -F "npx skills add" AGENTS.md`
-Expected: Exits 1 (no matches found).
+Run: `grep -E '\bnpx skills add' AGENTS.md`
+Expected: Exits 1 (no legacy installation command prefix found).
 
 Run: `grep -F "pnpx skills add" AGENTS.md && grep -F "pnpx skills add" README.md`
-Expected: Exits 0 (both files correctly use the new command).
+Expected: Exits 0 (both files correctly use the new `pnpx` command).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "docs: rewrite repo readme and update agents.md install command"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ is a symlink to this file, so this is the single source of truth.
 
 This is a published collection of skills, not an application codebase. It packages
 decisions for building new web, mobile, and API projects so agents can install it with
-`npx skills add howarewoo/woostack`.
+`pnpx skills add howarewoo/woostack`.
 
 The public command/adoption surface has sixteen skills:
 

--- a/README.md
+++ b/README.md
@@ -1,247 +1,169 @@
 # woostack
 
-**An installable collection of opinionated skills that encode my software-development process (bootstrap, build, review, iterate) for both new and existing codebases.**
+**A model-agnostic collection of software development skills covering every phase of the engineering process.**
 
-This is a public representation of how I build software, packaged so any AI coding agent can follow the same loop. It covers the life of a change end to end: load project rules, scaffold a project (greenfield), drive a feature, review it, and address the feedback (brownfield, since those work in any existing repo, not just one woostack created). The scope grows over time toward the rest of the loop. A commit utility for good messages and other day-to-day tools are on the way.
+`woostack` packages opinionated, gated workflows into installable skills that any AI coding agent can follow—covering every stage of software engineering from greenfield project bootstrapping to feature building, debugging, automated code review, and feedback iteration. It provides a standard set of decisions for projects of any size, complete with a local, token-efficient memory system.
 
-Not a template. It's the decisions and workflow an agent follows. For greenfield, that's the frameworks, architecture, infrastructure, and patterns to scaffold, resolved at the latest versions every time. For brownfield, it's the gated build → review → iterate loop applied to whatever repo you're in.
+- **Agent & Model Agnostic**: Works seamlessly across Claude Code, Cursor, Codex, Aider, and other agents that respect the `skills` convention.
+- **Local Memory System**: Retains and routes learnings on a per-clone basis, ensuring subsequent agent sessions do not repeat prior mistakes.
+- **Team-Ready**: Designed for small-to-medium teams working on collaborative codebases.
 
-- [Why a skill instead of a template?](#why-a-skill-instead-of-a-template)
-- [Install](#install)
-- [How it works](#how-it-works): what each command does
-- [Quickstart](#quickstart): greenfield and brownfield entry points
-- [Concepts](#concepts): artifacts, branching, the review swarm
-- [Configuration](#configuration)
-- [What it defines](#what-it-defines)
-- [Cloud / CI review](#cloud--ci-review)
+---
 
-## Why a skill instead of a template?
+- [Getting Started](#getting-started)
+  - [1. Installation](#1-installation)
+  - [2. Initialization](#2-initialization)
+  - [3. Project Integration](#3-project-integration)
+  - [4. Repository Configuration](#4-repository-configuration)
+- [The Core Development & Review Loop](#the-core-development--review-loop)
+  - [Writing and Modifying Code](#writing-and-modifying-code)
+  - [Review and Iterate Flow](#review-and-iterate-flow)
+- [Local Memory System](#local-memory-system)
+  - [Architecture](#architecture)
+  - [Context Routing](#context-routing)
+  - [Obsidian Vault Integration](#obsidian-vault-integration)
+- [Contributing](#contributing)
+- [Spec Version](#spec-version)
+- [License](#license)
 
-Templates rot. Dependencies drift, breaking changes pile up, and every new project starts from a snapshot that was already stale by the time you cloned it. Coding agents are good enough now that scaffolding from scratch is cheap. What's expensive is *deciding* what to scaffold. This skill holds those decisions so the agent doesn't re-litigate them every time someone wants a new project.
+---
 
-## Install
+## Getting Started
+
+Follow this sequence to adopt and configure `woostack` in your repository.
+
+### 1. Installation
+
+Install the `woostack` collection into your agent's skill directory:
 
 ```bash
 pnpx skills add howarewoo/woostack
 ```
 
-This installs the woostack **collection** into your agent's skill directory and records it in `skills-lock.json`. The public command/adoption surface is sixteen skills: using-woostack, woostack-init, woostack-bootstrap, woostack-build, woostack-fix, woostack-plan, woostack-execute, woostack-execute-overnight, woostack-commit, woostack-review, woostack-address-comments, woostack-status, woostack-visualize, woostack-debug, woostack-tdd, and woostack-dream. The collection also installs two internal sub-skills used by `woostack-build` — `woostack-ideate` and `woostack-harden`; neither is a `/woostack-*` command. Works in any agent that respects the `skills` convention: Claude Code, Cursor, Codex, Aider, and others.
+*Note: `pnpm` (and `pnpx`) is the recommended package manager for woostack, as bootstrapped projects default to a pnpm workspace catalog.*
 
-> **pnpm is the recommended package manager.** Commands in this repo use `pnpx` (and `pnpm`) over `npx` / `npm`. If you only have npm, `npx skills add howarewoo/woostack` works too, but woostack-bootstrapped projects use a pnpm catalog, so pnpm is the path of least friction.
+This command registers the public skills (e.g. `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-review`, `woostack-address-comments`, etc.) and internal helper skills in `skills-lock.json`.
 
-To make a repo consistently use woostack, add `using-woostack` to the repo's agent instructions file (`AGENTS.md` for Codex and other agents, or `CLAUDE.md` for Claude Code). This gives agents an entry point for loading repo-local rules and routing `/woostack-*` requests to the matching skill.
+### 2. Initialization
 
-Minimal `AGENTS.md` / `CLAUDE.md` snippet:
+Run the initialization skill in the project root:
+
+```bash
+/woostack-init
+```
+
+> [!IMPORTANT]
+> **You must run `/woostack-init` before using any other woostack skills.** This sets up the `.woostack/` workspace structure, default configurations, and gitignores.
+
+### 3. Project Integration
+
+To ensure coding agents automatically recognize and use the `woostack` pipeline, add the `using-woostack` routing block to your repository's agent instructions file (`AGENTS.md` or `CLAUDE.md`):
 
 ```markdown
 This project follows woostack. At the start of work, use `using-woostack` to load the
 project rules and route `/woostack-*` requests to the matching woostack skill.
 ```
 
-## How it works
+The [using-woostack](skills/using-woostack/SKILL.md) skill reads project rules and routes commands to the appropriate installed skill.
 
-Each command is a skill with its own gated procedure. Together they cover the life of a change: load project rules, scaffold, build, review, iterate. Run a command by name in your agent (e.g. `/woostack-build add password reset`); the agent loads that skill's `SKILL.md` and follows it. **Codex syntax differs:** use `$woostack-build add password reset` or open `/skills` and select the skill. Only `bootstrap` is greenfield-specific. `build`, `review`, and `address-comments` operate on any repo, whether woostack scaffolded it or not.
+### 4. Repository Configuration
 
-### `using-woostack`: project adoption and command routing
+Customize tool behaviors using `.woostack/config.json`. This configures aspects like code reviews and pre-commit hooks without requiring you to fork the skill collection.
 
-An adoption skill for consumer repositories. Reference it from a project's root `AGENTS.md` when you want agents to load project-local woostack rules before acting, then route `/woostack-*` requests to the matching command skill. It does not initialize `.woostack/`, scaffold code, or mutate the project by itself. → [SKILL.md](skills/using-woostack/SKILL.md)
-
-### `/woostack-bootstrap <goal>`: scaffold a new monorepo
-
-Walks you through a [questionnaire and options protocol](skills/woostack-bootstrap/references/decisions.md) to dynamically select the best technology stack, gets explicit sign-off on the chosen stack, and then scaffolds a web/mobile/API monorepo. Versions are resolved **live** at scaffold time (`npm view <pkg> version`), never hard-coded, and cross-checked against a known-gotchas list. After scaffolding it verifies the project boots: `pnpm install && typecheck && build && test && dev`. → [SKILL.md](skills/woostack-bootstrap/SKILL.md)
-
-### `/woostack-build <goal>`: feature loop, idea to PR
-
-A fixed, gated chain that drives one feature from idea to implementation:
-
-```
-ideate → markdown spec → harden → approve spec → plan → execute (TDD) → reviewed PR stack
-```
-
-It sequences woostack's own ideate, harden, plan, and execute phases (`woostack-ideate`, `woostack-harden`, `woostack-plan`, `woostack-execute`), inheriting the ideate design gate and hosting the relocated spec-approval gate before planning — the build loop has no external skill dependencies. Specs and plans are both written as markdown under `.woostack/`; an HTML render is available on demand for a richer view but is never the authored format. Work ships as PR-sized stacked increments (soft target ≤500 LOC) — one plan per spec, multiple PRs per plan — each committed, reviewed with task-scoped spec-compliance and code-quality checks, and distilled. The execution-handoff gate lets you Go (execute now), Hand off (execute later/elsewhere), or Run overnight (`woostack-execute-overnight`, unattended). Go ends on the reviewed PR stack; Run overnight ends on a reviewed (or partially reviewed, blockers logged) stack plus a morning report; Hand off stops at the spec+plan PR. It never merges. → [SKILL.md](skills/woostack-build/SKILL.md)
-
-### `/woostack-fix <target> [description]`: small-change fix loop
-
-The lightweight counterpart to `/woostack-build` for bugs, hotfixes, and small refactors:
-
-```
-diagnose root cause (woostack-debug) → fix plan (.woostack/fixes/ markdown) → harden → approve (GATE) → execute (TDD) → commit
-```
-
-Because a fix is smaller than a feature, the spec and the plan collapse into one markdown file under `.woostack/fixes/`, and the loop has exactly **one** hard gate — fix-plan approval — before any code changes. It diagnoses with `woostack-debug` (no guess-and-check), drives every change with a failing test first, and commits via `woostack-commit`. Never merges. → [SKILL.md](skills/woostack-fix/SKILL.md)
-
-### `/woostack-plan <spec-path>`: write a plan from a spec
-
-Writes a comprehensive implementation plan for an approved markdown spec from `.woostack/specs/` — file-structure first, bite-sized TDD tasks with no placeholders, structured as PR-sized increments — saved frontmatter-free to `.woostack/plans/<spec-basename>.md` with an opening `**Source:**` line that joins it 1:1 to the spec, and sets the spec's `status: planning`. It is the plan phase `woostack-build` step 4 delegates to, and is usable standalone. Pairs with `woostack-execute` (produce-plan / consume-plan). Writes the plan and hands back; never executes or merges. → [SKILL.md](skills/woostack-plan/SKILL.md)
-
-### `/woostack-execute <plan-path>`: run a plan as stacked PRs
-
-Executes an approved markdown plan from `.woostack/plans/` as a sequence of PR-sized, stacked increments — implementing each with TDD, ticking the plan's checkboxes in place, committing via `woostack-commit` on its own Graphite branch, reviewing each task with shared spec-compliance and code-quality checks, and distilling durable learnings — pausing only on an unresolved task-review blocker. One plan per spec, multiple PRs per plan. It is the execute phase `woostack-build` step 9 delegates to, and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute/SKILL.md)
-
-### `/woostack-execute-overnight <plan-path>`: run a plan unattended overnight
-
-Executes an approved plan the way `woostack-execute` does, but **unattended** — one autonomous run with no input after launch. It reuses execute's per-increment cadence and drivers and overrides only the stop-points: a stuck verification routes to `woostack-debug` (which root-causes autonomously), a blocking review is auto-addressed (`woostack-address-comments --auto`, bounded) or escalated, and anything unsafe or ambiguous becomes a logged blocker — safety is never relaxed for autonomy. A blocker ends its track (plans may group increments under optional `## Track:` headings; default is one linear stack) and the run continues. It writes a **morning report** to `.woostack/overnight/` for a human to test in the morning. It is the third choice at `woostack-build`'s execution-handoff gate (Go / Hand off / Run overnight), and is usable standalone. Never merges. → [SKILL.md](skills/woostack-execute-overnight/SKILL.md)
-
-### `/woostack-review [PR#]`: parallel review swarm
-
-Detects relevant review angles for the diff (bugs and security always on; SEO, design, react, database, tests, api, types, i18n, docs and more conditionally), fans out one sub-agent per angle in parallel, then runs an adversarial **Skeptical Validator** (a prosecutor pass and a defender pass) to cut false positives before anything is posted. With a PR number it posts a single batched native GitHub review; with no PR it reviews the local diff and prints findings. Host-agnostic: it falls back to a sequential loop on agents without parallel sub-agents. → [SKILL.md](skills/woostack-review/SKILL.md)
-
-### `/woostack-commit`: commit and update the PR
-
-Commits only the changes relevant to the current session, creates a `feature/*` branch first when the agent is on `staging` or `main`, then pushes/submits and updates the PR title/body with a concise bulleted summary and test plan. It prefers Graphite, never force-pushes, and stops before staging ambiguous unrelated work. → [SKILL.md](skills/woostack-commit/SKILL.md)
-
-### `/woostack-address-comments [PR#]`: work the review threads
-
-Walks every unresolved review thread on a PR, recommends a verdict per thread (fix / push back / clarify), then, once you approve the batch, applies fixes, replies, resolves, and pushes. Accept-by-design dismissals are recorded to `.woostack/memory.md` so future reviews don't re-raise them. Never merges. A thin delegator to the review skill's `address` verb. → [SKILL.md](skills/woostack-address-comments/SKILL.md)
-
-### `/woostack-status [--all] [--fetch]`: derived feature board
-
-A read-only, on-demand board derived fresh from your `.woostack/` artifacts: for every spec it shows the reconciled phase, plan progress, increment-PR rollup, owner, age, and the single next action, and flags any drift between the authored `status:` and what's on disk. It never fetches (except the opt-in `--fetch`), commits, or pushes, and writes no `STATUS.md`. Backed by the `spec : plan : PRs = 1 : 1 : N` invariant and the phase enum defined once in [conventions.md](skills/woostack-status/references/conventions.md). → [SKILL.md](skills/woostack-status/SKILL.md)
-
-### `/woostack-visualize <source> [for <audience>]`: audience-tailored HTML render
-
-A discovery command for rendering source material as an audience-tailored HTML view while keeping the source authoritative. → [SKILL.md](skills/woostack-visualize/SKILL.md)
-
-### `/woostack-debug <target>`: find the root cause before fixing
-
-Runs woostack's systematic-debugging method on a bug, test failure, or unexpected behavior: root-cause investigation → pattern analysis → hypothesis/test → handback, under the Iron Law (no fix without a root cause). It recalls known `gotcha`s from `.woostack/memory/` at the start. Running it performs the analysis autonomously and hands back the root cause, a proposed minimal fix, and the TDD context — it is investigative only and never writes code (the caller implements the fix: `woostack-fix`, or `woostack-execute` on a stuck verification). `woostack-review` points you at it for a confirmed bug. Never commits or merges. → [SKILL.md](skills/woostack-debug/SKILL.md)
-
-### `/woostack-tdd <target>`: test-driven development engine
-
-Applies the TDD kernel (Red → Green → Refactor) to add appropriate tests to an existing code block, PR, spec, or plan. New code requires tests first, while existing code characterization tests pin current behavior. → [SKILL.md](skills/woostack-tdd/SKILL.md)
-
-### `/woostack-dream [instructions]`: curate memory & recommend doc updates
-
-The agent-agnostic version of managed "dreams": a reflection pass over your `.woostack/` knowledge store. It reads the memory store and docs (static — no session mining), then proposes a single gated changeset that merges duplicate notes, replaces stale or contradicted ones, drops dead/orphaned notes, resolves conflicts `doctor.sh` only flags, surfaces consolidated insights, and recommends **evidence-guarded** edits to your docs (promoting recurring conventions, fixing claims memory now contradicts). Nothing changes before you approve; it ends on a summary and lets you request changes. Memory edits are local-only; doc edits land in the working tree (offer to `woostack-commit`). Never commits or merges. → [SKILL.md](skills/woostack-dream/SKILL.md)
-
-### Growing scope
-
-The collection tracks more of my day-to-day loop as it matures. Planned next: a commit utility that writes well-documented, conventional commit messages, plus other small tools that smooth the edges between the steps above.
-
-## Quickstart
-
-Install once, then pick the entry point that matches where you are.
-
-**Greenfield: start a new project**
-
-```bash
-pnpx skills add howarewoo/woostack          # install the collection into your agent
-
-/woostack-bootstrap a habit-tracker with web + mobile + API   # scaffolds a fresh repo; walks you through decisions first
-/woostack-build add streak tracking with a weekly reset       # build a feature in the new repo
-/woostack-review 42                                           # review the PR build opened
-/woostack-address-comments 42                                 # iterate on the review's findings
-```
-
-**Brownfield: work in an existing repo.** Skip `bootstrap` and run the loop in place.
-
-```bash
-pnpx skills add howarewoo/woostack          # install once
-# add `using-woostack` to AGENTS.md or CLAUDE.md so agents load repo rules
-
-/woostack-build add CSV export to the reports page   # feature loop in your current repo
-/woostack-review 1337                                # review the PR
-/woostack-address-comments 1337                      # iterate
-```
-
-Review and address-comments need the GitHub CLI (`gh`) authenticated for any step that touches a PR.
-
-## Concepts
-
-**Artifacts live under `.woostack/`.** Each project the skills touch keeps its working artifacts there: markdown specs in `.woostack/specs/`, markdown plans in `.woostack/plans/`, and review config in `.woostack/config.json`. `.woostack/metrics.json`, plus the local-only memory (`.woostack/memory.md` and `.woostack/memory/`), are per-clone and gitignored. See [development.md](skills/woostack-bootstrap/references/development.md).
-
-**Branching model.** Bootstrapped projects use `main` (production) ← `staging` (integration) ← `feature/*` (one change, one PR). Feature branches cut from `staging` and PR back into it; `staging` merges to `main` on a release cadence. → [development.md](skills/woostack-bootstrap/references/development.md)
-
-**Memory: scope-routed notes that persist across runs.** The skills accumulate durable learnings — patterns, decisions, gotchas, conventions, hotspots — so later runs don't re-litigate or re-discover what an earlier run already settled. Memory is two coexisting layers, both local-only and gitignored:
-
-- **Flat shard** (`.woostack/memory.md`) — a free-form bullet list, always loaded in full. This is where accept-by-design dismissals land (so future reviews don't re-raise a finding you intentionally accepted).
-- **Scope-routed store** (`.woostack/memory/`) — one Markdown note per fact, each with a `scope:` glob declaring which files it governs (e.g. `packages/api/**`). A derived index (`MEMORY.md`) carries one cheap line per note. When a skill loads context for a working set of files, it matches only the notes whose scope overlaps those files, plus their direct `[[wikilinks]]` (one hop). Recall stays sub-linear: on a repo with 500 notes, only the handful touching the changed files load, not the whole corpus.
-
-Notes are written two ways: **distillation** by `woostack-execute` after each implemented increment (durable cross-feature learnings, scoped to the touched files, with `source:` provenance back to the spec/plan), and the **accept-by-design** path from `woostack-address-comments` (review-noise suppression → flat shard). `/woostack-init` scaffolds the store; `build-index.sh` rebuilds the index; `doctor.sh` lints it. → [memory.md](skills/woostack-init/references/memory.md)
-
-**The review swarm + skeptical validation.** Review isn't a single agent reading a diff. It's `detect → fan-out (one sub-agent per angle) → merge → skeptical validator → post`. The validator runs as a prosecutor (find reasons each finding is real) and a defender (find reasons to drop it), and only findings that survive both get posted, which keeps the output low-noise. The chat-host swarm and the cloud GitHub Action run the *same* scripts and prompts. → [SKILL.md](skills/woostack-review/SKILL.md#architecture)
-
-**woostack-review is first-party here.** It lives at `skills/woostack-review/`; the standalone `howarewoo/woo-review` repo is deprecated.
-
-## Configuration
-
-Consumer repos can add `.woostack/config.json` to tune woostack behavior without forking the skill collection. Run `/woostack-init` once to scaffold the `.woostack/` workspace, or create the file directly when you only need a small override.
-
-Review settings live under a top-level `review` object so the same config file can grow sibling namespaces later without collisions. All keys are optional; missing config keeps the built-in defaults. The review defaults are intentionally quiet: `severity_floor` is `high`, bot-authored dependency/update PRs are skipped, and release-rollup PR titles are skipped unless you override those rules.
-
-Minimal example:
-
+Example `.woostack/config.json`:
 ```json
 {
   "review": {
     "severity_floor": "medium",
-    "angles": {
-      "skip": ["seo"],
-      "force": ["database"]
-    },
-    "ignore": ["**/*.generated.ts"],
-    "project_rules": ["docs/standards/*.md"]
+    "ignore": ["**/*.generated.ts"]
   }
 }
 ```
 
-Use config for repository-specific review policy: widen or narrow the severity floor, force or skip optional angles, ignore generated files, add rule documents, customize bot/release auto-skips, opt into local metrics, or adjust diff chunking for large PRs. `bugs` and `security` always run and cannot be skipped. Invalid JSON or unknown keys inside `review` fail loudly so configuration mistakes do not silently change review behavior. → [Per-repo Configuration](skills/woostack-review/SKILL.md#per-repo-configuration-woostackconfigjson)
+- **`review.severity_floor`**: Filter results by severity (e.g., `high`, `medium`, `low`).
+- **`review.ignore`**: Exclude generated or external code files from PR reviews.
 
-## What it defines
+For detailed configurations, see [woostack-review config options](skills/woostack-review/SKILL.md#per-repo-configuration-woostackconfigjson).
 
-The bootstrap skill's decisions live in reference files, loaded on demand:
+---
 
-| Reference | What it defines |
-|---|---|
-| [decisions.md](skills/woostack-bootstrap/references/decisions.md) | Questionnaire guide + confirmation protocol — the pre-scaffold gate |
-| [bootstrap.md](skills/woostack-bootstrap/references/bootstrap.md) | Step-by-step bootstrap procedure for AI agents |
-| [architecture.md](skills/woostack-bootstrap/references/architecture.md) | Monorepo layout, package tiers, import boundaries, naming |
-| [frameworks.md](skills/woostack-bootstrap/references/frameworks.md) | Recommended frameworks per layer, catalog protocol, known gotchas |
-| [infrastructure.md](skills/woostack-bootstrap/references/infrastructure.md) | Hosting, CI/CD, env, observability, auth, data layer |
-| [patterns.md](skills/woostack-bootstrap/references/patterns.md) | oRPC contracts, TanStack Query, RSC, navigation, TDD, feature exposure |
-| [development.md](skills/woostack-bootstrap/references/development.md) | Development workflow and branching model |
+## The Core Development & Review Loop
 
-## Cloud / CI review
+`woostack` enforces structured, gated pipelines to ensure high-quality code changes.
 
-`/woostack-review` also ships as a GitHub Action so the same swarm runs in your CI, with no local agent required. It's delivered two ways from this repo: a composite action ([`action.yml`](action.yml)) and a `workflow_call`-only reusable workflow ([`.github/workflows/reusable-review.yml`](.github/workflows/reusable-review.yml)). Both drive the same `skills/woostack-review/` scripts and prompts as the chat-host skill.
+### Writing and Modifying Code
 
-Drop this into the consumer repo at `.github/workflows/ai-review.yml`:
+No code changes should be made ad-hoc. All coding tasks must go through one of the three primary development entry points:
 
-```yaml
-name: AI PR Review
-on:
-  pull_request:
-    types: [opened, reopened, ready_for_review]
-  issue_comment:
-    types: [created]
+1. **Greenfield Applications** → [/woostack-bootstrap](skills/woostack-bootstrap/SKILL.md)
+   Walks through a technology selection protocol, obtains design approval, and scaffolds a clean monorepo architecture.
+2. **Features** → [/woostack-build](skills/woostack-build/SKILL.md)
+   A fixed, gated loop from idea to PR: `ideate → spec → spec-approval (gate) → plan → execute (TDD) → review → commit`.
+3. **Fixes & Refactors** → [/woostack-fix](skills/woostack-fix/SKILL.md)
+   A lightweight, unified fix loop for bugs: `diagnose root-cause → plan → plan-approval (gate) → execute (TDD) → commit`.
 
-jobs:
-  review:
-    # Authorization gate. issue_comment fires in the base-repo context where
-    # secrets are live, for ANY commenter, so restrict comment-triggered runs
-    # to trusted actors. Without this, a fork contributor's comment can spend
-    # your token (the GitHub "pwn-requests" pattern).
-    if: >-
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null &&
-       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
-    uses: howarewoo/woostack/.github/workflows/reusable-review.yml@main
-    with:
-      provider: anthropic
-    secrets:
-      anthropic_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+> [!WARNING]
+> **No code should be written or modified without using one of these three skills.** Greenfield apps use `/woostack-bootstrap`, features use `/woostack-build`, and fixes/bugs use `/woostack-fix`. This ensures all code changes follow a gated, structured design and test-driven workflow.
+
+### Review and Iterate Flow
+
+After writing code, use the verification and iteration loop:
+
+- **PR Reviews** → [/woostack-review](skills/woostack-review/SKILL.md)
+  Fans out sub-agents in parallel to check distinct angles (bugs, security, observability, database, etc.), then runs an adversarial **Skeptical Validator** (prosecutor and defender checks) to eliminate false positives before posting reviews.
+- **Addressing Reviews** → [/woostack-address-comments](skills/woostack-address-comments/SKILL.md)
+  Iteratively guides you through resolving, clarifying, or pushing back on PR review comments, applying changes, and pushing commits.
+
+---
+
+## Local Memory System
+
+The memory system allows agents to accumulate durable learnings (such as architecture patterns, gotchas, and conventions) locally on a per-clone basis, ensuring later sessions build upon previous ones.
+
+### Architecture
+
+All memories are saved locally as scoped per-fact Markdown notes under `.woostack/memory/` (which is gitignored to prevent cross-developer leakage). Each note defines a single fact and contains simple frontmatter declaring its context scope, type, and source:
+
+```markdown
+---
+name: orpc-error-mapping
+type: pattern
+scope: packages/api/**, packages/api/orpc/**
+hook: oRPC error → TanStack retry policy
+updated: 2026-06-02
+source: .woostack/specs/2026-06-02-api-errors.md
+---
+oRPC ORPCError maps to TanStack retry policy: throw typed,
+let [[tanstack-query-retries]] decide.
 ```
 
-The `if:` gate matters: the `issue_comment` trigger runs in the base-repo context with secrets available to *any* commenter, so it's restricted to the repo owner, members, and collaborators. Drop it and a fork contributor's comment could trigger a run on your token. Past that, there's zero local setup in the consumer repo: the action ships its own prompts and scripts and installs the `react-doctor` / `impeccable` CLIs via `npx` at run time. The provider is pluggable (Anthropic, OpenAI, Google, OpenRouter); pin `@main` to a release tag once one is cut. PR comments like `/woostack-review`, `/woostack-review recheck`, `/woostack-review --fast` (or `--deep`), and `/woostack-review force` re-trigger it without leaving the PR. → [SKILL.md](skills/woostack-review/SKILL.md#companion-github-action)
+### Context Routing
+
+Rather than loading the entire memory corpus on every run (which would bloat prompts and waste tokens), `woostack` routes context dynamically:
+1. **Scope Matching**: The recall script checks the files modified in the current session against note `scope` glob patterns.
+2. **One-Hop Expansion**: Only the matching notes—and any notes they link to directly via `[[wikilinks]]`—are loaded.
+This keeps prompt growth sub-linear, loading only the few notes relevant to the files under development.
+
+### Obsidian Vault Integration
+
+The `.woostack/memory/` store is designed to be fully compatible with Obsidian. Developers can open `.woostack/` directly as an Obsidian vault to visualize their local knowledge graph.
+
+- Scaffold Obsidian configuration files using:
+  ```bash
+  /woostack-init --obsidian
+  ```
+
+For more details on the memory specification, see the [Scope-Routed Memory Contract](skills/woostack-init/references/memory.md).
+
+---
 
 ## Contributing
 
-The skill evolves here. Open a PR to update default frameworks, revise patterns, document gotchas, or refine the bootstrap procedure. See [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
+The skills evolve here. Open a PR to update default frameworks, revise patterns, document gotchas, or refine the bootstrap and build procedures. See [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
 
-## Spec version
+## Spec Version
 
-`2.0.0`. First spec-only release. The prior template lives in git history.
+`2.0.0`
 
 ## License
 


### PR DESCRIPTION
## Goal

Rewrite the repository README.md to be clean, modern, and aligned with current woostack rules (installing with pnpx, running woostack-init first, using the gated coding loop, and understanding the scope-routed memory store).

## Summary

- Rewrote `README.md` to focus on the model-agnostic skill collection, installation via `pnpx`, initialization using `/woostack-init` before any other commands, config specs (`.woostack/config.json`), the Gated Code loop (Bootstrap, Build, Fix), and the local memory system (`.woostack/memory/`).
- Updated `AGENTS.md` to use the `pnpx` command format for consistency.
- Updated checkboxes in `.woostack/plans/2026-06-09-readme-rewrite.md`.

## Test plan

### Automated

- [x] Run `grep -E '(\.woostack/memory\.md|`memory\.md`)' README.md` to verify the deprecated flat shard is not referenced (exits 1).
- [x] Run `grep -E '\bnpx skills add' AGENTS.md` to verify the legacy installation command prefix is not used (exits 1).
- [x] Run `grep -F "pnpx skills add" AGENTS.md && grep -F "pnpx skills add" README.md` to verify the new command is in both files (exits 0).

### Manual

**Before merge**

- [ ] Inspect the rewritten `README.md` file for correctness and readability.
- [ ] Inspect `AGENTS.md` to ensure the installation command matches.

Spec: .woostack/specs/2026-06-09-readme-rewrite.md
