### PR TITLE
docs(fix): delegate woostack-fix execution to woostack-execute

### DIFF
--- a/.woostack/fixes/2026-06-10-fix-delegate-to-execute.md
+++ b/.woostack/fixes/2026-06-10-fix-delegate-to-execute.md
@@ -1,0 +1,129 @@
+---
+type: fix
+status: in-review
+branch: fix/fix-delegate-to-execute
+---
+
+# Fix: woostack-fix inlines execution instead of delegating to woostack-execute
+
+## 1. Root Cause
+
+`woostack-fix` re-implements plan execution inline instead of delegating to the canonical
+execution engine, `woostack-execute`. The duplication originates in three places in
+`skills/woostack-fix/SKILL.md`:
+
+- **Step 5 ("Execute")** spells out its own TDD loop (`failing test → minimal fix → verify →
+  tick checkboxes`) and its own branch creation. This is a weaker copy of
+  `woostack-execute`'s per-increment cadence.
+- **Step 6 ("Commit and PR")** invokes `woostack-commit` directly — but `woostack-execute`
+  already owns per-increment commit via `woostack-commit`.
+- **Step 7 ("Distill Memory gotchas")** runs its own distill pass — but `woostack-execute`
+  already owns per-increment distill into `.woostack/memory/`.
+
+Evidence: `grep "woostack-execute" skills/woostack-fix/SKILL.md` returns **no matches** — the
+fix loop never references the execute engine at all, even though `woostack-execute` is the
+documented owner of "implement each increment with TDD, tick checkboxes in place, commit via
+woostack-commit, review each task, distill, never merge."
+
+Consequences of the inline copy:
+- **No task-scoped review.** Fix's inline step 5 has no spec-compliance / code-quality check;
+  `woostack-execute` adds that review loop to every increment. Fixes ship unreviewed.
+- **Drift risk.** Two copies of the execution cadence (branch-before-edit, TDD kernel, tick,
+  commit, distill, never-merge) diverge over time. The recent
+  `2026-06-09-inline-execute-quality-checks` fix already had to patch execute's cadence; fix's
+  inline copy was not updated in lockstep.
+
+This mirrors the dependency-internalization pattern: `woostack-build` step 9 delegates execution
+to `woostack-execute` and "absorbs what used to be separate distill memory and offer the PR
+steps." `woostack-fix` should do the same.
+
+This is a skill-documentation/design change (Mode A), not a runtime bug, so the "test" is a
+text/grep assertion over the skill Markdown rather than a unit test.
+
+## 2. Proposed Fix
+
+Rewrite `skills/woostack-fix/SKILL.md` so the execute phase **delegates** to
+`woostack-execute`, passing the fix file as the plan. Fold the now-redundant commit and distill
+steps into that delegation (exactly as `woostack-build` step 9 folds them).
+
+Resulting procedure (7 steps → 6 steps):
+
+1. Diagnose (unchanged)
+2. Write fix plan (unchanged)
+3. Harden (unchanged)
+4. Approve — GATE (unchanged; fix's one gate stays upstream of delegation)
+5. **Execute via `woostack-execute`** — set `status: executing`, invoke
+   `/woostack-execute .woostack/fixes/<file>.md --inline`. The fix file's
+   `## 3. Implementation Plan` is the single increment. `woostack-execute` owns the cadence:
+   branch-before-edit, TDD per task (failing test → minimal fix → verify), tick the fix file's
+   checkboxes in place, commit via `woostack-commit`, run the task-scoped spec-compliance +
+   code-quality review, and distill durable learnings. Default `--inline` for this lightweight
+   loop (a fix is one increment / one PR); `--subagent` available for a larger fix.
+6. **Track PR & lifecycle** — no separate commit step (execute committed in step 5). Once the
+   PR is open, set `status: in-review` (`done` once merged). The fix file's frontmatter
+   `status:` stays the lifecycle source of truth; `woostack-commit` writes the
+   `Spec: .woostack/fixes/<file>.md` trailer.
+
+Cross-doc accuracy:
+- Update the frontmatter `description` (drop "execute via TDD, and commit via woostack-commit" →
+  "execute via woostack-execute").
+- Update the Overview flow diagram.
+- Update the Hard constraints: replace nothing essential; add a **Delegate execution**
+  constraint and keep TDD-kernel / wait-for-approval / one-file / no-guess-and-check /
+  never-merge.
+- Update `.claude/CLAUDE.md` quick-file-map line 99
+  (`diagnose → fix plan → approve → TDD → commit`) to reflect delegation.
+
+### Design decisions resolved during hardening
+
+- **Default driver = `--inline`.** A fix is small / single-increment; inline is the lightweight
+  fit. `--subagent` stays available for larger fixes. (Rather than letting execute take its
+  smart default, fix names `--inline` so the lightweight loop is the documented default.)
+- **Fold steps 6 & 7 into delegation.** Execute owns commit + review + distill, so fix must not
+  re-inline them — same as build step 9. The only post-execute work fix retains is the
+  frontmatter lifecycle transition (`executing` → `in-review` → `done`), which execute does not
+  touch (execute ticks checkboxes, not fix frontmatter).
+- **Preserve the root-cause gotcha distill intent.** Execute's distill is reject-by-default and
+  generic; a fix's distinctive value is the debugging gotcha from step 1. Step 5 notes that the
+  fix's distill should capture the root-cause gotcha learned in diagnosis.
+- **Fix file IS the plan for execute's purposes.** `woostack-execute` reads the named Markdown
+  file and ticks its checkboxes; it does not hard-require the `.woostack/plans/` directory or a
+  `**Source:**` line. Passing `.woostack/fixes/<file>.md` works; its `## 3. Implementation
+  Plan` is the single increment.
+- **Status ownership stays with fix.** Fix sets `executing` before delegating and
+  `in-review`/`done` after; execute owns no frontmatter and no approval gate, so no conflict.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Reproduce with a failing text check**
+  - Run `grep -n "woostack-execute" skills/woostack-fix/SKILL.md` and confirm it returns no
+    matches (the fix loop never references the execute engine — RED).
+  - Confirm the inline-execution markers are present: step 5 "Work through the implementation
+    plan tasks in order using TDD", the standalone `/woostack-commit` step 6, and the
+    standalone distill step 7.
+
+- [x] **Step 2: Apply the minimal documentation fix**
+  - Edit `skills/woostack-fix/SKILL.md`:
+    - Frontmatter `description`: replace "execute via TDD, and commit via woostack-commit" with
+      "execute via woostack-execute (which commits via woostack-commit and reviews each task)".
+    - Overview flow diagram: change the execute leg to delegate to `woostack-execute`.
+    - Step 5: replace the inline TDD/branch block with a delegation to
+      [`woostack-execute`](../woostack-execute/SKILL.md) (`--inline` default), describing that
+      execute owns branch / TDD / tick / commit / review / distill, and noting the root-cause
+      gotcha distill intent.
+    - Step 6: restate as PR/lifecycle tracking only (no separate commit); fold old step 7
+      (distill) into the step-5 delegation note.
+    - Hard constraints: add **Delegate execution** (step 5 hands the fix file to
+      `woostack-execute`; do not re-inline a TDD/commit/distill loop); keep TDD-kernel,
+      wait-for-approval, one-file, no-guess-and-check, never-merge.
+  - Edit `.claude/CLAUDE.md` quick-file-map line 99 to reflect delegation
+    (`diagnose → fix plan → approve → execute (woostack-execute) → PR`).
+
+- [x] **Step 3: Verification**
+  - `grep -n "woostack-execute" skills/woostack-fix/SKILL.md` now returns matches incl. the
+    `../woostack-execute/SKILL.md` cross-link (GREEN).
+  - `grep -n "Work through the implementation plan tasks in order using TDD" skills/woostack-fix/SKILL.md`
+    returns no matches (inline loop removed).
+  - The `../woostack-execute/SKILL.md` cross-link target exists.
+  - Step numbering is consistent (6 steps) and the Overview flow / description match the body.
+  - `.claude/CLAUDE.md` line for the fix loop no longer says the inline `TDD → commit` shape.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ directory, not in this repo.
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/)
 - Build loop:
   [`skills/woostack-build/SKILL.md`](skills/woostack-build/SKILL.md)
