### PR TITLE
fix(init): ignore .woostack/worktrees/ in gitignore and fix test-resolve-base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,8 @@ pnpm-debug.log*
 .woostack/overnight/
 # woostack: temporary review artifacts
 .woostack/tmp/
+# woostack: transient per-clone worktrees (managed by worktree lifecycle)
+.woostack/worktrees/
 # Claude Code scheduling runtime lock (generated, not source)
 .claude/scheduled_tasks.lock
+

--- a/.woostack/.gitignore
+++ b/.woostack/.gitignore
@@ -1,6 +1,9 @@
 # Transient, per-clone — not shared knowledge.
 metrics.json
 *.local.*
+visuals/
+overnight/
+worktrees/
 memory.md
 memory/
 

--- a/skills/woostack-init/scripts/tests/assert.sh
+++ b/skills/woostack-init/scripts/tests/assert.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 
 PASS=0; FAIL=0
 
+fail() {
+  FAIL=$((FAIL+1))
+  echo "  FAIL: $1"
+}
+
+pass() {
+  PASS=$((PASS+1))
+}
+
 assert_eq() { # actual expected msg
   if [ "$1" = "$2" ]; then PASS=$((PASS+1)); else
     FAIL=$((FAIL+1)); echo "  FAIL: $3"; echo "    expected: [$2]"; echo "    actual:   [$1]"; fi

--- a/skills/woostack-init/scripts/tests/test-resolve-base.sh
+++ b/skills/woostack-init/scripts/tests/test-resolve-base.sh
@@ -36,7 +36,7 @@ out5="$( cd "$repo1" && env -u WOOSTACK_BASE_BRANCH WOOSTACK_ROOT="$repo1" bash 
 assert_eq "$out5" "trunk" "executed mode prints resolved branch"
 
 # 6. config present + jq unavailable -> fail loudly instead of falling back
-bin6="$(mktemp -d)"; ln -s "$(command -v git)" "$bin6/git"
+bin6="$(mktemp -d)"; ln -s "$(command -v git)" "$bin6/git"; ln -s "$(command -v bash)" "$bin6/bash"
 if out6="$( cd "$repo1" && env -u WOOSTACK_BASE_BRANCH WOOSTACK_ROOT="$repo1" PATH="$bin6" bash "$resolver" 2>&1 )"; then
   fail "config without jq fails"
 fi


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
