### PR TITLE
feat(memory): move recall telemetry to sidecar

### DIFF
--- a/.woostack/plans/2026-06-11-woostack-dream-design-trends.md
+++ b/.woostack/plans/2026-06-11-woostack-dream-design-trends.md
@@ -258,7 +258,7 @@ gt modify -c -m "docs(skills): remove flat memory.md fallback prose across the c
 - Modify: `skills/woostack-init/scripts/lib.sh` (append helpers)
 - Test: `skills/woostack-init/scripts/tests/test-lib.sh`
 
-- [ ] **Step 1: Write failing tests for the new helpers**
+- [x] **Step 1: Write failing tests for the new helpers**
 
 Append to `test-lib.sh` before `finish`:
 
@@ -283,12 +283,12 @@ assert_eq "$(field "$dfd/n.md" name)" "x" "del_field preserves other fields"
 assert_contains "$(note_body "$dfd/n.md")" "body" "del_field preserves body"
 ```
 
-- [ ] **Step 2: Run, confirm fail**
+- [x] **Step 2: Run, confirm fail**
 
 Run: `bash skills/woostack-init/scripts/tests/test-lib.sh`
 Expected: FAIL — `tel_bump: command not found` / `del_field: command not found`.
 
-- [ ] **Step 3: Implement the helpers in `lib.sh`**
+- [x] **Step 3: Implement the helpers in `lib.sh`**
 
 Append:
 
@@ -332,12 +332,12 @@ del_field() {
 }
 ```
 
-- [ ] **Step 4: Run, confirm pass**
+- [x] **Step 4: Run, confirm pass**
 
 Run: `bash skills/woostack-init/scripts/tests/test-lib.sh`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "feat(memory): lib.sh telemetry-sidecar (tel_get/tel_bump) + del_field helpers"
@@ -349,7 +349,7 @@ gt create -m "feat(memory): lib.sh telemetry-sidecar (tel_get/tel_bump) + del_fi
 - Modify: `skills/woostack-init/scripts/recall.sh:67-82`
 - Test: `skills/woostack-init/scripts/tests/test-recall.sh:69-97`
 
-- [ ] **Step 1: Rewrite the telemetry assertions (red)**
+- [x] **Step 1: Rewrite the telemetry assertions (red)**
 
 Replace the stamping assertions (lines 77-85) to read the sidecar via `tel_get` instead of `field … recall_count`:
 
@@ -369,12 +369,12 @@ assert_eq "$(tel_get "$md5" a recall_count)"  "2"          "second run bumps cou
 assert_eq "$(tel_get "$md5" a last_recalled)" "2026-06-03" "second run refreshes last_recalled"
 ```
 
-- [ ] **Step 2: Run, confirm fail**
+- [x] **Step 2: Run, confirm fail**
 
 Run: `bash skills/woostack-init/scripts/tests/test-recall.sh`
 Expected: FAIL — recall still writes `recall_count` into the note via `set_field`; `tel_get` finds no sidecar.
 
-- [ ] **Step 3: Rewrite `stamp_note` to use `tel_bump`**
+- [x] **Step 3: Rewrite `stamp_note` to use `tel_bump`**
 
 Replace lines 67-82 (the `stamp_note` block and its three loops). New `stamp_note`:
 
@@ -394,12 +394,12 @@ while IFS= read -r f; do [ -n "$f" ] && stamp_note "$f"; done < "$globals"
 
 (The read-only-dir best-effort case still holds: `tel_bump` returns non-zero when it can't write the temp file, so the existing "stamp failed" stderr + exit-0 test at lines 87-97 passes unchanged — verify the fixture makes `$MEM_DIR` read-only, not just the note.)
 
-- [ ] **Step 4: Run, confirm pass**
+- [x] **Step 4: Run, confirm pass**
 
 Run: `bash skills/woostack-init/scripts/tests/test-recall.sh`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(memory): recall.sh stamps telemetry to the sidecar, not note frontmatter"
@@ -411,7 +411,7 @@ gt modify -c -m "feat(memory): recall.sh stamps telemetry to the sidecar, not no
 - Modify: `skills/woostack-init/scripts/doctor.sh:85`
 - Test: `skills/woostack-init/scripts/tests/test-doctor.sh:147`
 
-- [ ] **Step 1: Update the "recalled note never dead" fixture (red)**
+- [x] **Step 1: Update the "recalled note never dead" fixture (red)**
 
 In `test-doctor.sh`, the case at line 147 encodes recall via frontmatter (`recall_count: 3`). Move that signal to the sidecar:
 
@@ -422,12 +422,12 @@ OUT="$(WOOSTACK_NOW=2026-06-01 bash "$DIR/../doctor.sh" "$dd2" 2>&1 || true)"
 assert_not_contains "$OUT" "dead note" "a note recalled per the sidecar is never flagged dead"
 ```
 
