### PR TITLE
feat(commit): resolve base branch via resolve-base.sh; worktree-agnostic note

### DIFF
--- a/.woostack/plans/2026-06-10-parallel-worktrees.md
+++ b/.woostack/plans/2026-06-10-parallel-worktrees.md
@@ -399,12 +399,12 @@ gt modify -c -m "docs(init): document base_branch + worktrees scaffold and link 
 
 > `resolve-base.sh` ships clean in Increment 1 (no deferral marker); this increment is its first consumer. No `woostack-defer` marker is used in this plan — the slices are doc/script additions where an isolated diff draws no "missing call site" finding.
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `grep -c "resolve-base.sh\|WOOSTACK_BASE_BRANCH" skills/woostack-commit/SKILL.md`
 Expected: FAIL — prints `0`.
 
-- [ ] **Step 2: Edit step 2 (branch shape) to use the resolved base + worktree-agnostic note**
+- [x] **Step 2: Edit step 2 (branch shape) to use the resolved base + worktree-agnostic note**
 
 In `skills/woostack-commit/SKILL.md` §"2. Enforce branch shape before committing", after the `gt create feature/<short-slug>` block, add:
 
@@ -423,7 +423,7 @@ contract](../woostack-init/references/worktrees.md)), this step finds a non-prot
 continues — `woostack-commit` commits whatever tree it is invoked in and creates no second branch.
 ```
 
-- [ ] **Step 3: Edit step 7 (PR create) to target the resolved base**
+- [x] **Step 3: Edit step 7 (PR create) to target the resolved base**
 
 In §"7. Update PR fields", replace the `gh pr create --base staging …` block with:
 
@@ -438,12 +438,12 @@ contract](../woostack-init/references/worktrees.md) §4); Graphite sets it autom
 `gt submit` when the branch was `gt track --parent`ed.
 ```
 
-- [ ] **Step 4: Confirm the verification passes**
+- [x] **Step 4: Confirm the verification passes**
 
 Run: `grep -c "resolve-base.sh\|worktree" skills/woostack-commit/SKILL.md`
 Expected: PASS — prints `≥ 2`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "feat(commit): resolve base branch via resolve-base.sh; worktree-agnostic note"
@@ -454,12 +454,12 @@ gt create -m "feat(commit): resolve base branch via resolve-base.sh; worktree-ag
 **Files:**
 - Modify: `skills/woostack-bootstrap/references/development.md`
 
-- [ ] **Step 1: Find the offending references**
+- [x] **Step 1: Find the offending references**
 
 Run: `grep -rn "\-\-base staging" skills/`
 Expected: a hit in `skills/woostack-bootstrap/references/development.md` (the `gt create --base staging` line).
 
-- [ ] **Step 2: Rewrite the branching model to reference the configurable base**
+- [x] **Step 2: Rewrite the branching model to reference the configurable base**
 
 In `skills/woostack-bootstrap/references/development.md` §"Branching model", replace the final line:
 
@@ -478,12 +478,12 @@ is **per-repo configurable** — resolve it with
 illustrate the integration role, not as a hardcoded requirement.
 ```
 
-- [ ] **Step 3: Confirm no hardcoded PR-base `staging` command remains**
+- [x] **Step 3: Confirm no hardcoded PR-base `staging` command remains**
 
 Run: `grep -rn "\-\-base staging" skills/`
 Expected: no output.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "docs(bootstrap): make branching-model base branch configurable, drop hardcoded staging"

--- a/skills/woostack-bootstrap/references/development.md
+++ b/skills/woostack-bootstrap/references/development.md
@@ -36,7 +36,7 @@ markdown plans in `.woostack/plans/`, and review config in `.woostack/config.jso
 - Never PR directly into `main` except for emergency hotfixes (and even then, cherry-pick into `staging` immediately after).
 - Never force-push to `main` or `staging`.
 
-Use Graphite (`gt create`, `gt modify`, `gt submit`) to manage stacks. `gt create --base staging` for the initial branch.
+Use Graphite (`gt create`, `gt modify`, `gt submit`) to manage stacks. The integration/trunk branch is **per-repo configurable** — resolve it with [`resolve-base.sh`](../../woostack-init/scripts/resolve-base.sh) (`.woostack/config.json` → `base_branch`, else the remote default, else `main`) and pass it as the base of the stack: `gt create --base "$(bash <wi>/resolve-base.sh)"`. The example table above uses `staging` to illustrate the integration role, not as a hardcoded requirement.
 
 ## When to deviate
 

