### PR TITLE
fix(review): honor config model overrides before spawning local workers (#295)

### DIFF
--- a/.woostack/fixes/2026-06-11-review-local-model-resolution.md
+++ b/.woostack/fixes/2026-06-11-review-local-model-resolution.md
@@ -1,0 +1,117 @@
+---
+type: fix
+status: in-review
+branch: fix/review-local-model-resolution
+---
+
+# Fix: woostack-review local workers ignore config model overrides (issue #295)
+
+## 1. Root Cause
+
+`woostack-review`'s shell resolver `scripts/load-prompt.sh` (`provider_tier_model`,
+lines 94–110) already implements the documented model-resolution precedence:
+`models.<provider>.<tier>` → flat `models.<tier>` (both from `$OUTDIR/config.json`) →
+default model table. `test-load-prompt-models.sh:132-143` proves a config
+`models.openai.standard` override wins there.
+
+But that resolver runs **only on the CI/Action path**: `load-prompt.sh` requires
+`PROVIDER`/`ACTION_PATH`, builds the entire prompt, and emits a single
+`run_model` to `$GITHUB_OUTPUT` for *single-session* hosts. The **local
+per-call-routing path** (Claude Code `Task`, where each angle is its own
+sub-agent with a `model` override) never calls it.
+
+For local runs, `SKILL.md` Stage 3 / "Model routing" (line 367) instructs the
+host: "The host resolves the tier to a concrete model via the table in
+`prompts/_header.md`." That table is the **default** table — precedence step 5
+only. Nothing on the local dispatch path reads `$OUTDIR/config.json`'s
+`models.<provider>.<tier>` / `models.<tier>` overrides (steps 3–4). So when a repo
+sets `review.models.openai.standard: gpt-5.3-codex-spark` (correctly flattened by
+`prefetch.sh` into `$OUTDIR/config.json` as `models.openai.standard`), the host
+still spawns standard-tier workers (`bugs`, `security`, `conventions`, `skills`)
+with the hardcoded default `gpt-5.4-mini`, and writes that wrong model into the
+receipts.
+
+**Evidence:** `$OUTDIR/config.json` carries `models.openai.standard` (issue body);
+`load-prompt.sh:94-110` reads it but only via `GITHUB_OUTPUT`; `SKILL.md:367,
+395-400` point local hosts at the static `_header.md` table with no config-read
+step; `grep` shows `provider_tier_model` has exactly one caller (`load-prompt.sh`)
+— there is no standalone per-spawn resolver a local host can call.
+
+**Gotcha (most reusable takeaway):** woostack-review has *two* execution paths
+that must honor the same precedence — the CI single-session host (resolved once in
+`load-prompt.sh` → `GITHUB_OUTPUT`) and the local per-call-routing host (resolves
+per spawn). A resolver wired into only one path silently regresses the other.
+
+## 2. Proposed Fix
+
+Extract the tier→model precedence into a standalone, config-aware helper that the
+local dispatch path can call per spawn, and make it the single source of truth so
+the CI path cannot diverge.
+
+1. **New `scripts/resolve-model.sh`** — `resolve-model.sh --provider <p> --tier
+   <fast|standard|deep>` prints the resolved model slug to stdout. Honors an
+   explicit `OUTDIR`, else sources `resolve-outdir.sh`; reads `$OUTDIR/config.json`
+   with precedence `models.<provider>.<tier>` → `models.<tier>` → default table
+   (the canonical mirror of `using-woostack/references/model-tiers.md`). Errors
+   (non-zero) on unknown provider or missing/invalid `--provider`/`--tier`. Safe to
+   `source` (dual-mode guard: defines `default_model_for`/`provider_tier_model`
+   without running main when sourced).
+2. **Refactor `load-prompt.sh`** to `source resolve-model.sh` and drop its
+   duplicated `default_model_for` / `provider_tier_model` — single source of truth,
+   CI behavior unchanged (`test-load-prompt-models.sh` stays green).
+3. **Update `SKILL.md`** Stage 3 + "Model routing": local per-call-routing hosts
+   MUST resolve each spawn's model via
+   `bash $WOO_REVIEW_ACTION_PATH/scripts/resolve-model.sh --provider <provider>
+   --tier <tier>` (which consults `$OUTDIR/config.json`), and use that value for
+   **both** the spawn `model` field **and** the receipt `model`. State that
+   `_header.md`'s table is the precedence-step-5 default; config `models.*`
+   overrides win.
+4. **Regression test `tests/test-resolve-model.sh`** covering the issue's exact
+   config (`models.openai.standard: gpt-5.3-codex-spark` ⇒ standard resolves to
+   `gpt-5.3-codex-spark`, not `gpt-5.4-mini`), plus flat-tier fallback,
+   provider-scoped-beats-flat, no-config default, and unknown-provider error.
+
+**Scope boundary (hardened):** `resolve-model.sh` owns precedence steps **3–5**
+(config `models.<provider>.<tier>` → flat `models.<tier>` → default table) for a
+*given* `(provider, tier)`. Steps **1–2** stay with the host: `FORCE_TIER` /
+comment override selects *which tier* to pass, and a global `inputs.model`, when
+present, wins outright (the host skips the helper). This mirrors `load-prompt.sh`,
+which already separates `RUN_TIER` selection from `provider_tier_model`. The helper
+emits the **model slug only** — `reasoning_effort` is a single-session-host knob
+owned by `load-prompt.sh`; the local per-call path and receipts need only the slug.
+The shared resolver reads `"${CONFIG_PATH:-${OUTDIR:-}/config.json}"` so both
+`load-prompt.sh` (sets `CONFIG_PATH`) and `resolve-model.sh` main (sets it from
+`OUTDIR`) work unchanged.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Reproduce with a failing test (Red)**
+  - Add `skills/woostack-review/scripts/tests/test-resolve-model.sh` (mirror
+    `test-load-prompt-models.sh` harness style: `env -i` + `assert.sh` from
+    `woostack-init/scripts/tests/assert.sh`; per-case `mktemp -d` OUTDIR).
+  - Assertions: with `$OUTDIR/config.json` = `{"models":{"openai":{"standard":"gpt-5.3-codex-spark"}}}`,
+    `resolve-model.sh --provider openai --tier standard` ⇒ `gpt-5.3-codex-spark`.
+    Also: flat `{"models":{"standard":"flat-x"}}` ⇒ `flat-x`; provider-scoped wins
+    over flat when both set; no config ⇒ `gpt-5.4-mini` (openai/standard) and
+    `claude-sonnet-4-6` (anthropic/standard); unknown provider ⇒ non-zero exit.
+  - Confirm it fails (script absent).
+- [x] **Step 2: Apply the minimal fix (Green)**
+  - Create `scripts/resolve-model.sh` with `default_model_for` +
+    `provider_tier_model` (precedence `.models[$p][$t]` → `.models[$t]` →
+    default), `--provider`/`--tier` arg parsing, OUTDIR/config resolution, dual-mode
+    sourcing guard. `chmod +x`.
+  - Re-run `test-resolve-model.sh` → green.
+- [x] **Step 3: De-duplicate the resolver (Refactor)**
+  - Refactor `load-prompt.sh` to `source resolve-model.sh` and remove its inline
+    `default_model_for` / `provider_tier_model`.
+  - Run `test-load-prompt-models.sh` → still green (CI path unchanged).
+- [x] **Step 4: Wire the local dispatch path (docs)**
+  - Update `SKILL.md` Stage 3 (≈line 367) and the per-call-routing bullet
+    (≈lines 395–400) plus the sub-agent brief's receipt `model` note (≈lines
+    357–360) to require `resolve-model.sh` for both the spawn model override and
+    receipt metadata; clarify `_header.md` table = default fallback.
+- [x] **Step 5: Verification**
+  - Run the full review test suite:
+    `for t in skills/woostack-review/scripts/tests/test-*.sh; do echo "== $t"; bash "$t" || break; done`
+  - `shellcheck skills/woostack-review/scripts/resolve-model.sh skills/woostack-review/scripts/load-prompt.sh`
+  - Manual: `OUTDIR=$(mktemp -d); echo '{"models":{"openai":{"standard":"gpt-5.3-codex-spark"}}}' > "$OUTDIR/config.json"; OUTDIR="$OUTDIR" bash skills/woostack-review/scripts/resolve-model.sh --provider openai --tier standard` ⇒ prints `gpt-5.3-codex-spark`.

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -364,7 +364,7 @@ and model, proving you executed (see _header.md). EXIT.
 
 Sub-agents MUST NOT post comments, edit the PR, touch other angles' files, run `prefetch.sh`, or delete/recreate `$OUTDIR`. `prefetch.sh` is a Stage-1-only operation; re-running it mid-swarm wipes `meta.json` / `prior-findings.json` and corrupts the posting stage (issue #48).
 
