### PR TITLE
fix(execute-overnight): sweep cap halts only on blocking findings

### DIFF
--- a/.woostack/fixes/2026-06-12-overnight-sweep-cap-nits.md
+++ b/.woostack/fixes/2026-06-12-overnight-sweep-cap-nits.md
@@ -1,0 +1,115 @@
+---
+type: fix
+status: in-review
+branch: fix/overnight-sweep-cap-nits
+---
+
+# Fix: Overnight review-sweep cap halts on approved-with-nits
+
+## 1. Root Cause
+
+The post-implementation **review sweep** in
+[`skills/woostack-execute-overnight/SKILL.md`](../../skills/woostack-execute-overnight/SKILL.md)
+treats **any not-clean PR at the cap as a blocker**, regardless of *why* it is not clean.
+
+- **"Clean?" (per-PR loop step 2)** = woostack-review verdict has **no blocking findings**
+  (`APPROVED` / `APPROVED WITH SUGGESTIONS`) **AND zero unresolved threads**.
+- **Termination backstop** ends the per-PR loop at `max_rounds` **or** the no-progress guard, then:
+  *"Either, without a clean PR, is a blocker → halt."*
+- **Halt** lists `cap-without-clean` as a sweep blocker → **ends that track's remaining sweep**
+  (blocked PR recorded `blocked`, every PR above → `not-attempted-review`) and advances to the next
+  track. For the default single-track plan, that halts the rest of the stack.
+
+This conflates two end-states at the cap:
+
+1. **Blocking findings still present** (verdict is request-changes) — genuinely unsafe to stack more
+   work on → halt is correct.
+2. **No blocking findings, only unresolved *nit* threads** (verdict `APPROVED` /
+   `APPROVED WITH SUGGESTIONS` + open non-blocking suggestion threads) — safe; the PR is approved.
+   Because "clean" also requires *zero* unresolved threads, a few leftover nits at the cap fail the
+   clean check and trip the **same** halt as a request-changes blocker.
+
+**Evidence:** SKILL.md §"Termination backstop" (`Either, without a clean PR, is a blocker → halt`)
+and §"Halt" (`A sweep blocker — cap-without-clean, …`). Neither branches on the verdict's blocking
+status — only on the binary clean/not-clean. The vocabulary to distinguish them already exists:
+"no blocking findings" (`APPROVED` / `APPROVED WITH SUGGESTIONS`) vs blocking (request-changes), and
+a `done-with-findings` per-increment status is already defined in §"Morning report".
+
+The per-increment early check (**Autonomy override #2**) is **already correct** — it halts only when
+*"Still blocking after the cap"* (keyed to blocking, not to nits) — so this fix is scoped to the
+**sweep**, which is what "continue to the next PR" refers to.
+
+## 2. Proposed Fix
+
+Classify by the **verdict's blocking status**, and treat **below-cap** and **at-cap** differently —
+nits keep the loop running until the cap, and only at the cap do nits let the sweep move on.
+
+**Below the cap (rounds remain):**
+- **Blocking findings** with no progress (a re-review returns the **same blocking findings** as the
+  prior round, or `address-comments` makes no headway on a **blocking** thread) → **blocker → halt**
+  (churning a stuck blocker is futile — unchanged in spirit, but now scoped to *blocking*).
+- **Only nits left** (`APPROVED` / `APPROVED WITH SUGGESTIONS`, open non-blocking threads) → **keep
+  reviewing/addressing** — do **not** let the no-progress guard early-terminate on nits. Spend the
+  remaining rounds trying to clear them, bounded by `max_rounds`.
+
+**At the cap (`max_rounds` reached) without a clean PR:**
+- **Blocking findings remain** (request-changes) → **blocker → halt** that track (unchanged).
+- **Only nits remain** → **not a blocker**: mark the PR `done-with-findings`, record the open nits in
+  the morning report (test checklist / "Needs you" as *address-in-morning*, distinct from a blocker),
+  and **move on to the next PR** (sweep continues upward; track proceeds normally).
+
+Net: the **no-progress guard is re-scoped to blocking findings only** (no early stop on nits), and
+the **`max_rounds` cap** is where nits-only converts to `done-with-findings` + continue rather than a
+halt.
+
+Prose-only edits to `skills/woostack-execute-overnight/SKILL.md` (no code/scripts; this repo has no
+app test runner). Sites:
+
+1. **§"The per-PR loop" — "Strictly bottom-up" closing line** (~L165): a PR moves up when it reaches
+   **clean *or* approved-with-nits-at-cap**, not only clean.
+2. **§"Termination backstop"** (~L170–178): (a) re-scope the **no-progress guard** to **blocking
+   findings** — "resolves no thread" / "same findings" / "`CLARIFY` leaves a thread open" trip an
+   early stop only when the unresolved item is **blocking**; when only nits remain, keep looping to
+   the cap. (b) Replace *"Either, without a clean PR, is a blocker → halt"* with the at-cap split:
+   blocking remains → halt; nits-only → `done-with-findings` + move on.
+3. **§"Halt"** (~L182): scope the `cap-without-clean` / no-progress blocker triggers to **blocking
+   findings still present**; state explicitly that approved-with-nits at the cap is **not** a sweep
+   blocker.
+4. **§"Morning report"** (~L207–211): note that cap-reached-with-only-nits PRs are
+   `done-with-findings`, surfaced in the test checklist as *address nits in the morning*, separate
+   from blockers.
+5. **Hard constraint "Drive the stack to clean review"** (~L244): clarify that hitting the cap with
+   only nits is not a blocker — only blocking findings at the cap halt the track.
+6. **§"Terminal state"** (~L217): a track now **completes** when every PR is clean **or**
+   approved-with-nits-at-cap (no blocking findings remain anywhere); it **halts** only on a blocking
+   blocker. Update the "swept to a clean review **or** halted" dichotomy to admit the
+   `done-with-findings` terminus.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Pin current behavior with a failing concrete check (no-runner verification)**
+  - Add a grep-based assertion (run in the fix's verification step, not a committed test file — this
+    repo ships no test runner) capturing that **after** the fix the SKILL.md:
+    - **no longer** contains the unconditional `without a clean PR, is a blocker` phrasing,
+    - **does** distinguish blocking-vs-nits at the cap (e.g. matches both `done-with-findings`
+      *within the sweep terminus prose* and a "blocking findings" condition on the halt), and
+    - **does** scope the no-progress guard to blocking (below-cap nits keep looping, not an early
+      halt).
+  - Before editing, confirm the assertion **fails** against the current file (the distinguishing
+    prose is absent) — this is the Red step.
+
+- [x] **Step 2: Apply the minimal prose fix**
+  - Edit the **six** sites in `skills/woostack-execute-overnight/SKILL.md` per §2 so the sweep
+    terminus branches on the verdict's blocking status at the **unified** terminus (cap *or*
+    no-progress): request-changes → halt; approved-with-nits → record nits + `done-with-findings` +
+    continue upward.
+  - Keep edits surgical; do not touch Autonomy override #2 (already correct) or the `Config` /
+    `max_rounds` mechanics.
+
+- [x] **Step 3: Verification**
+  - Re-run the Step-1 grep assertion — now **passes** (Green).
+  - Re-read the edited sections end-to-end for internal consistency: §"Terminal state" still holds
+    ("clean or halted"), but the per-track halt no longer fires on nits-at-cap; the
+    `done-with-findings` status is consistent between the sweep prose and the morning-report table.
+  - Confirm no other skill cross-links assume "cap-without-clean ⇒ always blocker"
+    (`grep -rn "cap-without-clean\|without a clean PR" skills/`).

