### PR TITLE
Enforce model routing for woostack-review subagents

### DIFF
--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -22,11 +22,13 @@ implicitly `fast`.
 
 ## Routing by host capability (generic)
 
-- **Per-call routing** (Claude Code `Task`, opencode `@subagent`): resolve the effective tier =
-  a forced tier if the host sets one, else the prompt's own `tier:` frontmatter; map it to the
-  column for the active provider; **pass that model on every spawn.**
-- **Single model per session** (Codex Action, Gemini CLI): resolve one run model up front;
-  per-tier behavior collapses onto that one model for the whole job.
+- **Per-call routing** (Claude Code `Task`, Codex local subagents with a `model` override,
+  opencode `@subagent`): resolve the effective tier = a forced tier if the host sets one, else
+  the prompt's own `tier:` frontmatter; map it to the column for the active provider; **pass that
+  model on every spawn.** Never rely on inherited parent-session model selection when a spawn API
+  accepts an explicit model.
+- **Single model per session** (Codex Action without subagent model overrides, Gemini CLI): resolve
+  one run model up front; per-tier behavior collapses onto that one model for the whole job.
 
 ## Override precedence (generic)
 

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -394,10 +394,10 @@ Per-provider resolution (full table in `_header.md`):
 
 **Host capability:**
 
-- **Per-call routing** (Claude Code `Task`, opencode `@subagent`): honor each prompt's `tier:` verbatim. Maximum savings.
-- **Single model per session** (Codex Action, Gemini CLI): pin the run to a resolved run-tier (`fast` or `deep` via `FORCE_TIER`, otherwise `standard`). `tier:` becomes informational once the run tier resolves. Split into multiple jobs if you want per-angle fast/deep split behavior.
+- **Per-call routing** (Claude Code `Task`, Codex local subagents with a `model` override, opencode `@subagent`): honor each prompt's `tier:` verbatim and pass the resolved model explicitly on every spawn. Maximum savings.
+- **Single model per session** (Codex Action without subagent model overrides, Gemini CLI): pin the run to a resolved run-tier (`fast` or `deep` via `FORCE_TIER`, otherwise `standard`). `tier:` becomes informational once the run tier resolves. Split into multiple jobs if you want per-angle fast/deep split behavior.
 
