### PR TITLE
chore(config): update standard OpenAI model to gpt-5.4-mini

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -3,7 +3,7 @@
 		"metrics": true,
 		"models": {
 			"openai": {
-				"standard": "gpt-5.4"
+				"standard": "gpt-5.4-mini"
 			}
 		}
 	}


### PR DESCRIPTION
## Goal

Configure the repository's OpenAI model defaults to use `gpt-5.4-mini` instead of `gpt-5.4`.

## Summary

- Update `openai.standard` model config in `.woostack/config.json` to `"gpt-5.4-mini"`.

## Test plan

### Manual

**Before merge**

- [ ] Verify that `.woostack/config.json` has the correct `openai.standard` model setting.
