### PR TITLE
feat(build): add `ready` phase for hardened-plan ready-for-execution state

### DIFF
--- a/.woostack/fixes/2026-06-12-build-loop-ready-phase.md
+++ b/.woostack/fixes/2026-06-12-build-loop-ready-phase.md
@@ -1,0 +1,159 @@
+---
+type: fix
+status: in-review
+branch: fix/build-loop-ready-phase
+---
+
+# Fix: Build loop has no "plan hardened, ready for execution" status
+
+## 1. Root Cause
+
+The spec frontmatter phase enum is
+`draft → hardened → approved → planning → executing → in-review → done` (+ `abandoned`),
+defined once in
+[`conventions.md`](../../skills/woostack-status/references/conventions.md).
+
+`woostack-build` authors a `status:` transition at each step **except after the plan
+harden**:
+
+| build step | action | status authored |
+|---|---|---|
+| 2 | write spec | `draft` |
+| 3 | harden spec → spec-approval gate | `hardened` → `approved` |
+| 4 | write plan (`woostack-plan`) | `planning` |
+| **6** | **harden the plan** | **— none —** |
+| 7 | commit spec+plan PR | — none — |
+| 8 | execution-handoff gate | — none — |
+| 9 | execute | `executing` → `in-review` |
+
+So from step 4 through step 8 the spec sits at `planning`, whose conventions meaning is
+"plan exists, **0 boxes done**" and whose board next-action is
+`harden plan, then open spec+plan PR` (`status.sh:198`). That single value conflates two
+distinct states:
+
+- **plan just written, not yet hardened** (step 4 output), and
+- **plan hardened, spec+plan PR ready, awaiting execution** (step 6 output).
+
+This is asymmetric with the spec, which earns its own `hardened` value after *its* harden
+(step 3). There is no phase that means "ready for execution," so the board cannot show that
+a plan is done and ready to hand to `woostack-execute`, and `/woostack-status`'s next-action
+keeps telling the user to "harden plan" after it is already hardened.
+
+**Evidence:** `woostack-build/SKILL.md:82-88` (step 6 amends the plan in place, authors no
+status) and `:164-169` (the "Author `status:` through the loop" constraint lists
+`draft`/`hardened`/`approved`/`planning`/`executing`/`in-review` — nothing at step 6).
+
+## 2. Proposed Fix
+
+Insert a new head-state phase **`ready`** between `planning` and `executing`, authored by
+`woostack-build` at the end of **step 6** once the plan harden stops producing questions:
+
+```
+draft → hardened → approved → planning → ready → executing → in-review → done   (+ abandoned)
+```
+
+- `planning` keeps its meaning: plan written, **not yet hardened** (authored at step 4 by
+  `woostack-plan`).
+- `ready` (new): plan **hardened**, 0 boxes done, spec+plan PR may be open, **ready for
+  execution** (authored at step 6 by `woostack-build`).
+- `ready` is a **head state** (pre-`executing`), not part of the execute→review→done band, so
+  it needs **no truth-table row** — the board displays the authored value via
+  `resolve_phase`'s `*) echo "$authored"` fall-through, which already returns any authored
+  head value once it is in `VALID_PHASES`.
+- `ready` **requires a plan** (like `planning`): it is intentionally absent from the
+  `draft|hardened|approved|abandoned` "no plan is OK" exemption at `status.sh:249`, so a
+  `ready` spec with no plan correctly flags.
+
+Scope is the build loop + the status board that reads the enum. `woostack-plan` still authors
+`planning` at write time (correct for standalone `/woostack-plan`); the `planning → ready`
+advance belongs to `woostack-build` step 6. `woostack-fix` does **not** use this enum (fixes
+track via their own fix-file frontmatter), so it is untouched.
+
+### Edit sites (8 across 6 files)
+
+1. `conventions.md:36` — enum string: insert `-> ready` after `planning`.
+2. `conventions.md` phase-enum table (≈41-50) — new row:
+   `| ready | plan hardened, 0 boxes done, ready for execution | 6 |`.
+3. `status.sh:35` — `VALID_PHASES`: add `ready`.
+4. `status.sh:194-205` `next_action` (spec branch) — retarget `planning)` to
+   `harden the plan (woostack-harden)` and add `ready)` →
+   `open spec+plan PR, then execute (woostack-execute)`.
+5. `status.sh:305` — reconcile "status lags" flag group: add `ready` to
+   `draft|hardened|approved|planning`.
+6. `test-status.sh` — update the `planning next-action` assertion (line ~70) to the new
+   planning text, and add a `ready` case (mkspec `ready` + mkplan 0-done) asserting the new
+   `ready` next-action.
+7. `spec-template.md:14` — enum string in the `status:` callout: insert `→ ready`.
+8. `woostack-build/SKILL.md` — step 6 body (set `status: ready` when the plan harden stops)
+   and the "Author `status:` through the loop" constraint (`:165`), and
+   `woostack-commit/SKILL.md:154` enum pipe-list: add `ready`.
+
+`woostack-tdd/SKILL.md:88` ("when `status:` is ≥ `planning`") and `woostack-plan/SKILL.md`
+already subsume `ready` conceptually (`ready` > `planning`, plan exists) — **verify only, no
+edit** unless a cross-link reads more clearly.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Reproduce with a failing test**
+  - In `skills/woostack-status/scripts/tests/test-status.sh`, add a `ready`-phase case:
+    `mkspec` a spec with `status: ready` + `mkplan` a 0-done plan (no branch commits), run
+    status, and `assert_contains "$OUT" "open spec+plan PR, then execute" "ready next-action"`.
+  - Also flip the existing `planning next-action` assertion (≈line 70) to the new planning
+    text `harden the plan`.
+  - Run the suite; confirm both new assertions **fail** first (Red): `ready` is currently an
+    unknown phase (flagged + next-action `set status:`), and `planning` still emits the old
+    text.
+
+- [x] **Step 2: Wire `ready` into the board (`status.sh`)**
+  - `VALID_PHASES` (`:35`): add ` ready ` so it is no longer flagged unknown and
+    `resolve_phase` returns it.
+  - `next_action` (`:194-205`): set `planning)` → `harden the plan (woostack-harden)`; add
+    `ready)` → `open spec+plan PR, then execute (woostack-execute)`.
+  - Reconcile flag (`:305`): add `ready` to `draft|hardened|approved|planning`.
+  - Re-run the suite → Green. Confirm no pre-existing assertion regressed (the
+    `commit-backed planning → executing` derivation at lines 103-111 must still pass —
+    `ready` only changes the authored head value, `resolve_phase`'s commit/PR rules are
+    unchanged).
+
+- [x] **Step 3: Update the enum's documentation sources**
+  - `conventions.md`: enum string (`:36`) + new table row for `ready` (authored at step 6).
+  - `spec-template.md:14`: enum string in the `status:` callout.
+  - `woostack-commit/SKILL.md:154`: enum pipe-list.
+
+- [x] **Step 4: Author the transition in `woostack-build`**
+  - Step 6 body (`:82-88`): after "hardening stops producing new questions", add "set the
+    spec's `status: ready`" (mirroring step 3's `status: hardened`).
+  - "Author `status:` through the loop" constraint (`:165`): add `ready` (step 6) to the
+    listed transitions.
+  - Sanity-check steps 8/9 prose still reads correctly with `ready` preceding `executing`.
+
+- [x] **Step 5: Verification**
+  - `bash skills/woostack-status/scripts/tests/test-status.sh` → all pass.
+  - `grep -rn "planning -> executing\|planning → executing"` across `skills/` returns no
+    stale enum missing `ready`.
+  - `grep -rn '\bready\b' skills/woostack-status skills/woostack-build skills/woostack-commit`
+    confirms every enum source lists `ready`.
+  - Confirm `woostack-tdd:88` / `woostack-plan` need no edit (verify-only).
+
+## 4. Hardening notes (resolved)
+
+- **Board visibility of `ready`.** A `ready` row renders only when no `Spec:`-trailered PR is
+  discovered (`open=0`, `prcount=0`); an open spec+plan PR flips `resolve_phase` to
+  `in-review` and a merged one is counted, so the clean `ready` next-action
+  `open spec+plan PR, then execute (woostack-execute)` is the correct single move. `planning)`
+  trims to `harden the plan (woostack-harden)`.
+- **No `resolve_phase` logic change.** `ready` is returned by the existing
+  `case "$authored" in ... *) echo "$authored"` fall-through; it is deliberately **not** in the
+  `executing|in-review|done` coercion branch, and `ready` + branch commits + 0 boxes stays
+  `ready` (identical to `planning`'s behavior). Adding `ready` to `VALID_PHASES` is the only
+  enablement needed.
+- **`ready` requires a plan.** Kept out of the `draft|hardened|approved|abandoned` no-plan
+  exemption (`status.sh:249`) so a planless `ready` spec still flags `no plan resolves`.
+- **Out of scope (pre-existing):** the spec+plan docs PR carries a `Spec:` trailer, so once
+  discovered the `:305` "status lags — PR already exists" flag fires on `ready` exactly as it
+  already does on `planning` today. This fix preserves that existing behavior rather than
+  changing the docs-PR-counted-as-increment interaction.
+- **Untouched by design:** `woostack-fix`'s own next-action map (fix lifecycle, not this enum),
+  `woostack-harden` / `woostack-plan` (author no `status:` themselves — the caller does),
+  `woostack-tdd:88` (`ready` > `planning`, already subsumed), and README/`action.yml` (do not
+  restate the enum).

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -85,7 +85,11 @@ sits after that PR. So the chain has exactly the three hard gates above.
    Amend the plan markdown in place as answers land. This adds **no approval gate**: harden
    owns none and hands straight back. The chain's last hard stop is the **execution-handoff
    gate (step 8)**, after the spec+plan PR — not a plan-*quality* gate here. Do not turn this
-   harden into a plan-approval gate.
+   harden into a plan-approval gate. When hardening stops producing new questions, set the
+   spec's `status: ready` — the [conventions.md](../woostack-status/references/conventions.md)
+   value for "plan hardened, ready for execution" (mirroring step 3's `hardened`, but for the
+   plan). Plans stay frontmatter-free, so this transition is authored on the **spec**, not the
+   plan. This is a status write, not a gate.
 7. **Commit the spec and plan as their own PR.** Before any implementation, commit the
    `.woostack/` spec and plan via [`woostack-commit`](../woostack-commit/SKILL.md) on a fresh
    Graphite branch and open a PR. This docs-only PR is the **base of the stack** — execution
@@ -162,9 +166,10 @@ sits after that PR. So the chain has exactly the three hard gates above.
 - **Never merge.** build ends on the terminal state (handoff PR, or reviewed stack), nothing
   further.
 - **Author `status:` through the loop.** Set the spec's `status:` at each step — `draft` (step
-  2), `hardened` then `approved` (step 3), `planning` (step 4, authored by woostack-plan); the
-  execute phase advances the `executing`/`in-review` band, which the board also computes from
-  artifacts. The phase enum and the `spec : plan : PRs = 1 : 1 : N` join contracts are defined once in
+  2), `hardened` then `approved` (step 3), `planning` (step 4, authored by woostack-plan),
+  `ready` (step 6, after the plan harden stops); the execute phase advances the
+  `executing`/`in-review` band, which the board also computes from artifacts. The phase enum
+  and the `spec : plan : PRs = 1 : 1 : N` join contracts are defined once in
   [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) —
   link it, never restate it.
 - **One increment per cycle.** Do not let a single build cycle balloon past a reviewable PR.