-Bounded runners MUST preserve the resolved tier/model context for every queued worker. In single-model hosts, pass the resolved run-tier (`FORCE_TIER` when set, otherwise the host's standard tier) to every worker. In per-call-routing hosts, apply each angle prompt's `tier:` while still preserving any explicit `FORCE_TIER` override. Bounded scheduling must not cause later queued angles to fall back to default model settings.
+Bounded runners MUST preserve the resolved tier/model context for every queued worker. In single-model hosts, pass the resolved run-tier (`FORCE_TIER` when set, otherwise the host's standard tier) to every worker. In per-call-routing hosts, apply each angle prompt's `tier:` while still preserving any explicit `FORCE_TIER` override, and set the spawn call's model field to the resolved slug. Omitting the spawn model field is a routing bug because the worker inherits the parent session's model and defeats the tier mapping. Bounded scheduling must not cause later queued angles to fall back to default model settings.
 
 **Receipt gate (hard fail).** After the swarm finishes — and before `merge-findings.sh` — run:
 

--- a/skills/woostack-review/prompts/openai.md
+++ b/skills/woostack-review/prompts/openai.md
@@ -73,7 +73,7 @@ Read `$OUTDIR/diff.txt`, `$OUTDIR/meta.json`, `$OUTDIR/angles.txt`. Draft a 1–
 
 If `$OUTDIR/chunks.txt` exists (issue #14), the outer loop iterates `(angle, chunk_id)` pairs instead of plain angles. For each pair, read the chunk-specific diff at `$OUTDIR/diff.chunk-<id>.txt` and write findings to `$OUTDIR/findings.<angle>.<chunk_id>.json`. When `chunks.txt` is absent, the inner steps use `diff.txt` and `findings.<angle>.json` as before.
 
-When the local Codex host exposes subagents with model overrides, dispatch one worker per angle (× each chunk when chunked), capped by the host's bounded-concurrency limit. Each spawn MUST set `model` to the OpenAI model resolved for that worker's effective tier (`fast` / `standard`, unless `FORCE_TIER` overrides). The worker receipt's `model` field must match the explicit spawn model.
+When the local Codex host exposes subagents with model overrides, dispatch one worker per angle (× each chunk when chunked), capped by the host's bounded-concurrency limit. Each spawn MUST set `model` to the OpenAI model resolved for that worker's effective tier (`fast` / `standard`, unless `FORCE_TIER` overrides). The worker receipt's `model` field must match the explicit spawn model, and its `tier` field must be set to the worker's effective tier (`fast`, `standard`, or `deep`); `verify-receipts.sh` validates both.
 
 When no such subagent primitive exists, run each angle listed in `$OUTDIR/angles.txt`, in order (× each chunk when chunked):
 

--- a/skills/woostack-review/prompts/openai.md
+++ b/skills/woostack-review/prompts/openai.md
@@ -1,6 +1,6 @@
-# OpenAI (Codex) — Sequential Multi-Angle Review
+# OpenAI (Codex) — Multi-Angle Review
 
-Codex Action does not expose a subagent primitive. Run the review as a single agentic loop with explicit phases. Use `bash` + `gh` for all GitHub interactions.
+Codex Action does not expose a subagent primitive. Run the review as a single agentic loop with explicit phases there. Local Codex hosts may expose subagents with per-spawn model overrides; when they do, use bounded parallel subagents and pass the resolved model explicitly on every spawn.
 
 The shared header above lists prefetched artifacts, findings schema, blocking criteria, and the do-NOT-flag list. **Apply them verbatim.** Per-angle prompt bodies live at `$WOO_REVIEW_ACTION_PATH/prompts/angles/<angle>.md` in the bundled action repo.
 
@@ -8,9 +8,12 @@ The shared header above lists prefetched artifacts, findings schema, blocking cr
 
 ## Model selection
 
-Codex Action runs one model for the full job. Per-call routing is not possible, so the `tier:` frontmatter on each angle prompt is **informational only** under this provider.
+Codex has two execution shapes:
 
-The action resolves one session model in `load-prompt.sh` using this precedence:
+- **Local Codex subagents with a `model` override:** per-call routing is available. Resolve the effective tier for each spawned angle/validator, then pass the mapped OpenAI model in the spawn call's `model` field. Do not omit the field; otherwise the subagent inherits the parent session model and silently defeats the tier mapping.
+- **Codex Action / no per-spawn model override:** one model runs the full job. The `tier:` frontmatter is informational only, and the action resolves one session model in `load-prompt.sh`.
+
+The single-session action path resolves one session model in `load-prompt.sh` using this precedence:
 1. `FORCE_TIER` from Review Context (from `/woostack-review --fast` or `--deep`, or `review.force_tier` in config): fast→`gpt-5.3-codex-spark`, deep→`gpt-5.5`. Only `fast` and `deep` are valid `FORCE_TIER` values; the `standard` tier (`gpt-5.4-mini`) is the implicit default when `FORCE_TIER` is unset — see step 3.
 2. `inputs.model` when explicitly set.
 3. Provider defaults (`gpt-5.4-mini` standard).
@@ -20,6 +23,16 @@ Per-repo override remains in effect during run-model resolution: if `$OUTDIR/con
 For quality/cost splits, GPT-5-family reasoning is a `reasoning_effort` parameter, not a slug suffix (`high`, `xhigh` etc.); there is no `gpt-5-pro`. Pass effort via `inputs.openai_effort` (wired through to codex-action `effort`). Defaults are `medium` for deep, `xhigh` for standard, and `xhigh` for fast.
 
 **Per-repo override:** resolve using the active run tier: if `$OUTDIR/config.json` has `models.openai.<run_tier>` set, use it; otherwise fall back to flat `models.<run_tier>` (precedence: `FORCE_TIER` > `inputs.model` > `models.openai.<run_tier>` > `models.<run_tier>` > default `gpt-5.4-mini`). Read with run-tier-aware lookup, e.g. when `run_tier=deep`: `jq -r '.models.openai.deep // .models.deep // empty' $OUTDIR/config.json`.
+
+For per-call local subagents, resolve each spawn with the same precedence, but use the target prompt's tier unless a forced tier is set:
+
+| Target | Effective tier when no `FORCE_TIER` | Default OpenAI model |
+|---|---|---|
+| `seo`, `aeo`, `i18n`, `docs`, `deps`, `comments`, context summary | `fast` | `gpt-5.3-codex-spark` |
+| all other angle workers | `standard` | `gpt-5.4-mini` |
+| prosecutor and defender validators | `deep` | `gpt-5.5` |
+
+If the spawn API accepts a reasoning-effort override, pass the mapped effort too (`xhigh` for fast/standard, `medium` for deep). If it only accepts `model`, still pass `model`; do not fall back to parent-model inheritance.
 
 ---
 
@@ -56,11 +69,13 @@ Perform all phases (1 through 4) sequentially.
 
 Read `$OUTDIR/diff.txt`, `$OUTDIR/meta.json`, `$OUTDIR/angles.txt`. Draft a 1–2 sentence summary, change bullets, files-by-category, optional manual test plan — all destined for the **Review body** in Phase 4. Do NOT call `gh pr edit`; the PR title and description must remain untouched.
 
-## Phase 2 — Per-Angle Audit (sequential loop, chunk-aware)
+## Phase 2 — Per-Angle Audit (bounded parallel when available, chunk-aware)
 
 If `$OUTDIR/chunks.txt` exists (issue #14), the outer loop iterates `(angle, chunk_id)` pairs instead of plain angles. For each pair, read the chunk-specific diff at `$OUTDIR/diff.chunk-<id>.txt` and write findings to `$OUTDIR/findings.<angle>.<chunk_id>.json`. When `chunks.txt` is absent, the inner steps use `diff.txt` and `findings.<angle>.json` as before.
 
-For each angle listed in `$OUTDIR/angles.txt`, in order (× each chunk when chunked):
+When the local Codex host exposes subagents with model overrides, dispatch one worker per angle (× each chunk when chunked), capped by the host's bounded-concurrency limit. Each spawn MUST set `model` to the OpenAI model resolved for that worker's effective tier (`fast` / `standard`, unless `FORCE_TIER` overrides). The worker receipt's `model` field must match the explicit spawn model.
+
+When no such subagent primitive exists, run each angle listed in `$OUTDIR/angles.txt`, in order (× each chunk when chunked):
 
 1. Read `$WOO_REVIEW_ACTION_PATH/prompts/angles/<angle>.md`.
 2. Execute the angle prompt against the angle's diff (full or chunk-specific). For `react` run `npx -y react-doctor@$REACT_DOCTOR_VERSION --diff $BASE_REF --offline`.
@@ -70,11 +85,11 @@ Stay within each angle's scope; do not let `bugs` flag a design issue or vice ve
 
 **Retry-once recovery.** Angle iterations can be cut short by tool-stream errors or turn-limit interrupts and leave no findings file. After the loop finishes, scan `$OUTDIR/angles.txt` (× `chunks.txt` when chunked) and check that each expected `findings.<angle>.json` (or `findings.<angle>.<chunk_id>.json`) exists and parses as a JSON array via `jq -e 'type == "array"'`. For any path that fails the check, re-run THAT angle iteration ONCE. Cap is one retry per `(angle, chunk)` pair; if the retry also fails, leave the file as-is and proceed to Phase 3 — the merge step recovers malformed JSON, and missing files just mean the angle produced no findings.
 
-## Phase 3 — Adversarial Validation (prosecutor + defender, sequential)
+## Phase 3 — Adversarial Validation (prosecutor + defender)
 
 Merge all `findings.<angle>.json` arrays into `$OUTDIR/raw_findings.json` (use `$WOO_REVIEW_ACTION_PATH/scripts/merge-findings.sh`).
 
-Then run TWO opposing-bias validation passes followed by a deterministic intersection (issue #13). Codex Action has no subagent primitive, so this is sequenced inside the single agentic loop using `bash` to invoke the intersect script. Read `disable_adversarial` first:
+Then run TWO opposing-bias validation passes followed by a deterministic intersection (issue #13). In local Codex with model-routed subagents, spawn both validator passes with the resolved `deep` model (`gpt-5.5` by default). In Codex Action / single-session mode, sequence them inside the single agentic loop using `bash` to invoke the intersect script. Read `disable_adversarial` first:
 
 ```bash
 DISABLE_ADV="$(jq -r '.disable_adversarial // false' $OUTDIR/config.json 2>/dev/null || echo false)"

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-chunked.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-chunked.sh
@@ -11,14 +11,14 @@ export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
 printf '%s\n' bugs > "$OUTDIR/angles.txt"
 printf '%s\n' chunk-0 chunk-1 > "$OUTDIR/chunks.txt"
 # chunk-0 executed, chunk-1 missing.
-printf '{"angle":"bugs","chunk":"chunk-0","runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.chunk-0.json"
+printf '{"angle":"bugs","chunk":"chunk-0","runner":"r","model":"m","tier":"standard"}\n' > "$OUTDIR/receipt.bugs.chunk-0.json"
 
 rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
 assert_exit 1 "$rc" "missing (angle,chunk) receipt → exit 1"
 assert_contains "$err" "bugs.chunk-1" "names the missing angle.chunk"
 
 # Add the missing chunk receipt → now passes.
-printf '{"angle":"bugs","chunk":"chunk-1","runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.chunk-1.json"
+printf '{"angle":"bugs","chunk":"chunk-1","runner":"r","model":"m","tier":"standard"}\n' > "$OUTDIR/receipt.bugs.chunk-1.json"
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
 assert_exit 0 "$rc" "all chunk receipts valid → exit 0"
 # Verify the chunked arithmetic: expected_total = 1 angle x 2 chunks, and both

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-list-missing.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-list-missing.sh
@@ -9,7 +9,7 @@ SCRIPT="$DIR/verify-receipts.sh"
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
 printf '%s\n' bugs security types > "$OUTDIR/angles.txt"
-printf '{"angle":"bugs","chunk":null,"runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.json"
+printf '{"angle":"bugs","chunk":null,"runner":"r","model":"m","tier":"standard"}\n' > "$OUTDIR/receipt.bugs.json"
 # security + types missing.
 
 rc=0; out="$(bash "$SCRIPT" --list-missing)" || rc=$?
@@ -24,7 +24,7 @@ assert_not_contains "$out" "bugs" "valid receipt not listed as missing"
 export OUTDIR="$work/out2"; mkdir -p "$OUTDIR"
 printf '%s\n' bugs > "$OUTDIR/angles.txt"
 printf '%s\n' chunk-0 chunk-1 > "$OUTDIR/chunks.txt"
-printf '{"angle":"bugs","chunk":"chunk-0","runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.chunk-0.json"
+printf '{"angle":"bugs","chunk":"chunk-0","runner":"r","model":"m","tier":"standard"}\n' > "$OUTDIR/receipt.bugs.chunk-0.json"
 # bugs.chunk-1 missing.
 rc=0; out="$(bash "$SCRIPT" --list-missing)" || rc=$?
 assert_exit 0 "$rc" "--list-missing exits 0 under chunking"

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+export WOO_REVIEW_PROVIDER=openai
+printf '%s\n' aeo bugs > "$OUTDIR/angles.txt"
+printf '{"angle":"aeo","chunk":null,"runner":"codex-subagent","model":"gpt-5.3-codex-spark","tier":"fast","ts":"t"}\n' > "$OUTDIR/receipt.aeo.json"
+printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-5.4-mini","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "OpenAI receipts matching tier models pass"
+
+printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-5.5","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "OpenAI standard worker inheriting deep model fails"
+assert_contains "$err" "bugs" "names the worker with mismatched model"
+
+printf '{"models":{"openai":{"standard":"gpt-custom-standard"}}}\n' > "$OUTDIR/config.json"
+printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-custom-standard","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "OpenAI provider-scoped config override is honored"
+
+finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh
@@ -9,9 +9,10 @@ SCRIPT="$DIR/verify-receipts.sh"
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
 export WOO_REVIEW_PROVIDER=openai
-printf '%s\n' aeo bugs > "$OUTDIR/angles.txt"
+printf '%s\n' aeo bugs validator > "$OUTDIR/angles.txt"
 printf '{"angle":"aeo","chunk":null,"runner":"codex-subagent","model":"gpt-5.3-codex-spark","tier":"fast","ts":"t"}\n' > "$OUTDIR/receipt.aeo.json"
 printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-5.4-mini","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+printf '{"angle":"validator","chunk":null,"runner":"codex-subagent","model":"gpt-5.5","tier":"deep","ts":"t"}\n' > "$OUTDIR/receipt.validator.json"
 
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
 assert_exit 0 "$rc" "OpenAI receipts matching tier models pass"
@@ -25,5 +26,22 @@ printf '{"models":{"openai":{"standard":"gpt-custom-standard"}}}\n' > "$OUTDIR/c
 printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-custom-standard","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
 assert_exit 0 "$rc" "OpenAI provider-scoped config override is honored"
+
+printf '{"models":{"standard":"gpt-flat-standard"}}\n' > "$OUTDIR/config.json"
+printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-flat-standard","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "OpenAI flat config override is honored"
+
+unset WOO_REVIEW_PROVIDER
+export WOO_REVIEW_HOST=codex
+rm -f "$OUTDIR/config.json"
+printf '{"angle":"bugs","chunk":null,"runner":"local-worker","model":"gpt-5.5","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "Codex host triggers model validation without provider or codex runner"
+assert_contains "$err" "bugs" "names the host-triggered worker with mismatched model"
+
+printf '{"angle":"bugs","chunk":null,"runner":"local-worker","model":"gpt-5.4-mini","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "Codex host accepts matching model without provider or codex runner"
 
 finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-wrong-angle.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-wrong-angle.sh
@@ -13,7 +13,7 @@ printf '%s\n' bugs > "$OUTDIR/angles.txt"
 # says "security" while it occupies the bugs slot. The is_valid_receipt
 # `.angle == $a` guard must reject it (a worker writing the wrong angle label is
 # a realistic failure mode and exercises a distinct jq branch).
-printf '{"angle":"security","chunk":null,"runner":"r","model":"m"}\n' > "$OUTDIR/receipt.bugs.json"
+printf '{"angle":"security","chunk":null,"runner":"r","model":"m","tier":"standard"}\n' > "$OUTDIR/receipt.bugs.json"
 
 rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
 assert_exit 1 "$rc" "mismatched .angle field → invalid receipt → exit 1"

--- a/skills/woostack-review/scripts/verify-receipts.sh
+++ b/skills/woostack-review/scripts/verify-receipts.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Postflight gate: assert every expected angle (from angles.txt × chunks.txt) wrote
 # a VALID execution receipt. A valid receipt is a JSON object whose `angle` (and
-# `chunk`, when chunking is active) matches and whose `runner` and `model` are both
-# non-empty. This is the single authority on "did the angle worker actually execute":
+# `chunk`, when chunking is active) matches and whose `runner`, `model`, and `tier`
+# are non-empty. For Codex/OpenAI workers, the model must also match the tier mapping.
+# This is the single authority on "did the angle worker actually execute":
 # empty findings are an honest clean review ONLY when the receipt proves the worker ran.
 #
 # Modes:
@@ -51,10 +52,54 @@ label() { # angle chunk
   if [ -n "$2" ]; then printf '%s.%s' "$1" "$2"; else printf '%s' "$1"; fi
 }
 
+default_openai_model_for_tier() {
+  case "$1" in
+    fast) echo "gpt-5.3-codex-spark" ;;
+    standard) echo "gpt-5.4-mini" ;;
+    deep) echo "gpt-5.5" ;;
+    *) return 1 ;;
+  esac
+}
+
+config_model_for_tier() {
+  local provider="$1" tier="$2" config="$OUTDIR/config.json" override=""
+  if [ -s "$config" ]; then
+    override="$(jq -r --arg p "$provider" --arg t "$tier" '.models[$p][$t] // empty' "$config" 2>/dev/null || true)"
+    if [ -n "$override" ]; then
+      echo "$override"
+      return 0
+    fi
+    override="$(jq -r --arg t "$tier" '.models[$t] // empty' "$config" 2>/dev/null || true)"
+    if [ -n "$override" ]; then
+      echo "$override"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+expected_openai_model_for_tier() {
+  local tier="$1"
+  if [ -z "${FORCE_TIER:-}" ] && [ -n "${INPUT_MODEL:-}" ]; then
+    echo "$INPUT_MODEL"
+    return 0
+  fi
+  config_model_for_tier "openai" "$tier" || default_openai_model_for_tier "$tier"
+}
+
+receipt_needs_openai_model_check() { # file
+  local f="$1" runner host provider
+  runner="$(jq -r '.runner // ""' "$f" 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)"
+  host="$(printf '%s' "${WOO_REVIEW_HOST:-}" | tr '[:upper:]' '[:lower:]')"
+  provider="$(printf '%s' "${WOO_REVIEW_PROVIDER:-}" | tr '[:upper:]' '[:lower:]')"
+  [ "$provider" = "openai" ] || [ "$host" = "codex" ] || [[ "$runner" == *codex* ]]
+}
+
 # Valid iff: JSON object; .angle == angle; (.chunk matches, or both empty/null);
-# .runner and .model are non-empty.
+# .runner, .model, and .tier are non-empty; and Codex/OpenAI receipts report the
+# model mapped from their effective tier.
 is_valid_receipt() { # angle chunk file
-  local angle="$1" chunk="$2" f="$3"
+  local angle="$1" chunk="$2" f="$3" tier model expected
   [ -s "$f" ] || return 1
   jq -e --arg a "$angle" --arg c "$chunk" '
     (type == "object")
@@ -62,7 +107,15 @@ is_valid_receipt() { # angle chunk file
     and ( (($c == "") and ((.chunk == null) or (.chunk == ""))) or (.chunk == $c) )
     and (((.runner // "") | tostring | length) > 0)
     and (((.model  // "") | tostring | length) > 0)
-  ' "$f" >/dev/null 2>&1
+    and (((.tier   // "") | tostring | length) > 0)
+  ' "$f" >/dev/null 2>&1 || return 1
+
+  if receipt_needs_openai_model_check "$f"; then
+    tier="$(jq -r '.tier' "$f")"
+    model="$(jq -r '.model' "$f")"
+    expected="$(expected_openai_model_for_tier "$tier" 2>/dev/null || true)"
+    [ -n "$expected" ] && [ "$model" = "$expected" ] || return 1
+  fi
 }
 
 missing=()


### PR DESCRIPTION
## Goal

Ensure `/woostack-review` subagents use the model mapped to their assigned tier instead of inheriting the parent session model unexpectedly. This prevents local Codex reviewer workers from accidentally running standard or fast angles on `gpt-5.5`.

## Summary

- Clarifies the shared model-tier guidance and `/woostack-review` docs so local Codex subagents with a `model` override are treated as per-call routed workers.
- Updates the OpenAI/Codex review prompt to distinguish Codex Action single-model execution from local Codex subagent execution, including explicit fast/standard/deep mappings.
- Hardens `verify-receipts.sh` so Codex/OpenAI receipts must include `tier` and report the model expected for that tier, including config overrides.
- Adds a receipt regression test for the misrouted `gpt-5.5` standard-worker case and updates existing receipt fixtures to include tiers.

## Test plan

### Automated

- [ ] `for t in skills/woostack-review/scripts/tests/test-verify-receipts-*.sh; do echo "$t"; bash "$t"; done` — passed
- [ ] `bash skills/woostack-review/scripts/tests/test-load-prompt-models.sh && bash skills/woostack-review/scripts/tests/test-bounded-swarm.sh` — passed

### Manual

**Before merge**

- [ ] Review the OpenAI/Codex prompt and receipt gate changes to confirm spawned local Codex workers must pass explicit mapped models and mismatched receipts fail the gate.
