### PR TITLE
fix: anchor .woostack/ to repo root, not CWD (#272)

### DIFF
--- a/.woostack/fixes/2026-06-09-woostack-root-anchoring.md
+++ b/.woostack/fixes/2026-06-09-woostack-root-anchoring.md
@@ -1,0 +1,145 @@
+---
+type: fix
+status: in-review
+branch: fix/woostack-root-anchoring
+---
+
+# Fix: `.woostack/` anchored to CWD, not repo root — pollutes packages in monorepos
+
+GitHub issue: https://github.com/howarewoo/woostack/issues/272
+
+## 1. Root Cause
+
+Several woostack scripts compute the `.woostack/` parent directory by falling back to the
+**current working directory** (`$(pwd)`) instead of the **git repository root**. When the host
+agent's CWD drifts into a workspace package (e.g. `packages/infrastructure/ai`), these scripts
+create/read `.woostack/` *inside that package* and append to the package's `.gitignore`,
+splitting woostack state across the tree.
+
+Confirmed sites (grep, line-level):
+
+| Script | Line | Defect |
+|---|---|---|
+| `skills/woostack-review/scripts/metrics-fold.sh` | 20 | `ROOT="${GITHUB_WORKSPACE:-$(pwd)}"` → writes `<cwd>/.woostack/metrics.json`, appends `.woostack/metrics.json` to `<cwd>/.gitignore` |
+| `skills/woostack-review/scripts/load-config.sh` | 67 | `ROOT="${GITHUB_WORKSPACE:-$(pwd)}"` → reads `<cwd>/.woostack/config.json`; under a package the config is silently missed → defaults used |
+| `skills/woostack-review/scripts/prefetch.sh` | 752 | `WOOSTACK_DIR="${GITHUB_WORKSPACE:-$(pwd)}/.woostack"` → memory recall reads the wrong dir |
+| `skills/woostack-review/scripts/memory-append.sh` | 13 | `MEMORY_FILE="${MEMORY_FILE:-.woostack/memory.md}"` (bare CWD-relative default) |
+| `skills/woostack-review/scripts/memory-record.sh` | 11-12 | `MEMORY_DIR="${MEMORY_DIR:-.woostack/memory}"`, `MEMORY_FILE="${MEMORY_FILE:-.woostack/memory.md}"` (bare CWD-relative defaults) |
+
+Same defect class in the **woostack-address-comments** copies (separate files, not symlinks):
+
+| Script | Line | Defect |
+|---|---|---|
+| `skills/woostack-address-comments/scripts/memory-append.sh` | 13 | bare `.woostack/memory.md` default |
+| `skills/woostack-address-comments/scripts/memory-record.sh` | 11-12 | bare `.woostack/memory{,.md}` defaults |
+| `skills/woostack-address-comments/scripts/prefetch.sh` | 30-33 | bare `.woostack/memory`, `.woostack/memory.md` reads |
+
+**Evidence of inconsistency:** `resolve-outdir.sh` (sourced by every review/address script for
+`OUTDIR`) already resolves the root correctly via `git rev-parse --show-toplevel 2>/dev/null ||
+pwd`. So `OUTDIR` lands at `<root>/.woostack/tmp/...` while `metrics-fold` / `load-config` /
+`memory-*` / `prefetch WOOSTACK_DIR` land relative to CWD. The two disagree whenever CWD ≠ repo
+root. The bug was hit in the wild on a Claude Code host where a `cd packages/infrastructure/ai`
+persisted as the shell CWD across tool calls, so `metrics-fold.sh` created
+`packages/infrastructure/ai/.woostack/`.
+
+**Why the bad value originates:** each script independently picks `$(pwd)` (or a bare relative
+path) as the fallback root rather than the git toplevel. There is no single shared resolver, so
+each new script re-introduces the CWD assumption.
+
+## 2. Proposed Fix
+
+Introduce one shared resolver, `resolve-root.sh`, sourced exactly like `resolve-outdir.sh`,
+exporting `WOOSTACK_ROOT` with this precedence:
+
+```sh
+#!/usr/bin/env bash
+# Single source of truth for the woostack repo root.
+# Sourced (not executed). Honors an explicit WOOSTACK_ROOT override; otherwise
+# prefers the CI checkout root, then the git toplevel, then the current directory.
+if [ -z "${WOOSTACK_ROOT:-}" ]; then
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    WOOSTACK_ROOT="$GITHUB_WORKSPACE"
+  else
+    WOOSTACK_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  fi
+fi
+export WOOSTACK_ROOT
+```
+
+Then anchor every default `.woostack/` path to `$WOOSTACK_ROOT`, keeping all existing explicit
+overrides (`MEMORY_DIR`, `MEMORY_FILE`, `OUTDIR`) working unchanged — only the *default* switches
+from CWD-relative to root-anchored:
+
+- `metrics-fold.sh`: `ROOT="$WOOSTACK_ROOT"` (source `resolve-root.sh`).
+- `load-config.sh`: `ROOT="$WOOSTACK_ROOT"` (source `resolve-root.sh`).
+- `prefetch.sh`: `WOOSTACK_DIR="$WOOSTACK_ROOT/.woostack"` (source `resolve-root.sh`).
+- `memory-append.sh`: default `MEMORY_FILE="$WOOSTACK_ROOT/.woostack/memory.md"` when unset.
+- `memory-record.sh`: default `MEMORY_DIR`/`MEMORY_FILE` under `$WOOSTACK_ROOT/.woostack/` when unset.
+- `resolve-outdir.sh`: source `resolve-root.sh` and reuse `WOOSTACK_ROOT` for its root computation
+  (zero behavior change — in CI `GITHUB_WORKSPACE == toplevel`; locally the git toplevel; keeps the
+  two resolvers from drifting, which is exactly the bug's root cause).
+
+`resolve-root.sh` is duplicated per-skill-scripts dir, matching the existing `resolve-outdir.sh`
+duplication pattern (review and address-comments each keep their own copy).
+
+**Scope (RESOLVED):** fix BOTH woostack-review and woostack-address-comments — identical root
+cause, one PR closes it everywhere. The address-comments dir gets its own `resolve-root.sh` copy
+plus the same `memory-append.sh` / `memory-record.sh` / `prefetch.sh` edits.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Failing tests (RED)** under `skills/woostack-review/scripts/tests/`
+  - `test-resolve-root.sh` — unit the resolver precedence: (a) `GITHUB_WORKSPACE` set wins even
+    inside a git repo; (b) unset + git subdir → git toplevel; (c) explicit `WOOSTACK_ROOT` honored.
+    Fails first because `resolve-root.sh` does not exist yet.
+  - `test-metrics-fold-root.sh` — in a real git repo with a subdir, `GITHUB_WORKSPACE` unset, run
+    `metrics-fold.sh` from the subdir; assert `metrics.json` + the `.gitignore` append land at the
+    git toplevel `.woostack/`, and **no** `.woostack/` is created in the subdir. Fails first
+    (current code writes `<subdir>/.woostack/`).
+  - `test-load-config-root.sh` — config at `<root>/.woostack/config.json` with a non-default value;
+    run `load-config.sh` from a subdir with `GITHUB_WORKSPACE` unset; assert the emitted config
+    reflects the root config (not silent defaults). Fails first.
+  - `test-memory-record-root.sh` — no `MEMORY_DIR` override; run `memory-record.sh` from a subdir
+    of a git repo whose root has `.woostack/memory/`; assert the note lands under
+    `<root>/.woostack/memory/`, not `<subdir>/.woostack/memory/`. Fails first.
+  - Confirm each new test FAILS against current code before editing scripts.
+  - ✅ Done. All 4 confirmed RED before edits (e.g. metrics-fold wrote `<subdir>/.woostack/`;
+    load-config emitted `severity_floor=high` default instead of the root's `low`).
+- [x] **Step 2: Minimal fix (GREEN)**
+  - Add `skills/woostack-review/scripts/resolve-root.sh` (the resolver above).
+  - Edit review `metrics-fold.sh`, `load-config.sh`, `prefetch.sh`, `memory-append.sh`,
+    `memory-record.sh`, `resolve-outdir.sh` to source the resolver and anchor defaults to
+    `$WOOSTACK_ROOT`.
+  - Mirror into `skills/woostack-address-comments/scripts/`: add `resolve-root.sh`, then edit
+    `memory-append.sh`, `memory-record.sh`, `prefetch.sh`, and `resolve-outdir.sh` to anchor on
+    `$WOOSTACK_ROOT` (prefetch's `ROOT` for skill-script discovery stays script-relative; only the
+    `.woostack/` memory reads switch from bare-CWD to root-anchored).
+  - No bundled refactors beyond the resolver consolidation named above.
+  - ✅ Done. Added `resolve-root.sh` to both `woostack-review/scripts/` and
+    `woostack-address-comments/scripts/`; anchored `metrics-fold.sh`, `load-config.sh`,
+    `prefetch.sh`, `memory-append.sh`, `memory-record.sh`, `resolve-outdir.sh` (review) and
+    `memory-append.sh`, `memory-record.sh`, `prefetch.sh`, `resolve-outdir.sh` (address-comments)
+    on `$WOOSTACK_ROOT`.
+- [x] **Step 3: Verification**
+  - ✅ All 4 new `test-*-root.sh` green; existing `test-metrics-fold-overlap.sh`,
+    `test-load-config-nits.sh`, `test-memory-record.sh` stay green; full review suite + the
+    woostack-init (27+14) and woostack-status (59) runners pass. (Two pre-existing
+    `test-detect-angles-*` files lack a `finish` line and print no summary — unrelated to #272,
+    identical on baseline, left untouched.)
+  - ✅ `shellcheck -x` clean on every new/edited script (intentional SC2016 in the resolver test
+    suppressed with a directive; prefetch's remaining style infos are pre-existing, on untouched lines).
+  - ✅ Wild repro closed: `test-metrics-fold-root.sh` proves that from a package subdir with
+    `GITHUB_WORKSPACE` unset, `metrics-fold.sh` writes only the git-toplevel `.woostack/` and
+    creates no `.woostack/` (and no `.gitignore`) inside the package.
+
+## Open Questions
+
+1. ~~**Address-comments scope** — fix the woostack-address-comments copies in this PR, or
+   review-only?~~ **RESOLVED: include them (both).**
+
+## Notes
+
+- `GITHUB_WORKSPACE` first is correct for CI (it *is* the checkout root there).
+- The optional "warn if `.woostack` parent ≠ git toplevel" guard from the issue is intentionally
+  omitted: with a single shared resolver it is redundant, and it would mis-fire on legitimate
+  non-git checkouts (where `pwd` is the correct fallback).

--- a/skills/woostack-address-comments/scripts/memory-append.sh
+++ b/skills/woostack-address-comments/scripts/memory-append.sh
@@ -6,11 +6,14 @@
 #
 # Inputs (env):
 #   LEARNING   the pattern-phrased rule (required, non-empty)
-#   MEMORY_FILE  path (default ./.woostack/memory.md)
+#   MEMORY_FILE  path (default <repo-root>/.woostack/memory.md)
 set -euo pipefail
 
+# shellcheck source=skills/woostack-address-comments/scripts/resolve-root.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/resolve-root.sh"
+
 LEARNING="${LEARNING:?LEARNING env var required}"
-MEMORY_FILE="${MEMORY_FILE:-.woostack/memory.md}"
+MEMORY_FILE="${MEMORY_FILE:-$WOOSTACK_ROOT/.woostack/memory.md}"
 
 # Normalize: collapse runs of whitespace, trim ends — for the dup comparison.
 norm() { printf '%s' "$1" | tr -s '[:space:]' ' ' | sed 's/^ *//; s/ *$//'; }

--- a/skills/woostack-address-comments/scripts/memory-record.sh
+++ b/skills/woostack-address-comments/scripts/memory-record.sh
@@ -6,10 +6,12 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INIT_SCRIPTS="$(cd "$HERE/../../woostack-init/scripts" 2>/dev/null && pwd || true)"
+# shellcheck source=skills/woostack-address-comments/scripts/resolve-root.sh
+source "$HERE/resolve-root.sh"
 
 LEARNING="${LEARNING:?LEARNING env var required}"
-MEMORY_DIR="${MEMORY_DIR:-.woostack/memory}"
-MEMORY_FILE="${MEMORY_FILE:-.woostack/memory.md}"
+MEMORY_DIR="${MEMORY_DIR:-$WOOSTACK_ROOT/.woostack/memory}"
+MEMORY_FILE="${MEMORY_FILE:-$WOOSTACK_ROOT/.woostack/memory.md}"
 MEMORY_SCOPE="${MEMORY_SCOPE:-*}"
 MEMORY_TYPE="${MEMORY_TYPE:-convention}"
 MEMORY_SOURCE="${MEMORY_SOURCE:-${PR_NUMBER:+pr-$PR_NUMBER}}"

--- a/skills/woostack-address-comments/scripts/prefetch.sh
+++ b/skills/woostack-address-comments/scripts/prefetch.sh
@@ -7,6 +7,9 @@ ROOT="$(cd "$HERE/../../.." && pwd)"
 
 # shellcheck source=skills/woostack-address-comments/scripts/resolve-outdir.sh
 source "$HERE/resolve-outdir.sh"
+# shellcheck source=skills/woostack-address-comments/scripts/resolve-root.sh
+source "$HERE/resolve-root.sh"
+WOOSTACK_DIR="$WOOSTACK_ROOT/.woostack"
 mkdir -p "$OUTDIR"
 
 PR_NUMBER="${PR_NUMBER:-$(gh pr view --json number --jq .number 2>/dev/null || echo)}"
@@ -27,10 +30,10 @@ fi
 
 MEMORY_OUT="$OUTDIR/memory.md"
 rm -f "$MEMORY_OUT"
-if [ -d ".woostack/memory" ] && [ -x "$ROOT/skills/woostack-init/scripts/recall.sh" ]; then
-  bash "$ROOT/skills/woostack-init/scripts/recall.sh" ".woostack" "$PATHS_FILE" > "$MEMORY_OUT" 2>"$OUTDIR/recall.log" || : > "$MEMORY_OUT"
-elif [ -f ".woostack/memory.md" ]; then
-  head -c 102400 ".woostack/memory.md" > "$MEMORY_OUT"
+if [ -d "$WOOSTACK_DIR/memory" ] && [ -x "$ROOT/skills/woostack-init/scripts/recall.sh" ]; then
+  bash "$ROOT/skills/woostack-init/scripts/recall.sh" "$WOOSTACK_DIR" "$PATHS_FILE" > "$MEMORY_OUT" 2>"$OUTDIR/recall.log" || : > "$MEMORY_OUT"
+elif [ -f "$WOOSTACK_DIR/memory.md" ]; then
+  head -c 102400 "$WOOSTACK_DIR/memory.md" > "$MEMORY_OUT"
 fi
 
 if [ -f "$MEMORY_OUT" ]; then

--- a/skills/woostack-address-comments/scripts/resolve-outdir.sh
+++ b/skills/woostack-address-comments/scripts/resolve-outdir.sh
@@ -6,16 +6,17 @@
 # derive a per-project path so concurrent reviews of different repos on one
 # machine do not share — and clobber — the same /tmp/pr-review tree.
 #
-# Derivation: hash the git toplevel (stable across subdirs of one repo); fall
-# back to the current directory when not in a git repo. Two distinct repo roots
-# hash to two distinct dirs; the same repo always resolves to the same dir.
+# Derivation: hash the woostack root (the git toplevel, via resolve-root.sh —
+# stable across subdirs of one repo); two distinct repo roots hash to two
+# distinct dirs; the same repo always resolves to the same dir.
 #
 # NOTE: per-project granularity only. Two concurrent runs of the SAME repo still
 # share one dir (rare; accepted). For full per-run isolation, set OUTDIR yourself.
 if [ -z "${OUTDIR:-}" ]; then
-  _wr_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  _wr_hash="$(printf '%s' "$_wr_root" | { sha1sum 2>/dev/null || shasum; } | cut -c1-12)"
+  # shellcheck source=skills/woostack-address-comments/scripts/resolve-root.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/resolve-root.sh"
+  _wr_hash="$(printf '%s' "$WOOSTACK_ROOT" | { sha1sum 2>/dev/null || shasum; } | cut -c1-12)"
   OUTDIR="/tmp/pr-review-${_wr_hash}"
-  unset _wr_root _wr_hash
+  unset _wr_hash
 fi
 export OUTDIR

--- a/skills/woostack-address-comments/scripts/resolve-root.sh
+++ b/skills/woostack-address-comments/scripts/resolve-root.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Single source of truth for the woostack repo root (issue #272).
+#
+# Sourced (not executed) by every woostack script that anchors a `.woostack/`
+# path — metrics, config, memory, prefetch, and resolve-outdir. Resolving ONE
+# root here keeps the `.woostack/` tree from splitting across a monorepo when the
+# host agent's CWD drifts into a workspace package: every consumer lands at the
+# repo root, never `<cwd>/.woostack/` inside a package.
+#
+# Precedence:
+#   1. explicit WOOSTACK_ROOT override (host pins, tests) — honored as-is
+#   2. GITHUB_WORKSPACE — the CI checkout root (it *is* the repo root there)
+#   3. git rev-parse --show-toplevel — the repo root for any subdir of a clone
+#   4. pwd — fallback when not inside a git repo
+#
+# Honors explicit MEMORY_DIR / MEMORY_FILE / OUTDIR overrides downstream
+# unchanged; only the *default* base switches from CWD-relative to root-anchored.
+if [ -z "${WOOSTACK_ROOT:-}" ]; then
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    WOOSTACK_ROOT="$GITHUB_WORKSPACE"
+  else
+    WOOSTACK_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  fi
+fi
+export WOOSTACK_ROOT

--- a/skills/woostack-address-comments/scripts/tests/test-memory-record-root.sh
+++ b/skills/woostack-address-comments/scripts/tests/test-memory-record-root.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Regression for issue #272: the address-comments memory-record must anchor its
+# default MEMORY_DIR to the git repo root. With no MEMORY_DIR override, running
+# from a package subdir (GITHUB_WORKSPACE unset) must write the scoped note under
+# the ROOT .woostack/memory store — not create a stray .woostack/ inside the
+# package. Mirrors the woostack-review counterpart so a future CWD-relative
+# regression in the address-comments copy is caught too.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/memory-record.sh"
+
+repo="$(mktemp -d)"
+( cd "$repo" && git init -q )
+toplevel="$(cd "$repo" && git rev-parse --show-toplevel)"
+sub="$toplevel/packages/pkg"
+mkdir -p "$sub" "$toplevel/.woostack/memory"
+
+note_count() { find "$toplevel/.woostack/memory" -maxdepth 1 -type f -name '*.md' ! -name MEMORY.md | wc -l | tr -d ' '; }
+before="$(note_count)"
+
+( cd "$sub" && env -u GITHUB_WORKSPACE \
+    WOOSTACK_NOW=2026-06-09 \
+    LEARNING='Issue #272 root anchoring: woostack paths resolve to the git toplevel.' \
+    MEMORY_SCOPE='skills/**' \
+    bash "$SCRIPT" ) >"$repo/memory-record-root.out" 2>&1
+
+after="$(note_count)"
+assert_eq "$([ "$after" -gt "$before" ] && echo grew || echo same)" "grew" \
+  "scoped note written under the ROOT .woostack/memory store"
+assert_eq "$(test -e "$sub/.woostack" && echo yes || echo no)" "no" \
+  "no .woostack/ polluting the package subdir"
+
+rm -rf "$repo"
+finish

--- a/skills/woostack-review/scripts/load-config.sh
+++ b/skills/woostack-review/scripts/load-config.sh
@@ -62,9 +62,11 @@ set -euo pipefail
 
 # shellcheck source=skills/woostack-review/scripts/resolve-outdir.sh
 source "$(dirname "${BASH_SOURCE[0]}")/resolve-outdir.sh"
+# shellcheck source=skills/woostack-review/scripts/resolve-root.sh
+source "$(dirname "${BASH_SOURCE[0]}")/resolve-root.sh"
 mkdir -p "$OUTDIR"
 
-ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+ROOT="$WOOSTACK_ROOT"
 CFG_PATH="$ROOT/.woostack/config.json"
 
 if [ ! -f "$CFG_PATH" ]; then

--- a/skills/woostack-review/scripts/memory-append.sh
+++ b/skills/woostack-review/scripts/memory-append.sh
@@ -6,11 +6,14 @@
 #
 # Inputs (env):
 #   LEARNING   the pattern-phrased rule (required, non-empty)
-#   MEMORY_FILE  path (default ./.woostack/memory.md)
+#   MEMORY_FILE  path (default <repo-root>/.woostack/memory.md)
 set -euo pipefail
 
+# shellcheck source=skills/woostack-review/scripts/resolve-root.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/resolve-root.sh"
+
 LEARNING="${LEARNING:?LEARNING env var required}"
-MEMORY_FILE="${MEMORY_FILE:-.woostack/memory.md}"
+MEMORY_FILE="${MEMORY_FILE:-$WOOSTACK_ROOT/.woostack/memory.md}"
 
 # Normalize: collapse runs of whitespace, trim ends — for the dup comparison.
 norm() { printf '%s' "$1" | tr -s '[:space:]' ' ' | sed 's/^ *//; s/ *$//'; }

--- a/skills/woostack-review/scripts/memory-record.sh
+++ b/skills/woostack-review/scripts/memory-record.sh
@@ -6,10 +6,12 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INIT_SCRIPTS="$(cd "$HERE/../../woostack-init/scripts" 2>/dev/null && pwd || true)"
+# shellcheck source=skills/woostack-review/scripts/resolve-root.sh
+source "$HERE/resolve-root.sh"
 
 LEARNING="${LEARNING:?LEARNING env var required}"
-MEMORY_DIR="${MEMORY_DIR:-.woostack/memory}"
-MEMORY_FILE="${MEMORY_FILE:-.woostack/memory.md}"
+MEMORY_DIR="${MEMORY_DIR:-$WOOSTACK_ROOT/.woostack/memory}"
+MEMORY_FILE="${MEMORY_FILE:-$WOOSTACK_ROOT/.woostack/memory.md}"
 MEMORY_SCOPE="${MEMORY_SCOPE:-*}"
 MEMORY_TYPE="${MEMORY_TYPE:-convention}"
 MEMORY_SOURCE="${MEMORY_SOURCE:-${PR_NUMBER:+pr-$PR_NUMBER}}"

--- a/skills/woostack-review/scripts/metrics-fold.sh
+++ b/skills/woostack-review/scripts/metrics-fold.sh
@@ -15,9 +15,11 @@ set -euo pipefail
 
 # shellcheck source=skills/woostack-review/scripts/resolve-outdir.sh
 source "$(dirname "${BASH_SOURCE[0]}")/resolve-outdir.sh"
+# shellcheck source=skills/woostack-review/scripts/resolve-root.sh
+source "$(dirname "${BASH_SOURCE[0]}")/resolve-root.sh"
 CONFIG="$OUTDIR/config.json"
 PER_RUN="$OUTDIR/findings.metrics.json"
-ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+ROOT="$WOOSTACK_ROOT"
 ROLLING="$ROOT/.woostack/metrics.json"
 GITIGNORE="$ROOT/.gitignore"
 SCHEMA_VERSION=3

--- a/skills/woostack-review/scripts/prefetch.sh
+++ b/skills/woostack-review/scripts/prefetch.sh
@@ -33,6 +33,8 @@ set -euo pipefail
 # wipe (the only legitimate caller is a genuinely fresh run).
 # shellcheck source=skills/woostack-review/scripts/resolve-outdir.sh
 source "$(dirname "${BASH_SOURCE[0]}")/resolve-outdir.sh"
+# shellcheck source=skills/woostack-review/scripts/resolve-root.sh
+source "$(dirname "${BASH_SOURCE[0]}")/resolve-root.sh"
 if [ "${WOO_REVIEW_FRESH:-}" != "1" ] && compgen -G "$OUTDIR/findings.*" >/dev/null 2>&1; then
   echo "::warning::prefetch: $OUTDIR holds in-flight findings.* — refusing rm -rf (set WOO_REVIEW_FRESH=1 to force a fresh wipe)" >&2
 else
@@ -749,7 +751,7 @@ echo "Prior review threads (open + resolved): $PRIOR_COUNT"
 # cap-protected global shard (flat memory.md). Falls back to a raw flat copy
 # when recall.sh is unavailable (e.g. single-skill install). Missing both => no
 # memory context (normal for fresh repos).
-WOOSTACK_DIR="${GITHUB_WORKSPACE:-$(pwd)}/.woostack"
+WOOSTACK_DIR="$WOOSTACK_ROOT/.woostack"
 MEMORY_SRC="$WOOSTACK_DIR/memory.md"
 MEMORY_OUT="$OUTDIR/memory.md"
 RECALL="$SCRIPT_DIR/../../woostack-init/scripts/recall.sh"

--- a/skills/woostack-review/scripts/resolve-outdir.sh
+++ b/skills/woostack-review/scripts/resolve-outdir.sh
@@ -6,22 +6,23 @@
 # derive a per-project path so concurrent reviews of different repos on one
 # machine do not share — and clobber — the same /tmp/pr-review tree.
 #
-# Derivation: hash the git toplevel (stable across subdirs of one repo); fall
-# back to the current directory when not in a git repo. Two distinct repo roots
-# hash to two distinct dirs; the same repo always resolves to the same dir.
+# Derivation: hash the woostack root (the git toplevel, via resolve-root.sh —
+# stable across subdirs of one repo); two distinct repo roots hash to two
+# distinct dirs; the same repo always resolves to the same dir.
 #
 # NOTE: per-project granularity only. Two concurrent runs of the SAME repo still
 # share one dir (rare; accepted). For full per-run isolation, set OUTDIR yourself.
 if [ -z "${OUTDIR:-}" ]; then
-  _wr_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  _wr_hash="$(printf '%s' "$_wr_root" | { sha1sum 2>/dev/null || shasum; } | cut -c1-12)"
+  # shellcheck source=skills/woostack-review/scripts/resolve-root.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/resolve-root.sh"
+  _wr_hash="$(printf '%s' "$WOOSTACK_ROOT" | { sha1sum 2>/dev/null || shasum; } | cut -c1-12)"
   # Place inside the workspace's .woostack/tmp/ directory to leverage pre-approved
   # workspace permissions and avoid sandbox permission prompt loops locally.
-  if [ -d "${_wr_root}/.woostack" ]; then
-    OUTDIR="${_wr_root}/.woostack/tmp/pr-review-${_wr_hash}"
+  if [ -d "${WOOSTACK_ROOT}/.woostack" ]; then
+    OUTDIR="${WOOSTACK_ROOT}/.woostack/tmp/pr-review-${_wr_hash}"
   else
     OUTDIR="/tmp/pr-review-${_wr_hash}"
   fi
-  unset _wr_root _wr_hash
+  unset _wr_hash
 fi
 export OUTDIR

--- a/skills/woostack-review/scripts/resolve-root.sh
+++ b/skills/woostack-review/scripts/resolve-root.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Single source of truth for the woostack repo root (issue #272).
+#
+# Sourced (not executed) by every woostack script that anchors a `.woostack/`
+# path — metrics, config, memory, prefetch, and resolve-outdir. Resolving ONE
+# root here keeps the `.woostack/` tree from splitting across a monorepo when the
+# host agent's CWD drifts into a workspace package: every consumer lands at the
+# repo root, never `<cwd>/.woostack/` inside a package.
+#
+# Precedence:
+#   1. explicit WOOSTACK_ROOT override (host pins, tests) — honored as-is
+#   2. GITHUB_WORKSPACE — the CI checkout root (it *is* the repo root there)
+#   3. git rev-parse --show-toplevel — the repo root for any subdir of a clone
+#   4. pwd — fallback when not inside a git repo
+#
+# Honors explicit MEMORY_DIR / MEMORY_FILE / OUTDIR overrides downstream
+# unchanged; only the *default* base switches from CWD-relative to root-anchored.
+if [ -z "${WOOSTACK_ROOT:-}" ]; then
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    WOOSTACK_ROOT="$GITHUB_WORKSPACE"
+  else
+    WOOSTACK_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  fi
+fi
+export WOOSTACK_ROOT

--- a/skills/woostack-review/scripts/tests/test-load-config-root.sh
+++ b/skills/woostack-review/scripts/tests/test-load-config-root.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Regression for issue #272: load-config must read .woostack/config.json from the
+# git repo root, not the current working directory. Run it from a package subdir
+# with GITHUB_WORKSPACE unset; a non-default severity_floor in the ROOT config
+# must be honored (CWD-anchored code silently misses it and emits defaults).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/load-config.sh"
+
+repo="$(mktemp -d)"
+( cd "$repo" && git init -q )
+toplevel="$(cd "$repo" && git rev-parse --show-toplevel)"
+sub="$toplevel/packages/pkg"
+mkdir -p "$sub" "$toplevel/.woostack"
+# Non-default value (loader default is severity_floor=high).
+printf '%s\n' '{"review":{"severity_floor":"low"}}' > "$toplevel/.woostack/config.json"
+
+out="$(mktemp -d)/out"
+mkdir -p "$out"
+
+( cd "$sub" && env -u GITHUB_WORKSPACE OUTDIR="$out" bash "$SCRIPT" ) >/tmp/load-config-root.out 2>&1
+
+assert_eq "$(jq -r '.severity_floor' "$out/config.json")" "low" \
+  "root .woostack/config.json honored from a subdir (not silent defaults)"
+
+rm -rf "$repo" "$(dirname "$out")"
+finish

--- a/skills/woostack-review/scripts/tests/test-load-config-root.sh
+++ b/skills/woostack-review/scripts/tests/test-load-config-root.sh
@@ -21,7 +21,7 @@ printf '%s\n' '{"review":{"severity_floor":"low"}}' > "$toplevel/.woostack/confi
 out="$(mktemp -d)/out"
 mkdir -p "$out"
 
-( cd "$sub" && env -u GITHUB_WORKSPACE OUTDIR="$out" bash "$SCRIPT" ) >/tmp/load-config-root.out 2>&1
+( cd "$sub" && env -u GITHUB_WORKSPACE OUTDIR="$out" bash "$SCRIPT" ) >"$out/load-config-root.out" 2>&1
 
 assert_eq "$(jq -r '.severity_floor' "$out/config.json")" "low" \
   "root .woostack/config.json honored from a subdir (not silent defaults)"

--- a/skills/woostack-review/scripts/tests/test-memory-record-root.sh
+++ b/skills/woostack-review/scripts/tests/test-memory-record-root.sh
@@ -23,7 +23,7 @@ before="$(note_count)"
     WOOSTACK_NOW=2026-06-09 \
     LEARNING='Issue #272 root anchoring: woostack paths resolve to the git toplevel.' \
     MEMORY_SCOPE='skills/**' \
-    bash "$SCRIPT" ) >/tmp/memory-record-root.out 2>&1
+    bash "$SCRIPT" ) >"$repo/memory-record-root.out" 2>&1
 
 after="$(note_count)"
 assert_eq "$([ "$after" -gt "$before" ] && echo grew || echo same)" "grew" \

--- a/skills/woostack-review/scripts/tests/test-memory-record-root.sh
+++ b/skills/woostack-review/scripts/tests/test-memory-record-root.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Regression for issue #272: memory-record must anchor its default MEMORY_DIR to
+# the git repo root. With no MEMORY_DIR override, running from a package subdir
+# (GITHUB_WORKSPACE unset) must write the scoped note under the ROOT .woostack/
+# memory store — not create a stray .woostack/ inside the package.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/memory-record.sh"
+
+repo="$(mktemp -d)"
+( cd "$repo" && git init -q )
+toplevel="$(cd "$repo" && git rev-parse --show-toplevel)"
+sub="$toplevel/packages/pkg"
+mkdir -p "$sub" "$toplevel/.woostack/memory"
+
+note_count() { find "$toplevel/.woostack/memory" -maxdepth 1 -type f -name '*.md' ! -name MEMORY.md | wc -l | tr -d ' '; }
+before="$(note_count)"
+
+( cd "$sub" && env -u GITHUB_WORKSPACE \
+    WOOSTACK_NOW=2026-06-09 \
+    LEARNING='Issue #272 root anchoring: woostack paths resolve to the git toplevel.' \
+    MEMORY_SCOPE='skills/**' \
+    bash "$SCRIPT" ) >/tmp/memory-record-root.out 2>&1
+
+after="$(note_count)"
+assert_eq "$([ "$after" -gt "$before" ] && echo grew || echo same)" "grew" \
+  "scoped note written under the ROOT .woostack/memory store"
+assert_eq "$(test -e "$sub/.woostack" && echo yes || echo no)" "no" \
+  "no .woostack/ polluting the package subdir"
+
+rm -rf "$repo"
+finish

--- a/skills/woostack-review/scripts/tests/test-metrics-fold-root.sh
+++ b/skills/woostack-review/scripts/tests/test-metrics-fold-root.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Regression for issue #272: metrics-fold must anchor .woostack/ to the git repo
+# root, never the current working directory. Run it from a package subdir with
+# GITHUB_WORKSPACE unset and assert the rolling metrics + the .gitignore append
+# land at the git toplevel, and that no .woostack/ is created inside the package.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/metrics-fold.sh"
+
+repo="$(mktemp -d)"
+( cd "$repo" && git init -q )
+toplevel="$(cd "$repo" && git rev-parse --show-toplevel)"
+sub="$toplevel/packages/infrastructure/ai"
+mkdir -p "$sub"
+
+out="$(mktemp -d)/out"
+mkdir -p "$out"
+printf '%s\n' '{"metrics": true}' > "$out/config.json"
+cat > "$out/findings.metrics.json" <<'JSON'
+{
+  "schema_version": 3,
+  "mode": "defender-only",
+  "degraded": false,
+  "angles": {
+    "bugs": {"raw_count": 1, "kept": 1, "nit_count": 0, "overlap_total": 0, "overlap_with": {}}
+  }
+}
+JSON
+
+# Run from the package subdir, GITHUB_WORKSPACE unset, OUTDIR pinned.
+( cd "$sub" && env -u GITHUB_WORKSPACE OUTDIR="$out" bash "$SCRIPT" ) >/tmp/metrics-fold-root.out 2>&1
+
+assert_eq "$(test -f "$toplevel/.woostack/metrics.json" && echo yes || echo no)" "yes" \
+  "rolling metrics.json written at the git toplevel"
+assert_eq "$(test -e "$sub/.woostack" && echo yes || echo no)" "no" \
+  "no .woostack/ polluting the package subdir"
+assert_contains "$(cat "$toplevel/.gitignore" 2>/dev/null || true)" ".woostack/metrics.json" \
+  ".gitignore append lands at the git toplevel"
+assert_eq "$(test -e "$sub/.gitignore" && echo yes || echo no)" "no" \
+  "no .gitignore created inside the package subdir"
+
+rm -rf "$repo" "$(dirname "$out")"
+finish

--- a/skills/woostack-review/scripts/tests/test-metrics-fold-root.sh
+++ b/skills/woostack-review/scripts/tests/test-metrics-fold-root.sh
@@ -31,7 +31,7 @@ cat > "$out/findings.metrics.json" <<'JSON'
 JSON
 
 # Run from the package subdir, GITHUB_WORKSPACE unset, OUTDIR pinned.
-( cd "$sub" && env -u GITHUB_WORKSPACE OUTDIR="$out" bash "$SCRIPT" ) >/tmp/metrics-fold-root.out 2>&1
+( cd "$sub" && env -u GITHUB_WORKSPACE OUTDIR="$out" bash "$SCRIPT" ) >"$out/metrics-fold-root.out" 2>&1
 
 assert_eq "$(test -f "$toplevel/.woostack/metrics.json" && echo yes || echo no)" "yes" \
   "rolling metrics.json written at the git toplevel"

--- a/skills/woostack-review/scripts/tests/test-resolve-root.sh
+++ b/skills/woostack-review/scripts/tests/test-resolve-root.sh
@@ -26,6 +26,8 @@ toplevel="$(cd "$repo" && git rev-parse --show-toplevel)"
 sub="$toplevel/packages/pkg"
 mkdir -p "$sub"
 ws="$(mktemp -d)"
+# A throwaway dir that is NOT inside any git repo, for the pwd-fallback branch.
+nogit="$(mktemp -d)"
 
 for resolver in "$DIR/resolve-root.sh" "$ROOT/skills/woostack-address-comments/scripts/resolve-root.sh"; do
   tag="$(basename "$(dirname "$(dirname "$resolver")")")"  # skill dir name
@@ -42,7 +44,11 @@ for resolver in "$DIR/resolve-root.sh" "$ROOT/skills/woostack-address-comments/s
   got="$( cd "$sub" && env -u GITHUB_WORKSPACE WOOSTACK_ROOT=/custom/root \
             bash -c 'source "$0"; printf "%s" "$WOOSTACK_ROOT"' "$resolver" )"
   assert_eq "$got" "/custom/root" "[$tag] explicit WOOSTACK_ROOT override honored"
+
+  # (d) Outside any git repo, no overrides -> pwd fallback (safe degradation).
+  got="$(resolve "$resolver" "$nogit" -u GITHUB_WORKSPACE)"
+  assert_eq "$got" "$nogit" "[$tag] pwd fallback used outside any git repo"
 done
 
-rm -rf "$repo" "$ws"
+rm -rf "$repo" "$ws" "$nogit"
 finish

--- a/skills/woostack-review/scripts/tests/test-resolve-root.sh
+++ b/skills/woostack-review/scripts/tests/test-resolve-root.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Unit the shared woostack-root resolver precedence:
+#   explicit WOOSTACK_ROOT override > GITHUB_WORKSPACE > git toplevel > pwd.
+# Both the woostack-review and woostack-address-comments copies must agree.
+#
+# shellcheck disable=SC2016  # single quotes are intentional: $0/$WOOSTACK_ROOT
+# must expand inside the child `bash -c`, not in this parent shell.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+
+# Resolve WOOSTACK_ROOT in a clean child shell with controlled env + cwd.
+#   $1 resolver path, $2 cwd, $3..$n env assignments (KEY=VALUE), `-u KEY` honored.
+resolve() {
+  local resolver="$1" cwd="$2"; shift 2
+  ( cd "$cwd" && env -u WOOSTACK_ROOT "$@" bash -c \
+      'source "$0"; printf "%s" "$WOOSTACK_ROOT"' "$resolver" )
+}
+
+# Build a throwaway git repo with a nested package subdir.
+repo="$(mktemp -d)"
+( cd "$repo" && git init -q )
+toplevel="$(cd "$repo" && git rev-parse --show-toplevel)"
+sub="$toplevel/packages/pkg"
+mkdir -p "$sub"
+ws="$(mktemp -d)"
+
+for resolver in "$DIR/resolve-root.sh" "$ROOT/skills/woostack-address-comments/scripts/resolve-root.sh"; do
+  tag="$(basename "$(dirname "$(dirname "$resolver")")")"  # skill dir name
+
+  # (a) GITHUB_WORKSPACE wins even when cwd is inside a git repo.
+  got="$(resolve "$resolver" "$sub" -u GITHUB_WORKSPACE GITHUB_WORKSPACE="$ws")"
+  assert_eq "$got" "$ws" "[$tag] GITHUB_WORKSPACE wins over git toplevel"
+
+  # (b) No GITHUB_WORKSPACE, inside a git subdir -> git toplevel.
+  got="$(resolve "$resolver" "$sub" -u GITHUB_WORKSPACE)"
+  assert_eq "$got" "$toplevel" "[$tag] git toplevel used from a subdir when GITHUB_WORKSPACE unset"
+
+  # (c) Explicit WOOSTACK_ROOT override is honored above everything.
+  got="$( cd "$sub" && env -u GITHUB_WORKSPACE WOOSTACK_ROOT=/custom/root \
+            bash -c 'source "$0"; printf "%s" "$WOOSTACK_ROOT"' "$resolver" )"
+  assert_eq "$got" "/custom/root" "[$tag] explicit WOOSTACK_ROOT override honored"
+done
+
+rm -rf "$repo" "$ws"
+finish


### PR DESCRIPTION
## Goal

woostack-review and woostack-address-comments scripts defaulted their `.woostack/` paths to the current working directory. When a host agent's CWD drifts into a monorepo workspace package, they create/read `.woostack/` inside that package and pollute its `.gitignore`, splitting woostack state across the tree. Anchor every `.woostack/` path to the git repo root so state never splits. Fixes #272.

## Summary

- Add a shared `resolve-root.sh` (sourced like `resolve-outdir.sh`) exporting `WOOSTACK_ROOT` with precedence: explicit `WOOSTACK_ROOT` override → `GITHUB_WORKSPACE` (CI checkout root) → `git rev-parse --show-toplevel` → `pwd`. One copy each under `woostack-review/scripts/` and `woostack-address-comments/scripts/`.
- Anchor `metrics-fold.sh`, `load-config.sh`, `prefetch.sh` (`WOOSTACK_DIR`), `memory-append.sh`, and `memory-record.sh` defaults on `$WOOSTACK_ROOT` instead of `$(pwd)` / bare-relative paths. Existing `MEMORY_DIR` / `MEMORY_FILE` / `OUTDIR` overrides are honored unchanged — only the *default* base switches from CWD-relative to root-anchored.
- Consolidate both `resolve-outdir.sh` copies onto `resolve-root.sh` so the two resolvers can no longer drift (the root cause).
- Fix the same defect in the woostack-address-comments copies (`memory-append.sh`, `memory-record.sh`, `prefetch.sh` memory reads).
- Add 4 RED-first regression tests: resolver precedence, metrics-fold, load-config, and memory-record root-anchoring.

## Test plan

### Automated

- [ ] `bash skills/woostack-review/scripts/tests/test-{resolve-root,metrics-fold-root,load-config-root,memory-record-root}.sh` — all green (each confirmed RED before the fix)
- [ ] Existing `test-metrics-fold-overlap.sh`, `test-load-config-nits.sh`, `test-memory-record.sh` stay green; full review suite + woostack-init (27+14) and woostack-status (59) runners pass
- [ ] `shellcheck -x` clean on every new/edited script

### Manual

**Before merge**

- [ ] From a package subdir with `GITHUB_WORKSPACE` unset, run `metrics-fold.sh`; confirm it writes only the git-toplevel `.woostack/metrics.json` and creates no `.woostack/` or `.gitignore` inside the package

Spec: .woostack/fixes/2026-06-09-woostack-root-anchoring.md
