### PR TITLE
docs: Output Discipline for internal comms — spec+plan

### DIFF
--- a/.woostack/plans/2026-06-12-output-discipline.md
+++ b/.woostack/plans/2026-06-12-output-discipline.md
@@ -1,0 +1,516 @@
+**Source:** .woostack/specs/2026-06-12-output-discipline.md
+
+# Native Output Discipline for Internal Comms — Implementation Plan
+
+**Goal:** Add one canonical cross-skill Output Discipline reference for internal comms, dedup the ≤100-char memory rule into it, and wire the four high-frequency channels to it by thin cross-link — without touching user-facing output or the review JSON contract.
+
+**Architecture:** A single new reference `skills/using-woostack/references/output-discipline.md` is the source of truth (sibling of `model-tiers.md`, reached by relative-path cross-link like it). It is created first, then the two spelled-out ≤100-char copies collapse to cross-links (plus a one-line collision pointer in `_header.md`), then one-line pointers are added at the four core channels. ~145 LOC of pure docs → one increment. No app runtime exists, so every "test" is a concrete `grep`/`test` verification with exact expected output.
+
+**Tech Stack:** Markdown skill assets; `grep`/`bash` for verification; Graphite (`gt`) for the stacked PR.
+
+---
+
+## Increment 1: Output Discipline reference + dedup + wire core channels
+
+> One independently shippable PR (~145 LOC, pure docs) on the spec+plan base. Creates the canonical doc, removes the live 2-copy ≤100-char drift, and wires the four high-frequency channels. The doc is cross-linked by the dedup sites and the channel pointers, so it is never orphaned.
+
+### Task 1: Create the canonical Output Discipline reference
+
+**Files:**
+- Create: `skills/using-woostack/references/output-discipline.md`
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `test -f skills/using-woostack/references/output-discipline.md && echo FOUND || echo MISSING`
+Expected: FAIL — prints `MISSING` (file not created yet).
+
+- [ ] **Step 2: Confirm it fails**
+
+Run the command above; confirm output is `MISSING`.
+
+- [ ] **Step 3: Create the file with this exact content**
+
+```markdown
+# Output Discipline (internal comms)
+
+Canonical rules for **internal** woostack communication — subagent→parent handbacks, swarm/worker reports, and memory/log writes. Cross-linked from the channels that emit them; never restated. Sibling of [model-tiers.md](model-tiers.md).
+
+**Governing principle: strip the envelope, never the reasoning.** Terseness applies to the *wrapper prose* — preamble, narration, pleasantries, hedging. It never applies to structured/contract fields or to risk-bearing reasoning.
+
+## Scope
+
+Applies to internal comms only:
+
+- subagent→parent handbacks (implementer, spec/quality reviewers, debug),
+- swarm/worker reports,
+- memory note bodies and log/report writes.
+
+Does **NOT** apply to:
+
+- user-facing replies — including a controller's own inline-mode narration in `woostack-execute --inline`;
+- the review JSON-artifact contract — that is governed by the "Output Discipline (READ FIRST)" section of [woostack-review `_header.md`](../../woostack-review/prompts/_header.md), a different channel.
+
+## Default terse rules
+
+- Drop preamble, narration ("I have completed…", "I went ahead and…"), pleasantries ("sure", "happy to"), and hedging.
+- Use structured, named fields; fragments are fine.
+- Keep code symbols, file paths, line numbers, and error strings **verbatim**.
+- No invented abbreviations — a reader must be able to decode every term.
+
+## Contract fields are verbatim
+
+**Never compress a structured field the parent parses.** The controller's `subagent-driver.md` branches on exact tokens — compressing or renaming them breaks that branching:
+
+- `STATUS:` codes — `DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`
+- `VERDICT:` tokens — `PASS` / `FAIL` / `APPROVED` / `CHANGES_REQUESTED`
+- the named field labels themselves (`CHANGED FILES`, `MISSING`, `EXTRA`, `ISSUES`, …)
+
+Keep these labels and tokens exactly. Terseness applies to the prose *around* the contract, never the contract itself.
+
+## Auto-clarity carve-out
+
+Keep full, clear English for the **content** of:
+
+- security findings,
+- destructive-operation confirmations,
+- root-cause and architecture reasoning,
+- **any reviewer or implementer finding or concern** — the text under `CONCERNS`, `MISSING`, `EXTRA`, `ISSUES`, and the like — because each is reasoning a downstream decision depends on,
+- anything that word order or omission would make ambiguous.
+
+The envelope around these still goes terse (drop the preamble, keep the field label); the reasoning itself never does. *Strip the envelope, never the reasoning.*
+
+## Memory-note bodies
+
+A distilled memory note body is one terse reusable rule: **one line, `<pattern>: <reason>`, ideally ≤100 chars, no preamble or narration.** State the rule and stop — no instance line numbers, no restating the finding. This is the single canonical definition of the rule; the memory contract and the review / address-comments record steps link here instead of restating it.
+```
+
+- [ ] **Step 4: Confirm all five sections + the principle line are present**
+
+Run:
+```bash
+f=skills/using-woostack/references/output-discipline.md
+grep -c '^## Scope$\|^## Default terse rules$\|^## Contract fields are verbatim$\|^## Auto-clarity carve-out$\|^## Memory-note bodies$' "$f"
+grep -q 'strip the envelope, never the reasoning' "$f" && echo PRINCIPLE_OK
+```
+Expected: PASS — first command prints `5`; second prints `PRINCIPLE_OK`.
+
+- [ ] **Step 5: Confirm the carve-out anchor + key tokens resolve as specced**
+
+Run:
+```bash
+f=skills/using-woostack/references/output-discipline.md
+grep -q '^## Auto-clarity carve-out$' "$f" && echo ANCHOR_OK        # → #auto-clarity-carve-out
+grep -q 'STATUS:' "$f" && grep -q 'VERDICT:' "$f" && echo CONTRACT_OK
+grep -q 'CONCERNS' "$f" && grep -q 'ISSUES' "$f" && echo FINDINGS_OK
+```
+Expected: PASS — prints `ANCHOR_OK`, `CONTRACT_OK`, `FINDINGS_OK`. (Covers AC1 edge: contract rule names STATUS/VERDICT; carve-out names findings.)
+
+- [ ] **Step 6: Commit (first commit of the increment)**
+
+```bash
+gt create -m "docs(using-woostack): add canonical Output Discipline reference for internal comms"
+```
+
+### Task 2: Dedup the ≤100-char rule in woostack-review Stage 6
+
+**Files:**
+- Modify: `skills/woostack-review/SKILL.md:489`
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `grep -n 'output-discipline.md' skills/woostack-review/SKILL.md || echo NO_LINK`
+Expected: FAIL — prints `NO_LINK` (no cross-link yet).
+
+- [ ] **Step 2: Confirm it fails**
+
+Run the command above; confirm output is `NO_LINK`.
+
+- [ ] **Step 3: Replace the spelled-out rule at line 489 with a cross-link**
+
+Replace this line:
+```
+3. **Only when the learning is genuinely new**, record one terse reusable rule — one line, `<pattern>: <reason>`, ideally ≤100 chars, no preamble or narration. Write a scoped `.woostack/memory/` note when the scoped store exists; otherwise skip and defer to `/woostack-init`.
+```
+with:
+```
+3. **Only when the learning is genuinely new**, record one terse reusable rule — one line, `<pattern>: <reason>`, per the canonical memory-note-body discipline ([`output-discipline.md`](../using-woostack/references/output-discipline.md#memory-note-bodies)). Write a scoped `.woostack/memory/` note when the scoped store exists; otherwise skip and defer to `/woostack-init`.
+```
+
+- [ ] **Step 4: Confirm the cross-link is present and the spelled-out budget is gone from this line**
+
+Run:
+```bash
+grep -q 'output-discipline.md#memory-note-bodies' skills/woostack-review/SKILL.md && echo LINK_OK
+sed -n '489p' skills/woostack-review/SKILL.md | grep -q '≤100 chars' && echo STILL_SPELLED || echo DEDUP_OK
+```
+Expected: PASS — prints `LINK_OK` then `DEDUP_OK`. (The `≤100 chars` budget no longer appears on this line.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(review): cross-link canonical memory-body rule, drop duplicate ≤100-char copy"
+```
+
+### Task 3: Dedup the ≤100-char rule in woostack-address-comments (two spots)
+
+**Files:**
+- Modify: `skills/woostack-address-comments/prompts/address.md` (Phase 3 ACCEPT, lines 112–114; After-the-phases, lines 146–148)
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `grep -c 'output-discipline.md' skills/woostack-address-comments/prompts/address.md`
+Expected: FAIL — prints `0`.
+
+- [ ] **Step 2: Confirm it fails**
+
+Run the command above; confirm output is `0`.
+
+- [ ] **Step 3a: Replace the Phase 3 ACCEPT copy (lines 112–114)**
+
+Replace this passage:
+```
+an instance**: one line, `<pattern>: <reason>`, ideally ≤100 chars. State the
+  rule and stop — no preamble, no narration, no instance line numbers, no
+  restating the finding. Also stage `memory_scope`: the narrowest glob covering
+```
+with:
+```
+an instance**: one line, `<pattern>: <reason>`, per the canonical
+  memory-note-body discipline
+  ([`output-discipline.md`](../../using-woostack/references/output-discipline.md#memory-note-bodies)).
+  Also stage `memory_scope`: the narrowest glob covering
+```
+
+- [ ] **Step 3b: Replace the After-the-phases copy (lines 146–148)**
+
+Replace this passage:
+```
+   `/woostack-init`. Keep `LEARNING` terse — one line,
+   `<pattern>: <reason>`, ideally ≤100 chars, no filler. Set `MEMORY_SCOPE` to
+   the staged `memory_scope`:
+```
+with:
+```
+   `/woostack-init`. Keep `LEARNING` terse per the canonical memory-note-body
+   discipline ([`output-discipline.md`](../../using-woostack/references/output-discipline.md#memory-note-bodies)).
+   Set `MEMORY_SCOPE` to the staged `memory_scope`:
+```
+
+- [ ] **Step 4: Confirm both copies now cross-link and neither spells out the budget**
+
+Run:
+```bash
+f=skills/woostack-address-comments/prompts/address.md
+[ "$(grep -c 'output-discipline.md#memory-note-bodies' "$f")" = 2 ] && echo LINKS_OK
+grep -q '≤100 chars' "$f" && echo STILL_SPELLED || echo DEDUP_OK
+```
+Expected: PASS — prints `LINKS_OK` then `DEDUP_OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(address-comments): cross-link canonical memory-body rule, drop duplicate copies"
+```
+
+### Task 4: Add the collision pointer to woostack-review `_header.md`
+
+**Files:**
+- Modify: `skills/woostack-review/prompts/_header.md:5` (the `## Output Discipline (READ FIRST)` section)
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `grep -n 'output-discipline.md' skills/woostack-review/prompts/_header.md || echo NO_POINTER`
+Expected: FAIL — prints `NO_POINTER`.
+
+- [ ] **Step 2: Confirm it fails**
+
+Run the command above; confirm output is `NO_POINTER`.
+
+- [ ] **Step 3: Insert a one-line pointer right under the section heading**
+
+After this line:
+```
+## Output Discipline (READ FIRST)
+```
+insert a blank line and then:
+```
+> This section governs the **review JSON artifacts** below. For **prose handbacks** elsewhere in woostack (subagent reports, memory bodies), see the separate [internal-comms Output Discipline](../../using-woostack/references/output-discipline.md) — a different channel with different rules.
+```
+
+- [ ] **Step 4: Confirm the pointer is present and the JSON rules are unchanged**
+
+Run:
+```bash
+f=skills/woostack-review/prompts/_header.md
+grep -q 'internal-comms Output Discipline' "$f" && echo POINTER_OK
+grep -q 'MUST be a valid JSON array' "$f" && echo JSON_RULES_INTACT
+```
+Expected: PASS — prints `POINTER_OK` then `JSON_RULES_INTACT`. (AC4 edge: pointer disambiguates without altering JSON rules.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(review): point _header Output Discipline to the prose internal-comms doc"
+```
+
+### Task 5: Wire the implementer Report-back block
+
+**Files:**
+- Modify: `skills/woostack-execute/prompts/implementer.md:36-41` (the `## Report back (required)` block)
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `grep -q 'output-discipline.md' skills/woostack-execute/prompts/implementer.md && echo HAS_LINK || echo NO_LINK`
+Expected: FAIL — prints `NO_LINK`.
+
+- [ ] **Step 2: Confirm it fails**
+
+Run the command above; confirm output is `NO_LINK`.
+
+- [ ] **Step 3: Add a discipline line to the Report-back block**
+
+Replace this block:
+```
+## Report back (required)
+- STATUS: one of DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
+- CHANGED FILES: the exact paths you created or modified
+- DIFF: your task's diff (or a tight per-change summary)
+- TESTS/VERIFICATION: commands you ran and their result
+- CONCERNS / BLOCKER / MISSING CONTEXT: whenever STATUS is not plain DONE
+```
+with:
+```
+## Report back (required)
+Follow the internal-comms Output Discipline (`skills/using-woostack/references/output-discipline.md`): terse envelope, no preamble/narration. Keep the `STATUS` token **verbatim** (the controller branches on it); write any `CONCERNS` in full clear English (auto-clarity carve-out).
+- STATUS: one of DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED
+- CHANGED FILES: the exact paths you created or modified
+- DIFF: your task's diff (or a tight per-change summary)
+- TESTS/VERIFICATION: commands you ran and their result
+- CONCERNS / BLOCKER / MISSING CONTEXT: whenever STATUS is not plain DONE
+```
+
+- [ ] **Step 4: Confirm the pointer is present AND the STATUS contract survives verbatim (AC7)**
+
+Run:
+```bash
+f=skills/woostack-execute/prompts/implementer.md
+grep -q 'output-discipline.md' "$f" && echo LINK_OK
+grep -q 'STATUS: one of DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED' "$f" && echo STATUS_VERBATIM
+```
+Expected: PASS — prints `LINK_OK` then `STATUS_VERBATIM`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(execute): wire implementer report-back to Output Discipline"
+```
+
+### Task 6: Wire the spec + quality reviewer verdict blocks
+
+**Files:**
+- Modify: `skills/woostack-execute/prompts/spec-reviewer.md:28-32`
+- Modify: `skills/woostack-execute/prompts/quality-reviewer.md:26-29`
+
+- [ ] **Step 1: Write the failing verification**
+
+Run:
+```bash
+grep -lq 'output-discipline.md' skills/woostack-execute/prompts/spec-reviewer.md skills/woostack-execute/prompts/quality-reviewer.md && echo HAS || echo NONE
+```
+Expected: FAIL — prints `NONE`.
+
+- [ ] **Step 2: Confirm it fails**
+
+Run the command above; confirm output is `NONE`.
+
+- [ ] **Step 3a: Add the discipline line to `spec-reviewer.md`**
+
+Replace this block:
+```
+## Report back (required)
+- VERDICT: PASS (spec-compliant, nothing missing, nothing extra) or FAIL.
+- MISSING: <bullets, or "none">
+- EXTRA: <bullets, or "none">
+Quote the spec line each gap maps to. "Close enough" is FAIL.
+```
+with:
+```
+## Report back (required)
+Follow the internal-comms Output Discipline (`skills/using-woostack/references/output-discipline.md`): terse envelope. Keep the `VERDICT` token **verbatim**; write each `MISSING`/`EXTRA` item in full clear English (auto-clarity carve-out).
+- VERDICT: PASS (spec-compliant, nothing missing, nothing extra) or FAIL.
+- MISSING: <bullets, or "none">
+- EXTRA: <bullets, or "none">
+Quote the spec line each gap maps to. "Close enough" is FAIL.
+```
+
+- [ ] **Step 3b: Add the discipline line to `quality-reviewer.md`**
+
+Replace this block:
+```
+## Report back (required)
+- VERDICT: APPROVED or CHANGES_REQUESTED.
+- ISSUES: severity-tagged bullets (Important / Minor), each with a concrete fix; "none" if clean.
+Approve only when no Important issues remain outstanding.
+```
+with:
+```
+## Report back (required)
+Follow the internal-comms Output Discipline (`skills/using-woostack/references/output-discipline.md`): terse envelope. Keep the `VERDICT` token **verbatim**; write each `ISSUES` item in full clear English (auto-clarity carve-out).
+- VERDICT: APPROVED or CHANGES_REQUESTED.
+- ISSUES: severity-tagged bullets (Important / Minor), each with a concrete fix; "none" if clean.
+Approve only when no Important issues remain outstanding.
+```
+
+- [ ] **Step 4: Confirm both pointers present AND both VERDICT contracts survive verbatim (AC7)**
+
+Run:
+```bash
+grep -q 'output-discipline.md' skills/woostack-execute/prompts/spec-reviewer.md && \
+grep -q 'output-discipline.md' skills/woostack-execute/prompts/quality-reviewer.md && echo LINKS_OK
+grep -q 'VERDICT: PASS' skills/woostack-execute/prompts/spec-reviewer.md && \
+grep -q 'VERDICT: APPROVED or CHANGES_REQUESTED' skills/woostack-execute/prompts/quality-reviewer.md && echo VERDICTS_VERBATIM
+```
+Expected: PASS — prints `LINKS_OK` then `VERDICTS_VERBATIM`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(execute): wire reviewer verdict blocks to Output Discipline"
+```
+
+### Task 7: Wire the execute distill step
+
+**Files:**
+- Modify: `skills/woostack-execute/SKILL.md:121-129` (distill step 7)
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `grep -q 'output-discipline.md' skills/woostack-execute/SKILL.md && echo HAS || echo NO_LINK`
+Expected: FAIL — prints `NO_LINK`.
+
+- [ ] **Step 2: Confirm it fails**
+
+Run the command above; confirm output is `NO_LINK`.
+
+- [ ] **Step 3: Append a pointer to the distill step's note-body guidance**
+
+In step 7, immediately after the clause `…stamp `updated:` on every note you write.` add this sentence (same paragraph):
+```
+ Write each note body per the canonical memory-note-body discipline ([`output-discipline.md`](../using-woostack/references/output-discipline.md#memory-note-bodies)).
+```
+
+- [ ] **Step 4: Confirm the pointer is present**
+
+Run: `grep -q 'output-discipline.md#memory-note-bodies' skills/woostack-execute/SKILL.md && echo LINK_OK`
+Expected: PASS — prints `LINK_OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(execute): point distill note bodies at Output Discipline"
+```
+
+### Task 8: Wire the memory contract note-body (§3)
+
+**Files:**
+- Modify: `skills/woostack-init/references/memory.md` (§3 note-format example region, the fence at ~line 50)
+
+- [ ] **Step 1: Write the failing verification**
+
+Run: `grep -q 'output-discipline.md' skills/woostack-init/references/memory.md && echo HAS || echo NO_LINK`
+Expected: FAIL — prints `NO_LINK`.
+
+- [ ] **Step 2: Confirm it fails**
+
+Run the command above; confirm output is `NO_LINK`.
+
+- [ ] **Step 3: Add a one-line pointer under the §3 note-format example**
+
+Immediately after the closing ``` ``` `` fence of the note-format code block (the block ending with `let [[tanstack-query-retries]] decide. Terse body.`) and before the `### Fields` heading, insert (a pure pointer — do **not** restate the ≤100-char budget here, or AC2's single-definition check fails):
+```
+The body follows the canonical memory-note-body discipline: see [`output-discipline.md`](../../using-woostack/references/output-discipline.md#memory-note-bodies).
+```
+
+- [ ] **Step 4: Confirm the pointer is present**
+
+Run: `grep -q 'output-discipline.md#memory-note-bodies' skills/woostack-init/references/memory.md && echo LINK_OK`
+Expected: PASS — prints `LINK_OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "docs(memory): point note-body format at canonical Output Discipline"
+```
+
+### Task 9: Whole-feature consistency verification (AC2, AC3, AC6, AC7)
+
+**Files:** none (read-only assertions over the full change).
+
+- [ ] **Step 1: Single-definition — the ≤100-char budget is spelled out in exactly one file (AC2)**
+
+Run:
+```bash
+grep -rl '≤100 chars' skills/ | sort
+```
+Expected: exactly one line — `skills/using-woostack/references/output-discipline.md`. (Any second path = dedup miss → FAIL.)
+
+- [ ] **Step 2: Core channels are all wired (AC3), no tail channel touched**
+
+Run:
+```bash
+for f in \
+  skills/woostack-execute/prompts/implementer.md \
+  skills/woostack-execute/prompts/spec-reviewer.md \
+  skills/woostack-execute/prompts/quality-reviewer.md \
+  skills/woostack-execute/SKILL.md \
+  skills/woostack-init/references/memory.md; do
+  grep -q 'output-discipline.md' "$f" && echo "OK  $f" || echo "MISS $f"
+done
+# tail channels must NOT be wired:
+for f in skills/woostack-debug/SKILL.md skills/woostack-commit/SKILL.md \
+         skills/woostack-execute-overnight/references/report-template.md; do
+  grep -q 'output-discipline.md' "$f" && echo "CREEP $f" || echo "clean $f"
+done
+```
+Expected: five `OK` lines, zero `MISS`; three `clean` lines, zero `CREEP`. (Address-comments is allowed a link — it's the dedup site, not a tail wiring.)
+
+- [ ] **Step 3: Every cross-link target resolves (AC6)**
+
+Run:
+```bash
+grep -rln 'output-discipline.md' skills/ | while read -r f; do
+  d=$(dirname "$f")
+  for rel in $(grep -oE '\.\.?/[^)]*output-discipline\.md' "$f" | sed 's/#.*//' | sort -u); do
+    tgt="$d/$rel"
+    [ -f "$tgt" ] && echo "RESOLVES $f -> $rel" || echo "DANGLING $f -> $rel"
+  done
+done
+```
+Expected: only `RESOLVES …` lines, zero `DANGLING`.
+
+- [ ] **Step 4: Contract tokens intact post-wiring (AC7)**
+
+Run:
+```bash
+grep -q 'STATUS: one of DONE | DONE_WITH_CONCERNS | NEEDS_CONTEXT | BLOCKED' skills/woostack-execute/prompts/implementer.md && echo STATUS_OK
+grep -q 'VERDICT: PASS' skills/woostack-execute/prompts/spec-reviewer.md && echo SPEC_VERDICT_OK
+grep -q 'VERDICT: APPROVED or CHANGES_REQUESTED' skills/woostack-execute/prompts/quality-reviewer.md && echo QUALITY_VERDICT_OK
+```
+Expected: PASS — prints `STATUS_OK`, `SPEC_VERDICT_OK`, `QUALITY_VERDICT_OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "test(output-discipline): assert dedup, wiring, link resolution, contract integrity"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — §4 canonical doc → Task 1; §4 dedup → Tasks 2–3; §4 collision pointer → Task 4; §4 core-channel wiring → Tasks 5–8; §4 deferred tail channels → asserted untouched in Task 9 Step 2.
+- [ ] **AC coverage** — AC1 → Task 1 Steps 4–5; AC2 → Tasks 2–3 + Task 9 Step 1; AC3 → Tasks 5–8 + Task 9 Step 2; AC4 → Task 4 Step 4 (JSON rules intact) + non-goal (no user-facing edits anywhere); AC5 → satisfied once Tasks 2–3 cross-link the doc (not orphaned) and re-confirmed by Task 9 Step 2; AC6 → Task 9 Step 3; AC7 → Task 5/6 Step 4 + Task 9 Step 4.
+- [ ] **No placeholders** — every step has the exact file, the exact before/after text, and exact verification commands with expected output.
+- [ ] **Type consistency** — the anchor `#memory-note-bodies` and section heading `## Memory-note bodies` match across the doc and all consumer links; `## Auto-clarity carve-out` → `#auto-clarity-carve-out` matches the spec.
+
+> woostack plan conventions: frontmatter-free; opens with the `**Source:**` line; basename mirrors the spec (`2026-06-12-output-discipline`); no required-sub-skill banner; in this runner-less target each "failing test" is a concrete `grep`/`test` verification with exact expected output. One increment (the user collapsed the original two), so the only `gt create` is Task 1; every later task commits with `gt modify -c`.

--- a/.woostack/specs/2026-06-12-output-discipline.md
+++ b/.woostack/specs/2026-06-12-output-discipline.md
@@ -1,0 +1,149 @@
+---
+name: output-discipline
+type: spec
+status: ready
+date: 2026-06-12
+branch: feature/output-discipline
+links:
+---
+
+# Native Output Discipline for Internal Comms — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
+## 1. Problem
+
+Internal communication inside the woostack collection — subagent→parent handbacks, swarm/review workers, and memory/log writes — is reinjected into the controller's context on every subsequent turn. Verbose, preamble-laden output bloats context fast and shortens session lifespan. Today there is **no shared discipline** governing the prose length or fluff of these channels:
+
+- The only named "Output Discipline" section (`woostack-review/prompts/_header.md`) governs **review JSON artifacts only** — it does not reach prose handbacks or memory bodies.
+- The only explicit terseness budget anywhere — the `<pattern>: <reason>`, ≤100-char memory rule — is **copy-pasted in two places** (`woostack-review` Stage 6, `woostack-address-comments` Phase 3 ACCEPT), drifting independently.
+- Several high-frequency channels carry no length/fluff rule at all: `woostack-execute` implementer + spec/quality reviewer handbacks, `woostack-debug` Phase 4 handback, `woostack-init` memory note bodies, `woostack-commit` drafting subagent, `woostack-address-comments` worker `reasoning`/`reply`, `woostack-execute-overnight` decision-log rationale.
+
+There is no single shared reference a skill can cross-link for internal-comm output conventions, so the rules are absent, inconsistent, or duplicated.
+
+## 2. Goal
+
+Add one canonical, cross-skill **Output Discipline** reference that defines a *tiered* terse style for internal comms — default no-fluff, with an explicit auto-clarity carve-out for content that must stay fully clear — and wire the **high-frequency, context-resident channels** to it with a thin one-line cross-link (no restating). Dedup the existing ≤100-char memory rule into the canonical home. Leave user-facing replies and the review JSON-artifact contract untouched.
+
+Scope is deliberately the **risk-adjusted core** (descoped 2026-06-12): the two justifiable wins are (a) killing the live 2-copy drift of the ≤100-char rule, and (b) trimming the channels that actually accumulate in long unattended / subagent-mode runs (implementer handbacks, spec/quality verdicts, memory bodies). Tail channels are deferred (§3) — they can adopt the doc later by cross-link.
+
+The win: lower context bloat on the channels that dominate long runs, one source of truth instead of drift-prone copies, and no loss of clarity where it matters (security, destructive ops, root-cause/architecture reasoning, and any reviewer/implementer finding).
+
+## 3. Non-goals
+
+- **User-facing replies.** The terse discipline governs *internal* comms only. Skills' final replies to the user stay natural and well-structured. **Out of scope entirely** — distinct from the auto-clarity carve-out (§4.3), which is internal content that *is* in scope but exempted from terseness. The controller's own **inline-mode narration** in `woostack-execute --inline` (reviews it performs directly, surfaced to the user) is user-facing and likewise out of scope; the discipline targets cross-agent handbacks and persisted writes (memory/logs/reports), not the controller talking to its user.
+- **The review JSON-artifact contract.** `_header.md`'s existing "Output Discipline" (JSON array shape, crash-guard, escape rules for angle workers) is a different channel and is **not** rewritten — it only gains a one-line pointer to the new doc for prose handbacks.
+- **Full lithic/article-dropping "caveman" style.** Rejected during ideate: the default is structured no-fluff (no preamble/narration/pleasantries, fragments OK, structured fields, length caps), not article-stripping, because parent agents must parse correctness/security content unambiguously.
+- **New tooling / lint enforcement.** No script enforces the discipline; it is prompt-level guidance. (A future lint pass is out of scope here.)
+- **The `status:`/board conventions, model-tiers, memory schema fields.** Unchanged except for the memory *body* discipline pointer.
+- **Tail channels — deferred (descoped 2026-06-12).** The low-frequency / low-payoff channels are **out of scope** for this feature: `woostack-debug` Phase 4 handback, `woostack-commit` drafting subagent, `woostack-address-comments` worker `reasoning`/`reply`, and `woostack-execute-overnight` decision-log rationale. They carry little context-resident weight and add risk surface for marginal savings; the canonical doc exists for them to adopt later by cross-link, but this feature does not wire them. (Note: `woostack-address-comments` is still touched for the ≤100-char **dedup** at Phase 3 ACCEPT — that is part of the dedup win, not tail-channel wiring.)
+
+## 4. Approach
+
+**One canonical shared reference + thin cross-links** (chosen over inlining a block per prompt, which would duplicate rules across ~8 files and drift). Mirrors the repo rule "cross-link, do not duplicate" and the proven `using-woostack/references/model-tiers.md` pattern (one reference, multiple skill consumers).
+
+Create `skills/using-woostack/references/output-discipline.md` — **a single file** with a stable `## Auto-clarity carve-out` heading consumers can deep-link (`output-discipline.md#auto-clarity-carve-out`). Its governing principle, stated up front: **strip the envelope, never the reasoning** — terseness applies to the *wrapper prose* (preamble, narration, pleasantries, hedging), and **never** to structured/contract fields or to risk-bearing reasoning. Contents:
+
+1. **Scope statement** — applies to internal comms (subagent handbacks, swarm/worker reports, memory/log writes); explicitly NOT user-facing replies (incl. inline-mode controller narration), NOT the review JSON-artifact contract.
+2. **Default terse rules** — drop preamble, narration ("I have completed…"), pleasantries, hedging; use structured named fields; fragments OK; keep code symbols, file paths, line numbers, and error strings **verbatim**; no invented abbreviations.
+3. **Contract-field rule (verbatim)** *(mitigation, 2026-06-12)* — **never compress structured/contract fields the parent parses** — `STATUS` codes (`DONE` / `BLOCKED` / `NEEDS_CONTEXT` / `DONE_WITH_CONCERNS`), `VERDICT` tokens (`PASS` / `FAIL` / `APPROVED` / `CHANGES_REQUESTED`), and named field labels the driver branches on — keep them **verbatim**. Terseness applies to the prose *around* the contract, never the contract itself. This protects `subagent-driver.md`'s status-code branching.
+4. **Auto-clarity carve-out** (`#auto-clarity-carve-out`) — keep full, clear English for the *content* of: security findings, destructive-operation confirmations, root-cause + architecture reasoning, and — *generalized (mitigation, 2026-06-12)* — **any reviewer or implementer finding/concern** (`CONCERNS`, `MISSING`, `EXTRA`, `ISSUES`, and the like), since each is reasoning a downstream decision depends on. The envelope around them still goes terse; the finding text itself never does. Also covers anything that word order/omission could make ambiguous.
+5. **Memory-body rule (canonical home)** — the one-line `<pattern>: <reason>`, ≤100 chars, no narration rule, defined **once** here.
+
+Then wire the **core, high-frequency channels** with a single cross-link line each (channel-scoped, no restating the ruleset):
+
+- `woostack-execute/prompts/implementer.md` (Report-back block — envelope terse; `STATUS` verbatim per §4.3; `CONCERNS` content rides the carve-out)
+- `woostack-execute/prompts/spec-reviewer.md`, `quality-reviewer.md` (verdict blocks — `VERDICT` verbatim; `MISSING`/`EXTRA`/`ISSUES` content rides the carve-out)
+- `woostack-execute/SKILL.md` distill step (note body)
+- `woostack-init/references/memory.md` §3 note body
+
+Tail channels (debug Phase 4, commit subagent, address-comments worker fields, overnight decision log) are **deferred** — see §3.
+
+Dedup: `woostack-review/SKILL.md` Stage 6 and `woostack-address-comments` Phase 3 ACCEPT replace their spelled-out ≤100-char rule with a cross-link to the canonical definition. (This is the dedup win — `woostack-address-comments` is touched here only for that, not for tail-channel wiring.) `_header.md`'s existing "Output Discipline" gains one line noting prose-handback discipline lives in the new doc (resolves the name collision; the JSON contract itself is unchanged).
+
+Discovery: follows the `model-tiers.md` precedent — that shared reference lives in `using-woostack/references/` and is **not** indexed in `using-woostack/SKILL.md`; consumers reach it purely by relative-path cross-link. So `output-discipline.md` is "discoverable" by being cross-linked from ≥1 consumer; no new SKILL-index or quick-map entry is required (an optional `using-woostack` mention is fine but not in scope).
+
+## 5. Components & data flow
+
+- **Canonical reference** — `skills/using-woostack/references/output-discipline.md`. New file, single source of truth. Read by consumers via relative path (same mechanism as `model-tiers.md`).
+- **Cross-link sites (core)** — each core consumer adds a pointer at the exact channel where output is specified: implementer Report-back block, spec/quality reviewer verdict blocks, execute distill step, `memory.md` §3 note body. The pointer names the canonical file and the carve-out, and does not restate the rules.
+- **Dedup sites** — the two ≤100-char memory rule copies collapse to cross-links; the canonical definition is the only spelled-out copy.
+- **Collision resolver** — `_header.md` one-line pointer disambiguates "review JSON Output Discipline" vs "prose internal-comm Output Discipline."
+
+Data flow: a subagent/worker reads its prompt → the prompt's cross-link routes it to the canonical rules → it emits terse, structured, carve-out-aware output → the parent reinjects a smaller payload → context lasts longer. No runtime/code path; this is prompt-authoring data flow.
+
+## 6. Error handling
+
+- **Broken cross-link** (target path doesn't resolve) → a consumer cannot find the rules. Mitigation: every cross-link uses a correct relative path verified against the worktree; AC checks all targets resolve.
+- **Residual duplication** (a site restates the ruleset instead of linking, or the ≤100-char rule survives in >1 place) → drift returns. Mitigation: AC asserts the rule is spelled out exactly once and no consumer restates the full ruleset.
+- **Over-compression** (security/root-cause/destructive content gets terse-stripped and becomes ambiguous) → real risk. Mitigation: the auto-clarity carve-out is mandatory and called out at each relevant channel (security findings, debug root-cause, destructive confirmations).
+- **Scope leak** (terse rules bleed into user-facing replies or the review JSON contract) → degrades UX / breaks parsers. Mitigation: explicit non-goals + scope statement; review JSON contract untouched.
+
+## 7. Acceptance criteria
+
+Each AC is a testable behavior → ≥1 plan task. No code runtime here, so "testable" = a verifiable assertion about the authored files.
+
+- **AC1 — Canonical reference exists and is complete**
+  - happy: `skills/using-woostack/references/output-discipline.md` exists and contains all five sections (scope statement, default terse rules, **contract-field verbatim rule**, auto-clarity carve-out, canonical memory-body rule) plus the "strip the envelope, never the reasoning" principle line.
+  - error: a missing section → AC fails; reviewer flags the absent heading.
+  - edge: the carve-out enumerates security findings, destructive confirmations, root-cause/architecture reasoning, **and any reviewer/implementer finding/concern (`CONCERNS`/`MISSING`/`EXTRA`/`ISSUES`)** explicitly (not a vague "be clear when needed"); the contract-field rule names `STATUS`/`VERDICT` tokens as verbatim.
+
+- **AC2 — ≤100-char memory rule defined exactly once**
+  - happy: the `<pattern>: <reason>`, ≤100-char rule is spelled out only in `output-discipline.md`; `woostack-review/SKILL.md` Stage 6 and `woostack-address-comments` Phase 3 ACCEPT cross-link it.
+  - error: the rule still spelled out in a second file → AC fails.
+  - edge: the cross-links preserve the existing behavior (one-line accept-record write) — no semantic change to what gets recorded.
+
+- **AC3 — Every core channel cross-links the canonical doc, none restates it**
+  - happy: each of the four core consumer sites (implementer Report-back, spec-reviewer + quality-reviewer verdict blocks, execute distill, `memory.md` §3) carries a one-line pointer to `output-discipline.md`.
+  - error: a core channel has no pointer, or a channel restates the full ruleset inline → AC fails. A **deferred tail channel** (debug, commit, address-comments worker, overnight log) being wired is scope creep → also fails.
+  - edge: each pointer is channel-scoped and notes the contract-field/carve-out split where it applies (e.g. reviewer verdicts → `VERDICT` verbatim, `ISSUES`/`MISSING`/`EXTRA` content rides the carve-out in full English).
+
+- **AC4 — Scope boundary preserved**
+  - happy: no user-facing reply guidance is made terse; `_header.md`'s JSON-artifact contract is unchanged except for a one-line pointer; the review angle/validator JSON schema is untouched.
+  - error: a user-facing section or the JSON schema is rewritten terse → AC fails.
+  - edge: the `_header.md` pointer disambiguates the two "Output Discipline" usages without altering the JSON rules.
+
+- **AC5 — Not orphaned (cross-linked, per model-tiers precedent)**
+  - happy: `output-discipline.md` is cross-linked from ≥1 consumer (the wiring of AC3), exactly as `model-tiers.md` is reached — no `using-woostack/SKILL.md` index entry is required.
+  - error: the file exists but no skill references it (true orphan) → AC fails.
+  - edge: a `using-woostack` quick-map/index mention is optional, not required for this AC to pass.
+
+- **AC6 — All cross-link targets resolve**
+  - happy: every relative path added (consumer→canonical, canonical→conventions/carve-out anchors) points to a real file.
+  - error: a dangling relative path → AC fails.
+  - edge: paths are correct from each file's own directory depth (prompts/ vs references/ vs SKILL root differ).
+
+- **AC7 — Contract fields stay parseable (mitigation)**
+  - happy: after wiring, `implementer.md` still emits a verbatim `STATUS:` line and `spec-reviewer.md`/`quality-reviewer.md` still emit verbatim `VERDICT:` lines — the `subagent-driver.md` branching tokens are intact; the canonical doc's contract-field rule names them.
+  - error: a wired prompt's cross-link or terse rewording drops/renames a `STATUS`/`VERDICT` token, or removes a label the driver parses → AC fails.
+  - edge: `CONCERNS`/`ISSUES`/`MISSING`/`EXTRA` content is preserved in full English (carve-out), not compressed away — the field stays, only its preamble goes.
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+No application runtime, package scripts, or CI exist for this repo (it is a skill collection). Verification is **doc-consistency review**, performed by the executing agent and the per-increment quality/spec reviewers:
+
+- **Link resolution** — for every cross-link added, confirm the relative target exists from that file's directory (grep/`ls` the resolved path).
+- **Single-definition check** — grep the collection for the ≤100-char rule wording; assert it is spelled out only in `output-discipline.md`.
+- **No-restatement check** — confirm each consumer site links rather than copies the ruleset.
+- **Scope check** — diff-review that no user-facing section and no review JSON schema lines were made terse.
+- **Carve-out presence** — confirm security/destructive/root-cause + finding/concern exemptions appear in the canonical doc and are referenced where those channels live.
+- **Contract-field check (AC7)** — grep the wired prompts; confirm `STATUS:`/`VERDICT:` contract tokens survive verbatim post-wiring and the canonical doc states the verbatim rule.
+
+Fixtures/CI: none. The "harness" is grep + the reviewer reading the diff. Each increment is independently shippable and reviewable as a docs PR.
+
+## 9. Open questions
+
+All resolved in harden + scope review (2026-06-12):
+
+- **Filename/anchor** → RESOLVED: a single file `using-woostack/references/output-discipline.md` with a stable `## Auto-clarity carve-out` heading consumers deep-link via `#auto-clarity-carve-out`. (§4)
+- **using-woostack index entry** → RESOLVED: not needed. Follows the `model-tiers.md` precedent — shared references in `using-woostack/references/` are reached by consumer cross-links, not SKILL-indexed. Discoverability = ≥1 consumer cross-link (AC5). (§4 Discovery)
+- **Scope (risk/ROI review)** → RESOLVED: descoped to the **core** — token savings alone don't clear the bar, so wire only the dedup win + the high-frequency context-resident channels (implementer, spec/quality reviewers, distill, memory body). Tail channels deferred (§3). (Option A.)
+- **Mitigation — contract-field integrity** → RESOLVED: added the verbatim contract-field rule (§4.3) + AC7, so terse rewording can't break `subagent-driver.md` status/verdict branching.
+- **Mitigation — carve-out generalization** → RESOLVED: the carve-out now covers all reviewer/implementer findings/concerns, not just debug (§4.4).
+- **Name collision** → RESOLVED (kept): canonical doc keeps the name `output-discipline.md`; `_header.md` gains a one-line pointer to disambiguate. (Rename to `handback-discipline.md` considered and declined — keep the source report's "Output Discipline" term.)
+- **woostack-debug Phase 4** → DEFERRED (resolution stands for later adoption): structure terse, reasoning full — strip the envelope, keep root-cause/fix/evidence in full clear English under the carve-out. Seeds the governing principle but is **not wired** by this feature (§3).
+- **Overnight decision-log budget** → DEFERRED (resolution stands for later adoption): no extra per-entry budget; rationale inherits the default terse rule, event-code vocabulary unchanged. **Not wired** by this feature (§3).


### PR DESCRIPTION
## Goal

Establish one canonical, cross-skill Output Discipline for woostack's *internal* communication (subagent handbacks, reviewer verdicts, memory bodies) so those context-resident channels stay terse without losing clarity — and kill the live duplication of the ≤100-char memory rule. This PR ships the spec + plan only; implementation lands in the stacked increment.

## Summary

- Adds the design spec `.woostack/specs/2026-06-12-output-discipline.md` (status: ready) and its 1:1 plan `.woostack/plans/2026-06-12-output-discipline.md`.
- Scope is the risk-adjusted core (Option A): new `using-woostack/references/output-discipline.md` + dedup the ≤100-char rule + wire 4 high-frequency channels (implementer, spec/quality reviewers, execute distill, memory note body). Tail channels (debug, commit subagent, address-comments worker, overnight log) deferred.
- Two safety mitigations baked into the canonical doc: contract-field verbatim rule (STATUS/VERDICT never compressed) and a carve-out generalized to all reviewer/implementer findings.
- Plan is one increment, 9 tasks, doc-verification TDD (grep/test assertions; no app runtime in this repo).

## Test plan

### Manual

**Before merge**

- [ ] Read the spec §1–§9 and confirm scope/non-goals match the descoped core.
- [ ] Read the plan increment: every task has exact before/after text + a grep/test verification with expected output.
- [ ] Confirm the plan's AC coverage maps each of the spec's 7 ACs to a task/step.

This is the docs-only base of the stack and is never merged by the build loop; the implementation increment stacks on top of it.

Spec: .woostack/specs/2026-06-12-output-discipline.md
