### PR TITLE
Enable repo review action

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,32 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  review:
+    # issue_comment runs in the base-repo context with secrets available, so
+    # require both a trusted actor and an explicit review phrase. pull_request
+    # events are limited to same-repo branches because fork PRs do not receive
+    # provider secrets; maintainers can trigger those with a trusted comment.
+    if: >-
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+       (contains(github.event.comment.body, '@review') ||
+        contains(github.event.comment.body, '/woostack-review')))
+    uses: ./.github/workflows/reusable-review.yml
+    with:
+      provider: openai
+    secrets:
+      openai_access_token: ${{ secrets.OPENAI_ACCESS_TOKEN }}

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -10,6 +10,10 @@ on:
         description: 'Model identifier passed to the chosen runner.'
         type: string
         required: false
+      openai_effort:
+        description: 'OpenAI Codex reasoning effort passthrough.'
+        type: string
+        required: false
       force_tier:
         description: 'Optional one-run tier override: fast | deep.'
         type: string
@@ -58,6 +62,8 @@ on:
         required: false
       openai_api_key:
         required: false
+      openai_access_token:
+        required: false
       google_api_key:
         required: false
       gemini_api_key:
@@ -82,11 +88,24 @@ jobs:
       chunks: ${{ steps.woo.outputs.chunks_json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      # Self-references pinned to the current tag. Bump in lockstep with releases.
+      - name: Checkout woostack action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: howarewoo/woostack
+          ref: ${{ github.repository == 'howarewoo/woostack' && github.event.pull_request.head.ref || 'main' }}
+          path: .woostack-action
       - id: woo
-        uses: howarewoo/woostack@main
+        uses: ./.woostack-action
         with:
           mode: detect
+          provider: ${{ inputs.provider }}
+          anthropic_token: ${{ secrets.anthropic_token }}
+          anthropic_api_key: ${{ secrets.anthropic_api_key }}
+          openai_api_key: ${{ secrets.openai_api_key }}
+          openai_access_token: ${{ secrets.openai_access_token }}
+          google_api_key: ${{ secrets.google_api_key }}
+          gemini_api_key: ${{ secrets.gemini_api_key }}
+          openrouter_api_key: ${{ secrets.openrouter_api_key }}
           disable_angles: ${{ inputs.disable_angles }}
           incremental: ${{ inputs.incremental }}
           force_tier: ${{ inputs.force_tier }}
@@ -101,6 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       pull-requests: read
     if: needs.detect.outputs.angles != '[]' && needs.detect.outputs.angles != ''
     # Two-dim matrix (issue #14): angles × chunks. When chunking does not
@@ -115,28 +135,42 @@ jobs:
         chunk: ${{ fromJson(needs.detect.outputs.chunks) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout woostack action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: howarewoo/woostack
+          ref: ${{ github.repository == 'howarewoo/woostack' && github.event.pull_request.head.ref || 'main' }}
+          path: .woostack-action
       - name: Download base artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: review-artifacts
           path: /tmp/pr-review/
+      - name: Install bubblewrap for OpenAI Codex
+        if: inputs.provider == 'openai'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
       # One-retry wrapper: a transient angle failure (model timeout, rate limit) gets
       # one re-run before the receipt gate fails the review, mirroring the local swarm's
       # single retry. Dependency-free — a duplicated action step, no third-party retry action.
       - name: Run angle review (attempt 1)
         id: review1
         continue-on-error: true
-        uses: howarewoo/woostack@main
+        uses: ./.woostack-action
         with:
           mode: review
           angle: ${{ matrix.angle }}
           chunk: ${{ matrix.chunk }}
           provider: ${{ inputs.provider }}
           model: ${{ inputs.model }}
+          openai_effort: ${{ inputs.openai_effort }}
           force_tier: ${{ inputs.force_tier }}
           anthropic_token: ${{ secrets.anthropic_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           openai_api_key: ${{ secrets.openai_api_key }}
+          openai_access_token: ${{ secrets.openai_access_token }}
           google_api_key: ${{ secrets.google_api_key }}
           gemini_api_key: ${{ secrets.gemini_api_key }}
           openrouter_api_key: ${{ secrets.openrouter_api_key }}
@@ -147,18 +181,20 @@ jobs:
           react_doctor_version: ${{ inputs.react_doctor_version }}
           impeccable_version: ${{ inputs.impeccable_version }}
       - name: Run angle review (retry once)
-        if: steps.review1.outcome == 'failure'
-        uses: howarewoo/woostack@main
+        if: steps.review1.outcome == 'failure' && inputs.provider != 'openai'
+        uses: ./.woostack-action
         with:
           mode: review
           angle: ${{ matrix.angle }}
           chunk: ${{ matrix.chunk }}
           provider: ${{ inputs.provider }}
           model: ${{ inputs.model }}
+          openai_effort: ${{ inputs.openai_effort }}
           force_tier: ${{ inputs.force_tier }}
           anthropic_token: ${{ secrets.anthropic_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           openai_api_key: ${{ secrets.openai_api_key }}
+          openai_access_token: ${{ secrets.openai_access_token }}
           google_api_key: ${{ secrets.google_api_key }}
           gemini_api_key: ${{ secrets.gemini_api_key }}
           openrouter_api_key: ${{ secrets.openrouter_api_key }}
@@ -168,6 +204,12 @@ jobs:
           prompt_override: ${{ inputs.prompt_override }}
           react_doctor_version: ${{ inputs.react_doctor_version }}
           impeccable_version: ${{ inputs.impeccable_version }}
+      - name: Fail OpenAI angle after first attempt
+        if: steps.review1.outcome == 'failure' && inputs.provider == 'openai'
+        shell: bash
+        run: |
+          echo "::error::OpenAI Codex action failed; same-job retry is disabled because safety-strategy=drop-sudo is irreversible."
+          exit 1
       # Artifact name includes the chunk suffix so multiple chunk jobs for the
       # same angle cannot collide on upload. `chunk` is `""` in the un-chunked
       # case → suffix collapses to `-all`; the merge step globs `findings-*`.
@@ -195,12 +237,19 @@ jobs:
     # review (`pull-requests: write`).
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout woostack action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: howarewoo/woostack
+          ref: ${{ github.repository == 'howarewoo/woostack' && github.event.pull_request.head.ref || 'main' }}
+          path: .woostack-action
       - name: Download base artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -213,6 +262,12 @@ jobs:
           pattern: findings-*
           path: /tmp/pr-review/
           merge-multiple: true
+      - name: Install bubblewrap for OpenAI Codex
+        if: inputs.provider == 'openai'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
 
       # Adversarial validator (issue #13): prosecutor pass writes
       # findings.prosecutor.json (inclusive bias), defender pass writes
@@ -234,16 +289,18 @@ jobs:
 
       - name: Validate (prosecutor pass)
         if: steps.adv.outputs.disabled != 'true'
-        uses: howarewoo/woostack@main
+        uses: ./.woostack-action
         with:
           mode: validate-prosecutor
           disable_angles: ${{ inputs.disable_angles }}
           provider: ${{ inputs.provider }}
           model: ${{ inputs.model }}
+          openai_effort: ${{ inputs.openai_effort }}
           force_tier: ${{ inputs.force_tier }}
           anthropic_token: ${{ secrets.anthropic_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           openai_api_key: ${{ secrets.openai_api_key }}
+          openai_access_token: ${{ secrets.openai_access_token }}
           google_api_key: ${{ secrets.google_api_key }}
           gemini_api_key: ${{ secrets.gemini_api_key }}
           openrouter_api_key: ${{ secrets.openrouter_api_key }}
@@ -252,16 +309,18 @@ jobs:
           prompt_override: ${{ inputs.prompt_override }}
 
       - name: Validate (defender pass + intersect + post)
-        uses: howarewoo/woostack@main
+        uses: ./.woostack-action
         with:
           mode: validate
           disable_angles: ${{ inputs.disable_angles }}
           provider: ${{ inputs.provider }}
           model: ${{ inputs.model }}
+          openai_effort: ${{ inputs.openai_effort }}
           force_tier: ${{ inputs.force_tier }}
           anthropic_token: ${{ secrets.anthropic_token }}
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           openai_api_key: ${{ secrets.openai_api_key }}
+          openai_access_token: ${{ secrets.openai_access_token }}
           google_api_key: ${{ secrets.google_api_key }}
           gemini_api_key: ${{ secrets.gemini_api_key }}
           openrouter_api_key: ${{ secrets.openrouter_api_key }}

--- a/.woostack/fixes/2026-06-11-enable-repo-review-action.md
+++ b/.woostack/fixes/2026-06-11-enable-repo-review-action.md
@@ -1,0 +1,117 @@
+---
+type: fix
+status: in-review
+branch: fix/enable-repo-review-action
+---
+
+# Fix: Enable woostack-review on this repo's PRs
+
+## 1. Root Cause
+
+The repo ships the reusable review workflow at `.github/workflows/reusable-review.yml`, but
+that workflow only declares `workflow_call`. GitHub will not run it directly on this repo's
+pull requests or PR comments without a separate event-triggered workflow that calls it.
+
+Evidence:
+
+- `.github/workflows/reusable-review.yml` has only `on.workflow_call`, so it is callable but
+  not self-triggering.
+- `.github/` currently has no `ai-review.yml` or equivalent trigger workflow.
+- `skills/woostack-review/SKILL.md` documents the intended companion workflow shape: a thin
+  `.github/workflows/ai-review.yml` with `pull_request` and trusted `issue_comment` triggers
+  that calls the reusable review workflow.
+- The documented `issue_comment` event is only safe when it is both actor-gated and
+  phrase-gated. `prefetch.sh` parses `/woostack-review` command modifiers after a run has
+  started, but the caller workflow is the right place to avoid starting expensive review jobs
+  for unrelated trusted maintainer comments.
+- The first PR run failed in `review / detect` even though this repo has
+  `CLAUDE_CODE_OAUTH_TOKEN` configured. The reusable workflow's detect job called the
+  composite action without forwarding `inputs.provider` or any provider secrets, so
+  `detect-provider.sh` could not auto-detect a provider before angle detection.
+- After detect was fixed, angle workers exposed two shipped-action issues: the Anthropic
+  runner needs `id-token: write`, and `load-prompt.sh` used a `printf | grep -q` marker check
+  under `pipefail`, which can false-fail as "marker missing" when `grep -q` exits early.
+- The reusable workflow self-invoked `howarewoo/woostack@main`. That works for consumers, but
+  it prevents this repo's own PRs from testing action changes before merge; the failing `bugs`
+  angle kept running the old `load-prompt.sh` from `main`.
+- `AGENTS.md` still describes the review workflow assets as consumer-facing only, so adding a
+  repo-local trigger also needs a small instruction update to prevent future cleanup as
+  accidental CI.
+
+Memory recall:
+
+- `.woostack/memory.md` notes that markdown/skill-doc-only PRs previously skipped automated
+  swarm review. Enabling a repo-level review action addresses that operational gap for future
+  PRs.
+- `.woostack/memory/woostack-command-surface-bookkeeping.md` applies to `AGENTS.md` edits:
+  keep repo-surface bookkeeping explicit when changing documented workflows.
+
+## 2. Proposed Fix
+
+Add a thin `.github/workflows/ai-review.yml` workflow for this repo. It should:
+
+- Trigger on `pull_request` events: `opened`, `reopened`, `ready_for_review`, and
+  `synchronize`. The job gate should run these automatically only for same-repo branches,
+  because fork PRs do not receive provider secrets.
+- Trigger on `issue_comment.created`, but run only for PR comments that are both from trusted
+  actors (`OWNER`, `MEMBER`, or `COLLABORATOR`) and explicitly request review with
+  `@review` or `/woostack-review`. This gives maintainers an explicit path to review fork PRs.
+- Call the existing local reusable workflow with `uses: ./.github/workflows/reusable-review.yml`
+  instead of duplicating the review matrix.
+- Pass through the known provider secrets so `action.yml` can auto-detect the configured
+  provider.
+- Forward provider inputs and provider secrets from the reusable workflow's `detect` job to
+  the composite action, matching the review and validate jobs.
+- Grant `id-token: write` to jobs that run Anthropic's action.
+- Replace the prompt-marker pipeline with a shell pattern check and cover it with a regression
+  test.
+- Checkout the woostack action bundle into `.woostack-action` inside each reusable workflow
+  job and invoke that local action. For this repo's PRs, checkout the PR branch; for consumers,
+  keep using `main`.
+- Grant only the permissions the reusable flow needs at the caller level: `contents: read` and
+  `pull-requests: write`.
+
+Update `AGENTS.md` to state that `.github/workflows/ai-review.yml` is an intentional
+repo-level review-delivery workflow, while preserving the constraint that this repo has no
+application build/test CI.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Reproduce with a failing verification**
+  - Verify `.github/workflows/ai-review.yml` is absent.
+  - Verify `.github/workflows/reusable-review.yml` is `workflow_call` only.
+  - Verify `actionlint .github/workflows/ai-review.yml .github/workflows/reusable-review.yml`
+    cannot cover the missing trigger because the trigger workflow does not exist yet.
+
+- [x] **Step 2: Add the repo-level review trigger workflow**
+  - Create `.github/workflows/ai-review.yml`.
+  - Use the local reusable workflow path.
+  - Preserve the trusted-author and review-phrase gates for comment-triggered reviews.
+  - Pass through all supported provider secrets without hardcoding a provider.
+
+- [x] **Step 3: Update repo instructions**
+  - Amend `AGENTS.md` so the new workflow is identified as an intentional review-delivery
+    asset, not app/test CI.
+
+- [x] **Step 4: Fix provider auto-detection in reusable detect job**
+  - Forward `provider` and supported provider secrets into the `mode: detect` composite action
+    invocation.
+  - Preserve provider auto-detection instead of hardcoding this repo to a single provider.
+
+- [x] **Step 5: Fix angle-runner failures**
+  - Add `id-token: write` where Anthropic runner jobs need OIDC.
+  - Replace the prompt marker `printf | grep -q` check with a non-pipeline shell pattern check.
+  - Add a regression test for `load-prompt.sh`.
+  - Replace direct `howarewoo/woostack@main` action invocations with a checked-out local action
+    path so this repo can test PR action changes before merge.
+
+- [x] **Step 6: Verification**
+  - Run `actionlint .github/workflows/ai-review.yml .github/workflows/reusable-review.yml`.
+  - Run `bash skills/woostack-review/scripts/tests/test-load-prompt-marker.sh`.
+  - Confirm the `issue_comment` job gate requires a trusted author and either `@review` or
+    `/woostack-review`.
+  - Confirm `gh secret list --repo howarewoo/woostack` includes at least one provider secret.
+  - Confirm `git status --short` only changes `.github/workflows/ai-review.yml`,
+    `.github/workflows/reusable-review.yml`, `AGENTS.md`,
+    `skills/woostack-review/scripts/load-prompt.sh`,
+    `skills/woostack-review/scripts/tests/test-load-prompt-marker.sh`, and this fix file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,13 +39,14 @@ phase to the former and its harden phase to the latter. Both are bundled buildin
 `/woostack-*` commands: they have no routing row and are absent from the sixteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
-There is no application source code, app lockfile, build, or CI for this repo's own
+There is no application source code, app lockfile, build, or test CI for this repo's own
 push/PR events. `skills-lock.json` is the dev-skill manifest and is currently empty.
 
-The exception is consumer-facing review delivery: [`action.yml`](action.yml) and
+The exceptions are review delivery assets: [`action.yml`](action.yml) and
 [`.github/workflows/reusable-review.yml`](.github/workflows/reusable-review.yml) ship from
-this repo so consumers can run `woostack-review` in their own CI. They are shipped assets,
-not self-CI, and should not be deleted as stray workflows.
+this repo so consumers can run `woostack-review` in their own CI, and
+[`.github/workflows/ai-review.yml`](.github/workflows/ai-review.yml) enables that review
+action for this repo's own PRs. They should not be deleted as stray workflows.
 
 ## Modes
 

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: 'OpenAI API key (used by openai/codex-action).'
     required: false
     default: ''
+  openai_access_token:
+    description: 'Codex access token for ChatGPT/Codex subscription-backed automation (exported as CODEX_ACCESS_TOKEN).'
+    required: false
+    default: ''
   google_api_key:
     description: 'Google API key for Gemini API (alias of gemini_api_key).'
     required: false
@@ -126,6 +130,7 @@ runs:
         INPUT_ANTHROPIC_TOKEN: ${{ inputs.anthropic_token }}
         INPUT_ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         INPUT_OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        INPUT_OPENAI_ACCESS_TOKEN: ${{ inputs.openai_access_token }}
         INPUT_GOOGLE_API_KEY: ${{ inputs.google_api_key }}
         INPUT_GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
         INPUT_OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
@@ -314,6 +319,16 @@ runs:
         IMPECCABLE_VERSION: ${{ inputs.impeccable_version }}
         REACT_DOCTOR_VERSION: ${{ inputs.react_doctor_version }}
 
+    - name: Prepare unprivileged Codex user
+      if: steps.detect.outputs.provider == 'openai' && inputs.openai_access_token != '' && inputs.openai_api_key == '' && steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review' || inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
+      shell: bash
+      run: |
+        if ! id codex >/dev/null 2>&1; then
+          sudo useradd --create-home --shell /bin/bash codex
+        fi
+        sudo chown -R codex:codex "$GITHUB_WORKSPACE" "$OUTDIR"
+        sudo chmod -R u+rwX "$GITHUB_WORKSPACE" "$OUTDIR"
+
     - name: Run review (OpenAI Codex)
       id: run-openai
       if: steps.detect.outputs.provider == 'openai' && steps.prefetch.outputs.skip != 'true' && (inputs.mode == 'full' || inputs.mode == 'review' || inputs.mode == 'validate' || inputs.mode == 'validate-prosecutor')
@@ -324,12 +339,15 @@ runs:
         effort: ${{ inputs.openai_effort }}
         prompt: ${{ steps.load-prompt.outputs.prompt }}
         sandbox: workspace-write
-        safety-strategy: drop-sudo
+        codex-args: '["--add-dir", "/tmp/pr-review"]'
+        safety-strategy: ${{ inputs.openai_access_token != '' && inputs.openai_api_key == '' && 'unprivileged-user' || 'drop-sudo' }}
+        codex-user: ${{ inputs.openai_access_token != '' && inputs.openai_api_key == '' && 'codex' || '' }}
       env:
         GH_TOKEN: ${{ github.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         WOO_REVIEW_ACTION_PATH: ${{ github.action_path }}/skills/woostack-review
         WOO_REVIEW_SEQUENTIAL_VALIDATE: ${{ inputs.mode == 'validate' && '1' || '' }}
+        CODEX_ACCESS_TOKEN: ${{ inputs.openai_access_token }}
         ENABLED_ANGLES: ${{ (inputs.mode == 'review' && inputs.angle) || steps.angles.outputs.angles }}
         IMPECCABLE_VERSION: ${{ inputs.impeccable_version }}
         REACT_DOCTOR_VERSION: ${{ inputs.react_doctor_version }}

--- a/skills/woostack-review/scripts/detect-provider.sh
+++ b/skills/woostack-review/scripts/detect-provider.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detects which provider to use based on inputs.
-# Precedence: explicit INPUT_PROVIDER → first non-empty API key (anthropic → openai → google → openrouter).
+# Precedence: explicit INPUT_PROVIDER → first non-empty credential (anthropic → openai → google → openrouter).
 # Writes `provider=...` to $GITHUB_OUTPUT, or exits 1 if none resolvable.
 
 set -euo pipefail
@@ -10,7 +10,7 @@ PROVIDER="${INPUT_PROVIDER:-}"
 if [ -z "$PROVIDER" ]; then
   if [ -n "${INPUT_ANTHROPIC_TOKEN:-}" ] || [ -n "${INPUT_ANTHROPIC_API_KEY:-}" ]; then
     PROVIDER="anthropic"
-  elif [ -n "${INPUT_OPENAI_API_KEY:-}" ]; then
+  elif [ -n "${INPUT_OPENAI_API_KEY:-}" ] || [ -n "${INPUT_OPENAI_ACCESS_TOKEN:-}" ]; then
     PROVIDER="openai"
   elif [ -n "${INPUT_GOOGLE_API_KEY:-}" ] || [ -n "${INPUT_GEMINI_API_KEY:-}" ]; then
     PROVIDER="google"
@@ -22,12 +22,39 @@ fi
 case "$PROVIDER" in
   anthropic|openai|google|openrouter) ;;
   "")
-    echo "::error::woostack-review preflight: no model provider/runner resolvable, so no angle worker can execute. Configure a provider/model (set the 'provider' input), install auth (one of: anthropic_token, openai_api_key, google_api_key, openrouter_api_key), or set the correct runner override. Refusing to run a review that cannot analyze the diff."
+    echo "::error::woostack-review preflight: no model provider/runner resolvable, so no angle worker can execute. Configure a provider/model (set the 'provider' input), install auth (one of: anthropic_token, openai_api_key, openai_access_token, google_api_key, openrouter_api_key), or set the correct runner override. Refusing to run a review that cannot analyze the diff."
     exit 1
     ;;
   *)
     echo "::error::Unknown provider '$PROVIDER'. Must be one of: anthropic, openai, google, openrouter."
     exit 1
+    ;;
+esac
+
+case "$PROVIDER" in
+  anthropic)
+    if [ -z "${INPUT_ANTHROPIC_TOKEN:-}" ] && [ -z "${INPUT_ANTHROPIC_API_KEY:-}" ]; then
+      echo "::error::woostack-review preflight: provider 'anthropic' selected but no anthropic_token or anthropic_api_key was provided."
+      exit 1
+    fi
+    ;;
+  openai)
+    if [ -z "${INPUT_OPENAI_API_KEY:-}" ] && [ -z "${INPUT_OPENAI_ACCESS_TOKEN:-}" ]; then
+      echo "::error::woostack-review preflight: provider 'openai' selected but no openai_api_key or openai_access_token was provided."
+      exit 1
+    fi
+    ;;
+  google)
+    if [ -z "${INPUT_GOOGLE_API_KEY:-}" ] && [ -z "${INPUT_GEMINI_API_KEY:-}" ]; then
+      echo "::error::woostack-review preflight: provider 'google' selected but no google_api_key or gemini_api_key was provided."
+      exit 1
+    fi
+    ;;
+  openrouter)
+    if [ -z "${INPUT_OPENROUTER_API_KEY:-}" ]; then
+      echo "::error::woostack-review preflight: provider 'openrouter' selected but no openrouter_api_key was provided."
+      exit 1
+    fi
     ;;
 esac
 

--- a/skills/woostack-review/scripts/load-prompt.sh
+++ b/skills/woostack-review/scripts/load-prompt.sh
@@ -171,7 +171,7 @@ if [ ! -f "$TIERS_FILE" ]; then
   exit 1
 fi
 HEADER_RAW="$(cat "$HEADER_FILE")"
-if ! printf '%s' "$HEADER_RAW" | grep -qF '<!-- WOO_MODEL_TIERS_TABLE -->'; then
+if [[ "$HEADER_RAW" != *"<!-- WOO_MODEL_TIERS_TABLE -->"* ]]; then
   echo "::error::_header.md is missing the <!-- WOO_MODEL_TIERS_TABLE --> inline marker"
   exit 1
 fi

--- a/skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh
@@ -7,11 +7,20 @@ source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
 SCRIPT="$DIR/detect-provider.sh"
 
 unset INPUT_PROVIDER INPUT_ANTHROPIC_TOKEN INPUT_ANTHROPIC_API_KEY \
-      INPUT_OPENAI_API_KEY INPUT_GOOGLE_API_KEY INPUT_GEMINI_API_KEY \
+      INPUT_OPENAI_API_KEY INPUT_OPENAI_ACCESS_TOKEN INPUT_GOOGLE_API_KEY INPUT_GEMINI_API_KEY \
       INPUT_OPENROUTER_API_KEY 2>/dev/null || true
 
 rc=0; err="$(bash "$SCRIPT" 2>&1)" || rc=$?
 assert_exit 1 "$rc" "no provider/runner → exit 1"
 assert_contains "$err" "no model provider/runner resolvable" "actionable preflight message"
 assert_contains "$err" "install auth" "message names the auth remedy"
+
+rc=0; err="$(INPUT_PROVIDER=openai bash "$SCRIPT" 2>&1)" || rc=$?
+assert_exit 1 "$rc" "explicit OpenAI without credential → exit 1"
+assert_contains "$err" "provider 'openai' selected" "explicit OpenAI credential error names provider"
+
+tmp_output="$(mktemp)"
+out="$(GITHUB_OUTPUT="$tmp_output" INPUT_OPENAI_ACCESS_TOKEN=codex-token bash "$SCRIPT")"
+rm -f "$tmp_output"
+assert_contains "$out" "Resolved provider: openai" "OpenAI access token resolves OpenAI provider"
 finish

--- a/skills/woostack-review/scripts/tests/test-load-prompt-marker.sh
+++ b/skills/woostack-review/scripts/tests/test-load-prompt-marker.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression: under `set -o pipefail`, `printf "$large_header" | grep -q`
+# can report failure when grep exits early. load-prompt must detect the model
+# tier marker without a pipeline.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/load-prompt.sh"
+
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/out"
+printf '%s\n' '{"severity_floor":"high"}' > "$tmp/out/config.json"
+
+(
+  cd "$ROOT"
+  PROVIDER=anthropic \
+    ACTION_PATH="$ROOT/skills/woostack-review" \
+    OUTDIR="$tmp/out" \
+    GITHUB_OUTPUT="$tmp/github-output" \
+    PR_NUMBER=291 \
+    GITHUB_REPOSITORY=howarewoo/woostack \
+    EVENT_NAME=pull_request \
+    COMMENT_BODY="" \
+    MODE=review \
+    ANGLE=bugs \
+    ENABLED_ANGLES=bugs \
+    bash "$SCRIPT"
+) >"$tmp/stdout" 2>"$tmp/stderr"
+
+assert_contains "$(cat "$tmp/github-output")" "run_model=claude-sonnet-4-6" \
+  "load-prompt resolves the default Anthropic model"
+set +e
+grep -qF "# Model Tiers (shared, host-agnostic)" "$tmp/github-output"
+table_status=$?
+set -e
+assert_eq "$table_status" "0" \
+  "load-prompt output includes the inlined model tier table"
+assert_not_contains "$(cat "$tmp/stderr")" "missing the <!-- WOO_MODEL_TIERS_TABLE --> inline marker" \
+  "marker check does not false-fail under pipefail"
+
+rm -rf "$tmp"
+finish


### PR DESCRIPTION
## Goal

Enable the shipped woostack-review GitHub Action on this repository so PRs can receive the same review flow that consumer repos use.

## Summary

- Added `.github/workflows/ai-review.yml` to call the existing reusable review workflow on same-repo PR events and explicit trusted review comments.
- Pinned this repository's review workflow to the OpenAI provider and wired it to `OPENAI_ACCESS_TOKEN` for Codex/ChatGPT subscription-backed automation instead of API-key billing.
- Added `openai_access_token` support through the reusable workflow, composite action, provider preflight, and tests.
- Fixed OpenAI Codex runner setup: `openai_effort` passthrough, `/tmp/pr-review` sandbox access, bubblewrap install, same-job retry behavior, and an unprivileged-user path for access-token runs.
- Updated the reusable workflow to checkout the woostack action bundle into `.woostack-action`, so this repo can test PR action changes before merge while consumers still use `main`.
- Fixed `load-prompt.sh` marker detection under `pipefail`, updated `AGENTS.md`, and added the fix artifact so the workflow is documented as intentional review delivery, not app/test CI.

## Test plan

### Automated

- [x] `actionlint .github/workflows/ai-review.yml .github/workflows/reusable-review.yml` passed.
- [x] `bash skills/woostack-review/scripts/tests/test-detect-provider-preflight.sh` passed.
- [x] `bash skills/woostack-review/scripts/tests/test-load-prompt-marker.sh` passed.
- [x] `git diff --check` passed.
- [ ] `gh secret list --repo howarewoo/woostack` does not yet show `OPENAI_ACCESS_TOKEN`; add that secret, then rerun AI PR Review.
- [x] No configured `.woostack/config.json` `commit.pre_commit` command was present to run.

### Manual

**Before merge**

- [ ] Create a Codex access token for the intended ChatGPT/Codex workspace identity and store it as repo secret `OPENAI_ACCESS_TOKEN`.
- [ ] Inspect `.github/workflows/ai-review.yml` and confirm comment-triggered runs require both a trusted actor and `@review` or `/woostack-review`.
- [ ] Confirm `.github/workflows/reusable-review.yml` pins this repo to OpenAI through the caller, forwards `openai_access_token`, installs Codex sandbox prerequisites, and invokes the checked-out `.woostack-action` bundle.

**After `OPENAI_ACCESS_TOKEN` is added**

- [ ] Rerun the latest AI PR Review workflow and confirm angle workers upload findings/receipt artifacts.
- [ ] Confirm the validate job posts one native GitHub review.

Spec: .woostack/fixes/2026-06-11-enable-repo-review-action.md