--- a/skills/woostack-build/references/spec-template.md
+++ b/skills/woostack-build/references/spec-template.md
@@ -11,7 +11,7 @@ links:
 
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
-> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
 
 ## 1. Problem
 

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -151,7 +151,7 @@ For each affected spec/fix, check:
 
 - **1:1 plan** — exactly one plan resolves to it (for specs). (For fixes under `fixes/`, they are self-contained plans and this check is skipped).
 - **`branch:` present** — the frontmatter `branch:` is non-empty and not the literal `unknown`.
-- **`status:` in the enum** — the frontmatter `status:` is one of `draft｜hardened｜approved｜planning｜executing｜in-review｜done｜abandoned`.
+- **`status:` in the enum** — the frontmatter `status:` is one of `draft｜hardened｜approved｜planning｜ready｜executing｜in-review｜done｜abandoned`.
 
 The phase enum and the join contracts are defined once in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) — do not restate them here. If the `woostack-status` skill is not installed, skip this check silently.
 

--- a/skills/woostack-status/references/conventions.md
+++ b/skills/woostack-status/references/conventions.md
@@ -33,7 +33,7 @@ they do not restate these rules (cross-link, do not duplicate).
 
 ## Phase enum (spec frontmatter `status:`)
 
-`draft -> hardened -> approved -> planning -> executing -> in-review -> done`,
+`draft -> hardened -> approved -> planning -> ready -> executing -> in-review -> done`,
 plus the terminal `abandoned`. The build loop authors every transition; the board
 displays the authored value for head states and computes the execute/review/done
 band from artifacts (truth table below).
