### PR TITLE
docs: spec + plan — woostack-ask read-only codebase Q&A

### DIFF
--- a/.woostack/plans/2026-06-13-woostack-ask.md
+++ b/.woostack/plans/2026-06-13-woostack-ask.md
@@ -1,0 +1,361 @@
+**Source:** .woostack/specs/2026-06-13-woostack-ask.md
+
+# woostack-ask — read-only codebase Q&A — Implementation Plan
+
+**Goal:** Add a public `/woostack-ask <question>` skill — a purely investigative, read-only Q&A command wired into the woostack memory/knowledge framework — and register it on the command surface.
+
+**Architecture:** One prose-only `skills/woostack-ask/SKILL.md` (no scripts, no `references/`), modeled on `woostack-debug` (autonomous, recall-at-start, investigative-only) and positioned as the read-only twin of `woostack-dream`. Increment 1 ships the skill; Increment 2 wires it across the drift-prone command-surface bookkeeping sites. Verification is structural (grep / frontmatter parse / `git status`), since a prose skill has no test runner.
+
+**Tech Stack:** Markdown skill assets; bash verification (grep, `git status`); Graphite (`gt`) for stacked PRs. Reuses `woostack-init` scripts (`recall.sh`, `scope-match.sh`) at runtime — none added here.
+
+---
+
+## Increment 1: woostack-ask SKILL.md
+
+> One independently shippable PR (≤500 LOC soft target) — its own Graphite-stacked branch on the spec+plan base. The "missing from routing / surface lists" review finding is **expected** here and completed by Increment 2 (accepted skill-add → stacked-wiring split per [[woostack-review-is-not-stack-aware-224-a-skill-add-pr-may-de]]).
+
+### Task 1: Author `skills/woostack-ask/SKILL.md`
+
+**Files:**
+- Create: `skills/woostack-ask/SKILL.md`
+
+- [ ] **Step 1: Confirm the file does not yet exist (red)**
+
+Run: `test -f skills/woostack-ask/SKILL.md && echo EXISTS || echo ABSENT`
+Expected: `ABSENT`
+
+- [ ] **Step 2: Create the skill file with this exact content**
+
+```markdown
+---
+name: woostack-ask
+description: "Use as woostack's read-only investigation phase — answer a question about the codebase grounded in the .woostack knowledge surface (recall the scoped memory store, wholesale-load wisdom/ when present, then read the rest of the .woostack/ artifact tree — specs, plans, fixes, overnight, visuals, and any future store), plus repo code and, when the question calls for it, external references. Cites its evidence and hands the answer back; chains nothing. Invoke via /woostack-ask <question>. Investigative only — autonomous is its sole mode (no flag), and it never writes code, files, memory notes, commits, or merges."
+---
+
+# woostack-ask
+
+Answer a question about the codebase, read-only. This is woostack's own investigation phase: the
+place to ask "how does X work", "where does Y live", or "what would it take to integrate Z" and
+get an answer grounded in the project's accumulated knowledge — without any risk of a write. It is
+the investigative twin of [`woostack-debug`](../woostack-debug/SKILL.md) (which root-causes a bug)
+and the **read-only twin of** [`woostack-dream`](../woostack-dream/SKILL.md) (which curates the
+same corpus with writes and a gate). woostack-ask owns no approval gate, never writes anything, and
+hands the answer back.
+
+It is a public command — `/woostack-ask <question>` — with no internal callers. It always runs
+autonomously: there is no interactive mode and no flag.
+
+<WRITE-BLOCK>
+woostack-ask NEVER writes. No code, no `.woostack/` artifacts (specs, plans, fixes, memory notes),
+no commits, no merges — zero tracked writes, for EVERY request regardless of perceived simplicity.
+If answering seems to require a change, describe the change and name the command that makes it
+(e.g. `/woostack-build`, `/woostack-fix`); do not make it. The one inherited benign side effect is
+`recall.sh`'s gitignored telemetry sidecar (best-effort, non-fatal) — `git status` stays clean.
+</WRITE-BLOCK>
+
+## When to use
+
+Any read-only question about this codebase: how a subsystem works, where something lives, why a
+decision was made, what a spec/plan/fix says, or whether an external project has something worth
+adopting. Use it instead of an unscoped agent whenever you want an answer with **no chance of an
+edit**. For a bug's root cause use [`woostack-debug`](../woostack-debug/SKILL.md); to curate the
+knowledge store use [`woostack-dream`](../woostack-dream/SKILL.md).
+
+## Knowledge surface (all read-only)
+
+woostack-ask reads **wider** than the scoped recall other skills use. `woostack-review` /
+`woostack-execute` load a narrow per-working-set context; woostack-ask uses recall as an *entry
+point* but reaches the whole `.woostack/` tree, because answering can need the full decision
+history. Enumerate `.woostack/` subdirs **dynamically** — never hardcode the list — so future
+stores are automatically in scope.
+
+| Source | How read |
+|---|---|
+| `.woostack/memory/` | recall procedure (memory contract §6) — `recall.sh` when init scripts present, else the manual fallback. Entry point. |
+| `.woostack/wisdom/` | **wholesale-load** every `wisdom/*.md` when the directory exists; skip when absent. Consumer of the dream-wisdom store; ask only reads it. |
+| `.woostack/specs/ plans/ fixes/ overnight/ visuals/` | **direct read on demand**, by relevance (grep/glob). Specs and plans are recall-excluded by type, so a direct read is the only way to reach them. |
+| future `.woostack/<new>/` subdirs | enumerated dynamically alongside the above. |
+| repo code | Read / Grep / Glob; follow existing patterns. |
+| external references | WebFetch / WebSearch, only when the question names or implies them. Reads pull content **in**; never send codebase content out. |
+
+## The four phases
+
+### Phase 1 — Recall
+Infer the working set from the question (the files / skill dirs it implicates). Run the recall
+procedure; wholesale-load `wisdom/` if present; surface the matching notes before investigating —
+a note may already answer the question. State whether recall was script-assisted or manual; never
+fail silently.
+
+### Phase 2 — Investigate (read-only)
+Explore the evidence: repo code, the relevant `.woostack/` artifacts, and — when the question
+calls for it — external sources. Scope the investigation to the question (YAGNI on breadth); read
+what the answer needs, not the whole repo. Gather concrete evidence: `file:line`, note names,
+artifact paths, URLs.
+
+### Phase 3 — Synthesize
+Answer the question directly, citing every claim, and mark what is grounded vs inferred. For an
+"integration-benefit" question (e.g. "benefits we could integrate from `<external repo>` into our
+skill library"): enumerate the candidate benefits → map each to where it would land in the skill
+library → flag overlap or conflict with existing skills → give a recommendation. Propose no
+implementation.
+
+### Phase 4 — Handback
+The answer lives in the conversation. Offer a [`woostack-visualize`](../woostack-visualize/SKILL.md)
+render on request (pick the audience that fits). If the answer implies action, name the next
+command for the user to run. Chain nothing.
+
+## Operation
+
+Running `/woostack-ask <question>` works Phases 1–4 end to end and hands back the answer — no gate,
+no flag, autonomous only.
+
+- **No question given.** `/woostack-ask` with no argument → ask what the user wants to know; do not
+  guess (mirror `woostack-debug`).
+
+## Memory
+
+woostack-ask **recalls** the scoped `.woostack/memory/` store and **never distills** — the note
+schema, recall procedure, and degradation contract are defined once in
+[memory.md](../woostack-init/references/memory.md); this says only how ask uses them.
+
+- **Recall (start).** Compute the working set from the question; run recall: `recall.sh` when the
+  `woostack-init` scripts are present, the manual procedure (load `MEMORY.md` + scope-match +
+  one-hop link expand) otherwise. State script-assisted vs manual.
+- **No distill.** woostack-ask writes nothing, so it never creates or updates a note. Distillation
+  stays owned by `woostack-execute`; curation by `woostack-dream`.
+
+## Degradation
+
+- **No `.woostack/`** → report there is no memory/corpus to recall; answer from repo code (and
+  external) only; never scaffold (defer to `/woostack-init`).
+- **Init scripts missing** (individual install) → announce the manual recall fallback (memory
+  contract §10); never fail silently.
+- **A subdir is absent** (`wisdom/`, `overnight/`, …) → skip it, note the gap, continue.
+- **External fetch fails / blocked / private** → report it; answer from reachable evidence; never
+  fabricate.
+- **Non-git checkout** → filesystem reads still work; recall telemetry is best-effort.
+
+## Hard constraints
+
+- **WRITE-BLOCK.** Zero tracked writes — no code, artifacts, memory notes, commits, or merges. Keep
+  this prominent so it survives summarization.
+- **Recall-only memory.** Reads the store; never distills. Distillation belongs to
+  `woostack-execute`, curation to `woostack-dream`.
+- **Reads the whole `.woostack/` tree, enumerated dynamically.** Beyond scoped recall; never
+  hardcode the subdir list.
+- **Cite evidence; no fabrication.** Mark grounded vs inferred; external reads pull in, never push
+  out.
+- **Autonomous, owns no gate, chains nothing.** Answering is terminal; name the next command rather
+  than running it.
+- **Owns no spec/plan/status.** The phase enum and join contracts live in
+  [conventions.md](../woostack-status/references/conventions.md) — link, never restate.
+```
+
+- [ ] **Step 3: Verify the file exists and the frontmatter is installer-safe (green)**
+
+Run:
+```bash
+test -f skills/woostack-ask/SKILL.md && echo EXISTS
+# description is double-quoted (neutralizes the ": " colon-space ScannerError, [[skill-description-colon-space]]):
+grep -nE '^description: ".*"$' skills/woostack-ask/SKILL.md && echo DESC_QUOTED
+# name slug present:
+grep -nx 'name: woostack-ask' skills/woostack-ask/SKILL.md && echo NAME_OK
+```
+Expected:
+```
+EXISTS
+<line>:description: "Use as woostack's read-only investigation phase — ...merges."
+DESC_QUOTED
+<line>:name: woostack-ask
+NAME_OK
+```
+
+- [ ] **Step 4: Verify the core invariants are present (green)**
+
+Run:
+```bash
+grep -c 'WRITE-BLOCK' skills/woostack-ask/SKILL.md          # expect >=2 (block + hard constraint)
+grep -q 'wholesale-load' skills/woostack-ask/SKILL.md && echo WISDOM_OK
+grep -q 'recall procedure' skills/woostack-ask/SKILL.md && echo RECALL_OK
+grep -q 'enumerated dynamically' skills/woostack-ask/SKILL.md && echo ENUM_OK
+grep -q 'no flag' skills/woostack-ask/SKILL.md && echo AUTONOMOUS_OK
+```
+Expected: a count `>= 2`, then `WISDOM_OK`, `RECALL_OK`, `ENUM_OK`, `AUTONOMOUS_OK`.
+
+- [ ] **Step 5: Confirm no stray writes, then commit**
+
+Run: `git status --porcelain` → Expected: only `?? skills/woostack-ask/SKILL.md` (plus the already-committed `.woostack/` spec+plan on the base branch; nothing else).
+```bash
+gt create -m "feat(ask): woostack-ask read-only codebase Q&A skill"
+```
+
+---
+
+## Increment 2: register woostack-ask on the command surface
+
+> One independently shippable PR stacked on Increment 1. Wires every drift-prone bookkeeping site in lockstep ([[woostack-command-surface-bookkeeping]]): 16 → **17** public commands, 18 → **19** `SKILL.md` files. README and `development.md` are verified no-ops.
+
+### Task 1: AGENTS.md (six sub-edits; `.claude/CLAUDE.md` is a symlink, so editing AGENTS.md updates both)
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Bump the surface count**
+
+Replace:
+`The public command/adoption surface has sixteen skills:`
+With:
+`The public command/adoption surface has seventeen skills:`
+
+- [ ] **Step 2: Add the public-list bullet (after the woostack-debug bullet)**
+
+Replace:
+```
+- [`woostack-debug`](skills/woostack-debug/SKILL.md)
+- [`woostack-tdd`](skills/woostack-tdd/SKILL.md)
+```
+With:
+```
+- [`woostack-debug`](skills/woostack-debug/SKILL.md)
+- [`woostack-ask`](skills/woostack-ask/SKILL.md)
+- [`woostack-tdd`](skills/woostack-tdd/SKILL.md)
+```
+
+- [ ] **Step 3: Update the "N-skill command surface" phrase**
+
+Replace:
+`they have no routing row and are absent from the sixteen-skill command surface above.`
+With:
+`they have no routing row and are absent from the seventeen-skill command surface above.`
+
+- [ ] **Step 4: Add `/woostack-ask` to the Mode B trigger list**
+
+Replace:
+`` `/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, `/woostack-dream`, or ``
+With:
+`` `/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, `/woostack-ask`, `/woostack-dream`, or ``
+
+- [ ] **Step 5: Update the rename-constraint count (appears once, two numbers)**
+
+Replace:
+`- Do not move or rename any of the eighteen `SKILL.md` files (the sixteen public command/adoption`
+With:
+`- Do not move or rename any of the nineteen `SKILL.md` files (the seventeen public command/adoption`
+
+- [ ] **Step 6: Add the Quick file map entry (after the systematic-debugging entry)**
+
+Replace:
+```
+- Systematic-debugging engine (public command + internal hook invoked by execute/review):
+  [`skills/woostack-debug/SKILL.md`](skills/woostack-debug/SKILL.md)
+```
+With:
+```
+- Systematic-debugging engine (public command + internal hook invoked by execute/review):
+  [`skills/woostack-debug/SKILL.md`](skills/woostack-debug/SKILL.md)
+- Read-only codebase Q&A engine (public command; investigative, never writes):
+  [`skills/woostack-ask/SKILL.md`](skills/woostack-ask/SKILL.md)
+```
+
+- [ ] **Step 7: Verify AGENTS.md is consistent (green)**
+
+Run:
+```bash
+grep -c 'seventeen' AGENTS.md            # expect 3 (L17 surface count + L40 phrase + L94 "seventeen public")
+grep -c 'nineteen' AGENTS.md             # expect 1 (rename constraint "nineteen SKILL.md files")
+grep -c 'sixteen\|eighteen' AGENTS.md    # expect 0 (no stale counts remain)
+grep -c 'woostack-ask' AGENTS.md         # expect 3 (public bullet + Mode B + file-map link line)
+```
+Expected: `3`, `1`, `0`, `3`.
+
+### Task 2: using-woostack Command Routing row
+
+**Files:**
+- Modify: `skills/using-woostack/SKILL.md`
+
+- [ ] **Step 1: Insert the routing row (after the woostack-debug row)**
+
+Replace:
+`` | `/woostack-debug <target>`, run an autonomous root-cause analysis before fixing (investigative only — hands back the root cause and a proposed fix) | `woostack-debug` | ``
+With:
+```
+| `/woostack-debug <target>`, run an autonomous root-cause analysis before fixing (investigative only — hands back the root cause and a proposed fix) | `woostack-debug` |
+| `/woostack-ask <question>`, answer a read-only question about the codebase grounded in the .woostack knowledge surface (investigative only — never writes) | `woostack-ask` |
+```
+
+- [ ] **Step 2: Verify (green)**
+
+Run: `grep -c 'woostack-ask' skills/using-woostack/SKILL.md`
+Expected: `1`
+
+### Task 3: CONTRIBUTING.md (two sub-edits)
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Add to the intro public-surface list (after woostack-debug)**
+
+Replace:
+`` `woostack-status`, `woostack-visualize`, `woostack-debug`, `woostack-tdd`, and `woostack-dream`. ``
+With:
+`` `woostack-status`, `woostack-visualize`, `woostack-debug`, `woostack-ask`, `woostack-tdd`, and `woostack-dream`. ``
+
+- [ ] **Step 2: Add the "What to change" pointer row (after the woostack-debug row)**
+
+Replace:
+`` | Change the systematic-debugging behavior (`/woostack-debug`) | `skills/woostack-debug/SKILL.md` | ``
+With:
+```
+| Change the systematic-debugging behavior (`/woostack-debug`) | `skills/woostack-debug/SKILL.md` |
+| Change the read-only codebase Q&A command (`/woostack-ask`) | `skills/woostack-ask/SKILL.md` |
+```
+
+- [ ] **Step 3: Verify (green)**
+
+Run: `grep -c 'woostack-ask' CONTRIBUTING.md`
+Expected: `2`
+
+### Task 4: Verify README.md and development.md need no change (no-op confirmation)
+
+- [ ] **Step 1: Confirm README's command list is exemplary, not an exhaustive count**
+
+Run: `grep -n 'registers the public skills' README.md`
+Expected: a line containing `(e.g. ... etc.)` — exemplary, no count and no per-command sections for inspection commands (status/debug/dream are likewise absent). No change required.
+
+- [ ] **Step 2: Confirm development.md has no per-command loop row to update**
+
+Run: `grep -nc 'woostack-debug\|woostack-status\|woostack-ask' skills/woostack-bootstrap/references/development.md`
+Expected: `0` — the loop summary is generic; inspection commands are not loop phases, so this stays a no-op (consistent with [[woostack-command-surface-bookkeeping]]).
+
+### Task 5: Final surface consistency + commit
+
+- [ ] **Step 1: Cross-file consistency check (green)**
+
+Run:
+```bash
+# every surface site references the new command:
+for f in AGENTS.md CONTRIBUTING.md skills/using-woostack/SKILL.md; do
+  printf '%s: ' "$f"; grep -c 'woostack-ask' "$f"
+done
+# the skill dir from Increment 1 is present:
+test -f skills/woostack-ask/SKILL.md && echo SKILL_PRESENT
+```
+Expected: `AGENTS.md: 3`, `CONTRIBUTING.md: 2`, `skills/using-woostack/SKILL.md: 1`, `SKILL_PRESENT`.
+
+- [ ] **Step 2: Confirm clean tree apart from the wiring edits, then commit**
+
+Run: `git status --porcelain` → Expected: only `M AGENTS.md`, `M CONTRIBUTING.md`, `M skills/using-woostack/SKILL.md` (AGENTS.md edit also covers the `.claude/CLAUDE.md` symlink).
+```bash
+gt create -m "docs(ask): register woostack-ask on the command surface"
+```
+
+---
+
+## Self-review (run before handing back)
+
+- [ ] **Spec coverage** — §2 goal (skill + full knowledge surface + zero writes + 17th command) → Inc 1 Task 1 + Inc 2 Tasks 1-5. §5 knowledge-surface table → SKILL.md "Knowledge surface" table. §6 error handling → SKILL.md "Degradation".
+- [ ] **AC coverage** — AC1 write-block → WRITE-BLOCK block + Inc1 Step 5 / Inc2 Step (clean `git status`); AC2 recall → "Memory" + Phase 1; AC3 full `.woostack/` reach → "Knowledge surface" (direct read + dynamic enumeration + wisdom skip); AC4 external refs → Phase 3 integration-benefit flow + surface table; AC5 surface registered → Inc 2 Tasks 1-3 verified, gating-test clause N/A (no test exists), description-format edge → Inc1 Step 3 `DESC_QUOTED`.
+- [ ] **No placeholders** — full SKILL.md embedded; every wiring edit is an exact replace with expected grep counts.
+- [ ] **Type consistency** — command name `woostack-ask` / `/woostack-ask <question>` and link paths (`../woostack-*/SKILL.md`, `../woostack-init/references/memory.md`, `../woostack-status/references/conventions.md`) consistent across SKILL.md, routing row, and surface edits.
+
+> woostack plan conventions: frontmatter-free; opens with `**Source:**`; basename mirrors the spec (`2026-06-13-woostack-ask`); no sub-skill banner; in a runner-less target each "failing test" is a concrete grep/parse verification with exact expected output.

--- a/.woostack/specs/2026-06-13-woostack-ask.md
+++ b/.woostack/specs/2026-06-13-woostack-ask.md
@@ -1,0 +1,215 @@
+---
+name: woostack-ask
+type: spec
+status: ready
+date: 2026-06-13
+branch: feature/woostack-ask
+links:
+---
+
+# woostack-ask — read-only codebase Q&A — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+No woostack command answers a question *about* the codebase without risking a write. Users
+want investigative Q&A — "how does X work", "where does Y live", "are there benefits we could
+integrate from `<external repo>` into our skill library" — grounded in the project's accumulated
+knowledge and, when relevant, compared against external sources. Today the only way is an
+unscoped agent that may edit, scaffold, or distill memory as a side effect.
+
+[`woostack-debug`](../../skills/woostack-debug/SKILL.md) is investigative-only but narrowly
+aimed at root-causing a bug; it is not a general question-answerer, and its recall is scoped to a
+bug's working set. The scope-routed recall procedure (memory contract §6) deliberately **excludes**
+`type: spec` / `type: plan` (and the planned `type: wisdom`) from routing, so recall alone cannot
+reach the decision corpus a good answer often needs. There is no read-only counterpart to
+[`woostack-dream`](../../skills/woostack-dream/SKILL.md): dream curates (writes, gated) the
+`.woostack/` corpus; nothing simply *reads it to answer a question*.
+
+## 2. Goal
+
+A public `/woostack-ask <question>` command — a purely investigative, read-only Q&A skill that:
+
+- grounds answers in the full woostack knowledge surface: recall the scoped `memory/` store,
+  wholesale-load `wisdom/` when present, and read the rest of the `.woostack/` artifact tree
+  (`specs/ plans/ fixes/ overnight/ visuals/` and any future store) on demand;
+- reads repo code, and — when the question calls for it — external references, all read-only;
+- answers in conversation with cited evidence (note names, `file:line`, artifact paths, URLs);
+- writes **nothing** — no code, no `.woostack/` files, no memory notes, no commits, no merges;
+- is registered as the **17th** public command with full surface wiring.
+
+## 3. Non-goals
+
+- **No writes of any kind.** No code, no `.woostack/` artifacts, no memory distillation, no
+  commits/merges. Distillation stays owned by `woostack-execute`; curation by `woostack-dream`.
+- **No approval gate, no chaining.** Autonomous like `woostack-debug`; answering is terminal. It
+  never invokes build/plan/execute/fix — it may *name* the next command for the user to run.
+- **No new scripts.** Pure-prose skill; reuses `woostack-init` scripts (`recall.sh`,
+  `scope-match.sh`) exactly as `woostack-debug` does.
+- **No recall/contract change.** Does not modify the recall procedure or the memory contract; it
+  is a consumer of both. It does not add `wisdom/` — it only *reads* it when the in-flight
+  dream-wisdom feature has created it.
+- **Not a curator.** It is the read-only twin of `woostack-dream`, not a replacement.
+- **External reads pull in, never push out.** WebFetch/WebSearch bring external content *into*
+  the answer; the skill never sends codebase content to an external service.
+- **No session mining.** It answers the question the user asked using static sources as
+  evidence; unlike `woostack-dream` it never reflects over transcripts to write anything (it
+  writes nothing at all).
+
+## 4. Approach
+
+Model on `woostack-debug`: investigative-only, autonomous, recall-at-start, hands findings back,
+never writes. Four phases: **Recall → Investigate → Synthesize → Handback**.
+
+The defining design point is that woostack-ask's read surface is **wider than the scoped recall
+every other skill uses**. `woostack-review` / `woostack-execute` load a narrow per-working-set
+context; woostack-ask uses recall as an *entry point* but reaches the whole `.woostack/` tree,
+because answering a question can need the full decision history — the `woostack-dream` read
+pattern, minus the writes and the gate. The tree is **enumerated dynamically** so future stores
+(`wisdom/`, or anything added later) are automatically in scope; the subdir list is never
+hardcoded.
+
+A prominent **WRITE-BLOCK** invariant (mirroring debug's Iron Law, kept prominent so it survives
+summarization) forbids every write action regardless of perceived simplicity. "Zero writes" means
+zero *tracked* writes — no code, artifacts, memory notes, commits, or merges. The single inherited
+benign side effect is `recall.sh`'s gitignored `.telemetry.tsv` stamp (best-effort, non-fatal),
+identical to `woostack-debug`; `git status` stays clean because that sidecar is gitignored.
+
+Investigation is **scoped to the question** (YAGNI on breadth) — read what the answer needs, not
+the whole repo.
+
+woostack-ask only **consumes** `wisdom/`; it neither defines nor creates that store. The
+dependency direction is one-way: if/when the in-flight dream-wisdom feature lands `wisdom/`, ask's
+dynamic `.woostack/` enumeration picks it up with no change to ask.
+
+Surface registration follows the drift-prone bookkeeping sites captured in
+[[woostack-command-surface-bookkeeping]] — current surface 16 public + 2 internal = 18 SKILL.md
+files; adding ask makes it **17 public + 2 internal = 19**.
+
+## 5. Components & data flow
+
+One `skills/woostack-ask/SKILL.md`. No scripts, no `references/`.
+
+**Knowledge surface (all read-only):**
+
+| Source | How read | Notes |
+|---|---|---|
+| `.woostack/memory/` | recall procedure §6 — `recall.sh` when init scripts present, else manual (load `MEMORY.md` → `scope-match.sh` → one-hop `[[link]]` expand) | entry point; state script-assisted vs manual |
+| `.woostack/wisdom/` | **wholesale-load** all `wisdom/*.md` when the dir exists | consumer pattern from the dream-wisdom feature; skip when absent |
+| `.woostack/specs/ plans/ fixes/ overnight/ visuals/` | **direct read on demand**, by relevance (grep/glob) | specs/plans recall-excluded by type → direct read is the only path |
+| future `.woostack/<new>/` subdirs | enumerated dynamically | never hardcode the subdir list |
+| repo code | Read / Grep / Glob | follow existing patterns |
+| external references | WebFetch / WebSearch | only when the question names/implies them; read-only |
+
+**Data flow:** question → infer working set → recall + wisdom wholesale-load + targeted
+corpus/code/external reads → synthesized, cited answer in conversation → optional
+`woostack-visualize` render on request → stop.
+
+**Phases:**
+
+1. **Recall.** Infer the working set from the question. Run recall; wholesale-load `wisdom/` if
+   present; surface matching notes before investigating. Never fail silently.
+2. **Investigate (read-only).** Explore code, targeted `.woostack/` artifacts, and external
+   sources. Gather evidence: `file:line`, note names, artifact paths, URLs.
+3. **Synthesize.** Direct answer; cite every claim; mark grounded vs inferred. For an
+   integration-benefit question: enumerate candidate benefits → map each to where it would land in
+   the skill library → flag overlap/conflict with existing skills → give a recommendation. No
+   implementation.
+4. **Handback.** Answer in conversation; offer a `woostack-visualize` render on request; if the
+   answer implies action, name the next command (e.g. `/woostack-build`). Chain nothing.
+
+**No argument:** `/woostack-ask` with no question → ask what the user wants to know; do not guess
+(mirror `woostack-debug`).
+
+## 6. Error handling
+
+- **No `.woostack/`** → report there is no memory/corpus to recall; answer from repo code (+
+  external) only; never scaffold (defer to `/woostack-init`). Mirrors dream/debug degradation.
+- **Init scripts missing** (individual install) → announce the manual recall fallback (memory
+  contract §10); never fail silently.
+- **Missing subdir** (`wisdom/`, `overnight/`, …) → skip that source, note the gap, continue.
+- **External fetch fails / blocked / private URL** → report it; answer from reachable evidence;
+  never fabricate.
+- **Question implies a write** ("add X", "fix Y") → answer investigatively (what it would take,
+  where it lands) and name the command to do it; never perform the write.
+- **Non-git checkout** → filesystem corpus reads still work; recall telemetry stamping is
+  best-effort and non-fatal.
+
+## 7. Acceptance criteria
+
+- **AC1 — purely investigative (write-block)**
+  - happy: a question is answered in conversation with zero *tracked* mutations — no new or
+    changed tracked files, no commits, no memory notes; `git status` clean after (the gitignored
+    `recall.sh` telemetry sidecar is the only permitted side effect and does not dirty git).
+  - error: a question phrased as a command ("add a woostack-foo skill") yields an investigative
+    answer + the command to run, not an edit.
+  - edge: even a trivially "simple" question performs no write.
+- **AC2 — memory recall at start**
+  - happy: ask runs recall (`recall.sh` when scripts present), surfaces matching notes before
+    answering, and states whether recall was script-assisted or manual.
+  - error: scripts absent → manual §6 recall, announced; never silent.
+  - edge: empty/absent memory store → recall yields nothing; the answer still proceeds from
+    corpus/code/external.
+- **AC3 — full `.woostack/` reach beyond recall**
+  - happy: a question about a spec/plan/fix is answered from a direct read of that artifact
+    (recall-excluded by type, so direct read is required).
+  - error: a referenced artifact dir is missing → source skipped, answer notes the gap.
+  - edge: `wisdom/` present → wholesale-loaded; absent → skipped without error; a future
+    `.woostack/<new>/` subdir is enumerated, not ignored.
+- **AC4 — external reference comparison**
+  - happy: the ponytail-style question ("benefits to integrate from `<external repo>` into our
+    skill library") fetches the external source read-only and returns benefits mapped to
+    skill-library landing spots + a recommendation.
+  - error: external URL unreachable/private → reported; answer falls back to reachable evidence;
+    no fabrication.
+  - edge: a codebase-only question performs no external fetch.
+- **AC5 — public command surface registered**
+  - happy: `/woostack-ask <question>` routes via `using-woostack`; `AGENTS.md` count + lists,
+    `README.md`, and `CONTRIBUTING.md` all include woostack-ask and the counts agree.
+  - error: no automated command-count test exists in the repo (verified) — counts are prose in
+    AGENTS.md / README.md / CONTRIBUTING.md; verification is grep-based that every count string and
+    list agrees on 17.
+  - edge: the SKILL.md `description:` follows the colon-space and angle-bracket-placeholder
+    conventions ([[skill-description-colon-space]], [[skill-description-angle-bracket-placeholders]]).
+
+## 8. Testing
+
+> Strategy only — harness, levels, fixtures, CI. Per-behavior cases live in §7.
+
+Prose-only skill, no scripts → no unit harness. Verification is structural and manual:
+
+- grep assertions that every surface site references `woostack-ask` and the count strings agree
+  (the [[woostack-command-surface-bookkeeping]] sites: `using-woostack` routing, `AGENTS.md`,
+  `README.md`, `CONTRIBUTING.md`).
+- if a committed command-count gating test exists, update its expected count and run it; otherwise
+  N/A.
+- manual smoke: run `/woostack-ask` on (a) a codebase question and (b) the ponytail-style external
+  question; confirm a cited answer and a clean `git status` (zero writes).
+- `woostack-review` on each increment PR (the `skills` angle).
+
+## 9. Open questions
+
+Resolved during spec harden (recorded here as settled decisions):
+
+- **Command-count gating test?** No — verified there is no automated count test under
+  `skills/*/scripts/tests/`. Counts live only as prose. AC5 is grep-based.
+- **Exact wiring sites** (the authoritative map is [[woostack-command-surface-bookkeeping]]):
+  - `AGENTS.md` (`.claude/CLAUDE.md` symlink): "sixteen skills" → seventeen; bulleted public list
+    (+ask); "sixteen-skill command surface" → seventeen; rename constraint "eighteen … (sixteen
+    public + 2 internal)" → "nineteen … (seventeen public + 2 internal)"; Quick file map (+ask);
+    Mode B trigger list (+ask).
+  - `skills/using-woostack/SKILL.md`: one Command Routing row.
+  - `CONTRIBUTING.md`: intro public-surface list (+ask) **and** the "Change the …" pointer-table
+    row — two sub-sites.
+  - `README.md`: its command list is curated/exemplary ("e.g. … etc."), not an exhaustive count;
+    planning adds ask where investigation commands are surfaced, minimal.
+  - `skills/woostack-bootstrap/references/development.md`: **no-op** — ask is an inspection
+    command, not a build-loop phase (same as `woostack-status` / `woostack-debug`); verify only.
+- **Description format:** avoid any `": "` colon-space ([[skill-description-colon-space]] — it
+  breaks YAML and the installer silently drops the skill); angle-bracket placeholders like
+  `<question>` are fine ([[skill-description-angle-bracket-placeholders]]).
+
+None open.


### PR DESCRIPTION
## Goal

Introduce `woostack-ask` — a purely investigative, read-only `/woostack-ask <question>` command wired into the woostack memory/knowledge framework. This is the docs-only base of the build stack (spec + plan); it carries no code and is never merged by the build loop.

## Summary

- Spec `.woostack/specs/2026-06-13-woostack-ask.md`: design for the skill — knowledge surface (recall → wisdom wholesale-load → whole `.woostack/` tree, enumerated dynamically → repo code → external refs), the WRITE-BLOCK invariant (zero tracked writes), the four phases, and 5 acceptance criteria.
- Plan `.woostack/plans/2026-06-13-woostack-ask.md`: two PR-sized increments — (1) the `skills/woostack-ask/SKILL.md` (full content embedded), (2) command-surface wiring across the bookkeeping sites (16→17 public / 18→19 files). Verification is grep/parse-based (prose skill, no runner).

## Test plan

### Manual

**Before merge**

- [ ] Read the spec and plan; confirm the 1:1 join (plan `**Source:**` line + matching basename) and spec `status: ready`.
- [ ] Confirm the increment boundaries are reviewable and independently shippable (capability, then bookkeeping).

Spec: .woostack/specs/2026-06-13-woostack-ask.md
