### PR TITLE
Use Spark for OpenAI review

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -1,5 +1,10 @@
 {
   "review": {
-    "metrics": true
+    "metrics": true,
+    "models": {
+      "openai": {
+        "standard": "gpt-5.3-codex-spark"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Goal

Make this repo's OpenAI-powered woostack reviews use the Spark model for the standard tier so routine review runs use the lower-cost configured path.

## Summary

- Added a repo-local `review.models.openai.standard` override in `.woostack/config.json` pointing to `gpt-5.3-codex-spark`.
- Preserved the existing review metrics setting.

## Test plan

### Automated

- [ ] `jq . .woostack/config.json` succeeded.
- [ ] `OUTDIR=$(mktemp -d) bash skills/woostack-review/scripts/load-config.sh` accepted the repo config and emitted `models.openai.standard`.
- [ ] `load-prompt.sh` resolved OpenAI standard routing to `run_model=gpt-5.3-codex-spark` with `run_effort=xhigh`.

### Manual

**Before merge**

- [ ] Inspect `.woostack/config.json` and confirm only the OpenAI standard review model override was added.
