### PR TITLE
chore: gitignore .serena/ MCP sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ pnpm-debug.log*
 # Playwright MCP
 .playwright-mcp/
 
+# Serena MCP (local project cache + config sidecar)
+.serena/
+
 # Misc
 *.tsbuildinfo
 .vercel


### PR DESCRIPTION
## Goal

Keep the Serena MCP server's local sidecar (`.serena/` — project cache + config) out of git so it stops showing as untracked noise in every clone that uses the Serena MCP tools.

## Summary

- Add `.serena/` to root `.gitignore`, grouped under the existing MCP sidecar section beside `.playwright-mcp/`.

## Test plan

### Automated

- [x] `git check-ignore .serena/` → prints `.serena/` (now ignored)
- [x] `git status --short` → `.serena/` no longer listed as untracked

### Manual

**Before merge**

- [ ] Read the one-line `.gitignore` diff and confirm only the Serena sidecar is added (no other paths touched)
