### PR TITLE
feat(init): add resolve-base.sh base-branch resolver + test

### DIFF
--- a/.woostack/plans/2026-06-10-parallel-worktrees.md
+++ b/.woostack/plans/2026-06-10-parallel-worktrees.md
@@ -22,7 +22,7 @@
 - Create: `skills/woostack-init/scripts/resolve-base.sh`
 - Test: `skills/woostack-init/scripts/tests/test-resolve-base.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `skills/woostack-init/scripts/tests/test-resolve-base.sh`:
 
@@ -67,12 +67,12 @@ assert_eq "$out5" "trunk" "executed mode prints resolved branch"
 finish
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `bash skills/woostack-init/scripts/tests/test-resolve-base.sh`
 Expected: FAIL — the resolver does not exist yet, so `. "$resolver"` errors (`No such file or directory`) and the run exits non-zero.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 Create `skills/woostack-init/scripts/resolve-base.sh`:
 
@@ -127,17 +127,17 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 fi
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `bash skills/woostack-init/scripts/tests/test-resolve-base.sh`
 Expected: PASS — `5 passed, 0 failed`.
 
-- [ ] **Step 5: Shellcheck the new script**
+- [x] **Step 5: Shellcheck the new script**
 
 Run: `shellcheck -x skills/woostack-init/scripts/resolve-base.sh`
 Expected: clean (exit 0, no output).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 gt create -m "feat(init): add resolve-base.sh base-branch resolver + test"
@@ -149,7 +149,7 @@ gt create -m "feat(init): add resolve-base.sh base-branch resolver + test"
 - Modify: `skills/woostack-init/templates/gitignore`
 - Test: `skills/woostack-init/scripts/tests/test-gitignore-template.sh`
 
-- [ ] **Step 1: Write the failing test (extend the existing one)**
+- [x] **Step 1: Write the failing test (extend the existing one)**
 
 In `skills/woostack-init/scripts/tests/test-gitignore-template.sh`, add this line immediately after the `memory/` assertion (before `finish`):
 
@@ -157,12 +157,12 @@ In `skills/woostack-init/scripts/tests/test-gitignore-template.sh`, add this lin
 assert_contains "$body" "worktrees/" "gitignore template ignores per-PR worktrees"
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `bash skills/woostack-init/scripts/tests/test-gitignore-template.sh`
 Expected: FAIL — `gitignore template ignores per-PR worktrees` (`worktrees/` not yet in the template).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 In `skills/woostack-init/templates/gitignore`, add `worktrees/` to the transient block so it reads:
 
@@ -177,12 +177,12 @@ memory.md
 memory/
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `bash skills/woostack-init/scripts/tests/test-gitignore-template.sh`
 Expected: PASS — all assertions green including the new one.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(init): gitignore per-PR worktrees/ dir"
@@ -193,12 +193,12 @@ gt modify -c -m "feat(init): gitignore per-PR worktrees/ dir"
 **Files:**
 - Create: `skills/woostack-init/references/worktrees.md`
 
-- [ ] **Step 1: Confirm it is absent (RED)**
+- [x] **Step 1: Confirm it is absent (RED)**
 
 Run: `test ! -f skills/woostack-init/references/worktrees.md && echo MISSING`
 Expected: prints `MISSING`.
 
-- [ ] **Step 2: Create the contract**
+- [x] **Step 2: Create the contract**
 
 Create `skills/woostack-init/references/worktrees.md` with this exact content:
 
@@ -337,12 +337,12 @@ A pre-existing dir at a slug usually means a stale worktree from a crashed run �
 before retrying; never silently reuse or overwrite it.
 ```
 
-- [ ] **Step 3: Verify the contract exists with its key anchors**
+- [x] **Step 3: Verify the contract exists with its key anchors**
 
 Run: `grep -c "git worktree add -b\|WOOSTACK_BASE_BRANCH\|base_ref\|git-common-dir" skills/woostack-init/references/worktrees.md`
 Expected: a count ≥ 4.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "docs(init): add canonical worktree-lifecycle + base-branch contract"
@@ -353,12 +353,12 @@ gt modify -c -m "docs(init): add canonical worktree-lifecycle + base-branch cont
 **Files:**
 - Modify: `skills/woostack-init/SKILL.md`
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `grep -c "worktrees.md\|base_branch" skills/woostack-init/SKILL.md`
 Expected: FAIL — prints `0`.
 
-- [ ] **Step 2: Edit the SKILL**
+- [x] **Step 2: Edit the SKILL**
 
 In `skills/woostack-init/SKILL.md`, in the step-2 templates table, add a row after the `.woostack/.gitignore` row:
 
