### PR TITLE
chore: add GEMINI.md symlinks to AGENTS.md

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This repository follows woostack. At the start of work, use
 `/woostack-*` requests to the matching skill.
 
 Follow this file first when it conflicts with generic agent defaults. `.claude/CLAUDE.md`
-is a symlink to this file, so this is the single source of truth.
+and `.gemini/GEMINI.md` are symlinks to this file, so this is the single source of truth.
 
 ## What this repo is
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Goal

Provide `GEMINI.md` and `.gemini/GEMINI.md` symlinks to `AGENTS.md` for Gemini / Antigravity CLI to align with the existing `CLAUDE.md` symlink for Claude Code, ensuring both tools can discover project-level rules.

## Summary

- Created `.gemini/GEMINI.md` symlinking to `../AGENTS.md`.
- Created `GEMINI.md` symlinking to `AGENTS.md` at the repository root.
- Updated `AGENTS.md` to reference `.gemini/GEMINI.md` alongside `.claude/CLAUDE.md`.

## Test plan

### Manual

**Before merge**

- [ ] Run `ls -la .gemini/GEMINI.md` and verify it points to `../AGENTS.md`.
- [ ] Run `ls -la GEMINI.md` and verify it points to `AGENTS.md`.
- [ ] Verify that `AGENTS.md` correctly references `.gemini/GEMINI.md`.
