### PR TITLE
fix(overnight): stop doubling the date in morning report filenames

### DIFF
--- a/.woostack/fixes/2026-06-12-overnight-report-double-date.md
+++ b/.woostack/fixes/2026-06-12-overnight-report-double-date.md
@@ -1,0 +1,79 @@
+---
+type: fix
+status: in-review
+branch: fix/overnight-report-double-date
+---
+
+# Fix: Overnight reports get a doubled date in their filename
+
+## 1. Root Cause
+
+`woostack-execute-overnight` names its morning report
+`.woostack/overnight/YYYY-MM-DD-<plan-basename>.md` (SKILL.md lines 63 and 115). It
+unconditionally prefixes **today's date** to the **plan basename**.
+
+But the plan basename already starts with a date: `woostack-plan` saves the plan to
+`.woostack/plans/<spec-basename>.md` and that basename is, by contract, the **same
+`YYYY-MM-DD-<slug>`** as the spec (woostack-plan SKILL.md lines 135–136 — "reuse the spec's
+date"). So `<plan-basename>` = `YYYY-MM-DD-<slug>`, and prefixing another `YYYY-MM-DD-`
+produces two dates:
+
+```
+plan basename:   2026-06-12-memory-vault
+report path:     .woostack/overnight/2026-06-12-2026-06-12-memory-vault.md   ← doubled
+```
+
+**Evidence:** the doubled pattern is authored in exactly two places, both in
+`skills/woostack-execute-overnight/SKILL.md`:
+
+- line 63 — the "Open the report" pre-flight step
+- line 115 — the "Morning report" section
+
+`references/report-template.md` is **not** at fault — it uses `{{PLAN_BASENAME}}` as a display
+token in the report body, not as the path. No automated test pins the report filename, so the
+regression went unnoticed.
+
+## 2. Proposed Fix
+
+Change the documented report filename so the date is not doubled. The report is a **per-run**
+artifact, so its filename should be keyed to the **run date** (when the overnight run happened),
+not silently inherit the spec's authored date.
+
+Replace `YYYY-MM-DD-<plan-basename>` at both sites with: the **run date** (`YYYY-MM-DD`, today)
+joined to the plan basename **with any leading `YYYY-MM-DD-` stripped** (conditional — strip only
+when the basename starts with a date, so a hand-authored dateless plan basename still gets a clean
+single run-date prefix). Because the plan basename already begins with the spec's date, stripping
+it before prefixing the run date yields a single, run-keyed date:
+
+```
+spec authored 2026-06-01, run overnight 2026-06-12:
+  plan basename:  2026-06-01-memory-vault
+  report path:    .woostack/overnight/2026-06-12-memory-vault.md   ← single date = run date
+```
+
+Add a one-line parenthetical at the canonical site (line 115) explaining the strip, so the
+convention is self-documenting and the regression can't silently return.
+
+This is a Mode A (skill-collection) edit: the bug lives in the instruction text, so the fix is
+the corrected instruction. No script or template change is required.
+
+## 3. Implementation Plan
+
+No automated harness exercises the report path, and this is a doc-convention change, so the
+TDD-first kernel is satisfied by a **concrete grep red→green** (woostack-tdd's no-runner carve-out)
+rather than a committed test file.
+
+- [x] **Step 1: Red — observe the doubled token**
+  - Run `grep -n "YYYY-MM-DD-<plan-basename>" skills/woostack-execute-overnight/SKILL.md` and
+    confirm it **matches** at both sites (lines 63 and 115). This is the failing/red state.
+- [x] **Step 2: Apply the minimal fix**
+  - Edit `skills/woostack-execute-overnight/SKILL.md` line 63 (pre-flight "Open the report") and
+    line 115 ("Morning report") to use the **run-date + date-stripped-basename** naming. Add the
+    explanatory parenthetical (why the strip exists) at the canonical site (line 115) so the
+    convention is self-documenting and the regression can't silently return.
+- [x] **Step 3: Green — verify**
+  - `grep -rn "YYYY-MM-DD-<plan-basename>" skills/` returns **nothing** (the doubled token is gone
+    everywhere).
+  - Both edited passages name the run date and describe the conditional strip.
+  - Sanity-read for cross-link/wording consistency with `report-template.md` (`{{PLAN_BASENAME}}`
+    display token is unchanged and still correct) and `woostack-plan` SKILL.md §Filename.

--- a/skills/woostack-execute-overnight/SKILL.md
+++ b/skills/woostack-execute-overnight/SKILL.md
@@ -60,7 +60,9 @@ rather than burn the night on a doomed run:
    build, the spec+plan PR base is present (standalone: tracks branch off the current
    non-protected branch HEAD).
 3. **Open the report**: create `.woostack/overnight/` if missing and open
-   `.woostack/overnight/YYYY-MM-DD-<plan-basename>.md` from
+   `.woostack/overnight/<run-date>-<plan-slug>.md` — the run date (`YYYY-MM-DD`, today) plus the
+   plan basename with any leading `YYYY-MM-DD-` stripped (see
+   [Morning report](#morning-report)) — from
    [references/report-template.md](references/report-template.md). Write it **incrementally** so a
    crash still leaves a partial record.
 
@@ -112,7 +114,11 @@ increments in order. On a **blocker**:
 
 ## Morning report
 
-Written incrementally to `.woostack/overnight/YYYY-MM-DD-<plan-basename>.md` from
+Written incrementally to `.woostack/overnight/<run-date>-<plan-slug>.md` — the run date
+(`YYYY-MM-DD`, today) joined to the plan basename **with any leading `YYYY-MM-DD-` stripped** (the
+plan basename already begins with the spec's date, since `woostack-plan` reuses it, so stripping it
+before prefixing the run date keeps the filename a single, run-keyed date instead of doubling it,
+e.g. `2026-06-12-memory-vault.md`, not `2026-06-12-2026-06-12-memory-vault.md`) — from
 [references/report-template.md](references/report-template.md). It is **gitignored** (a per-run
 artifact, like `.woostack/visuals/`), so it never rides into an increment PR and never dirties the
 tree for the review / address-comments clean-tree preconditions. Sections:


### PR DESCRIPTION
## Goal

Overnight morning reports were written to filenames with the date repeated twice (e.g. `2026-06-12-2026-06-12-memory-vault.md`). Fix the naming so each report has a single, run-keyed date.

## Summary

- `woostack-execute-overnight` named its report `.woostack/overnight/YYYY-MM-DD-<plan-basename>.md`, prefixing today's date onto a plan basename that already starts with the spec's date (woostack-plan reuses it) — producing two dates.
- Both sites (the "Open the report" pre-flight and the "Morning report" section) now use `<run-date>-<plan-slug>.md`: the run date joined to the plan basename with any leading `YYYY-MM-DD-` stripped, yielding a single run-keyed date.
- Added a self-documenting parenthetical at the canonical site explaining the strip so the regression cannot silently return; the pre-flight site cross-links to it instead of restating.
- `references/report-template.md` is unchanged — its `{{PLAN_BASENAME}}` is a body display token, not the path.

## Test plan

### Automated

- [x] `grep -rn "YYYY-MM-DD-<plan-basename>" skills/` — returns nothing (doubled token gone repo-wide; red before the edit, green after).

### Manual

**Before merge**

- [ ] Read the diff at `skills/woostack-execute-overnight/SKILL.md` lines 62–66 and ~115–119; confirm both name the run date and describe the conditional strip, and that the worked example shows the single-date result.

Spec: .woostack/fixes/2026-06-12-overnight-report-double-date.md