@@ -43,7 +43,8 @@ band from artifacts (truth table below).
 | draft | spec written, not hardened | 2 |
 | hardened | grilled, awaiting approval gate | 3 |
 | approved | gate cleared, no plan yet | 3 |
-| planning | plan exists, 0 boxes done | 4 |
+| planning | plan written, not yet hardened, 0 boxes done | 4 |
+| ready | plan hardened, 0 boxes done, ready for execution | 6 |
 | executing | branch + commits, plan partial | 9 (execute) |
 | in-review | an increment PR is open | 9 (execute) |
 | done | plan 100% + all PRs merged, or trusted legacy authored `done` with no active branch commits/PR | post-merge |

--- a/skills/woostack-status/scripts/status.sh
+++ b/skills/woostack-status/scripts/status.sh
@@ -32,7 +32,7 @@ fi
 
 FLAGS=""
 SEEN_BRANCHES=""
-VALID_PHASES=" draft hardened approved planning executing in-review done abandoned "
+VALID_PHASES=" draft hardened approved planning ready executing in-review done abandoned "
 
 flag() { FLAGS="${FLAGS}  ! $1"$'\n'; }
 
@@ -195,7 +195,8 @@ next_action() {
     draft)      echo "harden the spec (woostack-harden)" ;;
     hardened)   echo "get spec approval (hard gate)" ;;
     approved)   echo "write the plan (woostack-plan)" ;;
