### PR TITLE
feat(execute): per-increment worktree cadence (parent base-ref, memory->primary, teardown)

### DIFF
--- a/.woostack/plans/2026-06-10-parallel-worktrees.md
+++ b/.woostack/plans/2026-06-10-parallel-worktrees.md
@@ -630,12 +630,12 @@ gt modify -c -m "docs(bootstrap): note the initial-scaffold worktree exemption +
 **Files:**
 - Modify: `skills/woostack-execute/SKILL.md`
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `grep -c "worktree" skills/woostack-execute/SKILL.md`
 Expected: FAIL — prints `0`.
 
-- [ ] **Step 2: Edit per-increment cadence step 1 (Start its branch before editing)**
+- [x] **Step 2: Edit per-increment cadence step 1 (Start its branch before editing)**
 
 In `skills/woostack-execute/SKILL.md` §"Per-increment cadence" step 1, replace its body with:
 
@@ -655,7 +655,7 @@ In `skills/woostack-execute/SKILL.md` §"Per-increment cadence" step 1, replace 
    (dispatched with **cwd = the worktree**) — happens inside it.
 ```
 
-- [ ] **Step 3: Edit the distill step (step 7) to anchor memory to the primary tree**
+- [x] **Step 3: Edit the distill step (step 7) to anchor memory to the primary tree**
 
 In step 7 of the cadence, after "distill the increment's durable, reusable learnings into `.woostack/memory/`", insert:
 
@@ -669,7 +669,7 @@ In step 7 of the cadence, after "distill the increment's durable, reusable learn
    ```
 ```
 
-- [ ] **Step 4: Add the teardown after the cycle (after distill)**
+- [x] **Step 4: Add the teardown after the cycle (after distill)**
 
 At the end of the cadence (after step 7, before "Then advance to the next increment."), insert:
 
@@ -681,12 +681,12 @@ At the end of the cadence (after step 7, before "Then advance to the next increm
    branch tip.
 ```
 
-- [ ] **Step 5: Confirm the verification passes**
+- [x] **Step 5: Confirm the verification passes**
 
 Run: `grep -c "worktree" skills/woostack-execute/SKILL.md`
 Expected: PASS — prints `≥ 3` and references the contract.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 gt create -m "feat(execute): per-increment worktree cadence (parent base-ref, memory->primary, teardown)"
@@ -697,12 +697,12 @@ gt create -m "feat(execute): per-increment worktree cadence (parent base-ref, me
 **Files:**
 - Modify: `skills/woostack-execute-overnight/SKILL.md`
 
-- [ ] **Step 1: Write the failing verification**
+- [x] **Step 1: Write the failing verification**
 
 Run: `grep -c "worktree" skills/woostack-execute-overnight/SKILL.md`
 Expected: FAIL — prints `0`.
 
-- [ ] **Step 2: Edit the per-increment cadence bullet to inherit worktrees**
+- [x] **Step 2: Edit the per-increment cadence bullet to inherit worktrees**
 
 In `skills/woostack-execute-overnight/SKILL.md`, change the "Per-increment cadence" bullet (currently `branch → implement (driver) → tick … → woostack-commit → review → distill`) to:
 