-**Model routing (token optimization, host-agnostic).** Each angle prompt and the validator declare a `tier:` in frontmatter — `fast`, `standard`, or `deep`. The host resolves the tier to a concrete model via the table in `prompts/_header.md`. Tier assignments:
+**Model routing (token optimization, host-agnostic).** Each angle prompt and the validator declare a `tier:` in frontmatter — `fast`, `standard`, or `deep`. The host resolves the tier to a concrete model with `scripts/resolve-model.sh` — it consults `$OUTDIR/config.json`'s `models.<provider>.<tier>` and flat `models.<tier>` overrides first and falls back to the default table in `prompts/_header.md`, so a per-repo model override in `.woostack/config.json` is honored on the next run. Reading the `_header.md` table directly skips the config step and is a routing bug (issue #295). Tier assignments:
 
 | Stage | Tier | Why |
 |---|---|---|
@@ -394,10 +394,10 @@ Per-provider resolution (full table in `_header.md`):
 
 **Host capability:**
 
-- **Per-call routing** (Claude Code `Task`, Codex local subagents with a `model` override, opencode `@subagent`): honor each prompt's `tier:` verbatim and pass the resolved model explicitly on every spawn. Maximum savings.
+- **Per-call routing** (Claude Code `Task`, Codex local subagents with a `model` override, opencode `@subagent`): honor each prompt's `tier:` verbatim and resolve every spawn's model with `bash $WOO_REVIEW_ACTION_PATH/scripts/resolve-model.sh --provider <provider> --tier <tier>` (which honors `$OUTDIR/config.json` overrides), passing that slug explicitly on the spawn. Maximum savings.
 - **Single model per session** (Codex Action without subagent model overrides, Gemini CLI): pin the run to a resolved run-tier (`fast` or `deep` via `FORCE_TIER`, otherwise `standard`). `tier:` becomes informational once the run tier resolves. Split into multiple jobs if you want per-angle fast/deep split behavior.
 
