### PR TITLE
docs(site): spec + plan for fumadocs documentation site

### DIFF
--- a/.woostack/plans/2026-06-12-fumadocs-docs-site.md
+++ b/.woostack/plans/2026-06-12-fumadocs-docs-site.md
@@ -1,0 +1,845 @@
+**Source:** .woostack/specs/2026-06-12-fumadocs-docs-site.md
+
+# Fumadocs docs site for the woostack skills — Implementation Plan
+
+**Goal:** Ship a Fumadocs (Next.js) documentation site at `site/` that generates one reference page per `SKILL.md` plus a few authored framing pages, deployable on the Vercel free tier.
+
+**Architecture:** Three stacked increments. (1) Scaffold a default Fumadocs app at `site/` and carve `site/` out of the repo's no-app-code constraint. (2) Add a code-aware `SKILL.md → MDX` generator (`scripts/gen-skills.mjs`) — pure transform functions (frontmatter map, title-strip, link rewrite, pseudo-tag neutralize, render) unit-tested with `node --test` — wired into `predev`/`prebuild` so content is always fresh and gitignored. (3) Author the landing page, the `index`/`getting-started`/`concepts` docs, the nav, and a deploy note. Each increment ends on a green `pnpm build`.
+
+**Tech Stack:** Next.js (App Router) · Fumadocs (`fumadocs-ui`, `fumadocs-mdx`) · pnpm · Node 22 · `node --test` (built-in). All package versions resolved live by the scaffolder at execute time — none pinned here.
+
+---
+
+## Increment 1: Scaffold the Fumadocs app + repo carve-out
+
+> One PR: a working default Fumadocs site at `site/` (vendored scaffold) + the `AGENTS.md` exception clause. Builds green as-is. Mostly generated scaffold files — review the carve-out clause and the scaffold choices.
+
+### Task 1: Scaffold `site/` with create-fumadocs-app
+
+**Files:**
+- Create: `site/**` (scaffolder output: `package.json`, `app/`, `content/docs/`, `source.config.ts`, `mdx-components.tsx`, `tsconfig.json`, `.gitignore`, `pnpm-lock.yaml`, …)
+
+- [ ] **Step 1: Run the scaffolder (pnpm)**
+
+From the repo root (worktree cwd):
+
+```bash
+pnpm create fumadocs-app@latest site
+```
+
+Answer the prompts: project type **Next.js**, content source **Fumadocs MDX**, **Tailwind CSS** yes, package manager **pnpm**, install deps **yes**. (Scaffolder UX changes between versions — match these intents to whatever it asks; do not pin versions.)
+
+- [ ] **Step 2: Confirm the scaffold layout, adapt if names differ**
+
+Run: `ls site && cat site/package.json | sed -n '1,40p'`
+Expected: a `site/` containing `app/`, `content/docs/`, `source.config.ts` (or `app/source.ts` / `lib/source.ts` in newer scaffolds), `mdx-components.tsx`, `package.json` with `dev`/`build` scripts, and `pnpm-lock.yaml`. Note the actual scripts/paths — later tasks reference `site/content/docs/` and `site/mdx-components.tsx`; adapt to the real names the scaffolder emitted.
+
+- [ ] **Step 3: Verify the default scaffold builds**
+
+Run: `pnpm --dir site build`
+Expected: PASS — `next build` exits 0, emits the default docs routes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+# first commit in this increment (stacks on the spec+plan base branch):
+gt create -m "feat(site): scaffold fumadocs docs app"
+```
+
+### Task 2: Carve `site/` out of the no-app-code constraint
+
+**Files:**
+- Modify: `AGENTS.md` (the "What this repo is" / "Hard constraints" area; `CLAUDE.md` and `GEMINI.md` are symlinks, so this one edit covers all three)
+
+- [ ] **Step 1: Write the failing check (the clause is absent)**
+
+Run: `grep -c 'site/' AGENTS.md`
+Expected: FAIL — `0` (no mention of the `site/` subtree yet).
+
+- [ ] **Step 2: Add the carve-out clause**
+
+In `AGENTS.md`, under the "There is no application source code…" paragraph, add:
+
+```markdown
+The second exception is the user-facing documentation site: [`site/`](site/) is a shipped
+Fumadocs (Next.js) application subtree — the docs site for these skills. Like
+[`action.yml`](action.yml), it is a shipped asset, not self-CI and not stray app code. Its
+`package.json`, `pnpm-lock.yaml`, and build config are the one sanctioned exception to the
+"no application source code / no app lockfile" rule above. Its skill reference pages are
+generated from `skills/*/SKILL.md` at build time and are gitignored.
+```
+
+Also extend the Mode A constraint note so it does not read as forbidding `site/`:
+
+```markdown
+**Mode A: edit this skill collection.** … do not add application code, app build configs, or
+app lockfiles **outside the sanctioned `site/` docs-app subtree**.
+```
+
+- [ ] **Step 3: Confirm the clause is present and symlinks still resolve**
+
+Run: `grep -c 'site/' AGENTS.md && readlink CLAUDE.md GEMINI.md`
+Expected: PASS — a non-zero count, and both symlinks print `AGENTS.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+gt modify -c -m "docs(agents): carve site/ docs-app out of no-app-code rule"
+```
+
+---
+
+## Increment 2: SKILL.md → MDX generator (tested) + build wiring
+
+> One PR: the transform engine. Pure functions unit-tested with `node --test`, a file-walk shell, wired into `predev`/`prebuild`, generated output gitignored. Running it produces 18 MDX pages; the build regenerates and compiles them.
+
+### Task 1: Pure module skeleton + `parseFrontmatter`
+
+**Files:**
+- Create: `site/scripts/gen-skills.mjs`
+- Test: `site/scripts/gen-skills.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// site/scripts/gen-skills.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFrontmatter } from './gen-skills.mjs';
+
+test('parseFrontmatter extracts name + description and returns the body', () => {
+  const raw = '---\nname: woostack-build\ndescription: Use when building a feature.\n---\n\n# woostack-build\n\nbody';
+  const { fm, body } = parseFrontmatter(raw, 'woostack-build');
+  assert.equal(fm.name, 'woostack-build');
+  assert.equal(fm.description, 'Use when building a feature.');
+  assert.match(body, /# woostack-build/);
+});
+
+test('parseFrontmatter throws when name is missing', () => {
+  assert.throws(() => parseFrontmatter('---\ndescription: x\n---\nbody', 'f'), /missing 'name'/);
+});
+
+test('parseFrontmatter strips surrounding YAML quotes (some SKILL.md descriptions are quoted)', () => {
+  const raw = '---\nname: woostack-tdd\ndescription: "TDD home: red→green. Quoted in source."\n---\nb';
+  const { fm } = parseFrontmatter(raw, 'woostack-tdd');
+  assert.equal(fm.description, 'TDD home: red→green. Quoted in source.'); // no leading/trailing "
+});
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: FAIL — `Cannot find module './gen-skills.mjs'` (or export missing).
+
+- [ ] **Step 3: Minimal implementation**
+
+```js
+// site/scripts/gen-skills.mjs
+import { readdir, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');       // site/scripts -> repo root
+const SKILLS_DIR = path.join(REPO_ROOT, 'skills');
+const OUT_DIR = path.resolve(__dirname, '..', 'content', 'docs', 'skills');
+const GH_BASE = 'https://github.com/howarewoo/woostack/blob/main';
+const INTERNAL = new Set(['woostack-ideate', 'woostack-harden']);
+
+export function parseFrontmatter(raw, file = '<input>') {
+  const m = /^---\n([\s\S]*?)\n---\n?/.exec(raw);
+  if (!m) throw new Error(`${file}: missing frontmatter`);
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const mm = /^(\w+):\s*(.*)$/.exec(line);
+    if (!mm) continue;
+    let v = mm[2].trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1).replace(/\\"/g, '"');   // some descriptions are YAML-quoted in source
+    }
+    fm[mm[1]] = v;
+  }
+  if (!fm.name) throw new Error(`${file}: frontmatter missing 'name'`);
+  if (!fm.description) throw new Error(`${file}: frontmatter missing 'description'`);
+  return { fm, body: raw.slice(m[0].length) };
+}
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: PASS — 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt create -m "feat(site): gen-skills parseFrontmatter"
+```
+
+### Task 2: `stripTitleHeading`
+
+**Files:**
+- Modify: `site/scripts/gen-skills.mjs`
+- Test: `site/scripts/gen-skills.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { stripTitleHeading } from './gen-skills.mjs';
+
+test('stripTitleHeading removes the first "# <name>" H1 only', () => {
+  const body = '\n# woostack-build\n\n## Overview\n\n# woostack-build (kept)\n';
+  const out = stripTitleHeading(body, 'woostack-build');
+  assert.equal(out.match(/^# woostack-build$/gm).length, 1); // the second one stays
+  assert.match(out, /## Overview/);
+});
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: FAIL — `stripTitleHeading is not a function`.
+
+- [ ] **Step 3: Minimal implementation**
+
+```js
+export function stripTitleHeading(body, name) {
+  const lines = body.split('\n');
+  const idx = lines.findIndex((l) => l.trim() === `# ${name}`);
+  if (idx !== -1) lines.splice(idx, 1);
+  return lines.join('\n');
+}
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "feat(site): gen-skills stripTitleHeading"
+```
+
+### Task 3: `rewriteLinks`
+
+**Files:**
+- Modify: `site/scripts/gen-skills.mjs`
+- Test: `site/scripts/gen-skills.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { rewriteLinks } from './gen-skills.mjs';
+
+test('rewriteLinks maps skill links to routes, refs to GitHub, leaves absolute/anchors', () => {
+  const r = (s) => rewriteLinks(s, 'woostack-build');
+  assert.equal(r('see [plan](../woostack-plan/SKILL.md)'), 'see [plan](/docs/skills/woostack-plan)');
+  assert.equal(r('[a](../woostack-plan/SKILL.md#x)'), '[a](/docs/skills/woostack-plan#x)');
+  assert.equal(
+    r('[wt](../woostack-init/references/worktrees.md)'),
+    '[wt](https://github.com/howarewoo/woostack/blob/main/skills/woostack-init/references/worktrees.md)'
+  );
+  assert.equal(
+    r('[self](references/plan-template.md)'),
+    '[self](https://github.com/howarewoo/woostack/blob/main/skills/woostack-build/references/plan-template.md)'
+  );
+  assert.equal(r('[ext](https://example.com)'), '[ext](https://example.com)');
+  assert.equal(r('[here](#section)'), '[here](#section)');
+});
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: FAIL — `rewriteLinks is not a function`.
+
+- [ ] **Step 3: Minimal implementation**
+
+```js
+export function rewriteLinks(body, name) {
+  return body.replace(/\]\(([^)]+)\)/g, (whole, target) => {
+    if (/^https?:\/\//.test(target) || target.startsWith('#') || target.startsWith('mailto:')) return whole;
+    const skill = /^\.\.\/([a-z0-9-]+)\/SKILL\.md(#.+)?$/.exec(target);
+    if (skill) return `](/docs/skills/${skill[1]}${skill[2] || ''})`;
+    const hash = (target.match(/#.*$/) || [''])[0];
+    const clean = target.replace(/#.*$/, '');
+    const rel = clean.replace(/^(\.\.\/)+/, '');             // strip leading ../
+    const ghPath = clean.startsWith('../') ? `skills/${rel}` : `skills/${name}/${rel}`;
+    return `](${GH_BASE}/${ghPath}${hash})`;
+  });
+}
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "feat(site): gen-skills rewriteLinks"
+```
+
+### Task 4: `neutralizeTags` (code-aware)
+
+**Files:**
+- Modify: `site/scripts/gen-skills.mjs`
+- Test: `site/scripts/gen-skills.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { neutralizeTags } from './gen-skills.mjs';
+
+test('neutralizeTags: block tag -> Callout, prose tag escaped, code-span tag preserved', () => {
+  const block = '<HARD-GATE>\nDo not proceed.\n</HARD-GATE>';
+  const out = neutralizeTags(block);
+  assert.match(out, /<Callout type="warn" title="Hard gate">/);
+  assert.match(out, /<\/Callout>/);
+  assert.doesNotMatch(out, /<HARD-GATE>/);
+
+  // bare uppercase tag in prose -> escaped
+  assert.match(neutralizeTags('a bare <FOO> here'), /a bare &lt;FOO&gt; here/);
+
+  // uppercase tag inside an inline code span -> preserved verbatim
+  const code = 'POST `gh api repos/<repo>/pulls/<PR>/reviews` now';
+  assert.equal(neutralizeTags(code), code);
+
+  // uppercase tag inside a fenced block -> preserved verbatim
+  const fenced = '```\n<PR> stays\n```';
+  assert.equal(neutralizeTags(fenced), fenced);
+});
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: FAIL — `neutralizeTags is not a function`.
+
+- [ ] **Step 3: Minimal implementation**
+
+```js
+function humanizeTag(t) {
+  const s = t.replace(/-/g, ' ').toLowerCase();
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function escapeBareTagsOutsideCode(line) {
+  // split on inline code spans; only escape in the non-code segments
+  return line
+    .split(/(`[^`]*`)/)
+    .map((seg) => (seg.startsWith('`') ? seg : seg.replace(/<(\/?[A-Z][A-Z-]*)>/g, '&lt;$1&gt;')))
+    .join('');
+}
+
+export function neutralizeTags(body) {
+  const out = [];
+  let inFence = false;
+  for (const line of body.split('\n')) {
+    if (/^\s*(```|~~~)/.test(line)) { inFence = !inFence; out.push(line); continue; }
+    if (inFence) { out.push(line); continue; }
+    const open = /^<([A-Z][A-Z-]*)>\s*$/.exec(line);
+    if (open) { out.push(`<Callout type="warn" title="${humanizeTag(open[1])}">`); continue; }
+    if (/^<\/[A-Z][A-Z-]*>\s*$/.test(line)) { out.push('</Callout>'); continue; }
+    out.push(escapeBareTagsOutsideCode(line));
+  }
+  return out.join('\n');
+}
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "feat(site): gen-skills code-aware neutralizeTags"
+```
+
+### Task 5: `renderPage` (frontmatter + internal note + source link)
+
+**Files:**
+- Modify: `site/scripts/gen-skills.mjs`
+- Test: `site/scripts/gen-skills.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+import { renderPage } from './gen-skills.mjs';
+
+test('renderPage emits title/description, source link, and an internal note for sub-skills', () => {
+  const fm = { name: 'woostack-build', description: 'Build a feature: end to end.' };
+  const page = renderPage('woostack-build', fm, '## Overview\n\nbody');
+  assert.match(page, /^---\ntitle: woostack-build\n/);
+  assert.match(page, /description: "Build a feature: end to end\."/);   // JSON-quoted, safe for the colon
+  assert.match(page, /\[View source on GitHub\]\(https:\/\/github\.com\/howarewoo\/woostack\/blob\/main\/skills\/woostack-build\/SKILL\.md\)/);
+  assert.doesNotMatch(page, /Internal sub-skill/);
+
+  const ideate = renderPage('woostack-ideate', { name: 'woostack-ideate', description: 'x' }, 'b');
+  assert.match(ideate, /Internal sub-skill/);
+});
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: FAIL — `renderPage is not a function`.
+
+- [ ] **Step 3: Minimal implementation**
+
+```js
+export function renderPage(name, fm, body) {
+  const front = `---\ntitle: ${name}\ndescription: ${JSON.stringify(fm.description)}\n---\n\n`;
+  const internal = INTERNAL.has(name)
+    ? `<Callout type="info" title="Internal sub-skill">Building block of [woostack-build](/docs/skills/woostack-build); not a directly-invocable \`/woostack-*\` command.</Callout>\n\n`
+    : '';
+  const source = `[View source on GitHub](${GH_BASE}/skills/${name}/SKILL.md)\n\n`;
+  return front + internal + source + body.replace(/^\n+/, '') + '\n';
+}
+```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+
+Run: `node --test site/scripts/gen-skills.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "feat(site): gen-skills renderPage"
+```
+
+### Task 6: File-walk shell + run against the real skills tree
+
+**Files:**
+- Modify: `site/scripts/gen-skills.mjs`
+
+- [ ] **Step 1: Add the `main()` walk + direct-invocation guard (so tests can import without running it)**
+
+```js
+async function main() {
+  if (!existsSync(SKILLS_DIR)) {
+    console.error(
+      `gen-skills: source dir not found: ${SKILLS_DIR}\n` +
+      `On Vercel, enable "Include files outside the root directory in the Build Step".`
+    );
+    process.exit(1);
+  }
+  await rm(OUT_DIR, { recursive: true, force: true });
+  await mkdir(OUT_DIR, { recursive: true });
+  const names = (await readdir(SKILLS_DIR, { withFileTypes: true }))
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+  let count = 0;
+  for (const name of names) {
+    const file = path.join(SKILLS_DIR, name, 'SKILL.md');
+    if (!existsSync(file)) continue;
+    const raw = await readFile(file, 'utf8');
+    const { fm, body } = parseFrontmatter(raw, name);
+    let b = stripTitleHeading(body, fm.name);
+    b = neutralizeTags(b);
+    b = rewriteLinks(b, name);
+    await writeFile(path.join(OUT_DIR, `${name}.mdx`), renderPage(name, fm, b), 'utf8');
+    count++;
+  }
+  console.log(`gen-skills: wrote ${count} pages -> ${path.relative(process.cwd(), OUT_DIR)}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => { console.error(e.message); process.exit(1); });
+}
+```
+
+- [ ] **Step 2: Run the generator against the real skills tree, confirm 18 pages**
+
+Run: `cd site && node scripts/gen-skills.mjs && ls content/docs/skills | wc -l`
+Expected: PASS — `gen-skills: wrote 18 pages …` and `ls | wc -l` prints `18`.
+
+- [ ] **Step 3: Confirm no JSX-interpretable pseudo-tag survives outside code**
+
+Run: `cd site && node scripts/gen-skills.mjs >/dev/null && ! grep -rnE '^<[A-Z][A-Z-]+>' content/docs/skills`
+Expected: PASS — exit 0 (no standalone-line uppercase tag remains; block tags are now `<Callout>`).
+
+- [ ] **Step 4: Confirm idempotence**
+
+Run: `cd site && node scripts/gen-skills.mjs && cp -r content/docs/skills /tmp/g1 && node scripts/gen-skills.mjs && diff -r /tmp/g1 content/docs/skills && echo IDEMPOTENT`
+Expected: PASS — `IDEMPOTENT` (no diff).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "feat(site): gen-skills file walk over skills/*/SKILL.md"
+```
+
+### Task 7: Wire generation into the build + gitignore output + register Callout
+
+**Files:**
+- Modify: `site/package.json` (scripts)
+- Modify: `site/.gitignore`
+- Modify: `site/mdx-components.tsx` (ensure `Callout` is in scope for generated MDX)
+
+- [ ] **Step 1: Add `predev`/`prebuild`/`test` scripts**
+
+In `site/package.json` `"scripts"`, add (keep the scaffolded `dev`/`build`):
+
+```json
+{
+  "scripts": {
+    "predev": "node scripts/gen-skills.mjs",
+    "prebuild": "node scripts/gen-skills.mjs",
+    "test": "node --test scripts/*.test.mjs"
+  }
+}
+```
+
+- [ ] **Step 2: Gitignore the generated output**
+
+Append to `site/.gitignore`:
+
+```gitignore
+# generated from skills/*/SKILL.md at build time (source of truth = skills/)
+/content/docs/skills/
+```
+
+- [ ] **Step 3: Ensure `Callout` is registered for MDX**
+
+Confirm `site/mdx-components.tsx` spreads Fumadocs defaults (which include `Callout`). If it does not, add it:
+
+```tsx
+import defaultMdxComponents from 'fumadocs-ui/mdx';
+import { Callout } from 'fumadocs-ui/components/callout';
+
+export function getMDXComponents(components) {
+  return { ...defaultMdxComponents, Callout, ...components };
+}
+```
+
+Run: `cd site && grep -q Callout mdx-components.tsx && echo OK`
+Expected: PASS — `OK`.
+
+- [ ] **Step 4: Build smoke — generation + compile of all 18 generated pages**
+
+Run: `cd site && rm -rf content/docs/skills && pnpm build`
+Expected: PASS — `prebuild` regenerates 18 pages, `next build` exits 0 and compiles every generated `skills/*.mdx` (proves the neutralization is load-bearing).
+
+- [ ] **Step 5: Confirm generated output is untracked/ignored**
+
+Run: `git status --porcelain site/content/docs/skills | wc -l`
+Expected: PASS — `0` (gitignored; not staged).
+
+- [ ] **Step 6: Run the unit suite once more, then commit**
+
+Run: `cd site && pnpm test`
+Expected: PASS — all `node --test` assertions green.
+
+```bash
+gt modify -c -m "build(site): wire gen-skills into pre(dev|build), gitignore output"
+```
+
+---
+
+## Increment 3: Authored pages, navigation, deploy note
+
+> One PR: the human-written surface — landing `/`, the three framing docs, the nav order, and the Vercel deploy note. Full site builds green with generated + authored content.
+
+### Task 1: Landing page at `/`
+
+**Files:**
+- Modify: the scaffold's home route — `site/app/page.tsx` in a flat scaffold, or
+  `site/app/(home)/page.tsx` if the scaffolder used a `(home)` route group. Locate it first
+  (`find site/app -name 'page.tsx' -maxdepth 2`) and replace whichever renders `/`.
+
+- [ ] **Step 1: Replace the scaffold landing with a minimal woostack landing**
+
+```tsx
+// site/app/page.tsx
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main className="flex flex-1 flex-col items-center justify-center gap-6 px-4 text-center">
+      <h1 className="text-4xl font-bold">woostack</h1>
+      <p className="max-w-xl text-fd-muted-foreground">
+        A model-agnostic collection of software-development skills covering every phase of the
+        engineering process — bootstrap, build, debug, review, and iterate.
+      </p>
+      <pre className="rounded-md bg-fd-muted px-4 py-2 text-sm">pnpx skills add howarewoo/woostack</pre>
+      <Link
+        href="/docs"
+        className="rounded-md bg-fd-primary px-5 py-2 font-medium text-fd-primary-foreground"
+      >
+        Read the docs →
+      </Link>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the landing renders (not the scaffold default) and links to /docs**
+
+Run: `cd site && pnpm build && grep -rq 'pnpx skills add howarewoo/woostack' .next/server/app/index*.html 2>/dev/null || echo CHECK_DEV`
+Expected: PASS — build exits 0. (If the static HTML grep is environment-dependent, fall back to `pnpm dev` and confirm `/` shows the woostack landing with a working "Read the docs" link to `/docs`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt create -m "feat(site): woostack landing page"
+```
+
+### Task 2: `index.mdx` (docs home)
+
+**Files:**
+- Modify/Create: `site/content/docs/index.mdx` (replace the scaffold sample)
+
+- [ ] **Step 1: Author the docs index**
+
+```mdx
+---
+title: What is woostack?
+description: A model-agnostic collection of gated software-development skills.
+---
+
+woostack packages opinionated, gated workflows into installable skills that any AI coding
+agent can follow — from greenfield bootstrapping to feature building, debugging, automated
+code review, and feedback iteration. It ships a local, token-efficient memory system so later
+agent sessions don't repeat earlier mistakes.
+
+```bash
+pnpx skills add howarewoo/woostack
+```
+
+- **Agent- & model-agnostic** — Claude Code, Cursor, Codex, Aider, and other agents that
+  respect the `skills` convention.
+- **Local memory** — learnings retained and routed per clone.
+- **Team-ready** — built for small-to-medium collaborative codebases.
+
+Start with [Getting started](/docs/getting-started), then skim [Core concepts](/docs/concepts)
+and the per-skill reference under **Skills**.
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Run: `cd site && pnpm build`
+Expected: PASS — `/docs` renders the authored index.
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "docs(site): authored docs index"
+```
+
+### Task 3: `getting-started.mdx`
+
+**Files:**
+- Create: `site/content/docs/getting-started.mdx`
+
+- [ ] **Step 1: Author getting-started (README stays canonical; link back)**
+
+```mdx
+---
+title: Getting started
+description: Install woostack, initialize the workspace, and wire it into your agent.
+---
+
+> The repository [`README`](https://github.com/howarewoo/woostack#getting-started) is the
+> canonical install reference. This page is a concise web-native version.
+
+## 1. Install
+
+```bash
+pnpx skills add howarewoo/woostack
+```
+
+`pnpm` (and `pnpx`) is the recommended package manager.
+
+## 2. Initialize
+
+```bash
+/woostack-init
+```
+
+Run this **before any other woostack skill** — it sets up the `.woostack/` workspace, default
+config, and gitignores.
+
+## 3. Integrate
+
+Add the `using-woostack` routing block to your repo's agent instructions
+(`AGENTS.md` or `CLAUDE.md`) so agents pick up the pipeline automatically.
+
+## 4. Build something
+
+Run [`/woostack-build`](/docs/skills/woostack-build) to drive a feature from idea to a
+reviewed PR stack, or [`/woostack-fix`](/docs/skills/woostack-fix) for a small change.
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Run: `cd site && pnpm build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "docs(site): authored getting-started"
+```
+
+### Task 4: `concepts.mdx`
+
+**Files:**
+- Create: `site/content/docs/concepts.mdx`
+
+- [ ] **Step 1: Author core-concepts**
+
+```mdx
+---
+title: Core concepts
+description: The build loop, its gates, and the local memory store.
+---
+
+## The build loop
+
+[`woostack-build`](/docs/skills/woostack-build) chains the phases in a fixed, gated order:
+
+> ideate → write spec → harden spec → **approve spec** → plan → harden plan → ship spec+plan PR
+> → **execution handoff** → execute (per increment: implement → commit → review → distill)
+
+## Three hard gates
+
+1. **Design approval** — owned by [`woostack-ideate`](/docs/skills/woostack-ideate).
+2. **Spec approval** — the written spec is presented before any planning.
+3. **Execution handoff** — after the spec+plan PR, you choose Go / Run overnight / Hand off.
+
+No phase advances past a hard gate without an explicit yes.
+
+## One spec, one plan, N PRs
+
+Every feature holds the `spec : plan : PRs = 1 : 1 : N` invariant — exactly one plan per spec,
+and that plan owns the N stacked increment PRs. [`woostack-status`](/docs/skills/woostack-status)
+derives the board from these artifacts.
+
+## Local memory
+
+woostack keeps a per-clone `.woostack/memory/` store. Each increment distills durable,
+deduplicated learnings; [`woostack-dream`](/docs/skills/woostack-dream) curates the store over
+time. A small curated store beats a large noisy one.
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Run: `cd site && pnpm build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "docs(site): authored core-concepts"
+```
+
+### Task 5: Navigation order (`meta.json`)
+
+**Files:**
+- Create/Modify: `site/content/docs/meta.json` (root order)
+- Create: `site/content/docs/skills/meta.json` — **gitignored** with the generated pages, so emit it from the generator instead (see Step 2)
+
+- [ ] **Step 1: Root nav order**
+
+```json
+{
+  "title": "Docs",
+  "pages": ["index", "getting-started", "concepts", "skills"]
+}
+```
+
+- [ ] **Step 2: Emit `skills/meta.json` from the generator (the folder is gitignored)**
+
+In `site/scripts/gen-skills.mjs` `main()`, after the write loop, add an ordered group meta so
+public commands lead and the internal sub-skills trail:
+
+```js
+const ORDER = [
+  'using-woostack', 'woostack-init', 'woostack-bootstrap', 'woostack-build', 'woostack-fix',
+  'woostack-plan', 'woostack-execute', 'woostack-execute-overnight', 'woostack-commit',
+  'woostack-review', 'woostack-address-comments', 'woostack-status', 'woostack-visualize',
+  'woostack-debug', 'woostack-tdd', 'woostack-dream',
+];
+const pages = [...ORDER.filter((n) => names.includes(n)), ...names.filter((n) => !ORDER.includes(n))];
+await writeFile(path.join(OUT_DIR, 'meta.json'), JSON.stringify({ title: 'Skills', pages }, null, 2) + '\n', 'utf8');
+```
+
+(The two internal sub-skills `woostack-ideate`/`woostack-harden` are absent from `ORDER`, so
+they sort last — matching the spec.)
+
+- [ ] **Step 3: Verify nav order**
+
+Run: `cd site && node scripts/gen-skills.mjs && node -e "const m=require('./content/docs/skills/meta.json'); console.log(m.pages.slice(0,1)[0], m.pages.slice(-2).join(','))"`
+Expected: PASS — prints `using-woostack woostack-ideate,woostack-harden` (public lead, internals last).
+
+- [ ] **Step 4: Full build smoke**
+
+Run: `cd site && rm -rf content/docs/skills && pnpm build`
+Expected: PASS — landing + 3 framing pages + 18 skill pages all compile; nav shows framing pages then the Skills group.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -m "feat(site): nav order (framing pages, then skills; internals last)"
+```
+
+### Task 6: Deploy note
+
+**Files:**
+- Create: `site/README.md`
+
+- [ ] **Step 1: Author the deploy note**
+
+```markdown
+# woostack docs site
+
+Fumadocs (Next.js) documentation site for the woostack skills. Skill reference pages are
+generated from `../skills/*/SKILL.md` at build time (`prebuild`) and are gitignored.
+
+## Local dev
+
+```bash
+pnpm install
+pnpm dev      # predev regenerates skill pages, then next dev
+```
+
+## Deploy (Vercel free tier)
+
+- **Root Directory:** `site/`
+- **Include files outside the root directory in the Build Step:** **ON** — required, because
+  `prebuild` reads `../skills/*/SKILL.md`, which lives outside `site/`. Without this, generation
+  fails and the deploy errors.
+- Framework preset: Next.js (auto-detected). Build command: default (`pnpm build`, which runs
+  `prebuild`). No server runtime needed (SSG) — fits the Hobby tier.
+```
+
+- [ ] **Step 2: Verify the critical setting is documented**
+
+Run: `grep -q 'Include files outside the root directory' site/README.md && echo OK`
+Expected: PASS — `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -m "docs(site): deploy note (Vercel root dir + include-files setting)"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [x] **Spec coverage** — Scaffold+carve-out (§5.1, §5.5 → Inc 1); generator transform: frontmatter map, title-strip, link rewrite, code-aware tag neutralize, source link, internal flag (§5.2 → Inc 2 Tasks 1–6); build wiring + gitignore (§5.5 → Inc 2 Task 7); landing + framing pages + nav (§5.3, §5.4 → Inc 3 Tasks 1–5); Vercel deploy note incl. include-files setting (§5.6 → Inc 3 Task 6). Every spec section maps to ≥1 task.
+- [x] **AC coverage** — AC1 (18 pages, mapped frontmatter, source link, H1 dropped) → Inc2 T1/T5/T6; AC2 (block→Callout, prose-tag escaped, code-span preserved, generic scan) → Inc2 T4 + T6 S3; AC3 (link classes) → Inc2 T3; AC4 (internal flag + nav last) → Inc2 T5 + Inc3 T5; AC5 (build green, landing route) → Inc2 T7 S4 + Inc3 T1/T4; AC6 (gitignore + carve-out + symlink consistency) → Inc2 T7 S2/S5 + Inc1 T2. Each filled happy/error/edge case has a test/command.
+- [x] **No placeholders** — every step has complete code/commands and expected output; no TBD/TODO.
+- [x] **Type consistency** — exported names (`parseFrontmatter`, `stripTitleHeading`, `rewriteLinks`, `neutralizeTags`, `renderPage`), constants (`SKILLS_DIR`, `OUT_DIR`, `GH_BASE`, `INTERNAL`, `ORDER`), and the `(fm, body)` shapes are used identically across Tasks 1–6.
+
+> Notes for execution: (1) the scaffolder's exact file names/scripts are resolved live in Inc 1 T1–T2 — adapt `mdx-components.tsx`/`source.config.ts`/script names to what it emits. (2) Versions are never pinned here; the scaffolder installs current ones. (3) Increments are one linear `gt` stack on the spec+plan base (no `## Track:` headings).

--- a/.woostack/specs/2026-06-12-fumadocs-docs-site.md
+++ b/.woostack/specs/2026-06-12-fumadocs-docs-site.md
@@ -1,0 +1,311 @@
+---
+name: fumadocs-docs-site
+type: spec
+status: ready
+date: 2026-06-12
+branch: feature/fumadocs-docs-site
+links:
+---
+
+# Fumadocs docs site for the woostack skills — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+woostack ships eighteen `SKILL.md` files (sixteen public `/woostack-*` commands plus the
+internal `woostack-ideate` and `woostack-harden` building blocks). The only human-facing
+documentation today is the root `README.md`. There is no browsable, navigable site where a
+user adopting woostack can read what each skill does, how the build loop and its gates fit
+together, and how to install/initialize the collection.
+
+The `SKILL.md` files are the source of truth, but they are written **for agents**: imperative
+voice, hard-constraint pseudo-tag blocks (`<HARD-GATE>`, `<IRON-LAW>`, …), and relative
+cross-links (`../woostack-x/SKILL.md`) that only resolve on a local clone. Pasting them into a
+web docs site verbatim would (a) fail to render — the uppercase pseudo-tags parse as JSX
+components and break MDX compilation — and (b) produce dead links.
+
+## 2. Goal
+
+A Fumadocs (Next.js App Router) documentation site, living at `site/` in this repo, that:
+
+- Presents **one generated reference page per skill** (all 18), derived from each `SKILL.md`
+  so the site never forks skill content and cannot drift.
+- Adds **a few hand-authored framing pages** (home, getting-started, core concepts) for human
+  onboarding.
+- Deploys to the **Vercel free (hobby) tier** with Root Directory = `site/`, regenerating
+  skill pages at build time so deployed content is always fresh.
+- Is the first shipped **application subtree** in this repo, carved out as an explicit
+  exception to the "no app code" hard constraint in `AGENTS.md`/`CLAUDE.md`.
+
+## 3. Non-goals
+
+YAGNI — explicitly out of scope for this increment:
+
+- Search, doc versioning, i18n/localization.
+- Custom branding / bespoke design system / dark-mode tuning (default Fumadocs theme only).
+- Generated pages for bootstrap's `references/*.md` (frameworks, patterns, architecture,
+  infrastructure, development, procedure) — agent-facing deep detail, linked to GitHub source
+  instead.
+- Analytics, custom domain, auth.
+- Migrating the README into the site (the README stays the repo's canonical entry; the site
+  links back to GitHub for source).
+- Any change to the skills' own content or behavior. This work only *reads* `SKILL.md`.
+
+## 4. Approach
+
+Five pieces, each independently reviewable:
+
+1. **Scaffold** a Fumadocs app at `site/` via `create-fumadocs-app` (Next.js App Router,
+   `fumadocs-ui` + `fumadocs-mdx`). All package versions resolved **live** at plan/execute
+   time (`npm view <pkg> version`) — none fabricated in this spec.
+2. **Generation script** `site/scripts/gen-skills.mjs`: reads every `../skills/*/SKILL.md`,
+   transforms it (frontmatter mapping, pseudo-tag neutralization, link rewriting, a "View
+   source on GitHub" backlink), and writes `site/content/docs/skills/<name>.mdx`. The transform
+   is the heart of the work.
+3. **Authored pages**: a minimal landing page at `/` (`site/app/page.tsx`, replacing the
+   scaffolded default — tagline + install one-liner + CTA into the docs) plus framing pages
+   under `site/content/docs/`: `index.mdx`, `getting-started.mdx`, `concepts.mdx`. Hand-written,
+   committed (not generated).
+4. **Navigation** (`meta.json`): framing pages first, then a "Skills" group; internal
+   sub-skills (ideate, harden) sorted last and flagged.
+5. **Wiring**: `predev`/`prebuild` npm scripts run the generator so local dev and Vercel builds
+   always regenerate; `.gitignore` excludes generated MDX + `node_modules` + `.next`; the
+   `AGENTS.md` carve-out documents `site/` as a shipped subtree.
+
+### Source-of-truth & drift posture
+
+- `SKILL.md` files are the **only** source for skill page bodies. Generated MDX is gitignored
+  and rebuilt every `dev`/`build`, so it can never be stale or hand-edited into divergence.
+- Framing pages are **original prose** with no upstream source, so they are committed normally
+  and carry no drift risk.
+
+## 5. Components & data flow
+
+```
+skills/<name>/SKILL.md ──(gen-skills.mjs)──▶ site/content/docs/skills/<name>.mdx  (gitignored)
+                                                          │
+site/content/docs/index.mdx        (authored, committed) │
+site/content/docs/getting-started.mdx (authored)         ├─▶ Fumadocs (fumadocs-mdx loader)
+site/content/docs/concepts.mdx     (authored)            │        │
+site/content/docs/meta.json        (nav order)           │        ▼
+                                                          └──▶ Next.js App Router ──▶ Vercel (Root Dir = site/)
+```
+
+### 5.1 Scaffold (`site/`)
+
+- Next.js App Router + Fumadocs UI/MDX, default theme.
+- `source.config.ts` (or scaffolder equivalent) points the docs collection at
+  `content/docs`.
+- `site/package.json` scripts:
+  - `predev` → `node scripts/gen-skills.mjs`
+  - `dev` → `next dev`
+  - `prebuild` → `node scripts/gen-skills.mjs`
+  - `build` → `next build`
+- The real scaffolder output shape is resolved at execute time; the plan adapts script names
+  to whatever `create-fumadocs-app` emits rather than assuming.
+- **Package manager: pnpm** (repo convention; [[prefer-pnpx]]). `site/` is a standalone pnpm
+  project (the repo root has no workspace), with its own committed `site/pnpm-lock.yaml` — the
+  app lockfile the carve-out (§5.5) explicitly permits, required for reproducible Vercel builds.
+
+### 5.2 Generation script `site/scripts/gen-skills.mjs`
+
+Pure Node, no network. For each `skills/*/SKILL.md` (resolved relative to repo root, i.e.
+`../skills` from `site/`):
+
+**a. Frontmatter mapping.** Parse the YAML frontmatter (`name`, `description`). Emit Fumadocs
+frontmatter `title` (= `name`) and `description` (= the `description`, collapsed to a single
+line). Drop the `# <name>` H1 that follows in the body (Fumadocs renders `title` as the H1) to
+avoid a duplicate heading.
+
+**b. Internal-skill flagging.** For `woostack-ideate` and `woostack-harden`, inject a callout at
+the top of the body: an "Internal sub-skill" note stating it is a building block of
+`woostack-build`, not a directly-invocable `/woostack-*` command.
+
+**c. Pseudo-tag neutralization** (the MDX-breakers). The known set is
+`<HARD-GATE>`, `<IRON-LAW>`, `<EXTREMELY-IMPORTANT>`, `<CHARACTERIZATION-CARVE-OUT>`,
+`<SUBAGENT-STOP>`, `<PR>` (resolved by scanning, not hardcoded blindly — the script greps for
+`<[A-Z][A-Z-]*>` so a newly-added pseudo-tag is also caught):
+  - **Code-aware.** Neutralization runs only on content **outside** fenced code blocks and
+    inline code spans. Angle-bracket tokens inside `` `…` `` / fences are literal-and-safe in
+    MDX and are left verbatim — e.g. `<PR>` / `<repo>` inside
+    `` `gh api repos/<repo>/pulls/<PR>/reviews` `` (woostack-review) must survive untouched.
+  - **Block form** (an open `<TAG>` … `</TAG>` pair on their own lines, outside code) → convert
+    to a Fumadocs `<Callout type="warn">` with the tag name as a human title (e.g. `HARD-GATE`
+    → "Hard gate"), inner content preserved.
+  - **Inline / unpaired form outside code** (a bare `<TAG>` mid-prose) → escape the angle
+    brackets to literal text (`&lt;TAG&gt;`) so it renders verbatim, not as JSX.
+  - **Invariant:** no uppercase pseudo-tag is left to be interpreted as JSX — every `<UPPER>`
+    outside code spans/fences is either a `<Callout>` or escaped; the build smoke (AC5) is the
+    backstop that proves nothing un-neutralized reaches the MDX compiler.
+
+**d. Link rewriting.** Markdown links `](...)`:
+  - `../woostack-x/SKILL.md` (optionally `#anchor`) → site route
+    `/docs/skills/woostack-x` (`#anchor` preserved).
+  - `../using-woostack/SKILL.md` → `/docs/skills/using-woostack`.
+  - Any other relative link into the repo (`*/references/*.md`, `scripts/*.sh`, `*.html`,
+    `action.yml`, etc.) → absolute GitHub source URL
+    `https://github.com/howarewoo/woostack/blob/main/<path-from-repo-root>`.
+  - Already-absolute (`http(s)://`) links → left untouched.
+
+**e. View-source backlink.** Inject, just under the title, a small link to the page's source:
+`https://github.com/howarewoo/woostack/blob/main/skills/<name>/SKILL.md` ("View source on
+GitHub"). Reinforces that `SKILL.md` is the source of truth.
+
+**f. Write.** Output `site/content/docs/skills/<name>.mdx`. Deterministic ordering; idempotent
+(re-running yields byte-identical output). Creates the `skills/` output dir if missing.
+
+### 5.3 Authored pages
+
+- **Landing** `site/app/page.tsx` — replaces the scaffolded Fumadocs home: a minimal landing
+  (tagline, `pnpx skills add howarewoo/woostack` one-liner, CTA button into `/docs`). Default
+  theme components; no bespoke design.
+- `index.mdx` — what woostack is (distilled from README intro), the install one-liner, a link
+  into getting-started.
+- `getting-started.mdx` — install (`pnpx skills add howarewoo/woostack`) → `/woostack-init` →
+  AGENTS.md integration → first command. A concise web-native restatement of README's Getting
+  Started; the **README stays canonical** for install (accept minor drift — both are short and
+  install steps change rarely). Link back to the README on GitHub for the authoritative copy.
+- `concepts.mdx` — the build loop and its three gates, the spec→plan→PRs `1:1:N` invariant, the
+  local memory store. Links to the relevant generated skill pages.
+
+### 5.4 Navigation (`meta.json`)
+
+- Root order: `index`, `getting-started`, `concepts`, then the `skills` folder.
+- `skills/meta.json`: public commands first (a sensible reading order — using-woostack, init,
+  bootstrap, build, plan, execute, …), the two internal sub-skills (ideate, harden) last.
+
+### 5.5 Repo wiring
+
+- `site/.gitignore` (scaffolder-generated; extended) ignores: `node_modules`, `.next`, and the
+  generated `content/docs/skills/`. `site/pnpm-lock.yaml` is **committed** (reproducible builds).
+- `AGENTS.md` carve-out: a clause stating `site/` is a shipped application subtree (like
+  `action.yml`), not stray app code — so the "no application source code / no app lockfile"
+  constraint explicitly excepts it. `CLAUDE.md`/`GEMINI.md` are symlinks, so editing
+  `AGENTS.md` covers all three.
+
+### 5.6 Vercel deploy
+
+- Root Directory = `site/`; framework auto-detected (Next.js); build command runs `build`
+  (which fires `prebuild` → generation). No server runtime cost (SSG) → fits free tier.
+- **Required setting — "Include files outside the root directory in the Build Step" = ON.**
+  The prebuild generator reads `../skills/*/SKILL.md`, which lives *outside* the `site/` root
+  directory. Vercel clones the whole repo but, with Root Directory set, restricts the build's
+  visible files to that root unless this option is enabled. Without it, `prebuild` finds no
+  `../skills` and the deploy fails. This is the one non-default Vercel config the site depends
+  on; it is documented in the site deploy note.
+- Documented in the site README / a short deploy note; the Vercel project itself is created by
+  the user via the dashboard (out of code scope).
+
+## 6. Error handling
+
+- **Missing/malformed SKILL.md frontmatter** → the generator fails loudly (non-zero exit) with
+  the offending path, rather than emitting a page with an empty title. A broken source must
+  break the build, not ship silently.
+- **Unknown new pseudo-tag** → caught by the generic `<[A-Z][A-Z-]*>` scan and neutralized
+  (block→callout / inline→escaped); it never reaches MDX raw. If a tag is ambiguous
+  (open without close), default to inline-escape (safe, non-breaking).
+- **Link to a non-existent local path** → still rewritten to a GitHub source URL (the script
+  does not stat targets; GitHub 404s are acceptable and visible, unlike a hard build break).
+- **Generator output dir absent** → created automatically; re-run is idempotent.
+- **`../skills` source dir absent** (e.g. Vercel without "include files outside root dir") →
+  the generator exits non-zero with a clear message naming the expected path, so the deploy
+  fails fast and visibly rather than building an empty docs tree. See §5.6.
+- **MDX parse failure at build** → surfaces as a Next/Fumadocs build error naming the file;
+  the build smoke test (AC5) is the backstop that catches any un-neutralized construct.
+
+## 7. Acceptance criteria
+
+Each AC is a testable behavior → ≥1 plan task.
+
+- **AC1 — Generator emits one MDX per skill with mapped frontmatter**
+  - happy: running `gen-skills.mjs` produces exactly 18 files under
+    `site/content/docs/skills/`, each with `title` = the skill `name`, a single-line
+    `description` from the source frontmatter, and a "View source on GitHub" backlink to its
+    `SKILL.md`; the duplicate `# <name>` H1 is removed.
+  - error: a `SKILL.md` with missing/empty frontmatter `name` or `description` causes a
+    non-zero exit naming the file; no partial/empty-title page is written.
+  - edge: re-running the generator yields byte-identical output (idempotent); a pre-existing
+    stale file in the output dir is overwritten, not appended.
+
+- **AC2 — No raw pseudo-tag survives; block tags become callouts**
+  - happy: for `woostack-ideate` (`<HARD-GATE>`) and `woostack-debug` (`<IRON-LAW>`), the
+    emitted MDX contains a `<Callout …>` with a human title and the original inner text, and no
+    `<UPPER>` tag remains **outside** code spans/fences in any generated file.
+  - error: a bare uppercase pseudo-tag in prose (outside code) is escaped to literal text, not
+    left as a JSX tag; but a `<PR>` already inside an inline code span is preserved verbatim
+    (regression guard both ways).
+  - edge: a newly-introduced uppercase pseudo-tag (not in the known list) is still neutralized
+    by the generic scan when it sits outside code.
+
+- **AC3 — Cross-links are rewritten correctly**
+  - happy: `](../woostack-plan/SKILL.md)` → `](/docs/skills/woostack-plan)`; a `#anchor` is
+    preserved; `](../woostack-init/references/worktrees.md)` →
+    `](https://github.com/howarewoo/woostack/blob/main/skills/woostack-init/references/worktrees.md)`.
+  - error: an already-absolute `https://…` link is left unchanged (not double-rewritten).
+  - edge: a SKILL.md→SKILL.md link with both a path and a fragment keeps the fragment on the
+    site route.
+
+- **AC4 — Internal sub-skills are flagged**
+  - happy: `woostack-ideate.mdx` and `woostack-harden.mdx` open with an "internal sub-skill"
+    callout; the 16 public pages do not.
+  - edge: meta ordering places ideate/harden after the public commands.
+
+- **AC5 — The site builds (all MDX parses, landing renders)**
+  - happy: `pnpm --dir site build` (which runs `prebuild` generation first) exits 0 and emits
+    routes for the landing page `/`, the 18 skill pages, and 3 framing pages.
+  - error: if any generated or authored MDX fails to parse, the build exits non-zero and names
+    the file (proves the neutralization is load-bearing).
+  - edge: `/` serves the authored landing (not the scaffolded Fumadocs default); a link/CTA
+    reaches `/docs`.
+
+- **AC6 — Repo hygiene & carve-out**
+  - happy: `.gitignore` excludes `site/node_modules`, `site/.next`, and the generated
+    `site/content/docs/skills/`; `git status` after a build shows no generated MDX or build
+    artifacts as untracked.
+  - error/edge: `AGENTS.md` contains a clause excepting `site/` from the no-app-code
+    constraint; the three symlinked instruction files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`)
+    stay consistent (single source).
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+- **Unit (generator).** Test `gen-skills.mjs` with Node's built-in test runner
+  (`node --test`, zero extra deps) against small inline fixtures: a frontmatter sample, a block
+  pseudo-tag, an inline pseudo-tag, each link class. Assert the AC1–AC4 invariants — most
+  importantly the "no raw `<UPPER>` tag survives" and the link-rewrite mappings. Factor the
+  transform into pure exported functions (`mapFrontmatter`, `neutralizeTags`, `rewriteLinks`)
+  so they unit-test without filesystem I/O; the file-walk wrapper is the thin shell.
+- **Integration / build smoke.** A test (or CI/script step) runs the generator against the real
+  `skills/` tree then `next build` and asserts exit 0 — the end-to-end proof that every real
+  SKILL.md neutralizes and every page compiles (AC5).
+- **No app CI added to this repo's push/PR events** beyond what executing the plan needs;
+  the build smoke is run locally during execution. (Any future site CI is out of scope here.)
+- TDD per the [woostack-tdd kernel](../../skills/woostack-tdd/SKILL.md): the generator's pure
+  functions are written red-first; the scaffold is characterized by the build-smoke pass.
+
+## 9. Open questions
+
+**Resolved during hardening (2026-06-12):**
+
+- **Site root `/`** → a minimal hand-authored landing page (tagline + install + CTA), not a
+  redirect. (§5.3)
+- **Per-page provenance** → yes, each generated page carries a "View source on GitHub"
+  backlink to its `SKILL.md`. (§5.2e)
+- **Package manager** → pnpm; `site/pnpm-lock.yaml` committed. (§5.1, §5.5)
+- **GitHub link base** → confirmed `github.com/howarewoo/woostack` @ `main` (from the live
+  remote). (§5.2d)
+- **Vercel `../skills` access** → requires "Include files outside the root directory" = ON;
+  documented as a deploy requirement, generator fails fast if absent. (§5.6, §6)
+- **getting-started drift** → README stays canonical for install; the page is a concise
+  web-native restatement that links back. (§5.3)
+
+**Still open (deferred, non-blocking):**
+
+- Exact `create-fumadocs-app` output layout (`source.config.ts` vs `app/source.ts`, default
+  script names) — resolved at execute time against the real scaffolder, not assumed here.
+- Heading-anchor fidelity across rewritten `#anchor` links (Fumadocs slug vs source anchor) —
+  accepted as best-effort, non-blocking.


### PR DESCRIPTION
## Goal

Stand up a user-facing documentation site for the woostack skills (Fumadocs/Next.js, Vercel free tier) without forking skill content — skill pages are generated from `skills/*/SKILL.md`. This PR is the docs-only base of the stack: the approved spec + implementation plan, no code yet.

## Summary

- Spec `.woostack/specs/2026-06-12-fumadocs-docs-site.md` (status: ready) — app at `site/`, hybrid content (18 generated skill pages + authored framing pages), build-time gitignored generation, Vercel free-tier deploy, and a carve-out excepting `site/` from the repo's no-app-code rule.
- Plan `.woostack/plans/2026-06-12-fumadocs-docs-site.md` — 3 stacked PR-sized increments: (1) scaffold + carve-out, (2) code-aware `SKILL.md→MDX` generator with `node --test` unit tests + build wiring, (3) authored landing/framing pages + nav + deploy note.

## Test plan

### Manual

**Before merge**

- [ ] Read the spec — confirm scope (18 skills, generated+authored, gitignored build-time gen) and the Vercel "include files outside root dir" deploy requirement.
- [ ] Read the plan — confirm the 3 increments are independently shippable and each ends on a green `pnpm build`; spot-check the generator transform code (frontmatter quote-stripping, code-aware pseudo-tag neutralization, link rewriting).

Spec: .woostack/specs/2026-06-12-fumadocs-docs-site.md