@@ -715,12 +715,12 @@ In `skills/woostack-execute-overnight/SKILL.md`, change the "Per-increment caden
   track's last worktree is **left in place** for morning inspection, not torn down.
 ```
 
-- [ ] **Step 3: Confirm the verification passes**
+- [x] **Step 3: Confirm the verification passes**
 
 Run: `grep -c "worktree" skills/woostack-execute-overnight/SKILL.md`
 Expected: PASS — prints `≥ 2`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "docs(overnight): inherit the per-PR worktree cadence; leave blocked-track worktree for AM"

--- a/skills/woostack-execute-overnight/SKILL.md
+++ b/skills/woostack-execute-overnight/SKILL.md
@@ -32,8 +32,12 @@ logged — in the morning.
 Everything except the stop-points. Do **not** restate these — follow
 [`woostack-execute`](../woostack-execute/SKILL.md):
 
-- **Per-increment cadence**: branch → implement (driver) → tick the plan's checkboxes in place →
-  [`woostack-commit`](../woostack-commit/SKILL.md) → review → distill.
+- **Per-increment cadence**: create per-PR worktree → implement (driver) → tick the plan's
+  checkboxes in place → [`woostack-commit`](../woostack-commit/SKILL.md) → review → distill →
+  teardown worktree. Identical to [`woostack-execute`](../woostack-execute/SKILL.md)'s cadence,
+  including the per-PR [worktree contract](../woostack-init/references/worktrees.md) (parent-aware
+  `base_ref`, `WOOSTACK_ROOT`-anchored distill, leave-on-failure). On a track blocker the blocked
+  track's last worktree is **left in place** for morning inspection, not torn down.
 - **Drivers**: [inline](../woostack-execute/references/inline-driver.md) /
   [subagent](../woostack-execute/references/subagent-driver.md), and the **smart default**
   (subagent where the host can spawn subagents, else inline). `--inline` / `--subagent` override;

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -84,9 +84,20 @@ Run **one increment per cycle**, in order.
 
 For each increment:
 
-1. **Start its branch before editing.** Verify the current branch is not protected, then create
-   or checkout the fresh Graphite-stacked feature branch for this increment (`gt create`) so
-   all implementation work lands on the branch that will become that increment's PR.
+1. **Start its branch before editing — in a per-PR worktree.** Verify the current branch is not
+   protected, then create (or, when a caller like `woostack-fix` already made it, verify) the
+   increment's fresh Graphite-stacked branch **in its own worktree** off the **parent branch tip**,
+   per the [worktree contract](../woostack-init/references/worktrees.md):
+
+   ```bash
+   git worktree add -b <inc-branch> "$WOOSTACK_ROOT/.woostack/worktrees/<inc-slug>" "$parent_branch"
+   ( cd "$WOOSTACK_ROOT/.woostack/worktrees/<inc-slug>" && gt track --parent "$parent_branch" )
+   ```
+
+   `$parent_branch` is the spec+plan branch for increment 1, else the previous increment's branch
+   (the stack base uses the resolved base branch; stacked increments use their parent). All work —
+   the TDD code, the plan checkbox ticks (step 3), and, in subagent mode, the implementer subagents
+   (dispatched with **cwd = the worktree**) — happens inside it.
 2. **Implement** its tasks via the resolved driver (see [Execution mode](#execution-mode)):
    [references/inline-driver.md](references/inline-driver.md) in inline mode, or
    [references/subagent-driver.md](references/subagent-driver.md) in subagent mode. Both follow
@@ -116,6 +127,16 @@ For each increment:
    near-duplicate notes, and stamp `updated:` on every note you write. Then run `woostack-init`'s
    `build-index.sh` and `doctor.sh`; fix any error. When the store does not exist, skip (or offer
    `/woostack-init` first). Distill only cross-feature knowledge, never feature-specific trivia.
+   The cadence runs inside the per-PR worktree, but `.woostack/memory/` is local-only to the
+   **primary** tree, so export the primary root before distilling so the write lands in the primary
+   store (per the [worktree contract](../woostack-init/references/worktrees.md) §5):
+   `export WOOSTACK_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"`.
+
+8. **Teardown the worktree.** After the increment is committed, reviewed, and distilled, remove its
+   worktree (`git worktree remove "$WOOSTACK_ROOT/.woostack/worktrees/<inc-slug>"`); the
+   branch/commits/PR persist as the stack base for the next increment. **Leave it on a
+   blocker/failure** and report its path. The next increment's worktree is cut off this increment's
+   branch tip.
 
 Then advance to the next increment.
 


### PR DESCRIPTION
## Goal

Increment 4 of 4. Wire the parent-aware per-PR worktree cadence into woostack-execute (the case that builds the Graphite stack) and mirror it in woostack-execute-overnight.

## Summary

- `skills/woostack-execute/SKILL.md` — per-increment cadence step 1 now creates (or, for a `woostack-fix` hand-off, verifies) the increment's branch in its own worktree off the parent branch tip (`gt track --parent`); step 7 exports `WOOSTACK_ROOT` via `git rev-parse --git-common-dir` so distill lands in the primary store; new step 8 tears down the worktree after commit/review/distill (leave on blocker/failure).
- `skills/woostack-execute-overnight/SKILL.md` — per-increment cadence bullet inherits the worktree lifecycle; a blocked track's last worktree is left in place for morning inspection.

## Test plan

### Automated

- [x] `bash skills/woostack-init/scripts/tests/run-tests.sh` — 141 passed, 0 failed (whole suite, re-run on the full stack).
- [x] `grep -rn -- "--base staging" skills/` → no output (AC4).
- [x] Contract linked from build/execute/overnight/fix/commit/init (AC1).

### Manual

**Before merge**

- [ ] Read the execute cadence step 1/7/8 edits — confirm the parent-aware `base_ref`, the create-or-verify (fix reuse), the `git-common-dir` memory anchoring, and the teardown ordering are correct.
- [ ] Confirm overnight's "leave blocked-track worktree" behavior reads correctly.

Spec: .woostack/specs/2026-06-10-parallel-worktrees.md