-    planning)   echo "harden plan, then open spec+plan PR" ;;
+    planning)   echo "harden the plan (woostack-harden)" ;;
+    ready)      echo "open spec+plan PR, then execute (woostack-execute)" ;;
     executing)  if [ "$prcount" -gt 0 ]; then echo "finish plan ($done/$total); $merged/$prcount increments shipped";
                 else echo "finish plan ($done/$total) - open first increment PR"; fi ;;
     in-review)  echo "address comments / merge when green" ;;
@@ -302,7 +303,7 @@ for f in "${specs[@]}"; do
   fi
 
   case "$phase" in
-    draft|hardened|approved|planning)
+    draft|hardened|approved|planning|ready)
       [ "$prcount" -gt 0 ] && flag "$name: status lags - phase '$phase' but a PR already exists" ;;
   esac
 

--- a/skills/woostack-status/scripts/tests/test-status.sh
+++ b/skills/woostack-status/scripts/tests/test-status.sh
@@ -67,7 +67,7 @@ mkspec "$p" delta planning feature/delta
 mkplan "$p" delta 2026-06-01-delta.md 3 7
 run_status "$p"
 assert_contains "$OUT" "3/10" "plan progress counted"
-assert_contains "$OUT" "harden plan, then open spec+plan PR" "planning next-action"
+assert_contains "$OUT" "harden the plan" "planning next-action"
 legacy="$(mktemp -d)/.woostack"
 mkspec "$legacy" legacy planning feature/legacy
 mkdir -p "$legacy/plans"
