### PR TITLE
docs(review): document stack-aware review (#224, inc 3)

### DIFF
--- a/.woostack/plans/2026-06-09-review-stack-aware.md
+++ b/.woostack/plans/2026-06-09-review-stack-aware.md
@@ -737,17 +737,17 @@ gt modify -c -m "docs(review): document stack.md artifact, stack_deferred field,
 **Files:**
 - Modify: `skills/woostack-review/SKILL.md` — config schema block (~line 128), key reference (~line 174), artifact table (~line 236), and a new "Stack-aware review" section (after "Incremental Mode", ~line 68)
 
-- [ ] **Step 1: Write the failing test (concrete verification)**
+- [x] **Step 1: Write the failing test (concrete verification)**
 
 Run: `grep -c 'stack_aware' skills/woostack-review/SKILL.md; grep -c 'stack.md' skills/woostack-review/SKILL.md`
 Expected (current): `0`, `0`.
 
-- [ ] **Step 2: Confirm the gap**
+- [x] **Step 2: Confirm the gap**
 
 Run: `grep -n 'Incremental Mode' skills/woostack-review/SKILL.md | head -1`
 Expected: prints the section header the new "Stack-aware review" section follows.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Add the config-schema key inside the `review` object (~line 165, near `nits`):
 
@@ -780,12 +780,12 @@ When `review.stack_aware` is `true` (the default), `prefetch.sh` calls `detect-s
 The **defender validator** reads `stack.md` and, for a finding that asserts something is *missing / not-yet-wired / presented-before-it-lands*, checks whether a descendant's **diff** actually adds it. If so it sets `stack_deferred: "#N"`; `intersect-findings.sh` then forces the finding to a non-blocking **`Deferred to #N` nit** (visible, auditable, event-neutral → `APPROVE`), independent of `severity_floor`. Guards: `security` findings are never deferred; a finding about wrong code *present in this PR* is never deferred; when a descendant diff can't be fetched the finding stays a normal (low-confidence) finding rather than being blindly suppressed. Set `review.stack_aware: false` to turn the whole feature off.
 ```
 
-- [ ] **Step 4: Run the verification, confirm it passes**
+- [x] **Step 4: Run the verification, confirm it passes**
 
 Run: `grep -c 'stack_aware' skills/woostack-review/SKILL.md; grep -c 'stack.md' skills/woostack-review/SKILL.md`
 Expected: `≥4`, `≥3`. Spot-check the section renders: `grep -n 'Stack-aware review' skills/woostack-review/SKILL.md` prints the new header.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs(review): document stack-aware review in SKILL.md"
@@ -795,15 +795,15 @@ gt modify -c -m "docs(review): document stack-aware review in SKILL.md"
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — every spec requirement maps to a task above:
+- [x] **Spec coverage** — every spec requirement maps to a task above:
   - §4.1 detect (base-chaining, recursive, depth cap, cycle guard, off-switch, CI perms) → Task 2 + Task 1 + Task 3
   - §4.2 compose `stack.md` (full capped diff, metadata-survives) → Task 2
   - §4.3 defender judgment (`stack_deferred`, security excluded, body-cue-hint, degraded→low-confidence) → Task 5
   - §4.4 classifier demotion (floor-independent, `stack_deferred_count`) → Task 4
   - §4.5 render `Deferred to #N` → Task 6
   - config + docs surface (load-config, _header config table, SKILL schema/key/section/artifact) → Tasks 1, 6, 7
-- [ ] **AC coverage** — AC1 (detection happy/error/edge) → test-detect-stack: child+grandchild (happy), empty `gh pr list` → no stack.md graceful (error), cycle guard + depth cap at 10 (edge); AC2 (off-switch happy/error/edge) → test-load-config-stack-aware (accept/reject) + test-detect-stack off-switch (no stack.md); AC3 (`stack.md` happy/error/edge) → test-detect-stack diff-included (happy) + degraded-placeholder for an unfetchable descendant diff (error); the 100KB cap is parameterized via `WOO_REVIEW_STACK_CAP_BYTES` for an executor-added cap test if desired (edge — small, deterministic); AC4 (deferral happy/error/edge) → validator.md directive carries the security/in-PR-code/degraded guards, exercised end-to-end by the classifier (Task 4) + render (Task 6); AC5 (classifier floor-independent + metric) → test-intersect-stack-deferred (floor high AND low + `stack_deferred_count`).
-- [ ] **No placeholders** — every step carries real code, exact commands, expected output.
-- [ ] **Type consistency** — `stack_deferred` is a string `"#N"` or null everywhere (validator sets, intersect reads `(.stack_deferred // "") != ""`, body builder reads `(f.get("stack_deferred") or "").strip()`); `stack_aware` is a bool everywhere; `WOO_REVIEW_FAKE_STACK_PRS_JSON` / `_DIFFS_JSON` names match between detect-stack.sh and its test.
+- [x] **AC coverage** — AC1 (detection happy/error/edge) → test-detect-stack: child+grandchild (happy), empty `gh pr list` → no stack.md graceful (error), cycle guard + depth cap at 10 (edge); AC2 (off-switch happy/error/edge) → test-load-config-stack-aware (accept/reject) + test-detect-stack off-switch (no stack.md); AC3 (`stack.md` happy/error/edge) → test-detect-stack diff-included (happy) + degraded-placeholder for an unfetchable descendant diff (error); the 100KB cap is parameterized via `WOO_REVIEW_STACK_CAP_BYTES` for an executor-added cap test if desired (edge — small, deterministic); AC4 (deferral happy/error/edge) → validator.md directive carries the security/in-PR-code/degraded guards, exercised end-to-end by the classifier (Task 4) + render (Task 6); AC5 (classifier floor-independent + metric) → test-intersect-stack-deferred (floor high AND low + `stack_deferred_count`).
+- [x] **No placeholders** — every step carries real code, exact commands, expected output.
+- [x] **Type consistency** — `stack_deferred` is a string `"#N"` or null everywhere (validator sets, intersect reads `(.stack_deferred // "") != ""`, body builder reads `(f.get("stack_deferred") or "").strip()`); `stack_aware` is a bool everywhere; `WOO_REVIEW_FAKE_STACK_PRS_JSON` / `_DIFFS_JSON` names match between detect-stack.sh and its test.
 
 > woostack plan conventions: frontmatter-free; opens with `**Source:**`; basename mirrors the spec (`2026-06-09-review-stack-aware`); no sub-skill banner; prompt/doc edits use concrete grep/`bash -n` verifications in place of a runner.

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -66,6 +66,14 @@ When the incremental diff has no new commits (i.e. `LAST_SHA == HEAD_SHA`, e.g. 
 
 Marker semantics are state-light: the marker IS the state. There is no DB or workflow artifact retention beyond what GitHub already keeps in review history.
 
+## Stack-aware review (`review.stack_aware`, issue #224)
+
+woostack encourages PR-sized **stacked** increments, so an early PR in a stack often *intentionally* defers integration to a later PR. Reviewing the isolated diff would flag that deferred work as "missing" — noise that trains authors to ignore the review gate.
+
+When `review.stack_aware` is `true` (the default), `prefetch.sh` calls `detect-stack.sh`: it lists open PRs once and base-branch-chains from this PR's head branch (recursively, depth-capped, cycle-guarded) to find **descendant** PRs — host-agnostic, no Graphite runtime dependency. Their numbers, titles, bodies, changed files, and diffs are composed into `stack.md` (section-capped at 100KB; metadata never dropped).
+
+The **defender validator** reads `stack.md` and, for a finding that asserts something is *missing / not-yet-wired / presented-before-it-lands*, checks whether a descendant's **diff** actually adds it. If so it sets `stack_deferred: "#N"`; `intersect-findings.sh` then forces the finding to a non-blocking **`Deferred to #N` nit** (visible, auditable, event-neutral → `APPROVE`), independent of `severity_floor`. Guards: `security` findings are never deferred; a finding about wrong code *present in this PR* is never deferred; when a descendant diff can't be fetched the finding stays a normal (low-confidence) finding rather than being blindly suppressed. Set `review.stack_aware: false` to turn the whole feature off.
+
 ## Cross-PR Memory (`.woostack/memory/` + `.woostack/memory.md`)
 
 Reviews stay useful across PRs through the consumer repo's woostack memory store. The preferred write target is the scope-routed **`.woostack/memory/`** directory: one Markdown note per reusable fact, with frontmatter declaring the scope where it applies. The flat **`.woostack/memory.md`** remains the global shard and fallback for repos that have not initialized the scoped store.
@@ -132,6 +140,7 @@ Full schema (every key shown; all optional):
     },
     "severity_floor": "high",
     "nits": true,
+    "stack_aware": true,
     "ignore": [
       "**/*.generated.ts",
       "migrations/*.sql"
@@ -174,6 +183,7 @@ Key reference (JSON has no comments, so the per-key semantics live here):
 - **`angles.force`** — always run these, even if not auto-detected. **`angles.skip`** — never run these (`bugs`/`security` cannot be skipped).
 - **`severity_floor`** — one of `low` | `medium` | `high`; a blocking/visibility threshold, **not** a drop gate. **Default `high`**. Findings below the floor surface as non-blocking nits (see `nits`); set `low`/`medium` to treat more findings as normal (at/above-floor). Applied once by `intersect-findings.sh` (Stage 4c).
 - **`nits`** — `true` | `false`; default **`true`**. When `true`, validated findings below `severity_floor` surface as non-blocking nits instead of being dropped. Set `false` to drop them (the pre-reframe behavior). Below-floor `blocking` findings always surface regardless of this knob.
+- **`stack_aware`** — `true` | `false`; default **`true`**. When `true`, `prefetch.sh` runs `detect-stack.sh` to find later PRs in the same Graphite stack and compose `stack.md`; the defender validator then demotes a finding a descendant PR verifiably fixes to a non-blocking `Deferred to #N` nit (issue #224). Set `false` to disable stack detection entirely (no `gh pr list`, no `stack.md`). Never defers `security` findings; degrades to a low-confidence finding when a descendant diff can't be fetched.
 - **`ignore`** — fnmatch globs; ignored paths skip angle triggers + diff body.
 - **`project_rules`** — fnmatch globs appended to auto-discovered `rules.md`.
 - **`authors_skip`** — PR author logins that short-circuit the entire review. Defaults: `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`. Set to `[]` to opt out.
@@ -234,6 +244,7 @@ When prefetch resolves a PR number AND finds an open PR, it produces the full ar
 | `prior-findings.json` | `prefetch.sh` | event-floor gate | Unresolved + resolved prior review threads |
 | `rules.md` | `prefetch.sh` | `conventions` angle, validator | Concatenated project rule files; triggers `conventions` angle when present |
 | `memory.md` | `prefetch.sh` | all angles, validator | Cross-PR memory composed from `.woostack/memory/` and/or `.woostack/memory.md`; findings it records as known/accepted are dropped. Present only when the consumer repo has memory |
+| `stack.md` | `prefetch.sh` → `detect-stack.sh` | all angles, validator | Later stack PRs' diffs; present only when this PR has open descendants and `stack_aware` ≠ false. Drives `stack_deferred` demotion |
 | `angles.txt` | `detect-angles.sh` | Stage 3 orchestrator | One angle name per line |
 | `findings.<angle>.json` | angle workers | `merge-findings.sh` | Raw per-angle output |
 | `raw_findings.json` | `merge-findings.sh` | validator passes | Merged, chunk-collapsed findings |


### PR DESCRIPTION
## Goal

Increment 3 of stack-aware review (#224): bring the human-facing `SKILL.md` in line with the shipped behavior so consumers can discover and configure the feature.

## Summary

- `review.stack_aware` added to the config-schema example and the key reference (default `true`, with the security/degraded guarantees).
- `stack.md` row added to the prefetch artifact table.
- New **"Stack-aware review"** section explaining detection, `stack.md`, the `Deferred to #N` demotion, and the guards.

## Test plan

### Automated

- [x] `grep` verification: `stack_aware` (6) and `stack.md` (4) present; the full-schema JSON block still `json.loads`-parses with the new key.

### Manual

**Before merge**

- [ ] Read the new "Stack-aware review" section and the `stack_aware` key reference for accuracy.

Spec: .woostack/specs/2026-06-09-review-stack-aware.md
