### PR TITLE
feat(execute-overnight): add review sweep

### DIFF
--- a/.woostack/plans/2026-06-11-overnight-review-sweep.md
+++ b/.woostack/plans/2026-06-11-overnight-review-sweep.md
@@ -24,12 +24,12 @@ Conventions for this increment:
 **Files:**
 - Modify: `skills/woostack-execute-overnight/SKILL.md` (insert a new section between `## Tracks & halt policy` and `## Morning report`)
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 Run: `grep -c "Post-implementation review sweep" skills/woostack-execute-overnight/SKILL.md`
 Expected: FAIL — prints `0` (section absent).
 
-- [ ] **Step 2: Insert the section**
+- [x] **Step 2: Insert the section**
 
 Insert the following block immediately **before** the `## Morning report` line in `skills/woostack-execute-overnight/SKILL.md`:
 
@@ -111,7 +111,7 @@ back to 3, and is recorded in the report — never a refuse-to-start (a sweep-ca
 plan).
 ```
 
-- [ ] **Step 3: Run the checks, confirm they pass**
+- [x] **Step 3: Run the checks, confirm they pass**
 
 Run:
 ```bash
@@ -125,7 +125,7 @@ grep -q "per-PR worktree" skills/woostack-execute-overnight/SKILL.md && echo "wo
 ```
 Expected: `1`, then `bottom-up: ok`, `full: ok`, `no-gt-sync: ok`, `config-key: ok`, `verdict-not-event: ok`, `worktree: ok`.
 
-- [ ] **Step 4: Confirm placement (between Tracks & halt and Morning report)**
+- [x] **Step 4: Confirm placement (between Tracks & halt and Morning report)**
 
 Run: `grep -n "^## \(Tracks & halt policy\|Post-implementation review sweep\|Morning report\)" skills/woostack-execute-overnight/SKILL.md`
 Expected: the three headings appear in that order (Tracks & halt policy < Post-implementation review sweep < Morning report).
@@ -141,7 +141,7 @@ gt create -m "feat(execute-overnight): post-implementation review sweep section"
 **Files:**
 - Modify: `skills/woostack-execute-overnight/SKILL.md` (override #2 cross-ref, terminal-state, hard-constraints, frontmatter `description`)
 
-- [ ] **Step 1: Write the failing checks**
+- [x] **Step 1: Write the failing checks**
 
 Run:
 ```bash
@@ -150,7 +150,7 @@ grep -c "Drive the stack to clean review" skills/woostack-execute-overnight/SKIL
 ```
 Expected: FAIL — both print `0`.
 
-- [ ] **Step 2a: Cross-ref from override #2**
+- [x] **Step 2a: Cross-ref from override #2**
 
 In the `## Autonomy overrides` item **2. Blocking review**, append a final sentence to the
 **subagent** sub-bullet (the last line of item 2), so the per-increment override points at the new
@@ -171,7 +171,7 @@ to:
    leaves this override unchanged.
 ```
 
-- [ ] **Step 2b: Update Terminal state**
+- [x] **Step 2b: Update Terminal state**
 
 In `## Terminal state`, replace:
 
@@ -190,7 +190,7 @@ increment PRs each driven to a clean review — or partially, with blockers logg
 morning report. Report the path. "Clean" is review-clean, never a merge. **Never merge.**
 ```
 
-- [ ] **Step 2c: Add a Hard-constraints bullet**
+- [x] **Step 2c: Add a Hard-constraints bullet**
 
 In `## Hard constraints`, immediately after the `**Tracks: author-driven, overnight-only.**`
 bullet, insert:
@@ -204,13 +204,13 @@ bullet, insert:
   blocker halts only that track. Both drivers. Never merge.
 ```
 
-- [ ] **Step 2d: Update the frontmatter `description`**
+- [x] **Step 2d: Update the frontmatter `description`**
 
 In the YAML frontmatter `description:` string, find the **exact** clause `drives every increment to a reviewed stack` (verified present on the `description:` line) and insert immediately after it — before the following `, swapping` — this text:
 ` then runs a post-implementation review sweep that drives each increment PR to a clean review (full woostack-review → auto-address → restack → re-review, bounded)`
 so the line reads `...drives every increment to a reviewed stack then runs a post-implementation review sweep that drives each increment PR to a clean review (full woostack-review → auto-address → restack → re-review, bounded), swapping woostack-execute's stop-and-ask gates...` (rest of the string unchanged).
 