-- Small-change fix loop (public command; diagnose → fix plan → approve → TDD → commit):
+- Small-change fix loop (public command; diagnose → fix plan → approve → delegate execution to woostack-execute):
   [`skills/woostack-fix/SKILL.md`](skills/woostack-fix/SKILL.md)
 - Plan-writing engine for the build loop (public command):
   [`skills/woostack-plan/SKILL.md`](skills/woostack-plan/SKILL.md)

--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: woostack-fix
-description: Use to resolve small technical issues (bugs, hotfixes, refactors) through a unified execution loop — diagnose root cause with woostack-debug, author a fix plan under .woostack/fixes/, harden, get explicit user approval, execute via TDD, and commit via woostack-commit.
+description: Use to resolve small technical issues (bugs, hotfixes, refactors) through a unified execution loop — diagnose root cause with woostack-debug, author a fix plan under .woostack/fixes/, harden, get explicit user approval, then delegate execution to woostack-execute (TDD per task, task review, commit via woostack-commit, distill).
 ---
 
 # woostack-fix
 
 ## Overview
 
-Drives a bug fix or a small technical change from diagnosis to implementation through a lightweight, unified loop. Fixes are smaller than features and combine the spec and the plan into a single markdown file under `.woostack/fixes/`.
+Drives a bug fix or a small technical change from diagnosis to implementation through a lightweight, unified loop. Fixes are smaller than features and combine the spec and the plan into a single markdown file under `.woostack/fixes/`. The fix loop owns diagnosis, the fix plan, hardening, and the approval gate, then **delegates the execution mechanics to [`woostack-execute`](../woostack-execute/SKILL.md)** — the same engine the build loop uses — passing the fix file as the plan. Fix does not re-inline a TDD/commit/distill loop of its own.
 
 ```
 diagnose root cause (woostack-debug) → write fix plan (fixes/ markdown) → harden fix plan 
-  → approve fix plan (GATE) → execute (TDD: failing test → minimal fix → verify) 
-  → commit (woostack-commit)
+  → approve fix plan (GATE) → execute via woostack-execute
+  (branch → TDD per task → tick → commit via woostack-commit → task review → distill)
 ```
 
