### PR TITLE
feat(site): SKILL.md→MDX generator with code-aware transform + tests

### DIFF
--- a/.woostack/plans/2026-06-12-fumadocs-docs-site.md
+++ b/.woostack/plans/2026-06-12-fumadocs-docs-site.md
@@ -99,7 +99,7 @@ gt modify -c -m "docs(agents): carve site/ docs-app out of no-app-code rule"
 - Create: `site/scripts/gen-skills.mjs`
 - Test: `site/scripts/gen-skills.test.mjs`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```js
 // site/scripts/gen-skills.test.mjs
@@ -126,12 +126,12 @@ test('parseFrontmatter strips surrounding YAML quotes (some SKILL.md description
 });
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: FAIL — `Cannot find module './gen-skills.mjs'` (or export missing).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 ```js
 // site/scripts/gen-skills.mjs
@@ -166,12 +166,12 @@ export function parseFrontmatter(raw, file = '<input>') {
 }
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: PASS — 2 tests.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "feat(site): gen-skills parseFrontmatter"
@@ -183,7 +183,7 @@ gt create -m "feat(site): gen-skills parseFrontmatter"
 - Modify: `site/scripts/gen-skills.mjs`
 - Test: `site/scripts/gen-skills.test.mjs`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```js
 import { stripTitleHeading } from './gen-skills.mjs';
@@ -196,12 +196,12 @@ test('stripTitleHeading removes the first "# <name>" H1 only', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: FAIL — `stripTitleHeading is not a function`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 ```js
 export function stripTitleHeading(body, name) {
@@ -212,12 +212,12 @@ export function stripTitleHeading(body, name) {
 }
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(site): gen-skills stripTitleHeading"
@@ -229,7 +229,7 @@ gt modify -c -m "feat(site): gen-skills stripTitleHeading"
 - Modify: `site/scripts/gen-skills.mjs`
 - Test: `site/scripts/gen-skills.test.mjs`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```js
 import { rewriteLinks } from './gen-skills.mjs';
@@ -251,12 +251,12 @@ test('rewriteLinks maps skill links to routes, refs to GitHub, leaves absolute/a
 });
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: FAIL — `rewriteLinks is not a function`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 ```js
 export function rewriteLinks(body, name) {
@@ -273,12 +273,12 @@ export function rewriteLinks(body, name) {
 }
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(site): gen-skills rewriteLinks"
@@ -290,7 +290,7 @@ gt modify -c -m "feat(site): gen-skills rewriteLinks"
 - Modify: `site/scripts/gen-skills.mjs`
 - Test: `site/scripts/gen-skills.test.mjs`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```js
 import { neutralizeTags } from './gen-skills.mjs';
@@ -315,12 +315,12 @@ test('neutralizeTags: block tag -> Callout, prose tag escaped, code-span tag pre
 });
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: FAIL — `neutralizeTags is not a function`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 ```js
 function humanizeTag(t) {
@@ -351,12 +351,12 @@ export function neutralizeTags(body) {
 }
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(site): gen-skills code-aware neutralizeTags"
@@ -368,7 +368,7 @@ gt modify -c -m "feat(site): gen-skills code-aware neutralizeTags"
 - Modify: `site/scripts/gen-skills.mjs`
 - Test: `site/scripts/gen-skills.test.mjs`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```js
 import { renderPage } from './gen-skills.mjs';
@@ -386,12 +386,12 @@ test('renderPage emits title/description, source link, and an internal note for 
 });
 ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: FAIL — `renderPage is not a function`.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
 
 ```js
 export function renderPage(name, fm, body) {
@@ -404,12 +404,12 @@ export function renderPage(name, fm, body) {
 }
 ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
 
 Run: `node --test site/scripts/gen-skills.test.mjs`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(site): gen-skills renderPage"
@@ -420,7 +420,7 @@ gt modify -c -m "feat(site): gen-skills renderPage"
 **Files:**
 - Modify: `site/scripts/gen-skills.mjs`
 
-- [ ] **Step 1: Add the `main()` walk + direct-invocation guard (so tests can import without running it)**
+- [x] **Step 1: Add the `main()` walk + direct-invocation guard (so tests can import without running it)**
 
 ```js
 async function main() {
@@ -457,22 +457,22 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
 }
 ```
 
-- [ ] **Step 2: Run the generator against the real skills tree, confirm 18 pages**
+- [x] **Step 2: Run the generator against the real skills tree, confirm 18 pages**
 
 Run: `cd site && node scripts/gen-skills.mjs && ls content/docs/skills | wc -l`
 Expected: PASS — `gen-skills: wrote 18 pages …` and `ls | wc -l` prints `18`.
 
-- [ ] **Step 3: Confirm no JSX-interpretable pseudo-tag survives outside code**
+- [x] **Step 3: Confirm no JSX-interpretable pseudo-tag survives outside code**
 
 Run: `cd site && node scripts/gen-skills.mjs >/dev/null && ! grep -rnE '^<[A-Z][A-Z-]+>' content/docs/skills`
 Expected: PASS — exit 0 (no standalone-line uppercase tag remains; block tags are now `<Callout>`).
 
-- [ ] **Step 4: Confirm idempotence**
+- [x] **Step 4: Confirm idempotence**
 
 Run: `cd site && node scripts/gen-skills.mjs && cp -r content/docs/skills /tmp/g1 && node scripts/gen-skills.mjs && diff -r /tmp/g1 content/docs/skills && echo IDEMPOTENT`
 Expected: PASS — `IDEMPOTENT` (no diff).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(site): gen-skills file walk over skills/*/SKILL.md"
@@ -485,7 +485,7 @@ gt modify -c -m "feat(site): gen-skills file walk over skills/*/SKILL.md"
 - Modify: `site/.gitignore`
 - Modify: `site/mdx-components.tsx` (ensure `Callout` is in scope for generated MDX)
 
-- [ ] **Step 1: Add `predev`/`prebuild`/`test` scripts**
+- [x] **Step 1: Add `predev`/`prebuild`/`test` scripts**
 
 In `site/package.json` `"scripts"`, add (keep the scaffolded `dev`/`build`):
 
@@ -499,7 +499,7 @@ In `site/package.json` `"scripts"`, add (keep the scaffolded `dev`/`build`):
 }
 ```
 
-- [ ] **Step 2: Gitignore the generated output**
+- [x] **Step 2: Gitignore the generated output**
 
 Append to `site/.gitignore`:
 
@@ -508,7 +508,7 @@ Append to `site/.gitignore`:
 /content/docs/skills/
 ```
 
-- [ ] **Step 3: Ensure `Callout` is registered for MDX**
+- [x] **Step 3: Ensure `Callout` is registered for MDX**
 
 Confirm `site/mdx-components.tsx` spreads Fumadocs defaults (which include `Callout`). If it does not, add it:
 
@@ -524,17 +524,17 @@ export function getMDXComponents(components) {
 Run: `cd site && grep -q Callout mdx-components.tsx && echo OK`
 Expected: PASS — `OK`.
 
-- [ ] **Step 4: Build smoke — generation + compile of all 18 generated pages**
+- [x] **Step 4: Build smoke — generation + compile of all 18 generated pages**
 
 Run: `cd site && rm -rf content/docs/skills && pnpm build`
 Expected: PASS — `prebuild` regenerates 18 pages, `next build` exits 0 and compiles every generated `skills/*.mdx` (proves the neutralization is load-bearing).
 
-- [ ] **Step 5: Confirm generated output is untracked/ignored**
+- [x] **Step 5: Confirm generated output is untracked/ignored**
 
 Run: `git status --porcelain site/content/docs/skills | wc -l`
 Expected: PASS — `0` (gitignored; not staged).
 
-- [ ] **Step 6: Run the unit suite once more, then commit**
+- [x] **Step 6: Run the unit suite once more, then commit**
 
 Run: `cd site && pnpm test`
 Expected: PASS — all `node --test` assertions green.

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -3,7 +3,8 @@
 
 # generated content
 .source
-/content/docs/skills
+# skill reference pages generated from ../skills/*/SKILL.md at build time (source of truth = skills/)
+/content/docs/skills/
 
 # test & build
 /coverage

--- a/site/package.json
+++ b/site/package.json
@@ -3,9 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "predev": "node scripts/gen-skills.mjs",
     "dev": "next dev",
+    "prebuild": "node scripts/gen-skills.mjs",
+    "build": "next build",
     "start": "next start",
+    "test": "node --test scripts/*.test.mjs",
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
     "postinstall": "fumadocs-mdx"
   },

--- a/site/scripts/gen-skills.mjs
+++ b/site/scripts/gen-skills.mjs
@@ -1,0 +1,134 @@
+import { readdir, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..'); // site/scripts -> repo root
+const SKILLS_DIR = path.join(REPO_ROOT, 'skills');
+const OUT_DIR = path.resolve(__dirname, '..', 'content', 'docs', 'skills');
+const GH_BASE = 'https://github.com/howarewoo/woostack/blob/main';
+const INTERNAL = new Set(['woostack-ideate', 'woostack-harden']);
+
+const ORDER = [
+  'using-woostack', 'woostack-init', 'woostack-bootstrap', 'woostack-build', 'woostack-fix',
+  'woostack-plan', 'woostack-execute', 'woostack-execute-overnight', 'woostack-commit',
+  'woostack-review', 'woostack-address-comments', 'woostack-status', 'woostack-visualize',
+  'woostack-debug', 'woostack-tdd', 'woostack-dream',
+];
+
+export function parseFrontmatter(raw, file = '<input>') {
+  const m = /^---\n([\s\S]*?)\n---\n?/.exec(raw);
+  if (!m) throw new Error(`${file}: missing frontmatter`);
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const mm = /^(\w+):\s*(.*)$/.exec(line);
+    if (!mm) continue;
+    let v = mm[2].trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1).replace(/\\"/g, '"'); // some descriptions are YAML-quoted in source
+    }
+    fm[mm[1]] = v;
+  }
+  if (!fm.name) throw new Error(`${file}: frontmatter missing 'name'`);
+  if (!fm.description) throw new Error(`${file}: frontmatter missing 'description'`);
+  return { fm, body: raw.slice(m[0].length) };
+}
+
+export function stripTitleHeading(body, name) {
+  const lines = body.split('\n');
+  const idx = lines.findIndex((l) => l.trim() === `# ${name}`);
+  if (idx !== -1) lines.splice(idx, 1);
+  return lines.join('\n');
+}
+
+export function rewriteLinks(body, name) {
+  return body.replace(/\]\(([^)]+)\)/g, (whole, target) => {
+    if (/^https?:\/\//.test(target) || target.startsWith('#') || target.startsWith('mailto:')) return whole;
+    const skill = /^\.\.\/([a-z0-9-]+)\/SKILL\.md(#.+)?$/.exec(target);
+    if (skill) return `](/docs/skills/${skill[1]}${skill[2] || ''})`;
+    const hash = (target.match(/#.*$/) || [''])[0];
+    const clean = target.replace(/#.*$/, '');
+    const rel = clean.replace(/^(\.\.\/)+/, ''); // strip leading ../
+    const ghPath = clean.startsWith('../') ? `skills/${rel}` : `skills/${name}/${rel}`;
+    return `](${GH_BASE}/${ghPath}${hash})`;
+  });
+}
+
+function humanizeTag(t) {
+  const s = t.replace(/-/g, ' ').toLowerCase();
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function escapeBareTagsOutsideCode(line) {
+  // split on inline code spans; only escape uppercase tags in the non-code segments
+  return line
+    .split(/(`[^`]*`)/)
+    .map((seg) => (seg.startsWith('`') ? seg : seg.replace(/<(\/?[A-Z][A-Z-]*)>/g, '&lt;$1&gt;')))
+    .join('');
+}
+
+export function neutralizeTags(body) {
+  const out = [];
+  let inFence = false;
+  for (const line of body.split('\n')) {
+    if (/^\s*(```|~~~)/.test(line)) { inFence = !inFence; out.push(line); continue; }
+    if (inFence) { out.push(line); continue; }
+    const open = /^<([A-Z][A-Z-]*)>\s*$/.exec(line);
+    if (open) { out.push(`<Callout type="warn" title="${humanizeTag(open[1])}">`); continue; }
+    if (/^<\/[A-Z][A-Z-]*>\s*$/.test(line)) { out.push('</Callout>'); continue; }
+    out.push(escapeBareTagsOutsideCode(line));
+  }
+  return out.join('\n');
+}
+
+export function renderPage(name, fm, body) {
+  const front = `---\ntitle: ${name}\ndescription: ${JSON.stringify(fm.description)}\n---\n\n`;
+  const internal = INTERNAL.has(name)
+    ? `<Callout type="info" title="Internal sub-skill">Building block of [woostack-build](/docs/skills/woostack-build); not a directly-invocable \`/woostack-*\` command.</Callout>\n\n`
+    : '';
+  const source = `[View source on GitHub](${GH_BASE}/skills/${name}/SKILL.md)\n\n`;
+  return front + internal + source + body.replace(/^\n+/, '') + '\n';
+}
+
+export function navOrder(names) {
+  return [...ORDER.filter((n) => names.includes(n)), ...names.filter((n) => !ORDER.includes(n))];
+}
+
+async function main() {
+  if (!existsSync(SKILLS_DIR)) {
+    console.error(
+      `gen-skills: source dir not found: ${SKILLS_DIR}\n` +
+      `On Vercel, enable "Include files outside the root directory in the Build Step".`
+    );
+    process.exit(1);
+  }
+  await rm(OUT_DIR, { recursive: true, force: true });
+  await mkdir(OUT_DIR, { recursive: true });
+  const names = (await readdir(SKILLS_DIR, { withFileTypes: true }))
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+  const written = [];
+  for (const name of names) {
+    const file = path.join(SKILLS_DIR, name, 'SKILL.md');
+    if (!existsSync(file)) continue;
+    const raw = await readFile(file, 'utf8');
+    const { fm, body } = parseFrontmatter(raw, name);
+    let b = stripTitleHeading(body, fm.name);
+    b = neutralizeTags(b);
+    b = rewriteLinks(b, name);
+    await writeFile(path.join(OUT_DIR, `${name}.mdx`), renderPage(name, fm, b), 'utf8');
+    written.push(name);
+  }
+  await writeFile(
+    path.join(OUT_DIR, 'meta.json'),
+    JSON.stringify({ title: 'Skills', pages: navOrder(written) }, null, 2) + '\n',
+    'utf8'
+  );
+  console.log(`gen-skills: wrote ${written.length} pages -> ${path.relative(process.cwd(), OUT_DIR)}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((e) => { console.error(e.message); process.exit(1); });
+}

--- a/site/scripts/gen-skills.test.mjs
+++ b/site/scripts/gen-skills.test.mjs
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseFrontmatter,
+  stripTitleHeading,
+  rewriteLinks,
+  neutralizeTags,
+  renderPage,
+  navOrder,
+} from './gen-skills.mjs';
+
+test('parseFrontmatter extracts name + description and returns the body', () => {
+  const raw = '---\nname: woostack-build\ndescription: Use when building a feature.\n---\n\n# woostack-build\n\nbody';
+  const { fm, body } = parseFrontmatter(raw, 'woostack-build');
+  assert.equal(fm.name, 'woostack-build');
+  assert.equal(fm.description, 'Use when building a feature.');
+  assert.match(body, /# woostack-build/);
+});
+
+test('parseFrontmatter throws when name is missing', () => {
+  assert.throws(() => parseFrontmatter('---\ndescription: x\n---\nbody', 'f'), /missing 'name'/);
+});
+
+test('parseFrontmatter strips surrounding YAML quotes (some descriptions are quoted)', () => {
+  const raw = '---\nname: woostack-tdd\ndescription: "TDD home: red→green. Quoted in source."\n---\nb';
+  const { fm } = parseFrontmatter(raw, 'woostack-tdd');
+  assert.equal(fm.description, 'TDD home: red→green. Quoted in source.'); // no leading/trailing "
+});
+
+test('stripTitleHeading removes only the first exact "# <name>" H1', () => {
+  const body = '\n# woostack-build\n\n## Overview\n\n# woostack-build\n';
+  const out = stripTitleHeading(body, 'woostack-build');
+  assert.equal((out.match(/^# woostack-build$/gm) || []).length, 1); // one removed, one stays
+  assert.match(out, /## Overview/);
+});
+
+test('rewriteLinks maps skill links to routes, refs to GitHub, leaves absolute/anchors', () => {
+  const r = (s) => rewriteLinks(s, 'woostack-build');
+  assert.equal(r('see [plan](../woostack-plan/SKILL.md)'), 'see [plan](/docs/skills/woostack-plan)');
+  assert.equal(r('[a](../woostack-plan/SKILL.md#x)'), '[a](/docs/skills/woostack-plan#x)');
+  assert.equal(
+    r('[wt](../woostack-init/references/worktrees.md)'),
+    '[wt](https://github.com/howarewoo/woostack/blob/main/skills/woostack-init/references/worktrees.md)'
+  );
+  assert.equal(
+    r('[self](references/plan-template.md)'),
+    '[self](https://github.com/howarewoo/woostack/blob/main/skills/woostack-build/references/plan-template.md)'
+  );
+  assert.equal(r('[ext](https://example.com)'), '[ext](https://example.com)');
+  assert.equal(r('[here](#section)'), '[here](#section)');
+});
+
+test('neutralizeTags: block tag -> Callout, prose tag escaped, code-span/fence preserved', () => {
+  const block = '<HARD-GATE>\nDo not proceed.\n</HARD-GATE>';
+  const out = neutralizeTags(block);
+  assert.match(out, /<Callout type="warn" title="Hard gate">/);
+  assert.match(out, /<\/Callout>/);
+  assert.doesNotMatch(out, /<HARD-GATE>/);
+
+  assert.match(neutralizeTags('a bare <FOO> here'), /a bare &lt;FOO&gt; here/);
+
+  const code = 'POST `gh api repos/<repo>/pulls/<PR>/reviews` now';
+  assert.equal(neutralizeTags(code), code); // uppercase tag inside inline code preserved
+
+  const fenced = '```\n<PR> stays\n```';
+  assert.equal(neutralizeTags(fenced), fenced); // inside fence preserved
+});
+
+test('renderPage emits title/description, source link, internal note for sub-skills', () => {
+  const fm = { name: 'woostack-build', description: 'Build a feature: end to end.' };
+  const page = renderPage('woostack-build', fm, '## Overview\n\nbody');
+  assert.match(page, /^---\ntitle: woostack-build\n/);
+  assert.match(page, /description: "Build a feature: end to end\."/); // JSON-quoted, colon-safe
+  assert.match(
+    page,
+    /\[View source on GitHub\]\(https:\/\/github\.com\/howarewoo\/woostack\/blob\/main\/skills\/woostack-build\/SKILL\.md\)/
+  );
+  assert.doesNotMatch(page, /Internal sub-skill/);
+
+  const ideate = renderPage('woostack-ideate', { name: 'woostack-ideate', description: 'x' }, 'b');
+  assert.match(ideate, /Internal sub-skill/);
+});
+
+test('navOrder puts public commands first, internal sub-skills last', () => {
+  const names = ['woostack-harden', 'woostack-build', 'woostack-ideate', 'using-woostack'];
+  const order = navOrder(names);
+  assert.deepEqual(order, ['using-woostack', 'woostack-build', 'woostack-harden', 'woostack-ideate']);
+  assert.ok(order.indexOf('woostack-build') < order.indexOf('woostack-ideate'));
+  assert.ok(order.indexOf('woostack-build') < order.indexOf('woostack-harden'));
+});


### PR DESCRIPTION
## Goal

Add the engine that turns every `skills/*/SKILL.md` into a Fumadocs MDX page, so the docs site never forks skill content. Increment 2 of 3; stacks on the scaffold PR (#318).

## Summary

- `site/scripts/gen-skills.mjs` — pure, exported transform functions (`parseFrontmatter` with YAML-quote stripping, `stripTitleHeading`, `rewriteLinks`, `neutralizeTags`, `renderPage`, `navOrder`) + a thin file-walk `main()`. Per skill: maps frontmatter→title/description, drops the duplicate H1, neutralizes uppercase pseudo-tags (`<HARD-GATE>` etc. → `<Callout>`; bare prose tags escaped; **code-span/fence tokens like `<PR>` preserved**), rewrites links (skill→route, refs→GitHub), adds a "View source on GitHub" backlink, flags the two internal sub-skills, and emits `skills/meta.json` (public commands first, internals last).
- `site/scripts/gen-skills.test.mjs` — 8 `node --test` cases covering every transform invariant.
- Wiring: `predev`/`prebuild` run the generator; `test` runs the suite; generated `content/docs/skills/` is gitignored.

## Test plan

### Automated

- [x] `node --test scripts/*.test.mjs` → 8/8 pass.
- [x] `node scripts/gen-skills.mjs` → 18 pages + meta.json; no standalone `<UPPER>` tag survives; `<PR>` preserved in the review page's code span; idempotent (byte-identical re-run).
- [x] `pnpm build` → exit 0, prebuild generates 18 pages, next build compiles 66 static routes.

### Manual

**Before merge**

- [ ] Skim a generated page (e.g. `/docs/skills/woostack-build`) — title, description, source link, cross-links resolve.
- [ ] Confirm `woostack-ideate`/`woostack-harden` show the "Internal sub-skill" callout.

Spec: .woostack/specs/2026-06-12-fumadocs-docs-site.md
