### PR TITLE
chore(config): update standard OpenAI model to gpt-5.4

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -1,10 +1,10 @@
 {
-  "review": {
-    "metrics": true,
-    "models": {
-      "openai": {
-        "standard": "gpt-5.3-codex-spark"
-      }
-    }
-  }
+	"review": {
+		"metrics": true,
+		"models": {
+			"openai": {
+				"standard": "gpt-5.4"
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Goal

Update the standard OpenAI model to `gpt-5.4` in the project configuration.

## Summary

- Update standard OpenAI model from `gpt-5.3-codex-spark` to `gpt-5.4` in `.woostack/config.json`.

## Test plan

### Manual

**Before merge**

- [ ] Inspect the change in `.woostack/config.json` to verify the `standard` OpenAI model has been updated to `gpt-5.4`.