-The skill has exactly **one** hard gate: **fix plan approval**. Because the plan contains both the diagnosis (the spec part) and the steps (the plan part), a single approval stop protects the codebase from wrong fixes or poor plans before implementation begins.
+The skill has exactly **one** hard gate: **fix plan approval**. Because the plan contains both the diagnosis (the spec part) and the steps (the plan part), a single approval stop protects the codebase from wrong fixes or poor plans before implementation begins. Delegation adds no gate: `woostack-execute` owns no approval gate and never merges, so the fix's one gate stays upstream of execution.
 
 ## Procedure
 
@@ -61,28 +61,43 @@ The skill has exactly **one** hard gate: **fix plan approval**. Because the plan
 4. **Get explicit approval (GATE).**
    **Always present the written fix plan to the user and get explicit approval before executing** — this is a hard gate. Point the user at the file path, wait for a clear yes, and make any requested changes. When approved, set the frontmatter `status: approved`.
 
-5. **Execute.**
-   Create the feature branch named in the frontmatter (`git switch -c fix/<slug>` or `gt create fix/<slug>`). Set the frontmatter `status: executing` on the fix file.
-   Work through the implementation plan tasks in order using TDD:
-   - Implement the failing test first (confirm it fails).
-   - Apply the minimal fix (no bundled refactoring, no "while I'm here" edits).
-   - Run the tests and verify they pass.
-   - Tick the checkboxes (`- [x]`) in the fix plan file as you complete each task.
-
-6. **Commit and PR.**
-   Stage the code changes, tests, and the modified fix plan. Invoke the commit skill:
+5. **Execute via [`woostack-execute`](../woostack-execute/SKILL.md).**
+   Set the fix file's frontmatter `status: executing`, then hand the fix file to the execute
+   engine — the fix file *is* the plan, and its `## 3. Implementation Plan` is the single
+   increment:
    ```
-   /woostack-commit
+   /woostack-execute .woostack/fixes/YYYY-MM-DD-<slug>.md --inline
    ```
-   Once the PR is open, update the fix plan's frontmatter to `status: in-review` (once merged, `status: done`). The fix file's frontmatter `status:` is the source of truth for the fix lifecycle — fixes are tracked by their `.woostack/fixes/` file, not the spec-centric `/woostack-status` board. [`woostack-commit`](../woostack-commit/SKILL.md) still writes a `Spec: .woostack/fixes/<file>.md` trailer on the fix PR (mirroring the `Spec: .woostack/specs/<file>.md` trailer it writes for spec increments), but that trailer attaches the PR to the fix file rather than to a spec — the fix file's frontmatter remains the lifecycle source of truth.
+   `woostack-execute` owns the execution cadence so the fix inherits the same discipline as a
+   build increment: create the increment's Graphite branch (named in the fix frontmatter) before
+   editing, implement each task TDD-first (failing test → minimal fix → verify) per the
+   [woostack-tdd kernel](../woostack-tdd/SKILL.md), tick the fix file's checkboxes in place,
+   commit via [`woostack-commit`](../woostack-commit/SKILL.md), run the task-scoped
+   spec-compliance and code-quality review, and distill durable learnings into `.woostack/memory/`.
+   A fix is one increment / one PR, so default to **`--inline`** for this lightweight loop;
+   use `--subagent` only for a larger fix. When distilling, make sure the increment captures the
+   root-cause **gotcha** learned in step 1 — the debugging insight is a fix's most reusable
+   takeaway. `woostack-execute` owns no approval gate and never merges; the fix's one gate
+   (step 4) stays upstream.
 