--- a/skills/woostack-execute-overnight/SKILL.md
+++ b/skills/woostack-execute-overnight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-execute-overnight
-description: Use to execute an approved woostack plan unattended overnight, with autonomous blocker handling, optional tracks, a post-implementation review sweep that drives each increment PR to a clean review, and a morning report. Never merges.
+description: Use to execute an approved woostack plan unattended overnight, with autonomous blocker handling, optional tracks, a post-implementation review sweep that clears blocking findings or records approved-with-nits outcomes, and a morning report. Never merges.
 ---
 
 # woostack-execute-overnight
@@ -162,29 +162,44 @@ blocker worktree, reuse it; otherwise set
    collides with any parallel run in flight). A restack/rebase conflict is a **blocker**.
 5. **Re-review** → back to step 1.
 
-Strictly bottom-up: a PR is driven to clean before the sweep moves up, and a fix only restacks the
-PRs **above** it — never a cleared lower PR — so each PR is reviewed exactly once on the way up.
+Strictly bottom-up: a PR is driven to clean — or, at the `max_rounds` cap, to approved-with-only-nits
+(see [Termination backstop](#termination-backstop)) — before the sweep moves up, and a fix only
+restacks the PRs **above** it — never a cleared lower PR — so each PR is reviewed exactly once on the
+way up.
 
 ### Termination backstop
 
 The per-PR loop is bounded — **whichever trips first**:
 
 - **Max rounds** — at most `max_rounds` review→address rounds per PR (default **3**; see Config).
-- **No-progress guard** — stop early when a round resolves **no** thread, **or** a re-review returns
-  the **same** blocking findings as the prior round, **or** an `address-comments` `CLARIFY` leaves a
-  thread open (an open thread fails the clean check and can never go clean by churning).
+- **No-progress guard (blocking only)** — stop early **only while blocking findings remain** with no
+  headway: a re-review returns the **same** blocking findings as the prior round, **or** a round
+  resolves **no blocking** thread, **or** an `address-comments` `CLARIFY` leaves a **blocking** thread
+  open. **Nits never trip this guard** — while only non-blocking nits remain, keep
+  reviewing/addressing them until the `max_rounds` cap (don't early-stop on a stalled nit).
 
-Either, without a clean PR, is a **blocker → halt** (below). The reason is written to the decision
-log.
+At either terminus **without a clean PR**, branch on the verdict (read `STATUS_LINE`, not the
+self-downgraded event):
+
+- **Blocking findings remain** (request-changes) → **blocker → halt** (below).
+- **Only nits remain** (`APPROVED` / `APPROVED WITH SUGGESTIONS`, open non-blocking threads) —
+  reachable only at the `max_rounds` cap, since the guard above never stops on nits → **not a
+  blocker**: mark the PR `done-with-findings`, record the open nits for the morning report, and
+  **move on to the next PR** (the sweep continues upward; the track is not halted).
+
+The reason for any halt is written to the decision log.
 
 ### Halt (reuses Tracks & halt policy)
 
-A sweep blocker — cap-without-clean, no-progress, a `woostack-review` error/hang, a restack
-conflict, or an `address-comments` step that would touch the never-auto-approve set (destructive /
-secret / auth / network / ambiguous) — **ends that track's remaining sweep** (the blocked PR is
-recorded `blocked`, and every PR above it becomes `not-attempted-review`) and the run **advances to
-the next track**, exactly the existing [Tracks & halt policy](#tracks--halt-policy). Safety is never
-relaxed for autonomy; the blocked PR's worktree is **left in place** for morning inspection.
+A sweep blocker — **the cap or no-progress guard reached with blocking findings still present**, a
+`woostack-review` error/hang, a restack conflict, or an `address-comments` step that would touch the
+never-auto-approve set (destructive / secret / auth / network / ambiguous) — **ends that track's
+remaining sweep** (the blocked PR is recorded `blocked`, and every PR above it becomes
+`not-attempted-review`) and the run **advances to the next track**, exactly the existing
+[Tracks & halt policy](#tracks--halt-policy). Reaching the `max_rounds` cap with **only nits** (no
+blocking findings) is **not** a sweep blocker — that PR is `done-with-findings` and the sweep moves
+on. Safety is never relaxed for autonomy; the blocked PR's worktree is **left in place** for morning
+inspection.
 
 ### Config
 
@@ -204,21 +219,24 @@ e.g. `2026-06-12-memory-vault.md`, not `2026-06-12-2026-06-12-memory-vault.md`) 
 artifact, like `.woostack/visuals/`), so it never rides into an increment PR and never dirties the
 tree for the review / address-comments clean-tree preconditions. Sections:
 
-- **Needs you** (top): blockers, and a morning **test checklist** (what to verify, the HEAD branch
-  per track).
-- **Run summary**: plan, driver, start/end, outcome (`clean` / `partial+blockers` /
-  `refused-to-start`).
+- **Needs you** (top): blockers, any **outstanding nits** on `done-with-findings` PRs
+  (approved-with-nits that hit the `max_rounds` cap — to address in the morning, distinct from
+  blockers), and a morning **test checklist** (what to verify, the HEAD branch per track).
+- **Run summary**: plan, driver, start/end, outcome (`clean` / `done-with-findings` /
+  `partial+blockers` / `refused-to-start`).
 - **Per-increment table**: status (`done` / `done-with-findings` / `blocked` / `not-attempted`),
   branch + PR URL, review verdict, auto-address rounds used, and sweep verdict.
-- **Review sweep**: per-PR rounds used, final sweep verdict, no-progress flag, and blocker reason.
+- **Review sweep**: per-PR rounds used, final sweep verdict (`clean` / `done-with-findings` /
+  `blocked`), no-progress flag, and blocker reason.
 - **Decision log**: every autonomous decision with its rationale.
 
 ## Terminal state
 
-Stop when every track has either completed (increments implemented **and** swept to a clean review)
-or halted at a blocker. The result is a Graphite stack (linear, or tree-stacked across tracks) of
-increment PRs each driven to a clean review — or partially, with blockers logged — plus a complete
-morning report. Report the path. "Clean" is review-clean, never a merge. **Never merge.**
+Stop when every track has either completed (increments implemented, then swept until every PR is
+**clean or approved-with-only-nits at the cap** — no blocking findings remain anywhere) or halted at
+a blocking blocker. The result is a Graphite stack (linear, or tree-stacked across tracks) of
+increment PRs each driven to a clean review — or, at the cap, approved with only nits logged for the
+morning — or partially, with blockers logged — plus a complete morning report. Report the path. "Clean" is review-clean, never a merge. **Never merge.**
 
 ## Gate boundary
 
@@ -244,7 +262,9 @@ an inference. It never merges and never relaxes safety for autonomy.
   **this stack only** (`gt restack`/`gt submit --stack`, never `gt sync`) → re-review — to a clean
   verdict (no blocking findings, read from `STATUS_LINE` not the self-downgraded event) + zero
   unresolved threads. Bounded by `overnight.review_sweep.max_rounds` (default 3) + a no-progress
-  guard; a blocker halts only that track. Both drivers. Never merge.
+  guard scoped to **blocking** findings (nits keep looping until the cap, never an early stop); at the
+  cap, **only blocking findings halt** the track — a PR left with **only nits** is `done-with-findings`
+  and the sweep moves on. A blocker halts only that track. Both drivers. Never merge.
 - **Morning report every run**, incremental and gitignored under `.woostack/overnight/`.
 - **Reuse execute; don't restate it.** Cross-link the cadence, drivers, safety, and memory
   contract.

--- a/skills/woostack-execute-overnight/references/report-template.md
+++ b/skills/woostack-execute-overnight/references/report-template.md
@@ -2,11 +2,11 @@
 
 # Overnight run — {{PLAN_BASENAME}}
 
-> Outcome: {{clean / partial+blockers / refused-to-start}} · Driver: {{inline / subagent}} · Started: {{START}} · Ended: {{END}}
+> Outcome: {{clean / done-with-findings / partial+blockers / refused-to-start}} · Driver: {{inline / subagent}} · Started: {{START}} · Ended: {{END}}
 
 ## ⚠ Needs you
 
-{{Blockers requiring a human, most important first. For a blocked sweep PR, include the branch and PR URL here. "None — clean stack." if there are none.}}
+{{Blockers requiring a human, plus outstanding nits from done-with-findings PRs. For a blocked sweep PR, include the branch and PR URL here. Use "None — clean stack." only when there are no blockers or outstanding nits.}}
 
 ### Morning test checklist
 
@@ -24,7 +24,7 @@
 
 | Track | Increment | Status | Branch / PR | Review | Auto-address rounds | Sweep |
 |---|---|---|---|---|---|---|
-| {{A}} | {{1}} | {{done / done-with-findings / blocked / not-attempted}} | {{branch / PR URL}} | {{verdict}} | {{0–2}} | {{clean / blocked / not-attempted-review}} |
+| {{A}} | {{1}} | {{done / done-with-findings / blocked / not-attempted}} | {{branch / PR URL}} | {{verdict}} | {{0–2}} | {{clean / done-with-findings / blocked / not-attempted-review}} |
 
 ## Review sweep
 
@@ -34,10 +34,10 @@
 
 | Track | PR | Rounds (of {{max_rounds}}) | Final verdict | No-progress? | Blocker |
 |---|---|---|---|---|---|
-| {{A}} | {{#}} | {{r}} | {{clean / blocked}} | {{yes / no}} | {{— / cap / no-progress / review-error / restack-conflict / unsafe}} |
+| {{A}} | {{#}} | {{r}} | {{clean / done-with-findings / blocked}} | {{yes / no}} | {{— / nits-at-cap / cap-blocking / no-progress / review-error / restack-conflict / unsafe}} |
 
 ## Decision log
 
 <!-- Appended live, one line per autonomous decision. -->
 
-- {{stamp}} — {{decision (debug fix / auto-address round / sweep review round / sweep PR clean / sweep blocked: cap | no-progress | review-error | restack-conflict | unsafe / BLOCKED / blocker recorded / track ended / increment not-attempted) + rationale}}
+- {{stamp}} — {{decision (debug fix / auto-address round / sweep review round / sweep PR clean / sweep PR done-with-findings: nits-at-cap / sweep blocked: cap-blocking | no-progress | review-error | restack-conflict | unsafe / BLOCKED / blocker recorded / track ended / increment not-attempted) + rationale}}


### PR DESCRIPTION
## Goal

Overnight review sweep should halt a track only on **blocking** (request-changes) findings. A PR approved with only non-blocking **nits** at the `max_rounds` cap should not halt the run — the user addresses leftover nits in the morning review.

## Summary

The sweep's Termination backstop + Halt treated *any* not-clean PR at the cap as a blocker. "Clean" requires no blocking findings **AND** zero unresolved threads, so a PR that's `APPROVED`/`APPROVED WITH SUGGESTIONS` with open nit threads tripped the same track-halt as a real request-changes blocker.

Now the sweep branches on the verdict's blocking status (read from `STATUS_LINE`, not the self-downgraded GitHub event):

- **Below the cap** — nits keep the loop running; the no-progress guard is re-scoped to **blocking** findings only, so only stuck blocking findings stop early.
- **At the cap** — blocking remains → blocker → halt the track (unchanged); only nits remain → mark `done-with-findings`, log the nits in the morning report's "Needs you", and move on to the next PR (sweep continues upward, track not halted).

Prose-only change to `woostack-execute-overnight/SKILL.md`, 6 sites: strictly-bottom-up line, Termination backstop, Halt, Morning report, drive-to-clean hard constraint, Terminal state. Autonomy override #2 (per-increment early check) was already correct (keys on "still blocking") and is untouched. Safety invariants unchanged — approved-with-nits means review found no blocking findings; the never-auto-approve set still halts.

## Test plan

**Automated** — no app test runner in this repo (skill-collection); verified with grep assertions (red → green):
- `cap-without-clean` / unconditional `without a clean PR ... blocker` phrasing removed everywhere under `skills/`.
- `done-with-findings` now appears in the sweep terminus prose (Termination backstop, Halt, drive-to-clean constraint), not only the morning-report table.
- No-progress guard scoped to blocking (`No-progress guard (blocking only)`, `Nits never trip this guard`).
- At-cap blocking-vs-nits split present (`Blocking findings remain` → halt; `Only nits remain` → continue).

**Manual** — read-through of the edited sweep section + Terminal state for internal consistency (`done-with-findings` terminus coherent across sweep prose, morning report, and terminal state).

Spec: `.woostack/fixes/2026-06-12-overnight-sweep-cap-nits.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
