### PR TITLE
docs(execute-overnight): post-implementation review sweep spec+plan

### DIFF
--- a/.woostack/plans/2026-06-11-overnight-review-sweep.md
+++ b/.woostack/plans/2026-06-11-overnight-review-sweep.md
@@ -1,0 +1,370 @@
+**Source:** .woostack/specs/2026-06-11-overnight-review-sweep.md
+
+# Overnight review sweep Implementation Plan
+
+**Goal:** Add a post-implementation review sweep to `woostack-execute-overnight` that drives every increment PR in a track to a clean review (full `woostack-review` → `woostack-address-comments --auto` → restack-this-stack → re-review, bottom-up, bounded), before advancing to the next track.
+
+**Architecture:** Pure skills-markdown change, no app runtime. Adds a `## Post-implementation review sweep` section to `skills/woostack-execute-overnight/SKILL.md`, cross-wires it from override #2 / terminal-state / hard-constraints / frontmatter, and extends `skills/woostack-execute-overnight/references/report-template.md` with a Review-sweep section + a per-increment sweep column. Additive: per-increment override #2 is unchanged. Verification is concrete presence/consistency checks (`grep`, `bash -n`) — the established woostack prompt/skill-edit pattern — not a live-LLM or app test.
+
+**Tech Stack:** Markdown (skill docs), `grep`/`bash` for verification, Graphite (`gt`) referenced in prose only.
+
+---
+
+## Increment 1: Post-implementation review sweep section + report wiring
+
+> One independently shippable PR (~120 lines of markdown across 2 files, ≪500 LOC) — its own Graphite-stacked branch. Splitting further is artificial: the SKILL section and the report rows it produces are one coupled unit and must land together.
+
+Conventions for this increment:
+- All paths are repo-relative (the increment worktree's cwd).
+- "Failing test" = a `grep`/`bash -n` check that returns non-zero / empty **before** the edit and the expected match **after** ([woostack-tdd](../../skills/woostack-tdd/SKILL.md) no-runner substitution).
+- Edit the **real installed** files under `skills/woostack-execute-overnight/`.
+
+### Task 1: Add the `## Post-implementation review sweep` section to the SKILL
+
+**Files:**
+- Modify: `skills/woostack-execute-overnight/SKILL.md` (insert a new section between `## Tracks & halt policy` and `## Morning report`)
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `grep -c "Post-implementation review sweep" skills/woostack-execute-overnight/SKILL.md`
+Expected: FAIL — prints `0` (section absent).
+
+- [ ] **Step 2: Insert the section**
+
+Insert the following block immediately **before** the `## Morning report` line in `skills/woostack-execute-overnight/SKILL.md`:
+
+```markdown
+## Post-implementation review sweep
+
+After a track's increments are all implemented and committed — and **before advancing to the
+next track** — drive that track's stack to a clean review. This is **additive**: the
+per-increment override #2 (the `--fast` blocking-review check during the build) is unchanged;
+the sweep is a separate, thorough pass over the finished stack. It runs for **both drivers**
+(inline and subagent), giving a subagent-built stack its first PR-level review. It **never
+merges**.
+
+A plan with no `## Track:` headings has one implicit track, so the default is exactly: implement
+the whole stack, then sweep it. The sweep covers **increment (code) PRs only** — never the
+docs-only spec+plan base PR. If a track halted mid-implementation, the sweep covers the
+increments that reached a committed PR, bottom-up.
+
+### The per-PR loop (bottom-up, drive-to-clean)
+
+For each increment PR in the track, from the **base of the stack upward**, work in a **per-PR
+worktree** on the existing increment branch. If that branch is already checked out in a preserved
+blocker worktree, reuse it; otherwise run `git worktree add "$wt" <inc-branch>` — **no** `-b`.
+The **primary tree is never edited**, per the [worktree contract](../woostack-init/references/worktrees.md)
+§3. Export `WOOSTACK_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"` first (contract
+§5) so any `address-comments` memory write lands in the primary store. Then loop, up to
+`max_rounds` rounds (see Config):
+
+1. **Review** — `woostack-review <PR#> --full`. **Every** round is `--full` (a complete re-review
+   of the whole PR), so a fix that breaks something *outside* its own diff is still caught, and
+   inline-mode override #2's per-increment SHA watermark can never silently narrow the pass to an
+   incremental one.
+2. **Clean?** Clean = woostack-review's computed verdict has **no blocking findings** (`STATUS_LINE`
+   `APPROVED` / `APPROVED WITH SUGGESTIONS`) **and zero unresolved threads** (checked via `gh`).
+   Read the **verdict, not the GitHub event**: overnight increment PRs are self-authored, so
+   woostack-review downgrades the posted event `APPROVE`→`COMMENT` (you cannot approve your own
+   PR). Clean ⇒ teardown the worktree, advance to the next PR. "Clean" is **review-clean, not a
+   human merge-approval** — the run still never merges.
+3. **Address** — otherwise run
+   [`woostack-address-comments --auto`](../woostack-address-comments/SKILL.md) from inside the
+   worktree (its clean-tree + branch=PR-head precondition holds there): it fixes / pushes back /
+   replies / resolves / pushes (via `woostack-commit --no-pr-update`). Never force-push a protected
+   base; never merge.
+4. **Restack this track's own stack** — `gt restack` then `gt submit` scoped to the current stack,
+   so the PRs above rebase onto the new tip. **Never `gt sync` or a repo-wide restack** (worktree
+   contract §4/§6: a repo-wide restack collides with any parallel run in flight). A restack/rebase
+   conflict is a **blocker**.
+5. **Re-review** → back to step 1.
+
+Strictly bottom-up: a PR is driven to clean before the sweep moves up, and a fix only restacks the
+PRs **above** it — never a cleared lower PR — so each PR is reviewed exactly once on the way up.
+
+### Termination backstop
+
+The per-PR loop is bounded — **whichever trips first**:
+
+- **Max rounds** — at most `max_rounds` review→address rounds per PR (default **3**; see Config).
+- **No-progress guard** — stop early when a round resolves **no** thread, **or** a re-review returns
+  the **same** blocking findings as the prior round, **or** an `address-comments` `CLARIFY` leaves a
+  thread open (an open thread fails the clean check and can never go clean by churning).
+
+Either, without a clean PR, is a **blocker → halt** (below). The reason is written to the decision
+log.
+
+### Halt (reuses Tracks & halt policy)
+
+A sweep blocker — cap-without-clean, no-progress, a restack conflict, or an `address-comments` step
+that would touch the never-auto-approve set (destructive / secret / auth / network / ambiguous) —
+**ends that track's remaining sweep** (the blocked PR and every PR above it become
+`not-attempted-review`) and the run **advances to the next track**, exactly the existing
+[Tracks & halt policy](#tracks--halt-policy). Safety is never relaxed for autonomy; the blocked
+PR's worktree is **left in place** for morning inspection.
+
+### Config
+
+`overnight.review_sweep.max_rounds` in `.woostack/config.json` (positive integer, default **3**)
+caps the per-PR rounds. Validated at **pre-flight**: a non-positive / non-integer value warns, falls
+back to 3, and is recorded in the report — never a refuse-to-start (a sweep-cap typo is not a doomed
+plan).
+```
+
+- [ ] **Step 3: Run the checks, confirm they pass**
+
+Run:
+```bash
+grep -c "Post-implementation review sweep" skills/woostack-execute-overnight/SKILL.md
+grep -q "base of the stack upward" skills/woostack-execute-overnight/SKILL.md && echo "bottom-up: ok"
+grep -q "woostack-review <PR#> --full" skills/woostack-execute-overnight/SKILL.md && echo "full: ok"
+grep -q 'gt sync' skills/woostack-execute-overnight/SKILL.md && echo "no-gt-sync: ok"   # 'gt sync' appears only in its prohibition
+grep -q "overnight.review_sweep.max_rounds" skills/woostack-execute-overnight/SKILL.md && echo "config-key: ok"
+grep -q "STATUS_LINE" skills/woostack-execute-overnight/SKILL.md && echo "verdict-not-event: ok"
+grep -q "per-PR worktree" skills/woostack-execute-overnight/SKILL.md && echo "worktree: ok"
+```
+Expected: `1`, then `bottom-up: ok`, `full: ok`, `no-gt-sync: ok`, `config-key: ok`, `verdict-not-event: ok`, `worktree: ok`.
+
+- [ ] **Step 4: Confirm placement (between Tracks & halt and Morning report)**
+
+Run: `grep -n "^## \(Tracks & halt policy\|Post-implementation review sweep\|Morning report\)" skills/woostack-execute-overnight/SKILL.md`
+Expected: the three headings appear in that order (Tracks & halt policy < Post-implementation review sweep < Morning report).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt create -m "feat(execute-overnight): post-implementation review sweep section"
+```
+
+### Task 2: Cross-wire override #2, terminal state, hard constraints, and the description
+
+**Files:**
+- Modify: `skills/woostack-execute-overnight/SKILL.md` (override #2 cross-ref, terminal-state, hard-constraints, frontmatter `description`)
+
+- [ ] **Step 1: Write the failing checks**
+
+Run:
+```bash
+grep -c "see \[Post-implementation review sweep\]" skills/woostack-execute-overnight/SKILL.md
+grep -c "Drive the stack to clean review" skills/woostack-execute-overnight/SKILL.md
+```
+Expected: FAIL — both print `0`.
+
+- [ ] **Step 2a: Cross-ref from override #2**
+
+In the `## Autonomy overrides` item **2. Blocking review**, append a final sentence to the
+**subagent** sub-bullet (the last line of item 2), so the per-increment override points at the new
+stack-wide pass. Change the end of item 2 from:
+
+```markdown
+     the loop already was the retry; no separate auto-address).
+```
+
+to:
+
+```markdown
+     the loop already was the retry; no separate auto-address).
+
+   Override #2 is the **per-increment early check** during the build. The stack-wide
+   **drive-to-clean** happens after implementation — see
+   [Post-implementation review sweep](#post-implementation-review-sweep), which is additive and
+   leaves this override unchanged.
+```
+
+- [ ] **Step 2b: Update Terminal state**
+
+In `## Terminal state`, replace:
+
+```markdown
+Stop when every track has either completed or halted at a blocker. The result is a Graphite stack
+(linear, or tree-stacked across tracks) of reviewed / partially-reviewed increment PRs, plus a
+complete morning report. Report the path. **Never merge.**
+```
+
+with:
+
+```markdown
+Stop when every track has either completed (increments implemented **and** swept to a clean review)
+or halted at a blocker. The result is a Graphite stack (linear, or tree-stacked across tracks) of
+increment PRs each driven to a clean review — or partially, with blockers logged — plus a complete
+morning report. Report the path. "Clean" is review-clean, never a merge. **Never merge.**
+```
+
+- [ ] **Step 2c: Add a Hard-constraints bullet**
+
+In `## Hard constraints`, immediately after the `**Tracks: author-driven, overnight-only.**`
+bullet, insert:
+
+```markdown
+- **Drive the stack to clean review.** After a track's increments are committed, sweep its
+  increment PRs bottom-up — `woostack-review --full` → `woostack-address-comments --auto` → restack
+  **this stack only** (`gt restack`/`gt submit`, never `gt sync`) → re-review — to a clean verdict
+  (no blocking findings, read from `STATUS_LINE` not the self-downgraded event) + zero unresolved
+  threads. Bounded by `overnight.review_sweep.max_rounds` (default 3) + a no-progress guard; a
+  blocker halts only that track. Both drivers. Never merge.
+```
+
+- [ ] **Step 2d: Update the frontmatter `description`**
+
+In the YAML frontmatter `description:` string, find the **exact** clause `drives every increment to a reviewed stack` (verified present on the `description:` line) and insert immediately after it — before the following `, swapping` — this text:
+` then runs a post-implementation review sweep that drives each increment PR to a clean review (full woostack-review → auto-address → restack → re-review, bounded)`
+so the line reads `...drives every increment to a reviewed stack then runs a post-implementation review sweep that drives each increment PR to a clean review (full woostack-review → auto-address → restack → re-review, bounded), swapping woostack-execute's stop-and-ask gates...` (rest of the string unchanged).
+
+- [ ] **Step 3: Run the checks, confirm they pass**
+
+Run:
+```bash
+grep -q "see \[Post-implementation review sweep\](#post-implementation-review-sweep)" skills/woostack-execute-overnight/SKILL.md && echo "override2-xref: ok"
+grep -q "Drive the stack to clean review" skills/woostack-execute-overnight/SKILL.md && echo "hard-constraint: ok"
+grep -q "swept to a clean review" skills/woostack-execute-overnight/SKILL.md && echo "terminal-state: ok"
+grep -q "post-implementation review sweep that drives each increment PR to a clean review" skills/woostack-execute-overnight/SKILL.md && echo "description: ok"
+```
+Expected: `override2-xref: ok`, `hard-constraint: ok`, `terminal-state: ok`, `description: ok`.
+
+- [ ] **Step 4: Regression — override #2's `--fast` per-increment text is unchanged**
+
+Run: `grep -q "woostack-review --fast" skills/woostack-execute-overnight/SKILL.md && echo "override2-fast: still present"`
+Expected: `override2-fast: still present` (the augment invariant — sweep did not remove or alter override #2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "feat(execute-overnight): wire sweep into override #2, terminal state, constraints, description"
+```
+
+### Task 3: Extend the morning-report template with the Review sweep
+
+**Files:**
+- Modify: `skills/woostack-execute-overnight/references/report-template.md` (per-increment table column + new Review-sweep section + decision-log examples)
+
+- [ ] **Step 1: Write the failing check**
+
+Run: `grep -c "## Review sweep" skills/woostack-execute-overnight/references/report-template.md`
+Expected: FAIL — prints `0`.
+
+- [ ] **Step 2a: Add a Sweep column to the per-increment table**
+
+Replace the per-increment table header + row:
+
+```markdown
+| Track | Increment | Status | Branch / PR | Review | Auto-address rounds |
+|---|---|---|---|---|---|
+| {{A}} | {{1}} | {{done / done-with-findings / blocked / not-attempted}} | {{branch / PR URL}} | {{verdict}} | {{0–2}} |
+```
+
+with:
+
+```markdown
+| Track | Increment | Status | Branch / PR | Review | Auto-address rounds | Sweep |
+|---|---|---|---|---|---|---|
+| {{A}} | {{1}} | {{done / done-with-findings / blocked / not-attempted}} | {{branch / PR URL}} | {{verdict}} | {{0–2}} | {{clean / blocked / not-attempted-review}} |
+```
+
+- [ ] **Step 2b: Add the Review sweep section**
+
+Immediately **after** the per-increment table block and **before** `## Decision log`, insert:
+
+```markdown
+## Review sweep
+
+> Post-implementation drive-to-clean over each track's stack, bottom-up. One row per swept
+> increment PR. "Clean" = no blocking findings (`STATUS_LINE`) + zero unresolved threads; never a
+> merge.
+
+| Track | PR | Rounds (of {{max_rounds}}) | Final verdict | No-progress? | Blocker |
+|---|---|---|---|---|---|
+| {{A}} | {{#}} | {{r}} | {{clean / blocked / not-attempted-review}} | {{yes / no}} | {{— / cap / no-progress / restack-conflict / unsafe}} |
+```
+
+- [ ] **Step 2c: Extend the decision-log examples**
+
+In `## Decision log`, replace the example line:
+
+```markdown
+- {{stamp}} — {{decision (debug fix / auto-address round / BLOCKED / blocker recorded / track ended / increment not-attempted) + rationale}}
+```
+
+with:
+
+```markdown
+- {{stamp}} — {{decision (debug fix / auto-address round / sweep review round / sweep PR clean / sweep blocked: cap | no-progress | restack-conflict | unsafe / BLOCKED / blocker recorded / track ended / increment not-attempted) + rationale}}
+```
+
+- [ ] **Step 3: Run the checks, confirm they pass**
+
+Run:
+```bash
+grep -q "## Review sweep" skills/woostack-execute-overnight/references/report-template.md && echo "sweep-section: ok"
+grep -q "| Track | Increment | Status | Branch / PR | Review | Auto-address rounds | Sweep |" skills/woostack-execute-overnight/references/report-template.md && echo "sweep-column: ok"
+grep -q "sweep review round" skills/woostack-execute-overnight/references/report-template.md && echo "decision-log: ok"
+```
+Expected: `sweep-section: ok`, `sweep-column: ok`, `decision-log: ok`.
+
+- [ ] **Step 4: Confirm Review-sweep sits between Per-increment and Decision log**
+
+Run: `grep -n "^## \(Per-increment\|Review sweep\|Decision log\)" skills/woostack-execute-overnight/references/report-template.md`
+Expected: the three headings in that order (Per-increment < Review sweep < Decision log).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "feat(execute-overnight): report-template Review sweep section + sweep column"
+```
+
+### Task 4: Full presence/consistency verification sweep (AC coverage)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full AC presence-check suite**
+
+Run:
+```bash
+S=skills/woostack-execute-overnight/SKILL.md
+R=skills/woostack-execute-overnight/references/report-template.md
+# AC1 — sweep phase: per-track, post-implementation, bottom-up, additive
+grep -q "Post-implementation review sweep" "$S" && grep -q "before advancing to the" "$S" && grep -q "base of the stack upward" "$S" && grep -q "additive" "$S" && echo "AC1 ok"
+# AC2 — per-PR loop end to end, full review, worktree, no merge, scoped restack
+grep -q "per-PR worktree" "$S" && grep -q "woostack-review <PR#> --full" "$S" && grep -q "woostack-address-comments --auto" "$S" && grep -q "Restack this track's own stack" "$S" && grep -q "never merge" "$S" -i && echo "AC2 ok"
+# AC3 — clean defined via verdict + threads, self-PR downgrade named
+grep -q "STATUS_LINE" "$S" && grep -q "zero unresolved threads" "$S" && grep -q "verdict, not the GitHub event" "$S" && grep -q "downgrades the posted event" "$S" && echo "AC3 ok"
+# AC4 — backstop: cap + no-progress + config key + halt mapping
+grep -q "max_rounds" "$S" && grep -q "No-progress guard" "$S" && grep -q "overnight.review_sweep.max_rounds" "$S" && grep -q "blocker → halt" "$S" && echo "AC4 ok"
+# AC5 — both drivers; halt by reference (not restated); never-auto-approve
+grep -q "both drivers" "$S" -i && grep -q "Tracks & halt policy](#tracks--halt-policy)" "$S" && grep -q "never-auto-approve set" "$S" && echo "AC5 ok"
+# AC6 — report + description
+grep -q "## Review sweep" "$R" && grep -q "Sweep |" "$R" && grep -q "post-implementation review sweep that drives each increment PR to a clean review" "$S" && grep -q "Drive the stack to clean review" "$S" && echo "AC6 ok"
+```
+Expected: `AC1 ok`, `AC2 ok`, `AC3 ok`, `AC4 ok`, `AC5 ok`, `AC6 ok` (each line prints only if its conjuncts all match).
+
+- [ ] **Step 2: Consistency — config key spelled identically everywhere**
+
+Run: `grep -rho "overnight.review_sweep.max_rounds" skills/woostack-execute-overnight/ | sort -u`
+Expected: a single line `overnight.review_sweep.max_rounds` (no spelling drift across the SKILL).
+
+- [ ] **Step 3: Consistency — halt policy referenced by link, not duplicated**
+
+Run: `grep -c "End the current track" skills/woostack-execute-overnight/SKILL.md`
+Expected: `1` — the halt policy is defined once (in `## Tracks & halt policy`); the sweep links to it (`#tracks--halt-policy`) rather than restating it.
+
+- [ ] **Step 4: No broken intra-doc anchors introduced**
+
+Run: `grep -n "#post-implementation-review-sweep\|#tracks--halt-policy" skills/woostack-execute-overnight/SKILL.md`
+Expected: both anchor references resolve to real `## Post-implementation review sweep` / `## Tracks & halt policy` headings (eyeball the heading lines from Task 1 Step 4 / above).
+
+- [ ] **Step 5: Commit (if any verification surfaced a fix; else no-op)**
+
+```bash
+# Only if Steps 1–4 revealed a gap you had to patch:
+gt modify -c -m "fix(execute-overnight): close sweep verification gap"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — every §1–§6 design point maps to a task: sweep phase/placement (Task 1), per-PR loop incl. worktree/full-review/restack-scope/clean-def (Task 1), backstop + config (Task 1), halt reuse (Task 1), override-#2 augment + terminal/constraints/description (Task 2), report template (Task 3).
+- [ ] **AC coverage** — spec §7 AC1–AC6 each map to a presence check in Task 4 Step 1 (plus per-task checks in Tasks 1–3); AC's happy/error/edge conjuncts are encoded in the grep conjunctions.
+- [ ] **No placeholders** — every edit step carries the exact final markdown block and every verify step an exact command + expected output; the only `{{...}}` are inside report-**template** literal content (intended).
+- [ ] **Type consistency** — the config key `overnight.review_sweep.max_rounds`, the anchor `#post-implementation-review-sweep`, the verdict tokens (`clean` / `blocked` / `not-attempted-review`), and `STATUS_LINE` are spelled identically across SKILL, plan, and report-template.
+
+> woostack plan conventions (kept): frontmatter-free; opens with the `**Source:**` line; filename mirrors the spec basename (`2026-06-11-overnight-review-sweep.md`, the spec's date); no required-sub-skill banner; no-runner "failing test" = a concrete `grep`/`bash -n` with exact expected output.

--- a/.woostack/specs/2026-06-11-overnight-review-sweep.md
+++ b/.woostack/specs/2026-06-11-overnight-review-sweep.md
@@ -1,0 +1,208 @@
+---
+name: overnight-review-sweep
+type: spec
+status: planning
+date: 2026-06-11
+branch: feature/overnight-review-sweep
+links:
+  - "[[2026-06-09-review-stack-aware]]"
+  - "[[2026-06-10-parallel-worktrees]]"
+---
+
+# Overnight review sweep — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
+## 1. Problem
+
+`woostack-execute-overnight` drives an approved plan to a stacked set of increment PRs unattended, but it never carries any PR to a **clean approval**. Its only PR-level review today is autonomy override #2, which is:
+
+- **Per-increment, not stack-wide** — it reviews each increment right after that increment is committed, with no pass over the finished stack.
+- **inline-driver only** — in `--subagent` mode there is *no* PR-level review at all; the per-task reviewer loops stand in for it, so a subagent-built stack lands overnight with zero GitHub-level review.
+- **`--fast`, 2-round capped** — a quick batched check, then on `REQUEST_CHANGES` up to two `woostack-address-comments --auto` rounds, then a blocker. It is an early correctness tripwire, not a drive-to-approval.
+
+So the morning artifact is a stack of *implemented* PRs, each possibly still carrying open review threads, and (in subagent mode) PRs that were never PR-reviewed at all. The human's morning job still includes "review every PR from scratch," which is exactly the toil the overnight run was supposed to absorb.
+
+The ask: after implementation, **drive the whole stack to clean approval autonomously** — start at the first PR, review it and address every comment until it has a clean approval, then do the same for the next PR, for the whole stack.
+
+## 2. Goal
+
+`woostack-execute-overnight` gains a **post-implementation review sweep**: once a track's increments are all implemented and committed, before advancing to the next track, it walks that track's stack **bottom-up** and drives each increment PR to a **clean approval** — full `woostack-review`, then `woostack-address-comments --auto` on any blocking findings, restack the PRs above, re-review — looping until clean or until a bounded backstop fires. It runs for **both** drivers (giving subagent stacks their first PR-level review) and is **additive**: the existing per-increment override #2 is unchanged; the sweep is a new phase layered on top.
+
+Every sweep decision is appended to the morning report's decision log, and a new **Review sweep** report section records per-PR rounds and final verdict. The sweep **never merges** and **never relaxes safety** — it inherits every existing invariant.
+
+## 3. Non-goals
+
+- **No merge.** Reaching a clean approval does not merge the PR. The merge decision stays with the human (unchanged hard constraint).
+- **No change to override #2.** The per-increment `--fast` review+auto-address during the build stays exactly as-is (the user chose *augment*, not *replace*). The sweep is a separate, later phase.
+- **No change to the per-increment cadence, drivers, worktree contract, tracks/halt policy, distill, or pre-flight** beyond adding the sweep as a new phase and its rows to the report.
+- **No unbounded loop.** "Until clean approval" is bounded by a max-rounds cap **and** a no-progress guard so an unattended run cannot churn forever (§4.4).
+- **No new review angles / no change to `woostack-review` internals.** The sweep *invokes* full `woostack-review` and `woostack-address-comments --auto` as they exist; it adds no flags to them and changes neither skill.
+- **No concurrency.** The sweep is sequential — one PR at a time, one track at a time — matching the single-session overnight model. No parallel review.
+- **No re-sweep of already-clean lower PRs.** Strictly bottom-up: a PR is driven to clean before the sweep moves up, and a fix never reaches down into an already-cleared lower PR, so lower PRs are never re-reviewed (§4.5).
+- **No relaxation of safety for autonomy.** A restack conflict, an `address-comments` action that would touch the never-auto-approve set (destructive / secret / auth / network / ambiguous), or a hung review is a **blocker → halt-the-track**, never an auto-approval.
+
+## 4. Approach
+
+A new autonomous phase inserted into `woostack-execute-overnight`, reusing the review and address-comments skills wholesale. Five parts.
+
+### 4.1 Where the sweep runs
+
+The sweep is a **per-track post-implementation phase**. For each `## Track:` (a plan with no track headings has one implicit track — `woostack-execute`'s linear behavior), the run already implements that track's increments in order via the unchanged per-increment cadence. **After the last increment of a track is committed (or the track halts mid-implementation at a blocker), and before advancing to the next track, run the review sweep over that track's committed increment PRs.**
+
+For the default single-track plan this is exactly the user's framing: implement the whole stack, then sweep it. If a track halted mid-implementation at increment *k*, the sweep covers the increments that reached a committed PR (1…*k*−1), bottom-up; it does not invent PRs for the not-attempted remainder.
+
+The sweep covers **increment (code) PRs only**. The docs-only **spec+plan base PR** (build step 7, the bottom of the stack, never reviewed or merged by build) is never swept — it is the common base every increment stacks on, not an increment. Standalone (no build) there is no spec+plan PR; the increments branch off the current non-protected HEAD and the sweep covers them all.
+
+### 4.2 The per-PR loop (bottom-up, drive-to-clean)
+
+For each increment PR in the track, from the **base of the stack upward**:
+
+1. **Checkout in a per-PR worktree.** Do **not** edit the primary tree — the [worktree contract](../../woostack-init/references/worktrees.md) §3 makes "the primary checkout stays on the base branch, clean" a hard invariant so parallel runs branch from it. If the increment branch is already checked out in a preserved blocker worktree, reuse that worktree; otherwise add a per-PR worktree that checks out the **existing** increment branch (`git worktree add "$wt" <inc-branch>` — *no* `-b`). All review/address writes happen there; `address-comments`' precondition (clean tree + branch = PR head) holds inside it. Export `WOOSTACK_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"` first (contract §5) so any `address-comments` memory write lands in the primary store. **Teardown on a clean PR; leave the worktree on a blocker** and report its path (contract §2).
+2. **Review** — `woostack-review <PR#> --full` posts a batched GitHub Review. **Every** sweep review — the first and every re-review (step 6) — is forced `--full` (§9-Q10): a complete re-review of the whole PR each round, so a fix that introduces a problem *outside* its own diff is still caught, and inline-mode override #2's per-increment SHA watermark can never silently narrow the pass to an incremental one.
+3. **Clean?** If the PR is **clean** (§4.3) → record clean, teardown the worktree, advance to the next PR.
+4. **Address** — otherwise run [`woostack-address-comments --auto`](../../woostack-address-comments/SKILL.md) from inside the worktree: it reads the PR's unresolved threads, fixes / pushes back / replies / resolves, and pushes (via `woostack-commit --no-pr-update`). Never force-push to a protected base; never merge.
+5. **Restack this track's own stack** — addressing moved this PR's branch tip, so its descendants are based on a stale commit. Restack **only this track's stack** — `gt restack` then `gt submit` scoped to the current stack — and **never `gt sync` or a repo-wide restack** (worktree contract §4/§6: a repo-wide restack collides with any parallel run in flight). This rebases *your own* stacked feature branches — not the prohibited force-push to a protected/shared base. A **restack/rebase conflict is a blocker** (§4.6).
+6. **Re-review** → go to step 2 (another `--full` review of the whole PR against the pushed fix; the §4.3 verdict + explicit zero-threads check gate clean).
+7. Loop until clean (step 3) or a backstop fires (§4.4).
+
+### 4.3 "Clean approval", defined
+
+A PR is **clean** when, after a `woostack-review` pass, **both** hold:
+
+- **No blocking findings** in woostack-review's computed verdict — its `STATUS_LINE` is `APPROVED` or `APPROVED WITH SUGGESTIONS`, **not** `CHANGES REQUESTED`. Read the **verdict**, not the posted GitHub event: overnight increment PRs are **self-authored** (the agent commits as the user), and GitHub forbids an `APPROVE`/`REQUEST_CHANGES` review on your own PR — woostack-review detects `reviewer == author` and **downgrades the posted event to `COMMENT`** while keeping the accurate verdict in `STATUS_LINE` (see woostack-review Troubleshooting). So a literal green "Approved" badge never appears overnight; the signal is the verdict.
+- **Zero unresolved review threads** on the PR, checked explicitly via `gh` (independent of the review event, robust to the self-PR downgrade and to `--full`'s event-floor behavior).
+
+A review whose only findings are non-blocking nits (including `Deferred to <ref>` deferral nits from [[2026-06-09-review-stack-aware]]) with no open threads is clean — the sweep does not chase nits.
+
+**"Clean" means review-clean, not a human merge-approval.** It is woostack-review finding nothing blocking and no open threads — never a human's GitHub approval and never a merge signal. The run still **never merges**; the human owns the merge decision in the morning.
+
+### 4.4 Termination backstop (cap + no-progress)
+
+The loop is bounded two ways, whichever trips first:
+
+- **Max rounds** — at most `max_rounds` review→address rounds per PR. Default **3**, overridable via `.woostack/config.json` key `overnight.review_sweep.max_rounds` (positive integer).
+- **No-progress guard** — stop early if a round makes no headway: an `address-comments --auto` round that resolves **no** thread (every thread `ACCEPT`/`CLARIFY`, nothing fixed) **or** a re-review that returns the **same** set of blocking findings as the previous round.
+
+Hitting either without a clean approval is a **blocker** for that PR → halt policy (§4.6). The chosen cap and the reason for stopping are written to the decision log.
+
+### 4.5 Why bottom-up needs no re-sweep
+
+The sweep clears PR *i* to clean **before** touching PR *i*+1. Addressing PR *i* changes only PR *i*'s branch and forces a restack of *i*+1…*N* (which sit **above** it). It never alters any PR **below** *i*, all of which are already clean. A restacked upper PR's own diff (vs its parent) is unchanged unless the restack conflicts — so reviewing it once, after the restack, is correct. Therefore each PR is reviewed-to-clean exactly once on the way up; lower PRs are never re-swept. (Resolved in §9-Q4.)
+
+### 4.6 Halt policy (reuses tracks & halt, unchanged)
+
+A sweep blocker — cap-without-clean, no-progress, a restack/rebase conflict, or an `address-comments` step that would require touching the never-auto-approve set — **ends that track's remaining sweep**: the blocked PR and every PR above it in that track are recorded `blocked` / `not-attempted-review`, and the run **advances to the next track's sweep** (each track is an independent stack off the common base). For a single-track plan the remainder halts at the blocker — expected and reported, not an error. Work already committed stays committed; nothing is rolled back; nothing is merged.
+
+## 5. Components & data flow
+
+```
+woostack-execute-overnight (per track, after that track's increments are committed)
+  │
+  ├─ for each increment PR, base → top of the track's stack:
+  │     add per-PR worktree on the EXISTING inc branch  (primary tree untouched)
+  │     export WOOSTACK_ROOT → primary store (memory writes)
+  │     round r = 1..max_rounds:
+  │        woostack-review <PR#> --full   (every round — posts GitHub Review)
+  │        clean? (verdict has no blocking findings  AND  0 unresolved threads via gh)
+  │           │     (verdict, not the event — self-PR review downgrades APPROVE→COMMENT)
+  │           └─ yes → teardown worktree, next PR
+  │        woostack-address-comments --auto   (fix/reply/resolve/push; never merge)
+  │        gt restack + gt submit  (THIS stack only — never gt sync / repo-wide)
+  │           └─ conflict → BLOCKER (leave worktree)
+  │        no-progress? (0 threads resolved, or identical blocking findings,
+  │                      or an open CLARIFY thread that can't auto-resolve)
+  │           └─ yes → BLOCKER (leave worktree)
+  │     cap reached, still not clean → BLOCKER (leave worktree)
+  │
+  ├─ BLOCKER → end this track's sweep (remaining PRs: not-attempted-review) → next track
+  │
+  └─ each decision appended to the morning-report decision log
+
+config:  .woostack/config.json → overnight.review_sweep.max_rounds   (default 3)
+
+morning report (.woostack/overnight/YYYY-MM-DD-<plan>.md, gitignored, incremental):
+  + "Review sweep" section: per-PR rounds used, final verdict (clean | blocked), no-progress flag
+  + per-increment table gains the sweep verdict
+  + decision log: every sweep decision + rationale
+  + "Needs you": a blocked PR (cap/no-progress/conflict) surfaces here with its branch
+  + Run summary outcome: a sweep blocker feeds `partial+blockers`
+```
+
+Reused verbatim, no edits: `woostack-review` (full), `woostack-address-comments --auto`, `woostack-commit --no-pr-update` (the push path inside address-comments), and the worktree/clean-tree preconditions. New surface is entirely inside `woostack-execute-overnight/SKILL.md` plus the report template and one config key.
+
+## 6. Error handling
+
+- **Clean on round 1** (no findings, no threads) → no `address-comments`, no restack; record clean, advance. The common happy path costs one review per PR.
+- **Cap reached, still blocking** → blocker → halt the track's sweep (§4.6); the PR is reported `blocked` with rounds used; remaining PRs `not-attempted-review`.
+- **No-progress** (a round resolves nothing, or re-review repeats the same blocking findings) → blocker, same handling; the decision log names which guard tripped so the morning reader knows it wasn't a cap exhaustion.
+- **Open CLARIFY thread** — `address-comments --auto` may judge a thread `CLARIFY` (genuine ambiguity), which it replies to but **leaves open** (`RESOLVE=0`). An open thread fails the §4.3 zero-threads check (and trips woostack-review's open-prior-thread event floor → `CHANGES REQUESTED`), so the PR can never go clean by churning — it surfaces as no-progress → blocker → the human resolves the ambiguity in the morning. This is the correct outcome, not a failure.
+- **Self-authored-PR event downgrade** — the posted GitHub review event is `COMMENT` even on a clean verdict (you cannot `APPROVE` your own PR). The sweep reads woostack-review's `STATUS_LINE` verdict + the `gh` thread count, never the event, so this never masquerades as "not clean" (§4.3).
+- **Restack/rebase conflict** when restacking the PRs above an addressed PR → blocker (a conflict needs human judgment; never auto-resolve overnight). The blocked PR's own fix is already committed/pushed; the conflict is on the *descendants*, which become `not-attempted-review`.
+- **`address-comments` hits the never-auto-approve set** (a fix that is destructive / secret-touching / auth-mutating / network, or a genuinely ambiguous thread) → `address-comments --auto` must not act on it; it is a blocker → halt-the-track. Safety is never relaxed for autonomy.
+- **Track halted mid-implementation** → the sweep still runs over the increments that reached a committed PR in that track (bottom-up), then the run advances to the next track. A track with **zero** committed increments has nothing to sweep.
+- **`woostack-review` itself errors / hangs** (host/API failure) → treated like a verification that cannot complete: a blocker → halt-the-track, logged. No partial "clean" is ever recorded on an errored review.
+- **Bad `overnight.review_sweep.max_rounds`** (non-positive / non-integer) → caught at **pre-flight**: warn, fall back to the default of 3, and note the bad value in the report; do not abort the whole run over a config typo (overnight must be resilient; §9-Q3).
+- **No PRs in a track** (e.g. dry implementation produced no committable change) → the sweep is a no-op for that track; recorded as such.
+
+## 7. Acceptance criteria
+
+> This is a skills-markdown + report-template + config-doc change. There is no app runtime; behaviors are verified by **concrete presence checks** (`grep` / `bash -n` over the edited skill, template, and config docs) confirming each directive is present, internally consistent, and cross-linked — the existing prompt/skill-edit verification pattern (see [[2026-06-09-review-stack-aware]] §8). Each AC names the text that must exist and the property a check asserts.
+
+- **AC1 — Sweep phase exists and is per-track, post-implementation, bottom-up**
+  - happy: `woostack-execute-overnight/SKILL.md` has a dedicated sweep section stating the sweep runs after a track's increments are committed, before the next track, walking the stack base→top; a presence check finds the section heading and the "bottom-up / base of the stack upward" wording.
+  - error: the section states the sweep is *additive* and does **not** remove or alter override #2; a check finds override #2 still present and a cross-reference that the sweep is separate.
+  - edge: a single-track (default, no `## Track:`) plan is named as the common case ("implement the whole stack, then sweep it").
+
+- **AC2 — Per-PR drive-to-clean loop is specified end to end**
+  - happy: the loop lists, in order, per-PR worktree on the existing branch → `woostack-review <PR#> --full` (first review) → clean-check → `woostack-address-comments --auto` → restack-this-stack → re-review; a check finds each step, that the first review is `--full`, and that the work runs in a per-PR worktree (primary tree untouched).
+  - error: the loop never merges, never force-pushes a protected base, and restacks **only this track's stack** (never `gt sync`); a check finds the no-merge wording and the scoped-restack / no-`gt sync` wording.
+  - edge: a round-1-clean PR skips address/restack and tears its worktree down (named happy path).
+
+- **AC3 — "Clean approval" is defined (verdict + threads, not the event)**
+  - happy: the skill defines clean = no blocking findings in the computed verdict (`STATUS_LINE` `APPROVED`/`APPROVED WITH SUGGESTIONS`) **and** zero unresolved threads via `gh`; a check finds both conjuncts and the explicit "read the verdict, not the event" wording.
+  - error: a `CHANGES REQUESTED` verdict or any unresolved thread is explicitly **not** clean; the self-authored-PR `APPROVE`→`COMMENT` event downgrade is named so a downgraded event is never read as "not clean."
+  - edge: nit-only / `Deferred to <ref>` with no open threads is explicitly clean (sweep does not chase nits); "clean" is stated to be review-clean, not a human merge-approval.
+
+- **AC4 — Termination backstop (cap + no-progress) is bounded and configurable**
+  - happy: the skill states a `max_rounds` cap (default 3) **and** a no-progress guard, either of which without a clean approval is a blocker; a check finds both backstops and the `overnight.review_sweep.max_rounds` key with default 3.
+  - error: cap-reached-without-clean and no-progress both map to **blocker → halt-the-track**; a check finds that mapping.
+  - edge: a bad `max_rounds` value is caught at pre-flight, falls back to default 3, and is logged — not fatal (§9-Q3).
+
+- **AC5 — Both drivers; halt policy reused**
+  - happy: the skill states the sweep runs for **both** inline and subagent drivers (subagent's first PR-level review); a check finds the both-drivers wording.
+  - error: a sweep blocker ends only that track's remaining sweep and advances to the next track, reusing the existing tracks/halt policy by reference (not a restated copy); a check finds the cross-reference to Tracks & halt and the never-auto-approve invariant.
+  - edge: restack conflict and never-auto-approve-set are both named blocker sources.
+
+- **AC6 — Morning report + description reflect the sweep**
+  - happy: `references/report-template.md` gains a **Review sweep** section (per-PR rounds + final verdict + no-progress flag) and the per-increment table carries a sweep verdict; checks find both.
+  - error: the decision log is stated to receive every sweep decision; the `Needs you` section surfaces a blocked PR with its branch; a check finds both.
+  - edge: the SKILL frontmatter `description` and the Terminal-state / Hard-constraints sections mention the post-implementation drive-to-clean sweep; a check finds the description string updated and a hard-constraint bullet for the sweep.
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+No app runtime and no script changes — this is markdown skill + template + config-doc edits, so testing follows woostack's established prompt/skill-edit verification pattern ([[2026-06-09-review-stack-aware]] §8): **concrete presence/consistency checks**, no live-LLM test.
+
+- **Presence checks** (`grep`/`bash -n`): each AC's named directive exists in the edited `woostack-execute-overnight/SKILL.md`, `references/report-template.md`, and the config docs — sweep section, bottom-up wording, full-review (no `--fast`), clean-approval definition, both-drivers, cap + no-progress + `overnight.review_sweep.max_rounds`, never-merge, halt-the-track cross-reference, report Review-sweep section, updated `description`.
+- **Cross-token / single-source consistency**: the config key name `overnight.review_sweep.max_rounds` is spelled identically wherever it appears (skill body + any config reference doc); the sweep references `woostack-review`, `woostack-address-comments --auto`, and the Tracks & halt section **by link**, not by restating them — a check greps for the link targets and for the *absence* of a duplicated halt-policy paragraph.
+- **No-regression on override #2**: a check confirms override #2's `--fast` per-increment text is still present and unmodified (the augment invariant).
+- **Manual smoke (documented, not automated)**: optionally dry-run the sweep prose against a small real 2-PR stack to confirm the bottom-up restack ordering reads correctly; this is a reviewer walkthrough, not a CI gate.
+
+## 9. Resolved decisions (hardened)
+
+All forks settled in ideation and hardening. No open questions remain — the spec is hardened.
+
+- **Q1 (decided) — Augment, not replace.** Keep per-increment override #2 (`--fast`, 2-round) during the build **and** add the post-implementation sweep. *Why:* the early per-increment check catches gross errors before later increments stack on them; the sweep is the thorough drive-to-clean at the end. Trade accepted: an inline-mode PR gets a cheap early pass and a full late pass.
+- **Q2 (decided) — Full review on the sweep.** The sweep invokes full `woostack-review`, not `--fast` (override #2 keeps `--fast`). *Why:* the sweep is the final clean-approval gate; thoroughness over speed is right for the last pass an unattended run makes.
+- **Q3 (decided) — Bad-config = fallback-and-log, not refuse-to-start.** A non-positive / non-integer `overnight.review_sweep.max_rounds` is validated at **pre-flight** (the one human touchpoint): warn, use the default 3, and record the bad value in the report — never refuse the whole run. *Why:* "refuse a doomed run" is for plans with critical gaps; a sweep-cap typo isn't doomed (a sane default exists), and execute-overnight's ethos is resolve-or-log-and-continue. Surfacing it at pre-flight (vs silently mid-run) is the cheap belt-and-suspenders.
+- **Q4 (decided) — Strictly bottom-up, no re-sweep.** Each PR is driven to clean before the sweep moves up; a fix only restacks PRs above and never alters a cleared lower PR, so lower PRs are reviewed exactly once (§4.5).
+- **Q5 (decided) — Both drivers.** The sweep is driver-independent (it acts on the GitHub PR), so it runs in inline and subagent mode — giving subagent stacks their first PR-level review.
+- **Q6 (decided) — Per-PR worktree on the existing branch; the primary tree is never edited.** The sweep does **not** check out PR heads on the primary tree (that would violate the [worktree contract](../../woostack-init/references/worktrees.md) §3 hard invariant). It reuses a preserved blocker worktree when the increment branch is already checked out there; otherwise it adds a per-PR worktree on the existing increment branch (`git worktree add "$wt" <inc-branch>`, no `-b`). It works there, and tears down on clean / leaves on a blocker — exactly the contract's lifecycle. A left-behind worktree from a halted track is inert/gitignored and doesn't block claiming a sibling branch in a fresh worktree (§4.2).
+- **Q7 (decided) — Default `max_rounds` = 3**, overridable via `overnight.review_sweep.max_rounds`. Three full-ish rounds per PR is a sane unattended ceiling; the no-progress guard usually trips first.
+- **Q8 (decided) — Restack this stack only; never `gt sync`.** After addressing a PR, restack just this track's own stack (`gt restack` + scoped `gt submit`), never a repo-wide `gt sync`/restack-all — the worktree contract §4/§6 forbids repo-wide restacks while any parallel run is in flight. A restack conflict is a blocker.
+- **Q9 (decided) — Clean = computed verdict + zero threads, not the GitHub event; first review forced `--full`.** Overnight PRs are self-authored, so woostack-review downgrades the posted event `APPROVE`→`COMMENT`; the sweep reads the `STATUS_LINE` verdict + the `gh` unresolved-thread count instead (§4.3). The first review of each PR is forced `--full` so inline-mode override #2's incremental SHA marker can't silently narrow it to a partial pass.
+- **Q10 (decided) — `--full` on every round.** Every sweep review — first pass and every re-review — is `woostack-review --full`, a complete re-review of the whole PR each round. *Why:* maximum thoroughness — a fix that introduces a problem outside its own diff is still caught, which an incremental re-review (fix-commit only) would miss. *Cost accepted:* up to `max_rounds` full reviews × every PR is the dominant new overnight cost; the cap (3) and the no-progress guard bound it, and most PRs go clean in one round.


### PR DESCRIPTION
## Goal

Add an automated review-and-address loop to `woostack-execute-overnight` so an unattended run drives every increment PR in the stack to a clean review after implementation. Today a morning stack is only per-increment fast-checked (inline) or has no PR-level review at all (subagent), leaving the review toil for the human.

## Summary

This PR carries only the spec and plan (docs-only). It is the base of the build stack and is never merged by the build loop.

- New `## Post-implementation review sweep` phase in `woostack-execute-overnight`: per-track, post-implementation, bottom-up drive-to-clean per PR (full `woostack-review` → `woostack-address-comments --auto` → restack-this-stack → re-review).
- Bounded by `overnight.review_sweep.max_rounds` (default 3) plus a no-progress guard; a blocker routes to the existing halt-the-track policy.
- Runs for both drivers (subagent's first PR-level review). Works in a per-PR worktree so the primary tree is never edited; restack is scoped to this stack only, never `gt sync`.
- "Clean" = `woostack-review`'s computed verdict (no blocking findings) plus zero unresolved threads, reading the verdict not the GitHub event (self-authored overnight PRs downgrade `APPROVE`→`COMMENT`). Never merges.
- `references/report-template.md` gains a Review-sweep section and a per-increment Sweep column.
- Augment, not replace: per-increment override #2 (`--fast`) is unchanged.

## Test plan

### Manual

**Before merge**

- [ ] Read `.woostack/specs/2026-06-11-overnight-review-sweep.md` (§4 approach, §7 acceptance criteria, §9 resolved decisions) and `.woostack/plans/2026-06-11-overnight-review-sweep.md` (single increment, 4 tasks).
- [ ] Confirm each plan edit-step anchor still matches the live `skills/woostack-execute-overnight/SKILL.md` and `references/report-template.md` (verified during plan harden at lines 89/130/151/3/113/94 and 25/33).
- [ ] Confirm the plan's `grep`/`bash -n` verification commands are valid; the implementation increment runs them as its red→green checks.

Spec: .woostack/specs/2026-06-11-overnight-review-sweep.md