-Bounded runners MUST preserve the resolved tier/model context for every queued worker. In single-model hosts, pass the resolved run-tier (`FORCE_TIER` when set, otherwise the host's standard tier) to every worker. In per-call-routing hosts, apply each angle prompt's `tier:` while still preserving any explicit `FORCE_TIER` override, and set the spawn call's model field to the resolved slug. Omitting the spawn model field is a routing bug because the worker inherits the parent session's model and defeats the tier mapping. Bounded scheduling must not cause later queued angles to fall back to default model settings.
+Bounded runners MUST preserve the resolved tier/model context for every queued worker. In single-model hosts, pass the resolved run-tier (`FORCE_TIER` when set, otherwise the host's standard tier) to every worker. In per-call-routing hosts, apply each angle prompt's `tier:` while still preserving any explicit `FORCE_TIER` override, and set the spawn call's model field to the slug from `resolve-model.sh` (config-aware — never the static `_header.md` table directly). Write that same resolved model into the worker's receipt (`model`) so receipts reflect the configured model, not the default. Omitting the spawn model field is a routing bug because the worker inherits the parent session's model and defeats the tier mapping. Bounded scheduling must not cause later queued angles to fall back to default model settings.
 
 **Receipt gate (hard fail).** After the swarm finishes — and before `merge-findings.sh` — run:
 

--- a/skills/woostack-review/scripts/load-prompt.sh
+++ b/skills/woostack-review/scripts/load-prompt.sh
@@ -55,59 +55,14 @@ sanitize_untrusted() {
 
 safe_comment_body=$(sanitize_untrusted "${COMMENT_BODY:-}" 2000)
 
-# canonical source: skills/using-woostack/references/model-tiers.md — keep these slugs in sync
-# with that table (Bash cannot read the markdown table, so this is its executable mirror).
-default_model_for() {
-  local provider="$1" tier="$2"
-  case "$provider" in
-    anthropic)
-      case "$tier" in
-        fast) echo "claude-haiku-4-5" ;;
-        standard) echo "claude-sonnet-4-6" ;;
-        deep) echo "claude-opus-4-8" ;;
-      esac
-      ;;
-    openai)
-      case "$tier" in
-        fast) echo "gpt-5.3-codex-spark" ;;
-        standard) echo "gpt-5.4-mini" ;;
-        deep) echo "gpt-5.5" ;;
-      esac
-      ;;
-    google)
-      echo "gemini-3-5-flash"
-      ;;
-    openrouter)
-      case "$tier" in
-        fast) echo "openrouter/deepseek/deepseek-v4-flash" ;;
-        standard) echo "openrouter/deepseek/deepseek-v4-pro" ;;
-        deep) echo "openrouter/deepseek/deepseek-v4-pro" ;;
-      esac
-      ;;
-    *)
-      echo "::error::Unknown provider '$provider' while resolving run model"
-      exit 1
-      ;;
-  esac
-}
-
-provider_tier_model() {
-  local provider="$1" tier="$2"
-  local override
-  if [ -f "$CONFIG_PATH" ]; then
-    override="$(jq -r --arg p "$provider" --arg t "$tier" '.models[$p][$t] // empty' "$CONFIG_PATH" 2>/dev/null || true)"
-    if [ -n "$override" ] && [ "$override" != "null" ]; then
-      echo "$override"
-      return 0
-    fi
-    override="$(jq -r --arg t "$tier" '.models[$t] // empty' "$CONFIG_PATH" 2>/dev/null || true)"
-    if [ -n "$override" ] && [ "$override" != "null" ]; then
-      echo "$override"
-      return 0
-    fi
-  fi
-  default_model_for "$provider" "$tier"
-}
+# Model resolution (config override → default table) is shared with the local
+# Stage-3 per-call dispatch path. Source the single source of truth so the CI
+# (single-session) path here and the local (per-call) path cannot diverge —
+# resolve-model.sh defines default_model_for + provider_tier_model and reads
+# $CONFIG_PATH (set above). Its dual-mode guard means sourcing only pulls in the
+# functions; main does not run (issue #295).
+# shellcheck source=skills/woostack-review/scripts/resolve-model.sh
+source "$(dirname "${BASH_SOURCE[0]}")/resolve-model.sh"
 
 default_openai_effort_for() {
   local tier="$1"

--- a/skills/woostack-review/scripts/resolve-model.sh
+++ b/skills/woostack-review/scripts/resolve-model.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Resolve the concrete model slug for a (provider, tier) pair, honoring per-repo
+# overrides in $OUTDIR/config.json. This is the config-aware resolver the LOCAL
+# Stage-3 per-call-routing path uses before each sub-agent spawn (and for the
+# receipt's `model`), so `.woostack/config.json` model overrides are honored
+# immediately instead of falling back to the static default table (issue #295).
+#
+# Owns precedence steps 3-5 for a GIVEN tier:
+#   3. models.<provider>.<tier>  (from $OUTDIR/config.json)
+#   4. flat models.<tier>        (from $OUTDIR/config.json)
+#   5. default model table       (canonical mirror of model-tiers.md)
+# Steps 1-2 (FORCE_TIER / comment override selects the tier; a global input model
+# wins outright) stay with the host, mirroring load-prompt.sh, which separates
+# RUN_TIER selection from provider_tier_model. This emits the model slug only;
+# OpenAI `reasoning_effort` is a single-session-host knob owned by load-prompt.sh.
+#
+# Usage: resolve-model.sh --provider <anthropic|openai|google|openrouter> \
+#                         --tier <fast|standard|deep>
+# Reads $OUTDIR/config.json when present (CONFIG_PATH overrides the path).
+# Safe to `source` for its functions — main only runs on direct execution.
+
+set -euo pipefail
+
+# canonical source: skills/using-woostack/references/model-tiers.md — keep these slugs in sync
+# with that table (Bash cannot read the markdown table, so this is its executable mirror).
+default_model_for() {
+  local provider="$1" tier="$2"
+  case "$provider" in
+    anthropic)
+      case "$tier" in
+        fast) echo "claude-haiku-4-5" ;;
+        standard) echo "claude-sonnet-4-6" ;;
+        deep) echo "claude-opus-4-8" ;;
+      esac
+      ;;
+    openai)
+      case "$tier" in
+        fast) echo "gpt-5.3-codex-spark" ;;
+        standard) echo "gpt-5.4-mini" ;;
+        deep) echo "gpt-5.5" ;;
+      esac
+      ;;
+    google)
+      echo "gemini-3-5-flash"
+      ;;
+    openrouter)
+      case "$tier" in
+        fast) echo "openrouter/deepseek/deepseek-v4-flash" ;;
+        standard) echo "openrouter/deepseek/deepseek-v4-pro" ;;
+        deep) echo "openrouter/deepseek/deepseek-v4-pro" ;;
+      esac
+      ;;
+    *)
+      echo "::error::Unknown provider '$provider' while resolving run model" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# provider_tier_model <provider> <tier> → resolved model (config override → default).
+# Reads CONFIG_PATH, defaulting to $OUTDIR/config.json.
+provider_tier_model() {
+  local provider="$1" tier="$2"
+  local config="${CONFIG_PATH:-${OUTDIR:-}/config.json}"
+  local override
+  if [ -n "$config" ] && [ -f "$config" ]; then
+    override="$(jq -r --arg p "$provider" --arg t "$tier" '.models[$p][$t] // empty' "$config" 2>/dev/null || true)"
+    if [ -n "$override" ] && [ "$override" != "null" ]; then
+      echo "$override"
+      return 0
+    fi
+    override="$(jq -r --arg t "$tier" '.models[$t] // empty' "$config" 2>/dev/null || true)"
+    if [ -n "$override" ] && [ "$override" != "null" ]; then
+      echo "$override"
+      return 0
+    fi
+  fi
+  default_model_for "$provider" "$tier"
+}
+
+main() {
+  local provider="" tier=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --provider)
+        [ "$#" -ge 2 ] || { echo "::error::--provider requires a value" >&2; exit 1; }
+        provider="$2"; shift 2 ;;
+      --tier)
+        [ "$#" -ge 2 ] || { echo "::error::--tier requires a value" >&2; exit 1; }
+        tier="$2"; shift 2 ;;
+      -h|--help)
+        grep -E '^# (Usage|Reads)' "${BASH_SOURCE[0]}" | sed 's/^# //'
+        exit 0 ;;
+      *)
+        echo "::error::unknown argument: $1" >&2
+        exit 1 ;;
+    esac
+  done
+
+  if [ -z "$provider" ]; then
+    echo "::error::--provider is required" >&2
+    exit 1
+  fi
+  case "$tier" in
+    fast|standard|deep) ;;
+    "")
+      echo "::error::--tier is required" >&2
+      exit 1 ;;
+    *)
+      echo "::error::--tier must be one of: fast, standard, deep (got '$tier')" >&2
+      exit 1 ;;
+  esac
+
+  # Resolve OUTDIR for local runs (same path convention as the rest of the swarm).
+  if [ -z "${OUTDIR:-}" ]; then
+    # shellcheck source=skills/woostack-review/scripts/resolve-outdir.sh
+    source "$(dirname "${BASH_SOURCE[0]}")/resolve-outdir.sh"
+  fi
+  : "${CONFIG_PATH:=${OUTDIR}/config.json}"
+
+  provider_tier_model "$provider" "$tier"
+}
+
+# Dual-mode: run main only on direct execution; a `source` (e.g. load-prompt.sh)
+# pulls in default_model_for / provider_tier_model without executing.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/skills/woostack-review/scripts/tests/test-resolve-model.sh
+++ b/skills/woostack-review/scripts/tests/test-resolve-model.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Test the standalone Stage-3 model resolver used by local per-call-routing hosts.
+# resolve-model.sh --provider <p> --tier <fast|standard|deep> prints the resolved
+# model slug, honoring $OUTDIR/config.json overrides (issue #295).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/resolve-model.sh"
+
+# Run resolve-model.sh under a clean env with an explicit OUTDIR. Echoes stdout
+# (the resolved model) on success; on failure prints captured streams and returns
+# the script's exit code so callers can assert on it.
+run_resolve() {
+  local outdir="$1"; shift
+  env -i \
+    PATH="$PATH" \
+    HOME="${HOME:-}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    OUTDIR="$outdir" \
+    bash "$SCRIPT" "$@"
+}
+
+# --- issue #295: provider-scoped config override wins over the default table ---
+outdir="$(mktemp -d)"
+printf '%s\n' '{"models":{"openai":{"standard":"gpt-5.3-codex-spark"}}}' > "$outdir/config.json"
+model="$(run_resolve "$outdir" --provider openai --tier standard)"
+assert_eq "$model" "gpt-5.3-codex-spark" \
+  "config models.openai.standard wins over default gpt-5.4-mini (issue #295)"
+rm -rf "$outdir"
+
+# --- provider-scoped override leaves other tiers on the default table ---
+outdir="$(mktemp -d)"
+printf '%s\n' '{"models":{"openai":{"standard":"gpt-5.3-codex-spark"}}}' > "$outdir/config.json"
+model="$(run_resolve "$outdir" --provider openai --tier deep)"
+assert_eq "$model" "gpt-5.5" "untouched tier (deep) falls through to default table"
+rm -rf "$outdir"
+
+# --- flat models.<tier> fallback when no provider-scoped entry ---
+outdir="$(mktemp -d)"
+printf '%s\n' '{"models":{"standard":"flat-standard-x"}}' > "$outdir/config.json"
+model="$(run_resolve "$outdir" --provider openai --tier standard)"
+assert_eq "$model" "flat-standard-x" "flat models.standard used when no provider-scoped entry"
+rm -rf "$outdir"
+
+# --- provider-scoped beats flat when both present ---
+outdir="$(mktemp -d)"
+printf '%s\n' '{"models":{"standard":"flat-standard-x","openai":{"standard":"scoped-y"}}}' > "$outdir/config.json"
+model="$(run_resolve "$outdir" --provider openai --tier standard)"
+assert_eq "$model" "scoped-y" "provider-scoped models.openai.standard beats flat models.standard"
+rm -rf "$outdir"
+
+# --- no config: default table per provider/tier ---
+outdir="$(mktemp -d)"
+assert_eq "$(run_resolve "$outdir" --provider openai --tier standard)" "gpt-5.4-mini" \
+  "default openai/standard is gpt-5.4-mini"
+assert_eq "$(run_resolve "$outdir" --provider openai --tier fast)" "gpt-5.3-codex-spark" \
+  "default openai/fast is gpt-5.3-codex-spark"
+assert_eq "$(run_resolve "$outdir" --provider openai --tier deep)" "gpt-5.5" \
+  "default openai/deep is gpt-5.5"
+assert_eq "$(run_resolve "$outdir" --provider anthropic --tier standard)" "claude-sonnet-4-6" \
+  "default anthropic/standard is claude-sonnet-4-6"
+assert_eq "$(run_resolve "$outdir" --provider anthropic --tier deep)" "claude-opus-4-8" \
+  "default anthropic/deep is claude-opus-4-8"
+assert_eq "$(run_resolve "$outdir" --provider google --tier standard)" "gemini-3-5-flash" \
+  "default google/standard is gemini-3-5-flash"
+rm -rf "$outdir"
+
+# --- config.json absent entirely (OUTDIR has no config) → defaults still resolve ---
+outdir="$(mktemp -d)"
+assert_eq "$(run_resolve "$outdir" --provider anthropic --tier fast)" "claude-haiku-4-5" \
+  "missing config.json falls back to default table"
+rm -rf "$outdir"
+
+# --- unknown provider errors out ---
+outdir="$(mktemp -d)"
+set +e
+run_resolve "$outdir" --provider bogus --tier standard >/dev/null 2>&1
+code=$?
+set -e
+assert_exit 1 "$code" "unknown provider exits non-zero"
+rm -rf "$outdir"
+
+# --- missing/invalid --tier errors out ---
+outdir="$(mktemp -d)"
+set +e
+run_resolve "$outdir" --provider openai --tier bogus >/dev/null 2>&1
+code=$?
+set -e
+assert_exit 1 "$code" "invalid tier exits non-zero"
+rm -rf "$outdir"
+
+# --- missing required flags error out ---
+outdir="$(mktemp -d)"
+set +e
+run_resolve "$outdir" --tier standard >/dev/null 2>&1
+code=$?
+set -e
+assert_exit 1 "$code" "missing --provider exits non-zero"
+rm -rf "$outdir"
+
+finish