-- [ ] **Step 2: Run, confirm fail**
+- [x] **Step 2: Run, confirm fail**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: FAIL — doctor reads `recall_count` from frontmatter (now absent) → treats the note as never-recalled → emits "dead note".
 
-- [ ] **Step 3: Read the count from the sidecar in `doctor.sh`**
+- [x] **Step 3: Read the count from the sidecar in `doctor.sh`**
 
 Replace line 85:
 
@@ -441,12 +441,12 @@ with:
 rc="$(tel_get "$MEM_DIR" "$name" recall_count)"; rc="${rc:-0}"
 ```
 
-- [ ] **Step 4: Run, confirm pass**
+- [x] **Step 4: Run, confirm pass**
 
 Run: `bash skills/woostack-init/scripts/tests/test-doctor.sh`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(memory): doctor.sh dead-note check joins recall_count from the sidecar"
@@ -458,11 +458,11 @@ gt modify -c -m "feat(memory): doctor.sh dead-note check joins recall_count from
 - Modify: `skills/woostack-init/references/memory.md` §3 (field table), §8 (dead-note source)
 - One-time data fix: this repo's `.woostack/memory/*.md`
 
-- [ ] **Step 1: Edit the contract**
+- [x] **Step 1: Edit the contract**
 
 §3: remove the `recall_count` and `last_recalled` rows from the note-frontmatter field table; add a short paragraph: telemetry lives in a tool-managed, gitignored `.woostack/memory/.telemetry.tsv` sidecar (`name⇥recall_count⇥last_recalled`), written by `recall.sh`, read by `doctor.sh`; stray copies in note frontmatter are inert. §8: change "reads `recall_count`/`last_recalled` (§3) … stamps … on every selected note" to "stamps the sidecar"; the dead-note check joins the sidecar by name.
 
-- [ ] **Step 2: One-time strip of telemetry frontmatter from this repo's notes**
+- [x] **Step 2: One-time strip of telemetry frontmatter from this repo's notes**
 
 Run (in the primary tree, before Inc C tracks them):
 
@@ -474,12 +474,12 @@ Run (in the primary tree, before Inc C tracks them):
   done )
 ```
 
-- [ ] **Step 3: Verify the strip + contract**
+- [x] **Step 3: Verify the strip + contract**
 
 Run: `grep -lE '^recall_count:|^last_recalled:' .woostack/memory/*.md; grep -nE 'recall_count|last_recalled' skills/woostack-init/references/memory.md`
 Expected: no note files listed (telemetry stripped); the contract mentions the fields only as "sidecar / inert", not as live frontmatter rows.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "docs(memory): contract §3/§8 telemetry → sidecar; strip stale frontmatter"

--- a/skills/woostack-init/references/memory.md
+++ b/skills/woostack-init/references/memory.md
@@ -63,10 +63,7 @@ let [[tanstack-query-retries]] decide. Terse body.
 | `tags` | no | Comma list; informational only in increment A. |
 | `updated` | no | ISO date the note's content was last written. Informational, **and** the age basis for `doctor.sh`'s dead-note check (see §8) — a note without it cannot be aged. |
 | `source` | no | Provenance path (used by the increment-C distill step; empty in A). |
-| `recall_count` | no | **Tool-managed.** Cumulative count of recall runs that loaded this note, written by `recall.sh`. Never hand-edit. Absent ⇒ never recalled. |
-| `last_recalled` | no | **Tool-managed.** ISO date of the most recent recall load, written by `recall.sh`. Never hand-edit. |
-
-`recall_count` and `last_recalled` are **written by tooling, not by hand** — `recall.sh` stamps them (best-effort) on every note it loads. They are the recall-telemetry signal feeding `doctor.sh`'s dead-note check (see §8).
+Recall telemetry lives in a tool-managed, gitignored `.woostack/memory/.telemetry.tsv` sidecar with rows `name<TAB>recall_count<TAB>last_recalled`. `recall.sh` writes it, and `doctor.sh` reads it for the dead-note check (see §8). Stray `recall_count` or `last_recalled` copies in note frontmatter are inert and should be removed.
 
 **Caution:** hook or body text containing a backtick can render as ambiguous Markdown in the derived index line; keep hooks plain text.
 
@@ -183,7 +180,7 @@ The scripts live under `skills/woostack-init/scripts/` relative to the woostack 
 
 - **Orphaned scope:** a note with a non-global `scope:` whose globs match no tracked files in `git ls-files` is flagged as stale. This catches notes scoped to paths that were deleted or moved.
 - **Stale provenance:** a note whose `source:` starts with `.woostack/specs/` or `.woostack/plans/` is expected to point at an authored spec or plan in the current repo. If that file is missing, the note is flagged for review. Other provenance forms, such as `source: pr-165`, are not treated as filesystem paths.
-- **Dead note:** `recall.sh` stamps `recall_count`/`last_recalled` (§3) on every selected note — matched + one-hop linked + global — as a best-effort side effect: a write failure (e.g. a read-only checkout) logs `recall: stamp failed <note>` to stderr but never changes recall's output or exit status. Ephemeral CI clones therefore simply do not accrue telemetry; persistent checkouts do. `doctor.sh` turns that signal into a warning when a note's `updated:` date is older than `WOOSTACK_DEAD_DAYS` (default 90) days and its `recall_count` is absent or 0. `WOOSTACK_NOW` (default `date +%F`) overrides "today" for deterministic runs and tests.
+- **Dead note:** `recall.sh` stamps the sidecar (§3) for every selected note — matched + one-hop linked + global — as a best-effort side effect: a write failure (e.g. a read-only checkout) logs `recall: stamp failed <note>` to stderr but never changes recall's output or exit status. Ephemeral CI clones therefore simply do not accrue telemetry; persistent checkouts do. `doctor.sh` joins the sidecar by note `name` and turns that signal into a warning when a note's `updated:` date is older than `WOOSTACK_DEAD_DAYS` (default 90) days and its sidecar `recall_count` is absent or 0. `WOOSTACK_NOW` (default `date +%F`) overrides "today" for deterministic runs and tests.
 - **Missing provenance:** a note with no `source:` is flagged — the distillation gate (§7) requires provenance on every note.
 - **Non-glob scope:** a note whose `scope:` is non-global and contains no `*` glob (a single literal path, or an all-literal comma list) is flagged as possible trivia. Notes with global scope (`*` or absent) and review-recorded notes (`source:` of `pr-<n>` or `address-comments`, which deliberately scope narrowly) are exempt.
 - **Missing age basis:** a note with no `updated:` field is flagged — it cannot be aged by the dead-note check above, so it is no longer silently skipped. (Both write paths stamp `updated:`; a note without it is anomalous.)

--- a/skills/woostack-init/scripts/doctor.sh
+++ b/skills/woostack-init/scripts/doctor.sh
@@ -81,7 +81,7 @@ for f in "$MEM_DIR"/*.md; do
     upd_e="$(_woo_epoch "$upd" || true)"
     if [ -n "$upd_e" ]; then
       now_e="$(_woo_epoch "$(_woo_now)")"
-      rc="$(field "$f" recall_count)"; rc="${rc:-0}"
+      rc="$(tel_get "$MEM_DIR" "$name" recall_count)"; rc="${rc:-0}"
       case "$rc" in (*[!0-9]*) rc=0 ;; esac
       age=$(( ( now_e - upd_e ) / 86400 ))
       if [ "$age" -gt "${WOOSTACK_DEAD_DAYS:-90}" ] && [ "$rc" -eq 0 ]; then

--- a/skills/woostack-init/scripts/lib.sh
+++ b/skills/woostack-init/scripts/lib.sh
@@ -56,3 +56,41 @@ set_field() {
   ' "$file" > "$tmp" || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$file" || { rm -f "$tmp"; return 1; }
 }
+
+# --- telemetry sidecar: per-clone, gitignored, line-based TSV ---
+# <memdir>/.telemetry.tsv rows: name<TAB>recall_count<TAB>last_recalled
+_tel_file() { printf '%s\n' "$1/.telemetry.tsv"; }
+
+# tel_get <memdir> <name> <recall_count|last_recalled> -> value, empty if absent.
+tel_get() {
+  local f col; f="$(_tel_file "$1")"; [ -f "$f" ] || return 0
+  case "$3" in recall_count) col=2 ;; last_recalled) col=3 ;; *) return 0 ;; esac
+  awk -F'\t' -v n="$2" -v c="$col" '$1==n{print $c; exit}' "$f"
+}
+
+# tel_bump <memdir> <name> <iso-date> — upsert: increment count, set date.
+# Atomic (temp + mv). Returns non-zero without changing the file on write failure.
+tel_bump() {
+  local memdir="$1" name="$2" date="$3" f tmp cur=0
+  f="$(_tel_file "$memdir")"
+  [ -d "$memdir" ] || return 1
+  if [ -f "$f" ]; then
+    cur="$(awk -F'\t' -v n="$name" '$1==n{print $2; exit}' "$f")"; cur="${cur:-0}"
+    case "$cur" in (*[!0-9]*) cur=0 ;; esac
+  fi
+  tmp="$(mktemp "$memdir/.tel.XXXXXX")" || return 1
+  { [ -f "$f" ] && awk -F'\t' -v n="$name" '$1!=n' "$f"
+    printf '%s\t%s\t%s\n' "$name" "$(( cur + 1 ))" "$date"; } > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$f" || { rm -f "$tmp"; return 1; }
+}
+
+# del_field <file> <key> — remove a frontmatter key (atomic). No-op if absent.
+del_field() {
+  local file="$1" key="$2" tmp dir
+  dir="$(dirname "$file")"; tmp="$(mktemp "$dir/.woomem.XXXXXX")" || return 1
+  awk -v key="$key" '
+    /^---$/{fence++; if(fence<=2){print; next}}
+    { if(fence==1 && index($0, key ":")==1) next; print }
+  ' "$file" > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$file" || { rm -f "$tmp"; return 1; }
+}

--- a/skills/woostack-init/scripts/recall.sh
+++ b/skills/woostack-init/scripts/recall.sh
@@ -64,18 +64,13 @@ while IFS= read -r line; do
   [ -n "$line" ] && linked_files+=("$line")
 done < "$linked"
 
-# --- Stamp recall telemetry on every selected note (best-effort). ---
-# Cumulative recall_count + last_recalled. Failures never break recall: they
-# log to stderr and recall still exits 0. Stamps matched + one-hop linked +
-# global notes (each appears in exactly one set, so no double-counting).
+# --- Stamp recall telemetry into the gitignored sidecar (best-effort). ---
+# Cumulative recall_count + last_recalled per note name. Failures never break
+# recall: they log to stderr and recall still exits 0.
 _now="$(_woo_now)"
 stamp_note() {
-  local f="$1" cur next
-  cur="$(field "$f" recall_count || true)"; cur="${cur:-0}"
-  case "$cur" in (*[!0-9]*) cur=0 ;; esac
-  next=$(( cur + 1 ))
-  { set_field "$f" recall_count "$next" && set_field "$f" last_recalled "$_now"; } \
-    || echo "recall: stamp failed $(basename "$f")" >&2
+  tel_bump "$MEM_DIR" "$(field "$1" name || basename "$1" .md)" "$_now" \
+    || echo "recall: stamp failed $(basename "$1")" >&2
 }
 for f in "${matched_files[@]:-}"; do [ -n "${f:-}" ] && stamp_note "$f"; done
 for f in "${linked_files[@]:-}"; do [ -n "${f:-}" ] && stamp_note "$f"; done

--- a/skills/woostack-init/scripts/tests/test-doctor.sh
+++ b/skills/woostack-init/scripts/tests/test-doctor.sh
@@ -144,9 +144,10 @@ assert_exit 0 "$CODE" "dead note is a warning (exit 0)"
 
 # old but recalled → not flagged
 dd2="$(mktemp -d)/m"; mkdir -p "$dd2"
-mk_note "$dd2" old.md $'name: old\ntype: pattern\nscope: *\nupdated: 2026-01-01\nrecall_count: 3' 'body'
+mk_note "$dd2" old.md $'name: old\ntype: pattern\nscope: *\nupdated: 2026-01-01' 'body'
+printf 'old\t3\t2026-05-01\n' > "$dd2/.telemetry.tsv"
 OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd2" 2>&1)"
-assert_not_contains "$OUT" "dead note" "a recalled note is never flagged dead"
+assert_not_contains "$OUT" "dead note" "a note recalled per the sidecar is never flagged dead"
 
 # fresh updated → not flagged
 dd3="$(mktemp -d)/m"; mkdir -p "$dd3"

--- a/skills/woostack-init/scripts/tests/test-lib.sh
+++ b/skills/woostack-init/scripts/tests/test-lib.sh
@@ -45,4 +45,25 @@ assert_exit 1 "$rc" "set_field fails on a note without frontmatter"
 assert_eq "$(cat "$sfd/bad.md")" "no frontmatter" "set_field leaves a malformed note unchanged"
 rm -rf "$sfd"
 
+# --- telemetry sidecar ---
+tmd="$(mktemp -d)"
+tel_bump "$tmd" "alpha" "2026-06-11"
+assert_eq "$(tel_get "$tmd" alpha recall_count)"  "1"          "tel_bump creates row count=1"
+assert_eq "$(tel_get "$tmd" alpha last_recalled)" "2026-06-11" "tel_bump sets date"
+tel_bump "$tmd" "alpha" "2026-06-12"
+assert_eq "$(tel_get "$tmd" alpha recall_count)"  "2"          "tel_bump increments existing row"
+assert_eq "$(tel_get "$tmd" alpha last_recalled)" "2026-06-12" "tel_bump refreshes date"
+assert_eq "$(tel_get "$tmd" missing recall_count)" ""          "tel_get of unknown note is empty"
+rm -rf "$tmd"
+
+# --- del_field ---
+dfd="$(mktemp -d)"; mk_note "$dfd" n.md $'name: x\ntype: pattern\nrecall_count: 3\nlast_recalled: 2026-01-01' 'body'
+del_field "$dfd/n.md" recall_count
+del_field "$dfd/n.md" last_recalled
+assert_eq "$(field "$dfd/n.md" recall_count)"  "" "del_field removes recall_count"
+assert_eq "$(field "$dfd/n.md" last_recalled)" "" "del_field removes last_recalled"
+assert_eq "$(field "$dfd/n.md" name)" "x" "del_field preserves other fields"
+assert_contains "$(note_body "$dfd/n.md")" "body" "del_field preserves body"
+rm -rf "$dfd"
+
 finish

--- a/skills/woostack-init/scripts/tests/test-recall.sh
+++ b/skills/woostack-init/scripts/tests/test-recall.sh
@@ -71,21 +71,22 @@ rm -rf "$woo" "$woo2" "$woo3" "$woo4" "$paths2"
 
 # --- telemetry stamping ---
 woo5="$(mktemp -d)"; md5="$woo5/memory"; mkdir -p "$md5"
-mk_note "$md5" a.md $'name: a\ntype: pattern\nscope: pkg/**'      'A body [[b]]'
+mk_note "$md5" alpha.md $'name: a\ntype: pattern\nscope: pkg/**'  'A body [[b]]'
 mk_note "$md5" b.md $'name: b\ntype: pattern\nscope: zzz/**'      'B linked body'
 mk_note "$md5" g.md $'name: g\ntype: convention\nscope: *'        'G global body'
 p5="$(mktemp)"; printf 'pkg/x.ts\n' > "$p5"
 
 WOOSTACK_NOW=2026-06-02 bash "$RECALL" "$woo5" "$p5" >/dev/null
-assert_eq "$(field "$md5/a.md" recall_count)"  "1"          "matched note stamped count=1"
-assert_eq "$(field "$md5/a.md" last_recalled)" "2026-06-02" "matched note last_recalled stamped"
-assert_eq "$(field "$md5/b.md" recall_count)"  "1"          "one-hop linked note stamped"
-assert_eq "$(field "$md5/g.md" recall_count)"  "1"          "global (scope:*) note stamped"
+assert_eq "$(tel_get "$md5" a recall_count)"  "1"          "matched note stamped count=1"
+assert_eq "$(tel_get "$md5" a last_recalled)" "2026-06-02" "matched note last_recalled stamped"
+assert_eq "$(tel_get "$md5" b recall_count)"  "1"          "one-hop linked note stamped"
+assert_eq "$(tel_get "$md5" g recall_count)"  "1"          "global note stamped"
+assert_eq "$(field "$md5/alpha.md" recall_count)" "" "recall does not write telemetry into note frontmatter"
 
 # second run bumps the cumulative count and refreshes the date
 WOOSTACK_NOW=2026-06-03 bash "$RECALL" "$woo5" "$p5" >/dev/null
-assert_eq "$(field "$md5/a.md" recall_count)"  "2"          "second run bumps count to 2"
-assert_eq "$(field "$md5/a.md" last_recalled)" "2026-06-03" "second run refreshes last_recalled"
+assert_eq "$(tel_get "$md5" a recall_count)"  "2"          "second run bumps count to 2"
+assert_eq "$(tel_get "$md5" a last_recalled)" "2026-06-03" "second run refreshes last_recalled"
 
 # best-effort: a read-only memory dir makes stamping fail, but recall still
 # produces output and exits 0, logging the failure to stderr.


### PR DESCRIPTION
## Goal

Move recall telemetry out of memory note frontmatter so future tracked notes do not churn when recall runs.

## Summary

- Added `.telemetry.tsv` helpers in `lib.sh` plus a `del_field` helper for one-time cleanup.
- Changed `recall.sh` to bump sidecar rows by note name instead of mutating note files.
- Changed `doctor.sh` dead-note checks to join recall counts from the sidecar.
- Updated the memory contract and checked off Increment B in the implementation plan.

## Test plan

### Automated

- [ ] `bash skills/woostack-init/scripts/tests/test-lib.sh` → 27 passed, 0 failed
- [ ] `bash skills/woostack-init/scripts/tests/test-recall.sh` → 27 passed, 0 failed
- [ ] `bash skills/woostack-init/scripts/tests/test-doctor.sh` → 47 passed, 0 failed
- [ ] `bash -n skills/woostack-init/scripts/lib.sh` → passed
- [ ] `bash -n skills/woostack-init/scripts/recall.sh` → passed
- [ ] `bash -n skills/woostack-init/scripts/doctor.sh` → passed

### Manual

**Before merge**

- [ ] Review that note frontmatter no longer receives `recall_count` or `last_recalled`, and `.telemetry.tsv` remains described as gitignored sidecar state.

Spec: .woostack/specs/2026-06-11-woostack-dream-design-trends.md
