### PR TITLE
fix(review): trust self-authored incremental marker on local re-run (#273)

### DIFF
--- a/.woostack/fixes/2026-06-11-review-marker-self-trust.md
+++ b/.woostack/fixes/2026-06-11-review-marker-self-trust.md
@@ -1,0 +1,90 @@
+---
+type: fix
+status: in-review
+branch: fix/review-marker-self-trust
+---
+
+# Fix: local `/woostack-review` writes an incremental SHA marker but never trusts its own on re-run
+
+Source issue: [howarewoo/woostack#273](https://github.com/howarewoo/woostack/issues/273)
+
+## 1. Root Cause
+
+Two separate mechanisms govern the incremental SHA watermark; only the **read** side is bot-gated, so a local review trusts no marker it ever wrote.
+
+- **Write side (CI *and* local).** `skills/woostack-review/prompts/_header.md:172` embeds `<!-- woostack-review:sha=${HEAD_SHA} -->` into **every** posted review body. A local review is posted under the human's own `gh` login.
+- **Read side (bot-only).** `skills/woostack-review/scripts/prefetch.sh:251-261` resolves `LAST_SHA` from prior review bodies, but the jq filter (line 255) trusts a marker only when its author matches `BOT_NAME_PATTERN` (`claude|openai|gemini|opencode`, hardcoded at line 64):
+
+  ```
+  | select(.login | test("^(" + $bots + ")"; "i"))
+  | select(.body | test("<!-- woo-?stack-review:sha=[a-f0-9]+ -->"))
+  ```
+
+A local review authored by e.g. `howarewoo` fails the bot filter → the marker is ignored → `LAST_SHA=""` → `prefetch.sh:278` logs `Marker: none` → the incremental branch at line 371 (`[ -n "$LAST_SHA" ]`) is never taken → `gh pr diff` full path (line 410-411). Every local re-review is a full re-review.
+
+**Why the bot gate exists (and why it is CI-only):** `prefetch.sh:240-249` — in CI any PR collaborator could post a review with a forged `sha=` marker pointing *past* their own malicious commits, narrowing the next incremental window to skip them. Trusting only bot-authored markers blocks that forge. That threat is a CI / untrusted-third-party concern: locally the user runs the review with their own token, reviewing as themselves — there is no other party forging against them.
+
+**Evidence:** confirmed by reading the code — the filter rejects every non-bot login; the write site embeds the marker unconditionally; the logged `Marker: none` in the issue matches the empty-`LAST_SHA` full-diff path.
+
+**Gotcha (distill at fix end):** local review *writes* a watermark on every run, but the trust gate was CI-shaped (bot-author-only) — a write/read trust asymmetry. Self-trust must be gated on *not-in-CI* to stay forge-safe.
+
+## 2. Proposed Fix
+
+Widen the marker-trust gate to: **bot-authored OR (local-run AND authored-by-self)**, gating self-trust on `GITHUB_ACTIONS != "true"`.
+
+Extract the marker-trust resolution into a single-authority helper, matching the repo idiom — `resolve-root.sh`, `resolve-model.sh`, `resolve-outdir.sh` are all extracted and unit-tested, whereas the current inline jq is untestable in isolation. The TDD failing-test-first kernel needs a reachable unit, and a single authority keeps the test and the production filter from drifting.
+
+- **New `skills/woostack-review/scripts/resolve-marker.sh`** — owns the marker-trust jq. Reads the `gh --json reviews` JSON on stdin; args `$1=BOT_NAME_PATTERN`, `$2=ME` (authenticated gh login, lowercased; `''` disables self-trust), `$3=LOCAL` (`1` when not in CI, else `0`). Emits the trusted SHA or empty. The widened filter:
+
+  ```
+  | select((.login | test("^(" + $bots + ")"; "i"))
+           or ($local == "1" and $me != "" and (.login | ascii_downcase) == $me))
+  | select(.body | test("<!-- woo-?stack-review:sha=[a-f0-9]+ -->"))
+  ```
+
+  Preserves the legacy `woo-?stack` read alias and the `^`-anchored bot pattern unchanged.
+
+- **`skills/woostack-review/scripts/prefetch.sh:251-261`** — replace the inline jq with: resolve `AUTH_LOGIN` (`gh api user --jq .login`, lowercased, only when `GITHUB_ACTIONS != "true"`) and `LOCAL_RUN`, then pipe `REVIEWS_JSON` through `resolve-marker.sh`. In CI, `LOCAL_RUN=0` makes the self-clause dead → behavior identical to today (bot-only); `AUTH_LOGIN` is not even fetched.
+
+- **`skills/woostack-review/SKILL.md`** (Incremental Mode section) — document that local runs now honor their own marker, gated on not-in-CI + author==self; a *different* local reviewer or any CI third-party falls back to full review; `--full` / `incremental: off` escape hatches unchanged.
+
+**Safety:** anti-forge preserved — only markers authored *as you* on a *local* run are newly trusted; CI is untouched; a different local reviewer mismatches `$me` and degrades to full.
+
+### Hardening — resolved questions
+
+- **`gh api user` fails locally (no/expired auth):** `AUTH_LOGIN=""`; the filter's `$me != ""` clause makes the self-branch dead → falls back to full review. Safe by construction (use `|| true`).
+- **Case sensitivity:** GitHub logins are case-insensitive. Lowercase both sides — `tr '[:upper:]' '[:lower:]'` on `AUTH_LOGIN`, `ascii_downcase` on the review login inside jq.
+- **CI is provably unchanged:** when `GITHUB_ACTIONS == "true"`, `LOCAL_RUN=0`, the self-clause `($local == "1" and …)` is dead, and `AUTH_LOGIN` is not even fetched → byte-for-byte the current bot-only behavior. This is what test case 4 pins.
+- **"No new commits" skip (`prefetch.sh:362`) now fires on a local re-run with no new pushes** (`LAST_SHA == HEAD_SHA` → `skip=true`). This is *intended* — it is the cheaper local loop the issue asks for; previously a local re-run always full-reviewed. Document it in SKILL.md; `--full` still forces a pass.
+- **Bot-comment re-run guard (`prefetch.sh:269-296`) is intentionally NOT widened.** It counts only bot-authored comments (`TOTAL_BOT_COMMENTS`) to suppress auto-re-runs in CI; local runs are explicit user requests, so a human self-review never trips it. Leaving it bot-only is correct and keeps scope tight.
+- **Single copy.** `woostack-address-comments` has no marker reader (verified — only `resolve-root.sh` is twinned). `resolve-marker.sh` lives once under `skills/woostack-review/scripts/`.
+- **Helper interface:** reviews JSON on **stdin** (mirrors the current `printf '%s' "$REVIEWS_JSON" | jq …` shape); trust knobs as positional args. Pure jq, no `gh` dependency → unit-testable without network.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Reproduce with a failing test (Red).**
+  Add `skills/woostack-review/scripts/tests/test-resolve-marker.sh` (modeled on `test-resolve-model.sh`; source `skills/woostack-init/scripts/tests/assert.sh`). It pipes fake `{"reviews":[…]}` JSON into `resolve-marker.sh` and asserts the resolved SHA. Cases:
+  1. bot-authored marker + `LOCAL=0` (CI) → returns the SHA *(preserves CI behavior)*.
+  2. self-authored marker + `LOCAL=1`, `ME==author` → returns the SHA *(the fix — fails before Step 2, the Red)*.
+  3. third-party-authored marker + `LOCAL=1`, `ME != author` → empty *(anti-forge)*.
+  4. self/non-bot-authored marker + `LOCAL=0` (CI) → empty *(CI never self-trusts)*.
+  5. malformed / absent marker → empty *(silent fallback)*.
+  6. legacy `woo-stack-review:sha=` alias + trusted author → returns the SHA *(read-alias intact)*.
+  Run it first and confirm it fails (the helper does not yet exist).
+
+- [x] **Step 2: Apply the minimal fix (Green).**
+  - Create `skills/woostack-review/scripts/resolve-marker.sh` with the widened jq filter above (header comment documenting the trust contract: bot OR local-self, CI-gated, anti-forge rationale, legacy alias).
+  - Edit `prefetch.sh:251-261`: compute `AUTH_LOGIN` (only when `GITHUB_ACTIONS != "true"`) and `LOCAL_RUN`, replace the inline jq with a call to `resolve-marker.sh` (invoke via `$(dirname "${BASH_SOURCE[0]}")/resolve-marker.sh`, consistent with lines 35-37). Keep the surrounding trust-rationale comment, updated to mention the local self-trust clause.
+  - Make `resolve-marker.sh` executable.
+  - Re-run Step 1's test → green.
+
+- [x] **Step 3: Document the behavior.**
+  Update `skills/woostack-review/SKILL.md` Incremental Mode section (lines 50-67):
+  - Amend the line 58 sentence ("scans **bot-authored** prior review bodies …") to: scans bot-authored markers, **plus — on a local (not-in-CI) run — a marker authored by the gh user running the review**; a different local reviewer or any CI third-party still falls back to full (anti-forge intact).
+  - Amend the line 65 "no new commits" note to call out that this skip now also fires on a **local** re-run with no new pushes (the cheaper local loop); `--full` / `incremental: off` still force a pass.
+
+- [x] **Step 4: Verification.**
+  - `bash skills/woostack-review/scripts/tests/test-resolve-marker.sh` → all pass.
+  - Re-run the existing review test suite to confirm no regression: `for t in skills/woostack-review/scripts/tests/test-*.sh; do bash "$t"; done` (or the repo's documented runner).
+  - `bash -n skills/woostack-review/scripts/prefetch.sh skills/woostack-review/scripts/resolve-marker.sh` (syntax).
+  - Optional sanity: pipe a fake bot-marker reviews JSON through `prefetch.sh` in `WOO_REVIEW_TEST_MODE=1` is out of scope (prefetch hits live `gh` after the marker step); the unit test on `resolve-marker.sh` is the authority.

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -55,14 +55,14 @@ By default (`incremental: auto` on the GitHub Action), every posted review carri
 <!-- woostack-review:sha=<headRefOid> -->
 ```
 
-On the next run, `prefetch.sh` scans **bot-authored** prior review bodies (the same `BOT_NAME_PATTERN` used elsewhere) for the marker — non-bot reviewers cannot forge a marker to narrow the window. If found, prefetch diffs `<last_sha>...HEAD` via the GitHub compare API instead of the full PR diff — only the new commits since the last pass are reviewed. Unresolved prior review threads (any author) are dumped to `$OUTDIR/prior-findings.json` and consumed by the posting stage as an **event floor**: any non-empty priors list keeps the new review at minimum `REQUEST_CHANGES`, a conservative gate so a stale open thread is never auto-resolved by a clean incremental pass.
+On the next run, `prefetch.sh` (via `resolve-marker.sh`) scans **bot-authored** prior review bodies (the same `BOT_NAME_PATTERN` used elsewhere) for the marker — and, **on a local (not-in-CI) run, also a marker authored by the gh user running the review** (`gh api user`, matched case-insensitively). A CI collaborator cannot forge a marker (the self-trust clause is dead in CI, so only bots are honored), and a *different* local reviewer or any CI third-party still falls back to a full pass. This lets a local re-review trust the marker it wrote on the previous run instead of always re-reviewing in full. If a trusted marker is found, prefetch diffs `<last_sha>...HEAD` via the GitHub compare API instead of the full PR diff — only the new commits since the last pass are reviewed. Unresolved prior review threads (any author) are dumped to `$OUTDIR/prior-findings.json` and consumed by the posting stage as an **event floor**: any non-empty priors list keeps the new review at minimum `REQUEST_CHANGES`, a conservative gate so a stale open thread is never auto-resolved by a clean incremental pass.
 
 Override paths:
 - Action input `incremental: off` (workflow-level opt-out).
 - A trigger comment containing `--full` (e.g. `@review --full`) — fixed-string match, regex-injection safe.
 - Force-push that drops `<last_sha>` from the branch history — the compare API returns 404; prefetch emits a `::warning::` and falls back to the full diff for that run.
 
-When the incremental diff has no new commits (i.e. `LAST_SHA == HEAD_SHA`, e.g. someone re-triggers without pushing), prefetch emits `skip=true` with reason `no new commits since last review (<last_sha>)`. To force a re-review of the same SHA, pass `--full` (or set `incremental: off`).
+When the incremental diff has no new commits (i.e. `LAST_SHA == HEAD_SHA`, e.g. someone re-triggers without pushing), prefetch emits `skip=true` with reason `no new commits since last review (<last_sha>)`. Because a local run now trusts its own marker, this skip also fires on a **local** re-review with no new pushes (previously a local re-run always reviewed in full). To force a re-review of the same SHA, pass `--full` (or set `incremental: off`).
 
 Marker semantics are state-light: the marker IS the state. There is no DB or workflow artifact retention beyond what GitHub already keeps in review history.
 

--- a/skills/woostack-review/scripts/prefetch.sh
+++ b/skills/woostack-review/scripts/prefetch.sh
@@ -238,30 +238,31 @@ if [ "$TEST_MODE" = "1" ] && [ -n "${WOO_REVIEW_FAKE_PR_REVIEWS_JSON:-}" ]; then
 else
   REVIEWS_JSON=$(gh pr view "$PR_NUMBER" --json reviews 2>/dev/null || echo '{"reviews":[]}')
 fi
-# Marker trust: only honor reviews authored by woostack-review bots. Without this
-# filter any PR collaborator could submit a fake review with a forged marker
-# pointing past their own malicious commits, narrowing the next incremental
-# window to exclude them. The login pattern is anchored to the start of the
-# string so logins like `myclaudebot` are rejected; a residual risk remains
-# for logins that START with a bot prefix (e.g. `claude-evil`), which would
-# require an attacker to register such a login AND obtain PR-collaborator
-# access — defense-in-depth, not a hard guarantee.
-# Read side accepts the legacy `woo-stack-review:sha=` watermark too (woo-?stack), so a
-# PR last reviewed before the woostack rename still resolves incrementally. Writes use the new brand.
-LAST_SHA=$(printf '%s' "$REVIEWS_JSON" | jq -r --arg bots "$BOT_NAME_PATTERN" '
-  [ .reviews[]?
-    | { body: (.body // ""),
-        submittedAt: (.submittedAt // ""),
-        login: (.author.login // "") }
-    | select(.login | test("^(" + $bots + ")"; "i"))
-    | select(.body | test("<!-- woo-?stack-review:sha=[a-f0-9]+ -->"))
-  ]
-  | sort_by(.submittedAt)
-  | last
-  | if . == null then empty
-    else (.body | capture("<!-- woo-?stack-review:sha=(?<sha>[a-f0-9]+) -->") | .sha)
-    end
-' 2>/dev/null || true)
+# Marker trust: honor a marker authored by a woostack-review bot, OR — on a local
+# (not-in-CI) run only — one authored by the gh user running this review. Without
+# the bot gate any PR collaborator could submit a fake review with a forged marker
+# pointing past their own malicious commits, narrowing the next incremental window
+# to exclude them. The bot login pattern is anchored to the start of the string so
+# logins like `myclaudebot` are rejected; a residual risk remains for logins that
+# START with a bot prefix (e.g. `claude-evil`), which would require an attacker to
+# register such a login AND obtain PR-collaborator access — defense-in-depth, not a
+# hard guarantee. The local self-trust clause is gated on NOT running in CI so the
+# same forge threat does not apply: locally the user reviews as themselves with
+# their own token (a local re-review can then trust the marker it wrote last run);
+# a different local reviewer or any CI third-party still falls back to a full pass.
+# resolve-marker.sh owns the trust filter (single authority) and the legacy
+# `woo-stack-review:sha=` read alias (woo-?stack), so a PR last reviewed before the
+# woostack rename still resolves incrementally. Writes use the new brand.
+LOCAL_RUN=0
+AUTH_LOGIN=""
+if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+  LOCAL_RUN=1
+  # Authenticated gh login of whoever is running this local review (lowercased);
+  # empty on auth failure → self-trust disabled → safe fall back to full diff.
+  AUTH_LOGIN=$(gh api user --jq '.login' 2>/dev/null | tr '[:upper:]' '[:lower:]' || true)
+fi
+LAST_SHA=$(printf '%s' "$REVIEWS_JSON" \
+  | bash "$(dirname "${BASH_SOURCE[0]}")/resolve-marker.sh" "$BOT_NAME_PATTERN" "$AUTH_LOGIN" "$LOCAL_RUN")
 
 # Re-run guard: if a prior AI bot has already commented and the current trigger is
 # not an explicit user request, skip. Skipped when a marker is present — the marker

--- a/skills/woostack-review/scripts/resolve-marker.sh
+++ b/skills/woostack-review/scripts/resolve-marker.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# resolve-marker.sh — single authority for the woostack-review incremental
+# SHA-watermark trust gate. Reads `gh pr view --json reviews` JSON on stdin and
+# prints the trusted `<!-- woostack-review:sha=<oid> -->` watermark from the most
+# recent prior review body, or empty when none is trusted.
+#
+# Usage:
+#   printf '%s' "$REVIEWS_JSON" | resolve-marker.sh <bot-pattern> <me> <local>
+#     $1 bot-pattern : regex alternation of trusted bot login prefixes
+#                      (e.g. "claude|openai|gemini|opencode"), start-anchored.
+#     $2 me          : authenticated gh login (lowercased) of the user running
+#                      this review; '' disables self-trust.
+#     $3 local       : "1" when NOT running in GitHub Actions, else "0".
+#   stdout: the trusted SHA, or empty.
+#
+# Trust rule — a marker is honored iff its review author is:
+#   - a woostack-review bot (login starts with the bot pattern), OR
+#   - (local run only) the authenticated gh user running this review (login==me).
+# The self-trust clause is gated on a local run ($local=="1"). In CI any PR
+# collaborator could otherwise post a review with a forged sha= marker pointing
+# PAST their own malicious commits, narrowing the next incremental window to skip
+# them. Locally the user reviews as themselves with their own token, so trusting
+# a marker authored as themselves introduces no new forger. A different local
+# reviewer (me mismatch) or any CI third-party still falls back to a full review.
+#
+# The read side accepts the legacy `woo-stack-review:sha=` watermark too
+# (woo-?stack), so a PR last reviewed before the woostack rename still resolves
+# incrementally; writes use the new brand. Hand-edited / malformed / absent
+# markers yield empty → silent fallback to the full diff.
+set -euo pipefail
+
+BOTS="${1:?bot pattern required}"
+ME="${2:-}"
+LOCAL="${3:-0}"
+
+jq -r --arg bots "$BOTS" --arg me "$ME" --arg local "$LOCAL" '
+  [ .reviews[]?
+    | { body: (.body // ""),
+        submittedAt: (.submittedAt // ""),
+        login: (.author.login // "") }
+    | select((.login | test("^(" + $bots + ")"; "i"))
+             or ($local == "1" and $me != "" and (.login | ascii_downcase) == $me))
+    | select(.body | test("<!-- woo-?stack-review:sha=[a-f0-9]+ -->"))
+  ]
+  | sort_by(.submittedAt)
+  | last
+  | if . == null then empty
+    else (.body | capture("<!-- woo-?stack-review:sha=(?<sha>[a-f0-9]+) -->") | .sha)
+    end
+' 2>/dev/null || true

--- a/skills/woostack-review/scripts/tests/test-resolve-marker.sh
+++ b/skills/woostack-review/scripts/tests/test-resolve-marker.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Test the marker-trust resolver that prefetch.sh uses to pull the incremental
+# SHA watermark from prior review bodies (issue #273).
+#
+# resolve-marker.sh <bot-pattern> <me> <local> reads `gh --json reviews` JSON on
+# stdin and prints the trusted SHA (or empty). A marker is trusted iff the review
+# author is a woostack-review bot, OR — on a local run only (local==1) — the
+# authenticated gh user running the review (login==me, case-insensitive). The
+# self-trust clause is gated on a local run so a CI collaborator cannot forge a
+# marker under a non-bot login.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/resolve-marker.sh"
+
+BOTS="claude|openai|gemini|opencode"
+
+# resolve <reviews-json> <bots> <me> <local> -> trusted SHA on stdout
+resolve() {
+  printf '%s' "$1" | bash "$SCRIPT" "$2" "$3" "$4"
+}
+
+# One review object with the current-brand marker.
+review() { # login sha submittedAt
+  printf '{"author":{"login":"%s"},"body":"LGTM\\n\\n<!-- woostack-review:sha=%s -->","submittedAt":"%s"}' "$1" "$2" "$3"
+}
+
+# --- (1) bot-authored marker, CI run (local=0) -> trusted (preserves CI behavior) ---
+json="{\"reviews\":[$(review "claude[bot]" "223ad82" "2026-06-01T00:00:00Z")]}"
+got="$(resolve "$json" "$BOTS" "" "0")"
+assert_eq "$got" "223ad82" "(1) bot-authored marker in CI is trusted"
+
+# --- (2) self-authored marker, local run, me==author -> trusted (the fix) ---
+json="{\"reviews\":[$(review "howarewoo" "deadbee" "2026-06-01T00:00:00Z")]}"
+got="$(resolve "$json" "$BOTS" "howarewoo" "1")"
+assert_eq "$got" "deadbee" "(2) local self-authored marker is trusted"
+
+# --- (2b) self-trust is case-insensitive on the login ---
+json="{\"reviews\":[$(review "HowAreWoo" "abc1234" "2026-06-01T00:00:00Z")]}"
+got="$(resolve "$json" "$BOTS" "howarewoo" "1")"
+assert_eq "$got" "abc1234" "(2b) local self-trust matches login case-insensitively"
+
+# --- (3) third-party marker, local run, me != author -> NOT trusted (anti-forge) ---
+json="{\"reviews\":[$(review "mallory" "f00ba12" "2026-06-01T00:00:00Z")]}"
+got="$(resolve "$json" "$BOTS" "howarewoo" "1")"
+assert_eq "$got" "" "(3) local third-party marker is rejected"
+
+# --- (4) self/non-bot marker, CI run (local=0) -> NOT trusted (CI never self-trusts) ---
+json="{\"reviews\":[$(review "howarewoo" "223ad82" "2026-06-01T00:00:00Z")]}"
+got="$(resolve "$json" "$BOTS" "howarewoo" "0")"
+assert_eq "$got" "" "(4) self-authored marker in CI is rejected"
+
+# --- (4b) empty me disables self-trust even on a local run ---
+json="{\"reviews\":[$(review "howarewoo" "223ad82" "2026-06-01T00:00:00Z")]}"
+got="$(resolve "$json" "$BOTS" "" "1")"
+assert_eq "$got" "" "(4b) empty me disables self-trust"
+
+# --- (5) malformed marker -> empty (silent fallback) ---
+json='{"reviews":[{"author":{"login":"claude[bot]"},"body":"no marker here","submittedAt":"2026-06-01T00:00:00Z"}]}'
+got="$(resolve "$json" "$BOTS" "" "0")"
+assert_eq "$got" "" "(5) review without a marker yields empty"
+
+# --- (5b) no reviews at all -> empty ---
+got="$(resolve '{"reviews":[]}' "$BOTS" "howarewoo" "1")"
+assert_eq "$got" "" "(5b) no reviews yields empty"
+
+# --- (6) legacy woo-stack-review:sha= alias + trusted author -> trusted ---
+json='{"reviews":[{"author":{"login":"claude[bot]"},"body":"<!-- woo-stack-review:sha=cafe123 -->","submittedAt":"2026-06-01T00:00:00Z"}]}'
+got="$(resolve "$json" "$BOTS" "" "0")"
+assert_eq "$got" "cafe123" "(6) legacy woo-stack-review alias is honored"
+
+# --- (7) latest review wins when several carry a marker ---
+json="{\"reviews\":[$(review "claude[bot]" "0000aaa" "2026-06-01T00:00:00Z"),$(review "claude[bot]" "1111bbb" "2026-06-02T00:00:00Z")]}"
+got="$(resolve "$json" "$BOTS" "" "0")"
+assert_eq "$got" "1111bbb" "(7) latest submittedAt marker wins"
+
+# --- (8) bot pattern is start-anchored: 'notclaude' is not a bot ---
+json="{\"reviews\":[$(review "notclaudebot" "223ad82" "2026-06-01T00:00:00Z")]}"
+got="$(resolve "$json" "$BOTS" "" "0")"
+assert_eq "$got" "" "(8) login not starting with a bot prefix is rejected in CI"
+
+finish


### PR DESCRIPTION
## Goal

A local `/woostack-review <PR#>` writes the incremental SHA watermark into every review body it posts, but the read side only trusted **bot-authored** markers — so a local re-review (authored by the human's own `gh` login) never trusted the marker it wrote last run and always re-reviewed in full. This makes the local review → address-comments → re-review loop cheaper. Fixes #273.

## Summary

- New `skills/woostack-review/scripts/resolve-marker.sh` — single authority for the marker-trust filter (extracted from the inline jq in `prefetch.sh`, matching the `resolve-root.sh` / `resolve-model.sh` idiom).
- Widened trust rule: honor a marker authored by a woostack-review **bot**, OR — on a **local (not-in-CI) run only** — by the gh user running the review (`gh api user`, matched case-insensitively).
- `prefetch.sh` resolves `AUTH_LOGIN` (only when not in CI) + `LOCAL_RUN` and pipes prior reviews through the helper; the inline jq is gone.
- `SKILL.md` Incremental Mode documents local self-trust and that the "no new commits" skip now also fires on a local re-run.
- Added `tests/test-resolve-marker.sh` (11 assertions).

**Safety:** CI is provably unchanged — when `GITHUB_ACTIONS=true`, `LOCAL_RUN=0`, the self-trust clause is dead and `AUTH_LOGIN` is never fetched. Anti-forge preserved: only a marker authored *as you* on a *local* run is newly trusted; a different local reviewer or any CI third-party still falls back to a full pass.

## Test plan

### Automated

- [x] `bash skills/woostack-review/scripts/tests/test-resolve-marker.sh` → 11 passed, 0 failed
- [x] Full review suite `for t in skills/woostack-review/scripts/tests/test-*.sh; do bash "$t"; done` → 30/30 pass, 0 fails
- [x] `bash -n` on `prefetch.sh` and `resolve-marker.sh` → clean

### Manual

**Before merge**

- [ ] Read the `prefetch.sh` diff: in CI (`GITHUB_ACTIONS=true`) the self-trust branch is dead and `AUTH_LOGIN` is not fetched — bot-only behavior is byte-for-byte unchanged.
- [ ] Confirm `resolve-marker.sh` rejects a third-party local marker (`me != author`) and honors the legacy `woo-stack-review:sha=` alias (test cases 3 and 6).

**After merge**

- [ ] On a real PR, run `/woostack-review <PR#>` locally, push a commit, re-run, and confirm the log shows `Marker: <sha>` (not `Marker: none`) and an incremental diff over only the new commit.

Spec: .woostack/fixes/2026-06-11-review-marker-self-trust.md