-- [ ] **Step 3: Run the checks, confirm they pass**
+- [x] **Step 3: Run the checks, confirm they pass**
 
 Run:
 ```bash
@@ -221,7 +221,7 @@ grep -q "post-implementation review sweep that drives each increment PR to a cle
 ```
 Expected: `override2-xref: ok`, `hard-constraint: ok`, `terminal-state: ok`, `description: ok`.
 
-- [ ] **Step 4: Regression — override #2's `--fast` per-increment text is unchanged**
+- [x] **Step 4: Regression — override #2's `--fast` per-increment text is unchanged**
 
 Run: `grep -q "woostack-review --fast" skills/woostack-execute-overnight/SKILL.md && echo "override2-fast: still present"`
 Expected: `override2-fast: still present` (the augment invariant — sweep did not remove or alter override #2).
@@ -237,12 +237,12 @@ gt modify -c -m "feat(execute-overnight): wire sweep into override #2, terminal 
 **Files:**
 - Modify: `skills/woostack-execute-overnight/references/report-template.md` (per-increment table column + new Review-sweep section + decision-log examples)
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
 
 Run: `grep -c "## Review sweep" skills/woostack-execute-overnight/references/report-template.md`
 Expected: FAIL — prints `0`.
 
-- [ ] **Step 2a: Add a Sweep column to the per-increment table**
+- [x] **Step 2a: Add a Sweep column to the per-increment table**
 
 Replace the per-increment table header + row:
 
@@ -260,7 +260,7 @@ with:
 | {{A}} | {{1}} | {{done / done-with-findings / blocked / not-attempted}} | {{branch / PR URL}} | {{verdict}} | {{0–2}} | {{clean / blocked / not-attempted-review}} |
 ```
 
-- [ ] **Step 2b: Add the Review sweep section**
+- [x] **Step 2b: Add the Review sweep section**
 
 Immediately **after** the per-increment table block and **before** `## Decision log`, insert:
 
@@ -276,7 +276,7 @@ Immediately **after** the per-increment table block and **before** `## Decision 
 | {{A}} | {{#}} | {{r}} | {{clean / blocked / not-attempted-review}} | {{yes / no}} | {{— / cap / no-progress / restack-conflict / unsafe}} |
 ```
 
-- [ ] **Step 2c: Extend the decision-log examples**
+- [x] **Step 2c: Extend the decision-log examples**
 
 In `## Decision log`, replace the example line:
 
@@ -290,7 +290,7 @@ with:
 - {{stamp}} — {{decision (debug fix / auto-address round / sweep review round / sweep PR clean / sweep blocked: cap | no-progress | restack-conflict | unsafe / BLOCKED / blocker recorded / track ended / increment not-attempted) + rationale}}
 ```
 
-- [ ] **Step 3: Run the checks, confirm they pass**
+- [x] **Step 3: Run the checks, confirm they pass**
 
 Run:
 ```bash
@@ -300,7 +300,7 @@ grep -q "sweep review round" skills/woostack-execute-overnight/references/report
 ```
 Expected: `sweep-section: ok`, `sweep-column: ok`, `decision-log: ok`.
 
-- [ ] **Step 4: Confirm Review-sweep sits between Per-increment and Decision log**
+- [x] **Step 4: Confirm Review-sweep sits between Per-increment and Decision log**
 
 Run: `grep -n "^## \(Per-increment\|Review sweep\|Decision log\)" skills/woostack-execute-overnight/references/report-template.md`
 Expected: the three headings in that order (Per-increment < Review sweep < Decision log).
@@ -315,7 +315,7 @@ gt modify -c -m "feat(execute-overnight): report-template Review sweep section +
 
 **Files:** none (verification only)
 
-- [ ] **Step 1: Run the full AC presence-check suite**
+- [x] **Step 1: Run the full AC presence-check suite**
 
 Run:
 ```bash
@@ -336,22 +336,22 @@ grep -q "## Review sweep" "$R" && grep -q "Sweep |" "$R" && grep -q "post-implem
 ```
 Expected: `AC1 ok`, `AC2 ok`, `AC3 ok`, `AC4 ok`, `AC5 ok`, `AC6 ok` (each line prints only if its conjuncts all match).
 
-- [ ] **Step 2: Consistency — config key spelled identically everywhere**
+- [x] **Step 2: Consistency — config key spelled identically everywhere**
 
 Run: `grep -rho "overnight.review_sweep.max_rounds" skills/woostack-execute-overnight/ | sort -u`
 Expected: a single line `overnight.review_sweep.max_rounds` (no spelling drift across the SKILL).
 
-- [ ] **Step 3: Consistency — halt policy referenced by link, not duplicated**
+- [x] **Step 3: Consistency — halt policy referenced by link, not duplicated**
 
 Run: `grep -c "End the current track" skills/woostack-execute-overnight/SKILL.md`
 Expected: `1` — the halt policy is defined once (in `## Tracks & halt policy`); the sweep links to it (`#tracks--halt-policy`) rather than restating it.
 
-- [ ] **Step 4: No broken intra-doc anchors introduced**
+- [x] **Step 4: No broken intra-doc anchors introduced**
 
 Run: `grep -n "#post-implementation-review-sweep\|#tracks--halt-policy" skills/woostack-execute-overnight/SKILL.md`
 Expected: both anchor references resolve to real `## Post-implementation review sweep` / `## Tracks & halt policy` headings (eyeball the heading lines from Task 1 Step 4 / above).
 
-- [ ] **Step 5: Commit (if any verification surfaced a fix; else no-op)**
+- [x] **Step 5: Commit (if any verification surfaced a fix; else no-op)**
 
 ```bash
 # Only if Steps 1–4 revealed a gap you had to patch:
@@ -362,9 +362,9 @@ gt modify -c -m "fix(execute-overnight): close sweep verification gap"
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — every §1–§6 design point maps to a task: sweep phase/placement (Task 1), per-PR loop incl. worktree/full-review/restack-scope/clean-def (Task 1), backstop + config (Task 1), halt reuse (Task 1), override-#2 augment + terminal/constraints/description (Task 2), report template (Task 3).
-- [ ] **AC coverage** — spec §7 AC1–AC6 each map to a presence check in Task 4 Step 1 (plus per-task checks in Tasks 1–3); AC's happy/error/edge conjuncts are encoded in the grep conjunctions.
-- [ ] **No placeholders** — every edit step carries the exact final markdown block and every verify step an exact command + expected output; the only `{{...}}` are inside report-**template** literal content (intended).
-- [ ] **Type consistency** — the config key `overnight.review_sweep.max_rounds`, the anchor `#post-implementation-review-sweep`, the verdict tokens (`clean` / `blocked` / `not-attempted-review`), and `STATUS_LINE` are spelled identically across SKILL, plan, and report-template.
+- [x] **Spec coverage** — every §1–§6 design point maps to a task: sweep phase/placement (Task 1), per-PR loop incl. worktree/full-review/restack-scope/clean-def (Task 1), backstop + config (Task 1), halt reuse (Task 1), override-#2 augment + terminal/constraints/description (Task 2), report template (Task 3).
+- [x] **AC coverage** — spec §7 AC1–AC6 each map to a presence check in Task 4 Step 1 (plus per-task checks in Tasks 1–3); AC's happy/error/edge conjuncts are encoded in the grep conjunctions.
+- [x] **No placeholders** — every edit step carries the exact final markdown block and every verify step an exact command + expected output; the only `{{...}}` are inside report-**template** literal content (intended).
+- [x] **Type consistency** — the config key `overnight.review_sweep.max_rounds`, the anchor `#post-implementation-review-sweep`, the verdict tokens (`clean` / `blocked` / `not-attempted-review`), and `STATUS_LINE` are spelled identically across SKILL, plan, and report-template.
 
 > woostack plan conventions (kept): frontmatter-free; opens with the `**Source:**` line; filename mirrors the spec basename (`2026-06-11-overnight-review-sweep.md`, the spec's date); no required-sub-skill banner; no-runner "failing test" = a concrete `grep`/`bash -n` with exact expected output.

--- a/skills/woostack-execute-overnight/SKILL.md
+++ b/skills/woostack-execute-overnight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-execute-overnight
-description: Use to execute an approved woostack plan UNATTENDED overnight — one autonomous run with no user input after launch that drives every increment to a reviewed stack, swapping woostack-execute's stop-and-ask gates for resolve-or-log-and-continue (woostack-debug on stuck verifications; bounded auto-address on a blocking review; halt-the-track on anything unsafe or ambiguous), honoring optional `## Track:` grouping in the plan (independent, fault-isolated tracks run sequentially), and writing a morning report under .woostack/overnight/ for a human to test in the morning. It is the third choice at woostack-build's execution-handoff gate (Go / Hand off / Run overnight); also usable standalone via /woostack-execute-overnight <plan-path> [--inline|--subagent]. One plan per spec, multiple PRs per plan. Never merges; never relaxes safety for autonomy.
+description: Use to execute an approved woostack plan unattended overnight, with autonomous blocker handling, optional tracks, a post-implementation review sweep that drives each increment PR to a clean review, and a morning report. Never merges.
 ---
 
 # woostack-execute-overnight
@@ -89,6 +89,9 @@ log as it happens**.
    - **subagent**: there is no PR-level review; the per-task spec→quality reviewer loops are the
      bounded review and their **`BLOCKED`** escalation is the terminal outcome → treat it directly
      as a **blocker** → halt policy (the loop already was the retry; no separate auto-address).
+
+   Override #2 is the **per-increment early check** during the build. The stack-wide
+   **drive-to-clean** happens after implementation — see [Post-implementation review sweep](#post-implementation-review-sweep), which is additive and leaves this override unchanged.
 3. **Unsafe or ambiguous plan step** → **safety is never relaxed for autonomy.** A
    destructive / secret-touching / auth-mutating / network step, or a genuinely ambiguous
    instruction, is **never auto-approved** → **blocker** → halt policy.
@@ -112,6 +115,84 @@ increments in order. On a **blocker**:
 - A single-track (default) plan therefore halts the remainder at the blocker — expected and
   reported, not an error.
 
+## Post-implementation review sweep
+
+After a track's increments are all implemented and committed — and **before advancing to the
+next track** — drive that track's stack to a clean review. This is **additive**: the
+per-increment override #2 (the `--fast` blocking-review check during the build) is unchanged;
+the sweep is a separate, thorough pass over the finished stack. It runs for **both drivers**
+(inline and subagent), giving a subagent-built stack its first PR-level review. It **never
+merges**.
+
+A plan with no `## Track:` headings has one implicit track, so the default is exactly: implement
+the whole stack, then sweep it. The sweep covers **increment PRs only** — never the
+docs-only spec+plan base PR. If a track halted mid-implementation, the sweep covers the
+increments that reached a committed PR, bottom-up.
+
+### The per-PR loop (bottom-up, drive-to-clean)
+
+For each increment PR in the track, from the **base of the stack upward**, work in a **per-PR
+worktree** on the existing increment branch. If that branch is already checked out in a preserved
+blocker worktree, reuse it; otherwise set
+`wt="$WOOSTACK_ROOT/.woostack/worktrees/<inc-slug>-sweep"` and run
+`git worktree add "$wt" <inc-branch>` — **no** `-b`. The **primary tree is never edited**, per the
+[worktree contract](../woostack-init/references/worktrees.md) §3. Export
+`WOOSTACK_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"` first (contract §5) so any
+`address-comments` memory write lands in the primary store. Then loop, up to `max_rounds` rounds
+(see Config):
+
+1. **Review** — `woostack-review <PR#> --full`. **Every** round is `--full` (a complete re-review
+   of the whole PR), so a fix that breaks something *outside* its own diff is still caught, and
+   inline-mode override #2's per-increment SHA watermark can never silently narrow the pass to an
+   incremental one.
+2. **Clean?** Clean = woostack-review's computed verdict has **no blocking findings** (`STATUS_LINE`
+   `APPROVED` / `APPROVED WITH SUGGESTIONS`) **and zero unresolved threads** (checked via `gh`).
+   Read the **verdict, not the GitHub event**: overnight increment PRs are self-authored, so
+   woostack-review downgrades the posted event `APPROVE`→`COMMENT` (you cannot approve your own
+   PR). Clean ⇒ teardown the worktree, advance to the next PR. "Clean" is **review-clean, not a
+   human merge-approval** — the run still never merges.
+3. **Address** — otherwise run
+   [`woostack-address-comments --auto`](../woostack-address-comments/SKILL.md) from inside the
+   worktree (its clean-tree + branch=PR-head precondition holds there): it fixes / pushes back /
+   replies / resolves / pushes (via `woostack-commit --no-pr-update`). Never force-push a protected
+   base; never merge.
+4. **Restack this track's own stack** — `gt restack` then `gt submit --stack` scoped to the
+   current stack, so the PRs above rebase onto the new tip and their rebased branches are pushed.
+   **Never `gt sync` or a repo-wide restack** (worktree contract §4/§6: a repo-wide restack
+   collides with any parallel run in flight). A restack/rebase conflict is a **blocker**.
+5. **Re-review** → back to step 1.
+
+Strictly bottom-up: a PR is driven to clean before the sweep moves up, and a fix only restacks the
+PRs **above** it — never a cleared lower PR — so each PR is reviewed exactly once on the way up.
+
+### Termination backstop
+
+The per-PR loop is bounded — **whichever trips first**:
+
+- **Max rounds** — at most `max_rounds` review→address rounds per PR (default **3**; see Config).
+- **No-progress guard** — stop early when a round resolves **no** thread, **or** a re-review returns
+  the **same** blocking findings as the prior round, **or** an `address-comments` `CLARIFY` leaves a
+  thread open (an open thread fails the clean check and can never go clean by churning).
+
+Either, without a clean PR, is a **blocker → halt** (below). The reason is written to the decision
+log.
+
+### Halt (reuses Tracks & halt policy)
+
+A sweep blocker — cap-without-clean, no-progress, a `woostack-review` error/hang, a restack
+conflict, or an `address-comments` step that would touch the never-auto-approve set (destructive /
+secret / auth / network / ambiguous) — **ends that track's remaining sweep** (the blocked PR is
+recorded `blocked`, and every PR above it becomes `not-attempted-review`) and the run **advances to
+the next track**, exactly the existing [Tracks & halt policy](#tracks--halt-policy). Safety is never
+relaxed for autonomy; the blocked PR's worktree is **left in place** for morning inspection.
+
+### Config
+
+`overnight.review_sweep.max_rounds` in `.woostack/config.json` (positive integer, default **3**)
+caps the per-PR rounds. Validated at **pre-flight**: a non-positive / non-integer value warns, falls
+back to 3, and is recorded in the report — never a refuse-to-start (a sweep-cap typo is not a doomed
+plan).
+
 ## Morning report
 
 Written incrementally to `.woostack/overnight/<run-date>-<plan-slug>.md` — the run date
@@ -128,14 +209,16 @@ tree for the review / address-comments clean-tree preconditions. Sections:
 - **Run summary**: plan, driver, start/end, outcome (`clean` / `partial+blockers` /
   `refused-to-start`).
 - **Per-increment table**: status (`done` / `done-with-findings` / `blocked` / `not-attempted`),
-  branch + PR URL, review verdict, auto-address rounds used.
+  branch + PR URL, review verdict, auto-address rounds used, and sweep verdict.
+- **Review sweep**: per-PR rounds used, final sweep verdict, no-progress flag, and blocker reason.
 - **Decision log**: every autonomous decision with its rationale.
 
 ## Terminal state
 
-Stop when every track has either completed or halted at a blocker. The result is a Graphite stack
-(linear, or tree-stacked across tracks) of reviewed / partially-reviewed increment PRs, plus a
-complete morning report. Report the path. **Never merge.**
+Stop when every track has either completed (increments implemented **and** swept to a clean review)
+or halted at a blocker. The result is a Graphite stack (linear, or tree-stacked across tracks) of
+increment PRs each driven to a clean review — or partially, with blockers logged — plus a complete
+morning report. Report the path. "Clean" is review-clean, never a merge. **Never merge.**
 
 ## Gate boundary
 
@@ -156,6 +239,12 @@ an inference. It never merges and never relaxes safety for autonomy.
   auto-approved.
 - **Tracks: author-driven, overnight-only.** Honor `## Track:` headings (default one implicit
   track); a blocker ends only its track. Never force-build on broken work.
+- **Drive the stack to clean review.** After a track's increments are committed, sweep its
+  increment PRs bottom-up — `woostack-review --full` → `woostack-address-comments --auto` → restack
+  **this stack only** (`gt restack`/`gt submit --stack`, never `gt sync`) → re-review — to a clean
+  verdict (no blocking findings, read from `STATUS_LINE` not the self-downgraded event) + zero
+  unresolved threads. Bounded by `overnight.review_sweep.max_rounds` (default 3) + a no-progress
+  guard; a blocker halts only that track. Both drivers. Never merge.
 - **Morning report every run**, incremental and gitignored under `.woostack/overnight/`.
 - **Reuse execute; don't restate it.** Cross-link the cadence, drivers, safety, and memory
   contract.

--- a/skills/woostack-execute-overnight/references/report-template.md
+++ b/skills/woostack-execute-overnight/references/report-template.md
@@ -6,7 +6,7 @@
 
 ## ⚠ Needs you
 
-{{Blockers requiring a human, most important first. "None — clean stack." if there are none.}}
+{{Blockers requiring a human, most important first. For a blocked sweep PR, include the branch and PR URL here. "None — clean stack." if there are none.}}
 
 ### Morning test checklist
 
@@ -22,12 +22,22 @@
 
 ## Per-increment
 
-| Track | Increment | Status | Branch / PR | Review | Auto-address rounds |
+| Track | Increment | Status | Branch / PR | Review | Auto-address rounds | Sweep |
+|---|---|---|---|---|---|---|
+| {{A}} | {{1}} | {{done / done-with-findings / blocked / not-attempted}} | {{branch / PR URL}} | {{verdict}} | {{0–2}} | {{clean / blocked / not-attempted-review}} |
+
+## Review sweep
+
+> Post-implementation drive-to-clean over each track's stack, bottom-up. One row per swept
+> increment PR. "Clean" = no blocking findings (`STATUS_LINE`) + zero unresolved threads; never a
+> merge.
+
+| Track | PR | Rounds (of {{max_rounds}}) | Final verdict | No-progress? | Blocker |
 |---|---|---|---|---|---|
-| {{A}} | {{1}} | {{done / done-with-findings / blocked / not-attempted}} | {{branch / PR URL}} | {{verdict}} | {{0–2}} |
+| {{A}} | {{#}} | {{r}} | {{clean / blocked}} | {{yes / no}} | {{— / cap / no-progress / review-error / restack-conflict / unsafe}} |
 
 ## Decision log
 
 <!-- Appended live, one line per autonomous decision. -->
 
-- {{stamp}} — {{decision (debug fix / auto-address round / BLOCKED / blocker recorded / track ended / increment not-attempted) + rationale}}
+- {{stamp}} — {{decision (debug fix / auto-address round / sweep review round / sweep PR clean / sweep blocked: cap | no-progress | review-error | restack-conflict | unsafe / BLOCKED / blocker recorded / track ended / increment not-attempted) + rationale}}


### PR DESCRIPTION
## Goal

Add the post-implementation review sweep behavior to `woostack-execute-overnight` so overnight runs can drive completed increment PRs to a clean review before moving on.

## Summary

- Adds the review-sweep phase to the overnight executor, including bottom-up per-PR worktrees, full review rounds, auto-address, scoped restack, clean-verdict criteria, bounded termination, and halt behavior.
- Wires the sweep into override #2, terminal state, hard constraints, and the skill description while preserving the existing per-increment `--fast` check.
- Extends the morning report template with a Sweep column, Review sweep table, and sweep decision-log events, and ticks the execution plan checks completed.

## Test plan

### Automated

- [x] `grep -c "Post-implementation review sweep" skills/woostack-execute-overnight/SKILL.md`
- [x] Task 1 section/placement grep checks from `.woostack/plans/2026-06-11-overnight-review-sweep.md`
- [x] Task 2 cross-wire and `woostack-review --fast` regression grep checks
- [x] Task 3 report-template section/column/decision-log grep checks
- [x] Full AC1-AC6 presence-check suite from Task 4
- [x] Config-key spelling check: `grep -rho "overnight.review_sweep.max_rounds" skills/woostack-execute-overnight/ | sort -u`
- [x] Halt-policy duplication check: `grep -c "End the current track" skills/woostack-execute-overnight/SKILL.md`
- [x] Anchor check for `#post-implementation-review-sweep` and `#tracks--halt-policy`

### Manual

**Before merge**

- [ ] Read the new `## Post-implementation review sweep` section for consistency with the spec.
- [ ] Confirm the report template fields are sufficient for morning handoff.

Spec: .woostack/specs/2026-06-11-overnight-review-sweep.md
