### PR TITLE
feat(review): demote stack-deferred findings to nits (#224, inc 2)

### DIFF
--- a/.woostack/plans/2026-06-09-review-stack-aware.md
+++ b/.woostack/plans/2026-06-09-review-stack-aware.md
@@ -479,7 +479,7 @@ gt modify -c -m "feat(review): fetch headRefName and compose stack.md in prefetc
 - Modify: `skills/woostack-review/scripts/intersect-findings.sh` — `classify_floor()` loop (~line 309), `write_metrics()` (~line 122), and both `write_metrics` call sites (~line 345, ~line 606)
 - Test: `skills/woostack-review/scripts/tests/test-intersect-stack-deferred.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```bash
 # skills/woostack-review/scripts/tests/test-intersect-stack-deferred.sh
@@ -529,12 +529,12 @@ rm -rf "$work"
 finish
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `bash skills/woostack-review/scripts/tests/test-intersect-stack-deferred.sh`
 Expected: FAIL — under `floor=high` the HIGH blocking finding stays `nit:false, blocking:true` (no override yet), and `.stack_deferred_count` is `null` in `validator-metrics.json` (key absent).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 In `classify_floor()`, add the override as the first branch of the per-finding loop (before the `rank >= floor_rank` check, ~line 309):
 
@@ -602,12 +602,12 @@ stack_deferred_count="$(jq '[.[] | select((.stack_deferred // "") != "")] | leng
 write_metrics adversarial false "$prosecutor_count" "$defender_count" "$kept_count" "$disagreement_count" "$dropped_by_defender" "$dropped_by_prosecutor" "$nit_count" "$stack_deferred_count"
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `bash skills/woostack-review/scripts/tests/test-intersect-stack-deferred.sh`
 Expected: PASS — `5 passed, 0 failed`. Then regression: `bash skills/woostack-review/scripts/tests/test-intersect-nits.sh` → still passes.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "feat(review): demote stack_deferred findings to nits in classifier"
@@ -618,19 +618,19 @@ gt create -m "feat(review): demote stack_deferred findings to nits in classifier
 **Files:**
 - Modify: `skills/woostack-review/prompts/validator.md` — Input Artifacts (~line 16) and Step 2 (~line 45, a new sub-step between Memory Check and Severity Check)
 
-- [ ] **Step 1: Write the failing test (concrete verification)**
+- [x] **Step 1: Write the failing test (concrete verification)**
 
 Prompt text — verify by presence of the directive the runtime reads.
 
 Run: `grep -c 'stack_deferred' skills/woostack-review/prompts/validator.md`
 Expected (current): `0`.
 
-- [ ] **Step 2: Confirm the gap**
+- [x] **Step 2: Confirm the gap**
 
 Run: `grep -n 'Memory Check' skills/woostack-review/prompts/validator.md`
 Expected: prints the Memory Check line (the anchor the new sub-step follows); no `stack_deferred` directive exists yet.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Add the input artifact (after the memory.md bullet, ~line 15):
 
@@ -651,12 +651,12 @@ Insert a new numbered sub-step in Step 2 immediately after "4. **Memory Check**"
 
 Note the schema field in the same file is documented centrally in `_header.md` (Task 6); the validator only needs to know to *set* it.
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -c 'stack_deferred' skills/woostack-review/prompts/validator.md`
 Expected: `≥3` (artifact mention + the set-directive + the security guard). Confirm the security exclusion is present: `grep -n 'Never.*security' skills/woostack-review/prompts/validator.md` prints the guard line.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(review): defender annotates stack_deferred from stack.md"
@@ -667,17 +667,17 @@ gt modify -c -m "feat(review): defender annotates stack_deferred from stack.md"
 **Files:**
 - Modify: `skills/woostack-review/prompts/_header.md` — Prefetched Artifacts list (~line 33), Findings Schema (~line 404), config table (~line 85), and the body-builder python (~line 245)
 
-- [ ] **Step 1: Write the failing test (concrete verification)**
+- [x] **Step 1: Write the failing test (concrete verification)**
 
 Run: `grep -c 'stack.md' skills/woostack-review/prompts/_header.md; grep -c 'stack_deferred' skills/woostack-review/prompts/_header.md; grep -c 'Deferred to' skills/woostack-review/prompts/_header.md`
 Expected (current): `0`, `0`, `0`.
 
-- [ ] **Step 2: Confirm the gap**
+- [x] **Step 2: Confirm the gap**
 
 Run: `grep -n 'Cross-PR memory' skills/woostack-review/prompts/_header.md | head -1`
 Expected: prints the memory artifact line (the anchor the stack.md artifact bullet follows).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Add the artifact bullet (after the Cross-PR memory bullet, ~line 33):
 
@@ -715,12 +715,12 @@ Render the deferral note in the body builder (~line 245, right after the `descri
         body += f"\n\nFix: {fix}"
 ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -c 'stack.md' skills/woostack-review/prompts/_header.md; grep -c 'stack_deferred' skills/woostack-review/prompts/_header.md; grep -c 'Deferred to' skills/woostack-review/prompts/_header.md`
 Expected: `≥2`, `≥3`, `≥2`. Sanity-check the body-builder python still parses by extracting and `python3 -c`-importing is overkill; instead confirm the edit sits inside the snippet: `grep -n 'Deferred to' skills/woostack-review/prompts/_header.md` shows the line within the `body = ` builder block.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs(review): document stack.md artifact, stack_deferred field, render note"

--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -31,6 +31,7 @@ Every artifact you write under `$OUTDIR/findings.*.json` (default `/tmp/pr-revie
 - **Incremental base SHA** (always present, may be empty): `/tmp/pr-review/last_sha.txt` — non-empty means `diff.txt` covers only the new commits since the last woostack-review pass. Treat findings as scoped to those commits.
 - **Prior unresolved review threads** (always present, may be `[]`): `/tmp/pr-review/prior-findings.json` — array of `{file, line, title, author}` for any unresolved thread on the PR. Consumed by the posting stage for the event-floor gate; angle workers MUST ignore this file. No per-entry `blocking` flag — any non-empty list floors the review event to `REQUEST_CHANGES` (conservative "do not APPROVE while threads open" rule).
 - **Cross-PR memory** (optional, present when the consumer repo has `.woostack/memory/` and/or `.woostack/memory.md`): `/tmp/pr-review/memory.md` — a plain-markdown composition of gotchas and previously-accepted issues the team curates. When the repo has a `.woostack/memory/` scope-routed store, this file is composed per-PR: it contains the notes whose `scope` matches the PR's changed files, any one-hop `[[linked]]` notes, plus the always-included global shard (the flat `memory.md`, when present). Treat it as additional rubric: do NOT re-flag an issue the memory file already records as known/accepted. See *Cross-PR memory* below.
+- **Stack context** (optional, present only when this PR has open descendant PRs in its Graphite stack and `review.stack_aware` is not false): `/tmp/pr-review/stack.md` — the later stack PRs' numbers, titles, bodies, changed files, and diffs. Treat it as verification context: a finding that something is *missing/not-yet-wired* may be intentionally completed by a descendant. The defender validator (`validator.md`) sets `stack_deferred: "#N"` on such a finding; it is demoted to a non-blocking `Deferred to #N` nit downstream. Angle workers may read it but MUST NOT defer — deferral is the validator's job.
 - **Chunk manifest** (optional, present only when the diff exceeds `chunking.max_loc`): `/tmp/pr-review/chunks.txt` (one chunk id per line) and `/tmp/pr-review/chunks.json` (manifest: `[{id, files, loc, diff_path, boundary}]`). Each chunk also has its own diff at `/tmp/pr-review/diff.chunk-<id>.txt`. When a worker is dispatched with a chunk id (env `CHUNK` non-empty), it MUST read the chunk-specific diff and write findings to `/tmp/pr-review/findings.<angle>.<chunk>.json`. In the GitHub Action this swap happens transparently — `diff.txt` is replaced with the chunk's diff before the worker runs, and the worker's output is renamed afterwards. When `chunks.txt` is absent, chunking did not activate and the diff fits a single worker (no overhead).
 
 If `/tmp/pr-review/rules.md` exists, treat it as an additional rubric on top of the per-angle scope. Each section is prefixed by a `## SOURCE: <path>` header identifying its origin file (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.windsurfrules`, or `GEMINI.md`). Any finding that claims a project-rule violation MUST populate `rule_quote` with a verbatim substring of `rules.md` (the rule text itself, not the source header). The validator discards rule-cited findings whose `rule_quote` is missing or not literally present in `rules.md`.
@@ -83,6 +84,7 @@ The prefetch step parses an optional `.woostack/config.json` in the consumer rep
 | `models.fast` / `.standard` / `.deep`; `models.<provider>.<tier>` | orchestrator prompts (tier resolution) | Stage 2 |
 | `fix_commands` | persisted only; consumed by `--loop` mode (#15) | n/a |
 | `chunking.max_loc` | `chunk-diff.sh` (split oversized diff into chunks; default 4000) | Stage 1 |
+| `stack_aware` | `prefetch.sh` → `detect-stack.sh` (compose `stack.md`) | Stage 1 — default `true`; `false` disables stack detection |
 
 ## Review Angles
 
@@ -243,6 +245,9 @@ for f in findings:
     blocking = bool(f.get("blocking", False))
 
     body = f"**{title}**\n\n{description}"
+    sd = (f.get("stack_deferred") or "").strip()
+    if sd:
+        body += f"\n\n_Deferred to {sd} — a later PR in this stack adds this; non-blocking._"
     if fix:
         body += f"\n\nFix: {fix}"
     # Render ```suggestion``` block only when validator-approved as fix_type=suggestion.
@@ -401,7 +406,8 @@ Every runner MUST write a final `findings.json` (for debugging + potential post-
     "fix_type": "suggestion",
     "fix": "Recommended change in prose (e.g. 'use `<=` instead of `<` so the boundary value is included').",
     "suggestion": "verbatim replacement code for the GitHub ```suggestion``` block — REQUIRED when fix_type == \"suggestion\", MUST be null when fix_type == \"prose\"",
-    "rule_quote": "exact quoted rule text if rule-based, else null"
+    "rule_quote": "exact quoted rule text if rule-based, else null",
+    "stack_deferred": "later-stack PR number (e.g. \"#225\") this finding is deferred to, set by the defender when a descendant diff adds the missing thing; else null"
   }
 ]
 ```
@@ -443,6 +449,8 @@ Fix: <fix>
 - **Attribution footer** — small-print line carrying the finding's `severity` (HIGH / MEDIUM / LOW; suffixed with `· BLOCKING` when `blocking == true`, or `· NIT` when `nit == true`) and the angle agent that flagged it (e.g. `<sub>— <strong>HIGH · BLOCKING</strong> · flagged by the <code>bugs</code> agent</sub>`, or `<sub>— <strong>LOW · NIT</strong> · flagged by the <code>bugs</code> agent</sub>`). The body builder appends this automatically from the finding's `severity` / `blocking` / `nit` / `angle` fields. Both `severity` and `angle` are whitelisted against their known sets; unknown/missing values are dropped from the footer rather than injecting raw text. If both are missing, the footer is omitted entirely.
 
 `nit` is a boolean set by `intersect-findings.sh` (the floor classifier), **not** by angle agents: `true` marks a validated below-floor non-blocking finding. The body builder renders a `nit: true` finding with a `Nit:` title prefix and a `· NIT` footer tag, and the event computation treats it as event-neutral (a PR whose only findings are nits still `APPROVE`s, with the nits posted inline). A nit is always non-blocking; a below-floor finding that is `blocking: true` stays a normal finding (`nit: false`).
+
+`stack_deferred` is a string (`"#N"`) or null, set by the defender validator (`validator.md`) when a later PR in the same stack verifiably implements the work a finding flags as missing. `intersect-findings.sh` forces any finding carrying a non-empty `stack_deferred` to `nit: true, blocking: false` (independent of `severity_floor`), and the body builder appends a `Deferred to #N` line. Never set on `security` findings.
 
 The body builder in the posting step (see python snippet above) renders this format automatically from `title` / `description` / `fix` / `fix_type` / `suggestion` / `angle` / `severity` / `blocking` / `nit`. Angle agents and the validator MUST populate `title`, `description`, `fix`, `fix_type`, `angle`, `severity`, and `blocking` for every finding; `nit` is added downstream by the classifier.
 

--- a/skills/woostack-review/prompts/validator.md
+++ b/skills/woostack-review/prompts/validator.md
@@ -13,6 +13,7 @@ This pass is one half of an adversarial validation pipeline (issue #13). The Pro
 - **Raw Findings**: /tmp/pr-review/raw_findings.json (Concatenated array from all angles)
 - **Project rules** (optional): /tmp/pr-review/rules.md — concatenated `AGENTS.md` / `CLAUDE.md` / `.cursorrules` / `.windsurfrules` / `GEMINI.md` discovered by prefetch. Absent when no rule files exist in the repo.
 - **Cross-PR memory** (optional): /tmp/pr-review/memory.md — team-curated markdown of gotchas and previously-accepted issues, composed from `.woostack/memory/` and/or `.woostack/memory.md`. Absent when the repo has no woostack memory store.
+- **Stack context** (optional): /tmp/pr-review/stack.md — when this PR is part of a Graphite stack, the LATER PRs' numbers, titles, bodies, files, and diffs. Absent when there are no descendants or `review.stack_aware` is false. See the Stack-deferral Check below.
 - **Per-repo config** (always present): /tmp/pr-review/config.json — parsed `.woostack/config.json`. The validator no longer reads any severity key from it; `severity_floor` and `nits` are consumed downstream by `intersect-findings.sh` (Stage 4c). Other keys are consumed upstream.
 
 ## Your Task
@@ -43,6 +44,12 @@ Launch one Haiku subagent. Task:
    - If `rule_quote` is not a verbatim substring of `rules.md` (exact match, not paraphrased), DISCARD the finding.
    - Use `grep -qF "$quote" /tmp/pr-review/rules.md` or equivalent literal-string check — not regex.
 4. **Memory Check**: If `/tmp/pr-review/memory.md` exists, read it. DROP any finding the team has already recorded there as known, intentional, accepted, or wontfix. Memory is advisory context only — never a basis for keeping or upgrading a finding.
+4b. **Stack-deferral Check** (issue #224): If `/tmp/pr-review/stack.md` exists, read it. For each finding that asserts something is **missing, not yet wired, or presented before it lands** (e.g. "X is referenced before it is defined", "command not yet routed", "integration absent"), check whether one of the descendant PR DIFFS in `stack.md` actually ADDS that exact thing.
+   - If a descendant diff verifiably adds it: set the finding's `stack_deferred` field to that PR's number string (e.g. `"#225"`) and set `blocking: false`. Do NOT drop it — it is demoted downstream to a non-blocking `Deferred to #N` nit, staying visible and auditable.
+   - **Never** set `stack_deferred` on a `security`-angle finding, or on a finding about WRONG code that is present in THIS PR (deferral is only for *missing/deferred* work that a later PR completes).
+   - PR-body phrases like "Increment N" / "lands in N+1" are a hint to LOOK, never proof — the descendant diff is the proof.
+   - If `stack.md` marks a descendant's diff as `[diff unavailable — degraded]`, do NOT defer against it; keep the finding as-is (the review stays honest rather than blind-suppressing).
+   - Findings with no `stack.md`, or no matching descendant, are unchanged (leave `stack_deferred` unset/null).
 5. **Severity Check**: You can downgrade severity (HIGH -> MEDIUM) or unset blocking: true -> false. You may NOT upgrade.
 6. **Severity Floor — applied downstream now (do NOT drop by severity here)**: The `severity_floor` filter has moved to `scripts/intersect-findings.sh` (Stage 4c). It reframes the floor from a drop gate into a blocking/visibility threshold: below-floor validated findings become non-blocking **nits**, below-floor **blocking** findings still surface as normal findings, and below-floor non-blocking findings are dropped only when `review.nits: false`. Your job is to keep every validated finding (after any allowed *downgrade* in step 5) so the downstream classifier can see it. Do not read or apply `severity_floor`.
 7. **Comment Shape Check**: For every surviving finding, ensure `title` (bold headline ≤60 chars, no trailing punctuation), `description` (issue only, no fix prescribed), and `fix` (recommended change in prose) are all populated. Rewrite minimally if an angle agent collapsed everything into `description` — split it into the three fields.

--- a/skills/woostack-review/scripts/intersect-findings.sh
+++ b/skills/woostack-review/scripts/intersect-findings.sh
@@ -130,6 +130,7 @@ write_metrics() {
     --argjson dropped_by_defender "$7" \
     --argjson dropped_by_prosecutor "$8" \
     --argjson nit_count "$9" \
+    --argjson stack_deferred_count "${10}" \
     '{
       mode: $mode,
       degraded: $degraded,
@@ -139,7 +140,8 @@ write_metrics() {
       disagreement_count: $disagreement_count,
       dropped_by_defender: $dropped_by_defender,
       dropped_by_prosecutor: $dropped_by_prosecutor,
-      nit_count: $nit_count
+      nit_count: $nit_count,
+      stack_deferred_count: $stack_deferred_count
     }' > "$METRICS"
 }
 
@@ -307,6 +309,14 @@ except (OSError, ValueError):
 
 out = []
 for f in findings:
+    # Stack-aware deferral (issue #224): a finding the defender confirmed a later
+    # stack PR fixes is forced to a non-blocking nit, INDEPENDENT of the floor.
+    sd = f.get("stack_deferred")
+    if isinstance(sd, str) and sd.strip():
+        f["nit"] = True
+        f["blocking"] = False
+        out.append(f)
+        continue
     # Unknown/missing severity -> MEDIUM (matches sev_rank() used in the merge).
     rank = RANK.get((f.get("severity") or "").lower(), 1)
     if rank >= floor_rank:
@@ -342,7 +352,8 @@ if [ "$disable_adversarial" = "true" ] || [ "$prosecutor_present" = "false" ]; t
   classify_floor
   kept_count="$(jq 'length' "$FINAL")"
   nit_count="$(jq '[.[] | select(.nit == true)] | length' "$FINAL")"
-  write_metrics "$mode" "$degraded" null "$defender_count" "$kept_count" 0 0 0 "$nit_count"
+  stack_deferred_count="$(jq '[.[] | select((.stack_deferred // "") != "")] | length' "$FINAL")"
+  write_metrics "$mode" "$degraded" null "$defender_count" "$kept_count" 0 0 0 "$nit_count" "$stack_deferred_count"
   echo "intersect-findings: mode=$mode degraded=$degraded kept=$kept_count nits=$nit_count"
   emit_angle_metrics "$mode" "$degraded" || echo "::warning::emit_angle_metrics failed (non-fatal)" >&2
   exit 0
@@ -597,13 +608,14 @@ cp "$FINAL" "$PRECLASSIFY"   # pre-floor snapshot for per-angle disagreement met
 classify_floor
 kept_count="$(jq 'length' "$FINAL")"
 nit_count="$(jq '[.[] | select(.nit == true)] | length' "$FINAL")"
+stack_deferred_count="$(jq '[.[] | select((.stack_deferred // "") != "")] | length' "$FINAL")"
 dropped_by_defender="$((prosecutor_count - intersection_size))"
 dropped_by_prosecutor="$((defender_count - intersection_size))"
 if [ "$dropped_by_defender" -lt 0 ]; then dropped_by_defender=0; fi
 if [ "$dropped_by_prosecutor" -lt 0 ]; then dropped_by_prosecutor=0; fi
 disagreement_count="$((dropped_by_defender + dropped_by_prosecutor))"
 
-write_metrics adversarial false "$prosecutor_count" "$defender_count" "$kept_count" "$disagreement_count" "$dropped_by_defender" "$dropped_by_prosecutor" "$nit_count"
+write_metrics adversarial false "$prosecutor_count" "$defender_count" "$kept_count" "$disagreement_count" "$dropped_by_defender" "$dropped_by_prosecutor" "$nit_count" "$stack_deferred_count"
 
 echo "intersect-findings: mode=adversarial degraded=false prosecutor=$prosecutor_count defender=$defender_count kept=$kept_count nits=$nit_count disagreement=$disagreement_count"
 emit_angle_metrics adversarial false || echo "::warning::emit_angle_metrics failed (non-fatal)" >&2

--- a/skills/woostack-review/scripts/tests/test-intersect-stack-deferred.sh
+++ b/skills/woostack-review/scripts/tests/test-intersect-stack-deferred.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/intersect-findings.sh"
+
+# A finding carrying stack_deferred must become a non-blocking nit regardless of
+# severity_floor. Run defender-only (disable_adversarial) to isolate the floor
+# classifier from the intersection logic.
+setup() { # $1 = severity_floor
+  work="$(mktemp -d)"
+  export OUTDIR="$work/out"
+  mkdir -p "$OUTDIR"
+  printf '{"disable_adversarial":true,"severity_floor":"%s"}\n' "$1" > "$OUTDIR/config.json"
+  cat > "$OUTDIR/findings.defender.json" <<'JSON'
+[
+  {"angle":"bugs","file":"x.ts","line":3,"severity":"HIGH","blocking":true,
+   "title":"Missing call-site wiring","description":"d","fix":"f","fix_type":"prose",
+   "suggestion":null,"rule_quote":null,"stack_deferred":"#225"}
+]
+JSON
+  printf '[]\n' > "$OUTDIR/raw_findings.json"
+}
+
+# Under floor=high: HIGH would normally be a normal blocking finding; the
+# stack_deferred override must still demote it to a nit.
+setup "high"
+bash "$SCRIPT" >/tmp/intersect-stack.out 2>&1
+assert_eq "$(jq -r '.[0].nit' "$OUTDIR/findings.json")" "true" "stack_deferred -> nit (floor=high)"
+assert_eq "$(jq -r '.[0].blocking' "$OUTDIR/findings.json")" "false" "stack_deferred -> non-blocking (floor=high)"
+assert_eq "$(jq -r '.stack_deferred_count' "$OUTDIR/validator-metrics.json")" "1" "stack_deferred_count counted"
+rm -rf "$work"
+
+# Under floor=low: HIGH is at/above floor (would be a normal finding); the
+# override must STILL force nit — proving it is floor-independent.
+setup "low"
+bash "$SCRIPT" >/tmp/intersect-stack.out 2>&1
+assert_eq "$(jq -r '.[0].nit' "$OUTDIR/findings.json")" "true" "stack_deferred -> nit (floor=low, floor-independent)"
+assert_eq "$(jq -r '.[0].blocking' "$OUTDIR/findings.json")" "false" "stack_deferred -> non-blocking (floor=low)"
+rm -rf "$work"
+
+finish


### PR DESCRIPTION
## Goal

Increment 2 of stack-aware review (#224): turn the `stack.md` context from Increment 1 into behavior — demote a finding a later stacked PR verifiably fixes to a non-blocking `Deferred to #N` nit, so the review stops flagging intentionally-deferred work.

## Summary

- **Defender validator** (`validator.md`) — new Stack-deferral Check: for a "missing / not-yet-wired" finding, if a descendant diff in `stack.md` actually adds it, set `stack_deferred: "#N"` and `blocking: false`. Never defers `security` findings or wrong code present in this PR; treats a degraded descendant diff as low-confidence, not a silent suppression.
- **`intersect-findings.sh`** — `classify_floor` forces any `stack_deferred` finding to `nit: true, blocking: false`, **independent of `severity_floor`**; `validator-metrics.json` gains `stack_deferred_count` (both validator paths).
- **`_header.md`** — documents the `stack.md` artifact, the `stack_deferred` schema field, the `stack_aware` config row, and renders the `Deferred to #N` note in the inline comment body.

## Test plan

### Automated

- [x] `bash skills/woostack-review/scripts/tests/test-intersect-stack-deferred.sh` → `5 passed, 0 failed` (nit + non-blocking under `severity_floor` high AND low; `stack_deferred_count`)
- [x] Full review suite: 22 test files, `0 failed` (no regressions in nits/overlap/farapart/etc.)
- [x] Body-builder render smoke: `Deferred to #225` renders only for a `stack_deferred` finding

### Manual

**Before merge**

- [x] This PR's own first increment (`stack.md` referencing) is the dogfood case — review with stack-aware off until merged.
- [ ] Read the `validator.md` Stack-deferral Check; confirm the security / in-PR-code / degraded guards read correctly.

Spec: .woostack/specs/2026-06-09-review-stack-aware.md