@@ -375,12 +375,12 @@ Resolution lives in [`scripts/resolve-base.sh`](scripts/resolve-base.sh); the pe
 lifecycle that consumes it is the [worktree contract](references/worktrees.md).
 ```
 
-- [ ] **Step 3: Confirm the verification passes**
+- [x] **Step 3: Confirm the verification passes**
 
 Run: `grep -c "worktrees.md\|base_branch" skills/woostack-init/SKILL.md`
 Expected: PASS — prints `≥ 2`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "docs(init): document base_branch + worktrees scaffold and link the contract"

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -43,6 +43,7 @@ Two callers:
    | `.woostack/fixes/.gitkeep` | `templates/fixes/.gitkeep` |
    | `.woostack/config.json` | `templates/config.json` (`{ "review": {}, "status": { "staleDays": 14 } }`) |
    | `.woostack/.gitignore` | `templates/gitignore` |
+   | `.woostack/worktrees/` directory | (create empty — per-PR git worktrees, gitignored) |
 
    `config.json` ships as `{ "review": {}, "status": { "staleDays": 14 } }`. Each tool owns
    its own namespace inside that object: for the `review` namespace see
@@ -50,6 +51,11 @@ Two callers:
    (default 14 — the age in days past which an executing spec is flagged stale on the
    `/woostack-status` board), defined in
    [../woostack-status/references/conventions.md](../woostack-status/references/conventions.md).
+
+   The optional top-level `base_branch` key sets the integration/trunk branch that base branches
+   are cut from and PRs target; unset, it auto-detects the remote default (`origin/HEAD`, else
+   `main`). Resolution lives in [`scripts/resolve-base.sh`](scripts/resolve-base.sh); the per-PR
+   worktree lifecycle that consumes it is the [worktree contract](references/worktrees.md).
 
 3. **Handle existing files.** For any file that already exists and `--force`
    is not active: prompt the user to keep or overwrite it. Under `--no-clobber`

--- a/skills/woostack-init/references/worktrees.md
+++ b/skills/woostack-init/references/worktrees.md
@@ -1,0 +1,132 @@
+# Worktree lifecycle + base-branch contract
+
+The single source of truth for **how woostack skills isolate every write in a per-PR git
+worktree** and **how the base/trunk branch is resolved**. `woostack-build`, `woostack-execute`,
+`woostack-execute-overnight`, `woostack-fix`, and `woostack-commit` link this file; none restate it.
+The point: let multiple bootstrap/build/fix runs proceed **in parallel on one machine** without
+collision.
+
+`<wi>` below = the installed `woostack-init` scripts directory (the same place `build-index.sh`
+lives; the agent resolves it when the skill is available).
+
+## 1. Base-branch resolution
+
+Resolve the integration/trunk branch with `<wi>/resolve-base.sh` — never a hardcoded `staging`. It
+exports `WOOSTACK_BASE_BRANCH` (and prints it when executed) with precedence:
+
+1. explicit `WOOSTACK_BASE_BRANCH` override (host pins, tests),
+2. `.woostack/config.json` → `base_branch` (when set and non-empty),
+3. `git symbolic-ref refs/remotes/origin/HEAD` (the remote default branch),
+4. `main` (fresh repo / no remote).
+
+```bash
+base="$(bash <wi>/resolve-base.sh)"     # capture in a fresh shell
+```
+
+This value is what a **stack base** branch is cut from and what a **base PR targets** (`--base`).
+
+## 2. Worktree lifecycle
+
+### Create (on the first write)
+
+```bash
+base="$(bash <wi>/resolve-base.sh)"            # or the parent branch tip for a stacked increment
+slug="${branch//\//-}"                          # branch feature/foo -> dir feature-foo
+wt="$WOOSTACK_ROOT/.woostack/worktrees/$slug"   # anchored to the PRIMARY repo root
+git worktree add -b "$branch" "$wt" "$base_ref"
+( cd "$wt" && gt track --parent "$base_parent_branch" )   # Graphite: register the stack parent
+```
+
+`-b` creates a **fresh** branch at `$base_ref`, so `$base_ref` is only a start-point and is never
+checked out — no "branch already checked out in another worktree" clash, and parallel runs (disjoint
+branch sets) never collide.
+
+### Operate (cwd = the worktree)
+
+From the first write onward the run operates with **cwd = `$wt`**. **All** writes happen there — the
+`.woostack/` spec/plan/fix markdown *and* the implementation code — and any sub-skill the run calls
+(`woostack-plan`, `woostack-harden`, `woostack-commit`) inherits that cwd so it authors into the
+worktree, not the primary tree. In subagent mode the controller dispatches implementers with cwd =
+`$wt`.
+
+### Teardown (after a SUCCESSFUL commit + push + PR)
+
+```bash
+git worktree remove "$wt"
+```
+
+Only the working dir is deleted; the **branch, commits, and PR persist**. **On failure** (commit /
+push errored, or an unresolved review blocker) → **leave the worktree** and report its path. **On
+abandon** (the run is dropped before a PR exists) → `git worktree remove --force "$wt"` and delete
+the dangling branch. Never lose committed work.
+
+## 3. Hard invariant: the primary tree is never edited
+
+A run does all its writes in its own worktree; the primary checkout stays on the base branch, clean,
+as the stable point all runs branch from. This is what makes parallel safe — two runs never touch
+the primary tree.
+
+- **Local-only exception:** `.woostack/memory/` and `.woostack/metrics.json` are gitignored and
+  primary-tree-only; they are written via the `WOOSTACK_ROOT` export of §5 so they survive teardown.
+- **Workflow exception:** `woostack-bootstrap`'s one-time initial repo creation + first commit (no
+  base branch exists yet, pre any parallelism).
+
+**Status visibility is by design.** In-flight artifacts live on a feature branch inside a worktree,
+never in the primary working tree, so `/woostack-status` (which scans the primary tree) surfaces
+**only merged / base-branch state**, not worktree WIP. A spec/plan/fix is not "on the board" until
+its PR merges.
+
+## 4. `base_ref` for stacked PRs
+
+`woostack-execute` produces a Graphite stack. `base_ref` is **parent-aware**:
+
+- **stack base** (the spec+plan branch, or a standalone fix/bootstrap branch) → the resolved
+  `WOOSTACK_BASE_BRANCH`.
+- **stacked increment k** → the **increment k-1 branch tip** (increment 1 → the spec+plan branch).
+
+Removal-after-commit is safe because `git worktree remove` deletes only the working dir — the branch
+outlives it, so the next increment's `base_ref` still exists to cut from. The plan file was committed
+on the spec+plan branch, so every increment worktree (branching off it) **has the plan**, and the
+increment's checkbox ticks are made there and ride that increment's PR.
+
+`gt track --parent <parent>` + `gt submit` open/update each PR with **base = parent branch** so
+GitHub renders the stack. **`gt submit` scope:** submit only the current branch's own (disjoint)
+stack — never `gt sync` / restack-all while a parallel run is in flight. Raw-git fallback (no `gt`):
+identical branch ancestry; `gh pr create --base <parent-branch>`.
+
+## 5. Memory / metrics resolve to the primary tree
+
+`.woostack/memory/` and `.woostack/metrics.json` are gitignored and local-only — they exist **only
+in the primary checkout**. Because the cadence runs inside a worktree, export the primary root before
+any distill/metrics write so it lands in the primary store, not the ephemeral worktree:
+
+```bash
+export WOOSTACK_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"   # primary root, from anywhere
+```
+
+`git rev-parse --git-common-dir` resolves to the **primary** `.git` from inside any worktree, so its
+parent is the primary root. `resolve-root.sh` honors that `WOOSTACK_ROOT` override as its
+highest-precedence source, so distill and metrics anchor to the primary `.woostack/`. No script
+change needed.
+
+## 6. Parallel-safety caveats (best-effort, documented)
+
+- **Shared `.git` / Graphite metadata** serializes via git's index/ref locks (brief contention, no
+  corruption). Each run submits only its own stack; never run a repo-wide `gt sync`/restack while a
+  parallel run is in flight.
+- **`.woostack/memory/` index rebuild + `.woostack/metrics.json`** are last-writer-wins. Different
+  runs write different note files; only the index/`MEMORY.md` rebuild and the metrics file are racy,
+  and both are local/rebuildable. No locking (YAGNI).
+
+## 7. Orphan worktrees
+
+Leave-on-failure can leave worktrees behind. They are inert (gitignored). Reclaim with:
+
+```bash
+git worktree list
+git worktree prune            # drops admin records for deleted dirs
+git worktree remove <path>    # or remove a specific stale worktree
+```
+
+A pre-existing dir at a slug usually means a stale worktree from a crashed run — remove/prune it
+before retrying; never silently reuse or overwrite it.

--- a/skills/woostack-init/scripts/resolve-base.sh
+++ b/skills/woostack-init/scripts/resolve-base.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Single source of truth for the woostack base / integration branch.
+#
+# Sourced (or executed) by every woostack skill that cuts a stack-base branch,
+# targets a PR base (`--base`), or resolves a worktree base-ref. Resolving ONE
+# base here keeps the trunk branch per-repo configurable instead of hardcoded
+# `staging`.
+#
+# Precedence:
+#   1. explicit WOOSTACK_BASE_BRANCH override (host pins, tests) — honored as-is
+#   2. .woostack/config.json -> base_branch, if set and non-empty
+#   3. git symbolic-ref refs/remotes/origin/HEAD -> the remote default branch
+#   4. main — fallback when there is no remote / fresh repo
+#
+# Root resolution mirrors resolve-root.sh (WOOSTACK_ROOT override ->
+# GITHUB_WORKSPACE -> git rev-parse --show-toplevel -> pwd) so `.woostack/`
+# anchors to the repo root. (woostack-init/scripts has no resolve-root.sh to
+# source, so the precedence is inlined here; keep it in sync with
+# skills/woostack-review/scripts/resolve-root.sh.)
+if [ -z "${WOOSTACK_ROOT:-}" ]; then
+  if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+    WOOSTACK_ROOT="$GITHUB_WORKSPACE"
+  else
+    WOOSTACK_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  fi
+fi
+export WOOSTACK_ROOT
+
+if [ -z "${WOOSTACK_BASE_BRANCH:-}" ]; then
+  _wb_cfg="$WOOSTACK_ROOT/.woostack/config.json"
+  _wb_base=""
+  if [ -f "$_wb_cfg" ] && command -v jq >/dev/null 2>&1; then
+    _wb_base="$(jq -r '.base_branch // empty' "$_wb_cfg" 2>/dev/null || true)"
+  fi
+  if [ -z "$_wb_base" ]; then
+    _wb_base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    _wb_base="${_wb_base#origin/}"
+  fi
+  [ -z "$_wb_base" ] && _wb_base="main"
+  WOOSTACK_BASE_BRANCH="$_wb_base"
+fi
+export WOOSTACK_BASE_BRANCH
+
+# When executed (not sourced), print the resolved branch so callers can capture it:
+#   base="$(bash <wi>/resolve-base.sh)"
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  printf '%s\n' "$WOOSTACK_BASE_BRANCH"
+fi

--- a/skills/woostack-init/scripts/resolve-base.sh
+++ b/skills/woostack-init/scripts/resolve-base.sh
@@ -29,8 +29,13 @@ export WOOSTACK_ROOT
 if [ -z "${WOOSTACK_BASE_BRANCH:-}" ]; then
   _wb_cfg="$WOOSTACK_ROOT/.woostack/config.json"
   _wb_base=""
-  if [ -f "$_wb_cfg" ] && command -v jq >/dev/null 2>&1; then
-    _wb_base="$(jq -r '.base_branch // empty' "$_wb_cfg" 2>/dev/null || true)"
+  if [ -f "$_wb_cfg" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      _wb_base="$(jq -r '.base_branch // empty' "$_wb_cfg" 2>/dev/null || true)"
+    else
+      printf 'woostack: %s exists but jq is unavailable; cannot read base_branch\n' "$_wb_cfg" >&2
+      return 1 2>/dev/null || exit 1
+    fi
   fi
   if [ -z "$_wb_base" ]; then
     _wb_base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"

--- a/skills/woostack-init/scripts/tests/test-gitignore-template.sh
+++ b/skills/woostack-init/scripts/tests/test-gitignore-template.sh
@@ -12,5 +12,6 @@ assert_contains "$body" "visuals/" "gitignore template ignores rendered visuals"
 assert_contains "$body" "overnight/" "gitignore template ignores overnight reports"
 assert_contains "$body" "memory.md" "gitignore template ignores flat local memory"
 assert_contains "$body" "memory/" "gitignore template ignores scoped local memory"
+assert_contains "$body" "worktrees/" "gitignore template ignores per-PR worktrees"
 
 finish

--- a/skills/woostack-init/scripts/tests/test-resolve-base.sh
+++ b/skills/woostack-init/scripts/tests/test-resolve-base.sh
@@ -35,4 +35,14 @@ assert_eq "$out4" "pinned" "explicit override wins over config"
 out5="$( cd "$repo1" && env -u WOOSTACK_BASE_BRANCH WOOSTACK_ROOT="$repo1" bash "$resolver" )"
 assert_eq "$out5" "trunk" "executed mode prints resolved branch"
 
+# 6. config present + jq unavailable -> fail loudly instead of falling back
+bin6="$(mktemp -d)"; ln -s "$(command -v git)" "$bin6/git"
+if out6="$( cd "$repo1" && env -u WOOSTACK_BASE_BRANCH WOOSTACK_ROOT="$repo1" PATH="$bin6" bash "$resolver" 2>&1 )"; then
+  fail "config without jq fails"
+fi
+case "$out6" in
+  *"jq is unavailable"*) pass "config without jq fails loudly" ;;
+  *) fail "config without jq explains jq requirement" ;;
+esac
+
 finish

--- a/skills/woostack-init/scripts/tests/test-resolve-base.sh
+++ b/skills/woostack-init/scripts/tests/test-resolve-base.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$DIR/tests/assert.sh"
+resolver="$DIR/resolve-base.sh"
+
+# Run the resolver SOURCED in a clean env (config/remote path), echo the result.
+resolved() { # repo
+  ( cd "$1" && env -u WOOSTACK_BASE_BRANCH WOOSTACK_ROOT="$1" \
+      bash -c 'set -e; . "$1"; printf "%s" "$WOOSTACK_BASE_BRANCH"' _ "$resolver" )
+}
+
+# 1. config.base_branch set -> wins
+repo1="$(mktemp -d)"; ( cd "$repo1" && git init -q && git commit -q --allow-empty -m init )
+mkdir -p "$repo1/.woostack"; printf '{"base_branch":"trunk"}\n' > "$repo1/.woostack/config.json"
+assert_eq "$(resolved "$repo1")" "trunk" "config base_branch wins"
+
+# 2. unset config -> remote default branch (origin/HEAD)
+origin="$(mktemp -d)"; ( cd "$origin" && git init -q --bare )
+repo2="$(mktemp -d)"
+( cd "$repo2" && git init -q && git checkout -q -b dev && git commit -q --allow-empty -m init \
+  && git remote add origin "$origin" && git push -q origin dev && git remote set-head origin dev )
+assert_eq "$(resolved "$repo2")" "dev" "remote default branch used when no config"
+
+# 3. unset config + no remote -> main
+repo3="$(mktemp -d)"; ( cd "$repo3" && git init -q && git commit -q --allow-empty -m init )
+assert_eq "$(resolved "$repo3")" "main" "no remote falls back to main"
+
+# 4. explicit WOOSTACK_BASE_BRANCH override honored as-is (config present, but pinned wins)
+out4="$( cd "$repo1" && WOOSTACK_ROOT="$repo1" WOOSTACK_BASE_BRANCH="pinned" \
+  bash -c '. "$1"; printf "%s" "$WOOSTACK_BASE_BRANCH"' _ "$resolver" )"
+assert_eq "$out4" "pinned" "explicit override wins over config"
+
+# 5. EXECUTED (not sourced) prints the resolved branch for $( ) capture
+out5="$( cd "$repo1" && env -u WOOSTACK_BASE_BRANCH WOOSTACK_ROOT="$repo1" bash "$resolver" )"
+assert_eq "$out5" "trunk" "executed mode prints resolved branch"
+
+finish

--- a/skills/woostack-init/templates/gitignore
+++ b/skills/woostack-init/templates/gitignore
@@ -3,6 +3,7 @@ metrics.json
 *.local.*
 visuals/
 overnight/
+worktrees/
 memory.md
 memory/
 


### PR DESCRIPTION
## Goal

Increment 1 of 4 (foundation). Establish the shared base-branch resolver, the gitignore entry, and the canonical worktree-lifecycle contract that every later increment links — no behavior change to existing flows yet.

## Summary

- `skills/woostack-init/scripts/resolve-base.sh` — sourced+executable helper resolving the base/trunk branch (`config.base_branch` → `origin/HEAD` → `main`), mirroring `resolve-root.sh`; `test-resolve-base.sh` covers all 5 cases (config / remote / main / override / executed-mode).
- `skills/woostack-init/templates/gitignore` — ignore per-PR `worktrees/`; `test-gitignore-template.sh` asserts it.
- `skills/woostack-init/references/worktrees.md` — canonical worktree-lifecycle + base-branch contract (lifecycle, never-edit-primary invariant, parent-aware `base_ref`, memory→primary via `git-common-dir`, parallel caveats, orphan cleanup).
- `skills/woostack-init/SKILL.md` — scaffold the `worktrees/` dir, document `base_branch`, link the contract.

## Test plan

### Automated

- [x] `bash skills/woostack-init/scripts/tests/run-tests.sh` — 141 passed, 0 failed (incl. new `test-resolve-base.sh` 5/5 and `test-gitignore-template.sh` 7/7).
- [x] `shellcheck -x skills/woostack-init/scripts/resolve-base.sh` — clean.

### Manual

**Before merge**

- [ ] Read `references/worktrees.md` — confirm the lifecycle, the `base_ref` rule, and the memory→primary mechanism are correct.

Spec: .woostack/specs/2026-06-10-parallel-worktrees.md