### PR DESCRIPTION
## Goal

Make local `/woostack-review` honor per-repo model overrides immediately: a `models.<provider>.<tier>` entry in `.woostack/config.json` should drive the next run's worker model without a manual override. Fixes #295.

## Summary

- New `scripts/resolve-model.sh` — `--provider <p> --tier <fast|standard|deep>` prints the resolved model, applying precedence `models.<provider>.<tier>` → flat `models.<tier>` (from `$OUTDIR/config.json`) → default table. Safe to `source` (dual-mode guard).
- `load-prompt.sh` now sources `resolve-model.sh` and drops its duplicated `default_model_for` / `provider_tier_model` — single source of truth so the CI (single-session) and local (per-call) paths cannot diverge. CI behavior unchanged.
- `SKILL.md` Stage 3 / Model routing: local per-call-routing hosts MUST resolve each spawn's model via `resolve-model.sh` (config-aware) and write that slug into both the spawn `model` field and the receipt `model`; the `_header.md` table is the step-5 default only.
- Regression test `tests/test-resolve-model.sh` covers the issue's exact config (`models.openai.standard: gpt-5.3-codex-spark` ⇒ `gpt-5.3-codex-spark`, not `gpt-5.4-mini`), flat-tier fallback, provider-scoped-beats-flat, no-config defaults, and error paths.

## Test plan

### Automated

- [x] Full review test suite — `for t in skills/woostack-review/scripts/tests/test-*.sh; do bash "$t"; done` → all green (incl. `test-resolve-model.sh` 14/14, `test-load-prompt-models.sh` 16/16 unchanged).
- [x] `shellcheck -x skills/woostack-review/scripts/resolve-model.sh` → clean (pre-existing SC2129 style nit on an untouched `load-prompt.sh` block left as-is).

### Manual

**Before merge**

- [ ] `OUTDIR=$(mktemp -d); echo '{"models":{"openai":{"standard":"gpt-5.3-codex-spark"}}}' > "$OUTDIR/config.json"; OUTDIR="$OUTDIR" bash skills/woostack-review/scripts/resolve-model.sh --provider openai --tier standard` ⇒ prints `gpt-5.3-codex-spark`.
- [ ] Confirm `SKILL.md` Stage 3 instructs local hosts to call `resolve-model.sh` for the spawn model and receipt model.

Spec: .woostack/fixes/2026-06-11-review-local-model-resolution.md