@@ -78,6 +78,27 @@ mkspec "$p" echo planning feature/echo
 run_status "$p"
 assert_contains "$OUT" "echo" "echo row present"
 assert_contains "$OUT" "no plan" "0-plan flagged"
+
+# `ready` = plan hardened, 0 boxes done, ready for execution (build step 6).
+rdy="$(mktemp -d)/.woostack"
+mkspec "$rdy" mike ready feature/mike
+mkplan "$rdy" mike 2026-06-01-mike.md 0 5
+run_status "$rdy"
+assert_contains "$OUT" "ready" "ready phase rendered"
+assert_contains "$OUT" "open spec+plan PR, then execute" "ready next-action"
+assert_not_contains "$OUT" "not a known phase" "ready is a valid phase"
+ready_no_plan="$(mktemp -d)/.woostack"
+mkspec "$ready_no_plan" november ready feature/november
+run_status "$ready_no_plan"
+assert_contains "$OUT" "no plan" "ready without plan flagged"
+ready_pr="$(mktemp -d)/.woostack"
+mkspec "$ready_pr" oscar ready feature/oscar
+mkplan "$ready_pr" oscar 2026-06-01-oscar.md 0 5
+ready_gh="$(mktemp -d)"; mk_fake_gh "$ready_gh"
+export FAKE_GH_JSON='[{"number":310,"state":"OPEN","headRefName":"feature/oscar","author":{"login":"olivia"},"updatedAt":"2026-06-03T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-oscar.md"}]'
+PATH="$ready_gh/bin:$PATH" run_status "$ready_pr"
+assert_contains "$OUT" "status lags" "ready with open PR flagged"
+unset FAKE_GH_JSON
 mkplan "$p" echo 2026-06-01-echo.md 1 1
 cp "$p/plans/2026-06-01-echo.md" "$p/plans/2026-06-02-echo-dup.md"
 run_status "$p"


### PR DESCRIPTION
## Goal

Give the build loop a status for "plan hardened, ready for execution." After the step-6 plan harden, `woostack-build` now advances the spec to a new `ready` phase instead of leaving it at `planning`.

## Summary

The phase enum jumped `planning → executing` with no ready state, so `planning` ("plan written, 0 boxes done") covered both *not-yet-hardened* and *hardened-and-ready*, and `/woostack-status` kept telling the user to "harden plan" after it was hardened.

Inserts `ready` between `planning` and `executing`:

```
draft → hardened → approved → planning → ready → executing → in-review → done   (+ abandoned)
```

- `planning` = plan written, not yet hardened (step 4, woostack-plan)
- `ready` = plan hardened, 0 boxes done, ready for execution (step 6, woostack-build) ← new

`ready` is a head state: displayed via `resolve_phase`'s authored fall-through, needs no truth-table row, and requires a plan (stays out of the no-plan exemption).

**Files:** `conventions.md` (enum + table row), `status.sh` (VALID_PHASES, `next_action`, status-lags flag group), `test-status.sh`, `spec-template.md`, `woostack-commit/SKILL.md`, `woostack-build/SKILL.md` (authoring at step 6 + constraint).

## Test plan

**Automated**
- `bash skills/woostack-status/scripts/tests/test-status.sh` → 62 passed, 0 failed (was 59; +3 for the `ready` case, added Red-first).
- `bash -n skills/woostack-status/scripts/status.sh` → clean.

**Manual**
- `grep` sweeps confirm every enum source lists `ready` and no stale `planning → executing` / old planning next-action text remains.
- Verified verify-only sites (`woostack-tdd` "≥ planning", `woostack-plan`, README/`action.yml`) need no edit.

Spec: .woostack/fixes/2026-06-12-build-loop-ready-phase.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