-7. **Distill Memory gotchas.**
-   At the end of a successful execution, write **one** `gotcha` note to the `.woostack/memory/` store describing the root cause and the fix patterns learned. Dedupe, update `MEMORY.md`, and rebuild the index using `build-index.sh` and `doctor.sh` as required by the [memory contract](../woostack-init/references/memory.md).
+6. **Track the PR and lifecycle.**
+   There is **no separate commit step** — `woostack-execute` already committed the increment and
+   opened its PR via [`woostack-commit`](../woostack-commit/SKILL.md) in step 5, and already ran
+   the task review and distill. Once the PR is open, update the fix file's frontmatter to
+   `status: in-review` (once merged, `status: done`). The fix file's frontmatter `status:` is the
+   source of truth for the fix lifecycle — fixes are tracked by their `.woostack/fixes/` file, not
+   the spec-centric `/woostack-status` board, and `woostack-execute` ticks the fix file's
+   checkboxes but does not touch its frontmatter, so the lifecycle transition stays with this
+   skill. `woostack-commit` writes a `Spec: .woostack/fixes/<file>.md` trailer on the fix PR
+   (mirroring the `Spec: .woostack/specs/<file>.md` trailer it writes for spec increments), but
+   that trailer attaches the PR to the fix file rather than to a spec — the fix file's frontmatter
+   remains the lifecycle source of truth.
 
 ## Hard constraints
 
 - **No guess-and-check.** Always run `woostack-debug` to trace the data flow and confirm the root cause before writing the fix plan.
 - **One combined markdown file under `.woostack/fixes/`.** Fixes are specified and planned in a single file under `.woostack/fixes/` (not `.woostack/specs/` or `.woostack/plans/`).
 - **Wait for explicit approval.** Never execute a fix plan on inferred or assumed approval. Silence is not a yes.
-- **TDD Kernel.** Every fix must be driven by a failing test first.
-- **Never merge.** The skill commits and opens/updates stacked PRs; it never merges.
+- **Delegate execution.** Step 5 hands the fix file to [`woostack-execute`](../woostack-execute/SKILL.md); never re-inline a TDD/commit/review/distill loop. Execute owns the branch, TDD per task, checkbox ticking, commit via `woostack-commit`, task review, and distill. This skill retains only diagnosis, the fix plan, hardening, the approval gate, and the frontmatter lifecycle.
+- **TDD Kernel.** Every fix is driven by a failing test first — enforced by `woostack-execute`'s per-task TDD loop.
+- **Never merge.** Execution (via `woostack-execute`) commits and opens/updates stacked PRs; this skill never merges.


### PR DESCRIPTION
## Goal

`woostack-fix` inlined its own weaker execution loop (TDD + commit + distill) instead of using the canonical execution engine. This makes the fix loop delegate execution to `woostack-execute` — the same engine `woostack-build` uses — so fixes inherit task review, a consistent cadence, and no duplicated logic that can drift.

## Summary

- `skills/woostack-fix/SKILL.md` step 5 rewritten: instead of an inline TDD/branch loop, it sets `status: executing` and hands the fix file to `/woostack-execute <fix-file> --inline` (the fix file *is* the plan; its `## 3` is the single increment). Execute owns branch / TDD / tick / commit via `woostack-commit` / task review / distill.
- Folded old step 6 (standalone commit) and step 7 (standalone distill) into the delegation — 7 steps → 6. Step 6 is now PR/lifecycle tracking only; fix retains the frontmatter `status:` transitions (execute does not touch frontmatter).
- Updated frontmatter description, Overview flow diagram, and Hard constraints (added **Delegate execution**; reworded TDD-kernel and never-merge to point at execute).
- Adds **task-scoped spec + quality review** to every fix, which the inline loop never had.
- Updated `AGENTS.md` quick-file-map line for the fix loop to reflect delegation.

## Test plan

### Automated

- [x] `grep -n "woostack-execute" skills/woostack-fix/SKILL.md` — now matches incl. the `../woostack-execute/SKILL.md` cross-link (was empty = RED before).
- [x] `grep "Work through the implementation plan tasks in order using TDD"` — no match (inline loop removed).
- [x] Cross-link target `skills/woostack-execute/SKILL.md` exists; step numbering renumbered 1–6.
- [x] `AGENTS.md` fix-map line no longer shows the `TDD → commit` shape.

### Manual

**Before merge**

- [ ] Read `skills/woostack-fix/SKILL.md`: confirm step 5 delegates to `woostack-execute` (`--inline` default, `--subagent` for larger fixes) and that diagnosis/plan/harden/gate stay with fix.
- [ ] Confirm no separate commit/distill step remains and the one approval gate is intact.

Spec: .woostack/fixes/2026-06-10-fix-delegate-to-execute.md