--- a/skills/woostack-bootstrap/references/development.md
+++ b/skills/woostack-bootstrap/references/development.md
@@ -25,18 +25,18 @@ markdown plans in `.woostack/plans/`, and review config in `.woostack/config.jso
 
 | Branch | Role | Parent | Direction |
 |---|---|---|---|
-| `main` | Production. What's running for users. | — | Receives from `staging` only |
-| `staging` | Integration. Pre-prod testing. | `main` | Receives from feature branches |
-| `feature/<name>` | One change. One PR. | `staging` | Merged into `staging` via PR |
+| `main` | Production. What's running for users. | — | Receives from the integration branch |
+| `staging` | Example integration branch. Pre-prod testing. | `main` | Receives from feature branches |
+| `feature/<name>` | One change. One PR. | resolved integration branch | Merged into the integration branch via PR |
 
 **Rules:**
-- Every feature branch is cut from `staging`, not `main`.
-- Every PR targets `staging`.
-- `staging` is merged into `main` on a regular cadence (weekly, or per release) after manual/automated testing on the staging environment.
-- Never PR directly into `main` except for emergency hotfixes (and even then, cherry-pick into `staging` immediately after).
-- Never force-push to `main` or `staging`.
+- Every feature branch is cut from the resolved integration branch, not `main`.
+- Every PR targets the resolved integration branch.
+- The integration branch is merged into `main` on a regular cadence (weekly, or per release) after manual/automated testing on the integration environment.
+- Never PR directly into `main` except for emergency hotfixes (and even then, cherry-pick into the integration branch immediately after).
+- Never force-push to `main` or the integration branch.
 
-Use Graphite (`gt create`, `gt modify`, `gt submit`) to manage stacks. The integration/trunk branch is **per-repo configurable** — resolve it with [`resolve-base.sh`](../../woostack-init/scripts/resolve-base.sh) (`.woostack/config.json` → `base_branch`, else the remote default, else `main`) and pass it as the base of the stack: `gt create --base "$(bash <wi>/resolve-base.sh)"`. The example table above uses `staging` to illustrate the integration role, not as a hardcoded requirement.
+Use Graphite (`gt create`, `gt modify`, `gt submit`) to manage stacks. The integration/trunk branch is **per-repo configurable**; resolve it through the [worktree/base-branch contract](../../woostack-init/references/worktrees.md) and use that value as the base of the stack. The example table above uses `staging` to illustrate the integration role, not as a hardcoded requirement.
 
 ## When to deviate
 

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -84,29 +84,30 @@ If relevance is ambiguous, stop and ask the user before staging.
 
 ### 2. Enforce branch shape before committing
 
-Never commit directly to protected integration branches: `main`, `staging`, `beta`, or `alpha`. These branch names do not need to exist in every repo, but when the current branch is one of them, create a `feature/*` branch before staging or committing.
-
-- If current branch matches `feature/*`, continue.
-- If current branch is `main`, `staging`, `beta`, or `alpha`, create a new feature branch from the current branch before staging:
+Resolve the integration branch before checking the current branch (`<wi>` = the installed `woostack-init` scripts dir):
 
 ```bash
+base="$(bash <wi>/resolve-base.sh)"
+```
+
+Never commit directly to protected integration branches: the resolved `$base`, plus conventional protected names `main`, `staging`, `beta`, or `alpha`. These branch names do not need to exist in every repo, but when the current branch is one of them, create a `feature/*` branch before staging or committing.
+
+- If current branch matches `feature/*` or `fix/*`, continue.
+- If current branch is `$base`, `main`, `staging`, `beta`, or `alpha`, create a new feature branch from the resolved integration branch before staging:
+
+```bash
+git switch "$base"
 gt create feature/<short-slug>
+gt track feature/<short-slug> --parent "$base"
 ```
 
 - If current branch is anything else, stop and ask whether to continue on the current branch or create a new `feature/*` branch.
 
-Use a short slug based on the change, such as `feature/review-model-defaults` or `feature/add-commit-skill`. Prefer Graphite (`gt`) for branch creation. Fall back to raw `git switch -c feature/<short-slug>` only when Graphite is unavailable or clearly not initialized.
-
-Resolve the integration/trunk branch with the shared helper rather than assuming `staging` (`<wi>` = the installed `woostack-init` scripts dir):
-
-```bash
-base="$(bash <wi>/resolve-base.sh)"
-gt create feature/<short-slug> --base "$base"
-```
+Use a short slug based on the change, such as `feature/review-model-defaults` or `feature/add-commit-skill`. Prefer Graphite for branch creation and tracking: switch to the resolved base, run `gt create feature/<short-slug>`, then ensure the parent is registered with `gt track feature/<short-slug> --parent "$base"`. If Graphite is unavailable or clearly not initialized, fall back to raw git only: `git switch -c feature/<short-slug> "$base"`.
 
 **Running inside a worktree:** when a driving skill (build / execute / fix) has already created a per-PR worktree on a `feature/*` or `fix/*` branch (see the [worktree contract](../woostack-init/references/worktrees.md)), this step finds a non-protected branch and continues — `woostack-commit` commits whatever tree it is invoked in and creates no second branch.
 
-Never force-push. Never commit directly to `main`, `staging`, `beta`, or `alpha`.
+Never force-push. Never commit directly to `$base`, `main`, `staging`, `beta`, or `alpha`.
 
 ### 3. Run configured pre-commit command
 
@@ -205,7 +206,7 @@ Resolve the PR:
 gh pr view --json number,title,body,headRefName,baseRefName,url
 ```
 
-If no PR exists after submit/push, create one targeting the resolved base branch:
+If no PR exists after submit/push, create one targeting the resolved base branch (`<wi>` = the installed `woostack-init` scripts dir, as in step 2):
 
 ```bash
 base="$(bash <wi>/resolve-base.sh)"

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -97,6 +97,15 @@ gt create feature/<short-slug>
 
 Use a short slug based on the change, such as `feature/review-model-defaults` or `feature/add-commit-skill`. Prefer Graphite (`gt`) for branch creation. Fall back to raw `git switch -c feature/<short-slug>` only when Graphite is unavailable or clearly not initialized.
 
+Resolve the integration/trunk branch with the shared helper rather than assuming `staging` (`<wi>` = the installed `woostack-init` scripts dir):
+
+```bash
+base="$(bash <wi>/resolve-base.sh)"
+gt create feature/<short-slug> --base "$base"
+```
+
+**Running inside a worktree:** when a driving skill (build / execute / fix) has already created a per-PR worktree on a `feature/*` or `fix/*` branch (see the [worktree contract](../woostack-init/references/worktrees.md)), this step finds a non-protected branch and continues — `woostack-commit` commits whatever tree it is invoked in and creates no second branch.
+
 Never force-push. Never commit directly to `main`, `staging`, `beta`, or `alpha`.
 
 ### 3. Run configured pre-commit command
@@ -196,11 +205,14 @@ Resolve the PR:
 gh pr view --json number,title,body,headRefName,baseRefName,url
 ```
 
-If no PR exists after submit/push, create one targeting `staging`:
+If no PR exists after submit/push, create one targeting the resolved base branch:
 
 ```bash
-gh pr create --base staging --head "$(git branch --show-current)" --title "<concise title>" --body-file <tmp-body-file>
+base="$(bash <wi>/resolve-base.sh)"
+gh pr create --base "$base" --head "$(git branch --show-current)" --title "<concise title>" --body-file <tmp-body-file>
 ```
+
+For a **stacked** increment PR the base is the **parent branch**, not `$base` (see the [worktree contract](../woostack-init/references/worktrees.md) §4); Graphite sets it automatically via `gt submit` when the branch was `gt track --parent`ed.
 
 Set or update the body with this structure:
 


### PR DESCRIPTION
## Goal

Increment 2 of 4. Make `woostack-commit` consume the base-branch resolver (instead of assuming `staging`) and sweep the remaining hardcoded `--base staging` reference from the docs.

## Summary

- `skills/woostack-commit/SKILL.md` — step 2 resolves the integration branch via `resolve-base.sh` (`gt create --base "$base"`) + a worktree-agnostic note (commits whatever tree it runs in, creates no second branch); step 7 targets the resolved base, with the stacked-increment-PR carve-out (base = parent branch).
- `skills/woostack-bootstrap/references/development.md` — branching model now resolves the base via `resolve-base.sh`; `staging` is illustrative, not hardcoded.

## Test plan

### Automated

- [x] `grep -rn -- "--base staging" skills/` → no output (all hardcoded PR-base references removed).

### Manual

**Before merge**

- [ ] Read the woostack-commit step 2 / step 7 edits — confirm the resolver usage and the stacked-PR base carve-out read correctly.

Spec: .woostack/specs/2026-06-10-parallel-worktrees.md
