### PR TITLE
feat: reshape woostack-dream — scan overnight, consolidate to wisdom, gated prune

### DIFF
--- a/.woostack/plans/2026-06-13-dream-wisdom.md
+++ b/.woostack/plans/2026-06-13-dream-wisdom.md
@@ -420,12 +420,12 @@ gt modify -c -m "test(init): assert sibling wisdom store never leaks into MEMORY
 **Files:**
 - Modify: `skills/woostack-dream/SKILL.md` (Phase 1 Gather; Phase 3 drop-visibility rationale)
 
-- [ ] **Step 1: Confirm dream does not scan overnight today (red)**
+- [x] **Step 1: Confirm dream does not scan overnight today (red)**
 
 Run: `grep -c 'overnight' skills/woostack-dream/SKILL.md || true`
 Expected: `0`
 
-- [ ] **Step 2: Broaden the Phase 1 corpus read to include `overnight/`**
+- [x] **Step 2: Broaden the Phase 1 corpus read to include `overnight/`**
 
 In `skills/woostack-dream/SKILL.md`, Phase 1 currently enumerates the design-trend corpus as
 `.woostack/{specs,plans,fixes}/*.md`. Change that enumeration to
@@ -438,7 +438,7 @@ track them — they are full-scanned every run; the prune step (Phase 2/4) bound
 fully-absorbed reports so the scan does not grow unbounded.
 ```
 
-- [ ] **Step 3: Correct the "gitignored memory is unrecoverable" claim**
+- [x] **Step 3: Correct the "gitignored memory is unrecoverable" claim**
 
 Search the file for the recoverability claim and rewrite it to name overnight as the unrecoverable
 surface. The two occurrences (Phase 2 `drop` op and Phase 3 full-body rule) currently assert memory
@@ -449,7 +449,7 @@ memory notes are git-tracked (recoverable), but `.woostack/overnight/` reports a
 **unrecoverable once deleted** — so the gate shows their full body before any prune
 ```
 
-- [ ] **Step 4: Verify the scan + correction (green)**
+- [x] **Step 4: Verify the scan + correction (green)**
 
 Run:
 ```bash
@@ -460,7 +460,7 @@ grep -q 'overnight' skills/woostack-dream/SKILL.md \
 ```
 Expected: `OK`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "feat(dream): scan overnight reports; fix recoverability claim"
@@ -471,12 +471,12 @@ gt create -m "feat(dream): scan overnight reports; fix recoverability claim"
 **Files:**
 - Modify: `skills/woostack-dream/SKILL.md` (Phase 2 operations list; Phase 4 apply)
 
-- [ ] **Step 1: Confirm the surface op still targets memory (red)**
+- [x] **Step 1: Confirm the surface op still targets memory (red)**
 
 Run: `grep -n 'surface' skills/woostack-dream/SKILL.md`
 Expected: matches showing the `surface` op consolidating into the memory store (≥1 line).
 
-- [ ] **Step 2: Rewrite the `surface` bullet as `consolidate`**
+- [x] **Step 2: Rewrite the `surface` bullet as `consolidate`**
 
 In Phase 2, replace the entire `- **surface**: …` bullet with:
 
@@ -493,7 +493,7 @@ In Phase 2, replace the entire `- **surface**: …` bullet with:
   distillation); it consolidates, hygienes, and prunes them.
 ```
 
-- [ ] **Step 3: Verify the retarget (green)**
+- [x] **Step 3: Verify the retarget (green)**
 
 Run:
 ```bash
@@ -504,7 +504,7 @@ grep -q '\*\*consolidate\*\*' skills/woostack-dream/SKILL.md \
 ```
 Expected: `OK`
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "feat(dream): retarget surface→consolidate into wisdom store"
@@ -515,12 +515,12 @@ gt modify -c -m "feat(dream): retarget surface→consolidate into wisdom store"
 **Files:**
 - Modify: `skills/woostack-dream/SKILL.md` (Phase 2 ops; Phase 3 gate; Phase 4 apply)
 
-- [ ] **Step 1: Confirm there is no prune op today (red)**
+- [x] **Step 1: Confirm there is no prune op today (red)**
 
 Run: `grep -c 'prune' skills/woostack-dream/SKILL.md || true`
 Expected: `0`
 
-- [ ] **Step 2: Add the `prune` bullet to Phase 2 (after `consolidate`)**
+- [x] **Step 2: Add the `prune` bullet to Phase 2 (after `consolidate`)**
 
 ```
 - **prune**: Delete the **fully-absorbed** scratch inputs of a wisdom file — only memory notes and
@@ -531,7 +531,7 @@ Expected: `0`
   [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md).
 ```
 
-- [ ] **Step 3: Extend the Phase 3 review gate for the prune list**
+- [x] **Step 3: Extend the Phase 3 review gate for the prune list**
 
 In Phase 3, add a bullet to the gate's presentation rules:
 
@@ -541,7 +541,7 @@ In Phase 3, add a bullet to the gate's presentation rules:
   (gitignored → unrecoverable). `fixes/specs/plans` never appear on a prune list.
 ```
 
-- [ ] **Step 4: Extend the Phase 4 apply step for prune execution**
+- [x] **Step 4: Extend the Phase 4 apply step for prune execution**
 
 In Phase 4, add to the **Memory** apply step (after the rewrite/delete + build-index sentence):
 
@@ -551,7 +551,7 @@ and overnight report (`.woostack/overnight/<file>.md`). Pruning memory notes is 
 re-run `build-index.sh` then `doctor.sh`; deleting overnight reports touches no index.
 ```
 
-- [ ] **Step 5: Verify prune is wired across phases (green)**
+- [x] **Step 5: Verify prune is wired across phases (green)**
 
 Run:
 ```bash
@@ -562,7 +562,7 @@ grep -q '\*\*prune\*\*' skills/woostack-dream/SKILL.md \
 ```
 Expected: `OK`
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 gt modify -c -m "feat(dream): add gated default-keep prune of absorbed scratch"
@@ -573,7 +573,7 @@ gt modify -c -m "feat(dream): add gated default-keep prune of absorbed scratch"
 **Files:**
 - Modify: `skills/woostack-dream/SKILL.md` (frontmatter `description`; Degradation; Hard constraints)
 
-- [ ] **Step 1: Update the frontmatter `description`**
+- [x] **Step 1: Update the frontmatter `description`**
 
 The `description:` currently says dream surfaces insights into memory. Update it to mention the
 wisdom store, overnight scan, and gated prune — keep it one concise sentence (discovery-driving).
@@ -585,7 +585,7 @@ recurring trends from memory + overnight + the specs/plans/fixes corpus into the
 store, and prunes the fully-absorbed scratch (memory notes + overnight reports) it merged…
 ```
 
-- [ ] **Step 2: Add degradation rules for wisdom + overnight**
+- [x] **Step 2: Add degradation rules for wisdom + overnight**
 
 In `## Degradation`, add:
 
@@ -596,7 +596,7 @@ In `## Degradation`, add:
   proceeds.
 ```
 
-- [ ] **Step 3: Update the legacy "no new scripts / don't modify the memory contract" constraint**
+- [x] **Step 3: Update the legacy "no new scripts / don't modify the memory contract" constraint**
 
 The `## Hard constraints` section has a `**Reuse existing scripts**` bullet forbidding new scripts
 and contract edits. Reword it so it bounds dream's **runtime** behavior (a dream *run* adds no
@@ -610,7 +610,7 @@ scripts and mutates no contract), not feature work, and add `wisdom/` as a write
   wisdom and prunes absorbed scratch, but never deletes `fixes/specs/plans`.
 ```
 
-- [ ] **Step 4: Verify description + degradation + constraints (green)**
+- [x] **Step 4: Verify description + degradation + constraints (green)**
 
 Run:
 ```bash
@@ -621,7 +621,7 @@ grep -q 'wisdom' skills/woostack-dream/SKILL.md \
 ```
 Expected: `OK`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs(dream): update description, degradation, constraints for wisdom"

--- a/skills/woostack-dream/SKILL.md
+++ b/skills/woostack-dream/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: woostack-dream
-description: Use to curate the .woostack/ knowledge store. Reflects over the static memory store, the specs/plans/fixes decision corpus, and docs (no session mining), then proposes a gated changeset that merges duplicate notes, replaces stale/contradicted ones, drops dead/orphaned notes, resolves conflicts, surfaces consolidated insights, and recommends evidence-guarded documentation edits. Nothing mutates before explicit approval; ends on a summary + iterate loop. Approved memory/doc edits hand off to woostack-commit. Never self-commits or merges. Invoke via /woostack-dream [instructions].
+description: Use to curate the .woostack/ knowledge store. Reflects over the static memory store, the specs/plans/fixes/overnight decision corpus, and docs (no session mining), then proposes a gated changeset that merges/replaces/drops/resolves memory notes, consolidates recurring trends from memory + overnight + the specs/plans/fixes corpus into the .woostack/wisdom/ store, and prunes the fully-absorbed scratch (memory notes + overnight reports) it merged. Nothing mutates before explicit approval; ends on a summary + iterate loop. Approved memory/wisdom/doc edits hand off to woostack-commit. Never self-commits or merges. Invoke via /woostack-dream [instructions].
 ---
 
 # woostack-dream
 
-`woostack-dream` reflects over the static memory store, the specs/plans/fixes decision corpus, and documentation (deterministic and repeatable) to clean and align knowledge, and it never reflects over session transcripts or the live conversation. It is a standalone maintenance command and is not part of the `woostack-build` phase. Instead, it serves as the agentic synthesis and apply layer on top of the mechanical lint checks provided by [`doctor.sh`](../woostack-init/scripts/doctor.sh).
+`woostack-dream` reflects over the static memory store, the specs/plans/fixes decision corpus, the overnight run reports, and documentation (deterministic and repeatable) to clean and align knowledge, and it never reflects over session transcripts or the live conversation. It is a standalone maintenance command and is not part of the `woostack-build` phase. Instead, it serves as the agentic synthesis and apply layer on top of the mechanical lint checks provided by [`doctor.sh`](../woostack-init/scripts/doctor.sh).
 
 ## Command
 
@@ -19,7 +19,9 @@ description: Use to curate the .woostack/ knowledge store. Reflects over the sta
 
 If the `.woostack/memory/` directory exists, run [`doctor.sh`](../woostack-init/scripts/doctor.sh) and capture its warnings (overlap clusters, stale provenance, orphaned scope, dead notes, missing provenance, and non-glob trivia). Next, read `.woostack/memory/MEMORY.md` and the body of every note. Enumerate the documentation surface by executing `git ls-files '*.md'` to gather only tracked markdown files, excluding gitignored memory and any `node_modules` directories. Exclude any files under `.woostack/{specs,plans,fixes}/*.md` from the promotion-target set, as they are provenance inputs rather than targets for documentation updates.
 
-Separately enumerate and read the `.woostack/{specs,plans,fixes}/*.md` corpus as design-trend input to the `surface` operation. This corpus read is distinct from following `source:` for staleness: it mines authored decisions for recurring trends, but those artifacts are still not documentation-promotion targets. Read it incrementally from the gitignored `.woostack/memory/.dream-watermark` ref when present: `git log <ref>..HEAD --name-only -- .woostack/specs .woostack/plans .woostack/fixes`. Matching is against the always-read memory note index as the history proxy: a new artifact corroborating a decision already captured as a note strengthens or rescopes that note; new-vs-new corroboration is a fresh trend. First run (missing, absent, corrupt watermark, or non-git checkout) is a full-corpus baseline. `instructions: "full corpus"` forces a re-baseline. The watermark advances to `HEAD` only after a successful, approved run.
+Separately enumerate and read the `.woostack/{specs,plans,fixes,overnight}/*.md` corpus (overnight is gitignored, so it is full-scanned separately — see next paragraph) as design-trend input to the `consolidate` operation. This corpus read is distinct from following `source:` for staleness: it mines authored decisions for recurring trends, but those artifacts are still not documentation-promotion targets. Read it incrementally from the gitignored `.woostack/memory/.dream-watermark` ref when present: `git log <ref>..HEAD --name-only -- .woostack/specs .woostack/plans .woostack/fixes`. Matching is against the always-read memory note index as the history proxy: a new artifact corroborating a decision already captured as a note strengthens or rescopes that note; new-vs-new corroboration is a fresh trend. First run (missing, absent, corrupt watermark, or non-git checkout) is a full-corpus baseline. `instructions: "full corpus"` forces a re-baseline. The watermark advances to `HEAD` only after a successful, approved run.
+
+`.woostack/overnight/*.md` (gitignored morning reports from woostack-execute-overnight) are also read as scratch trend-input. Because overnight reports are gitignored, the git-log watermark cannot track them — they are full-scanned every run; the prune step (Phase 2/4) bounds the set by deleting fully-absorbed reports so the scan does not grow unbounded.
 
 Read the recent `git log` and the specification, plan, or fix that a note's `source:` field points to, using this context to ground judgments of whether a note is stale or current. Honor any optional `instructions` steering argument provided. For further details on the store structure, cross-link the memory contract in [`../woostack-init/references/memory.md`](../woostack-init/references/memory.md).
 
@@ -28,9 +30,23 @@ Read the recent `git log` and the specification, plan, or fix that a note's `sou
 Produce a changeset of discrete, labeled operations. The changeset must explicitly enumerate the following operations:
 - **merge**: Collapse duplicate or fuzzy-near-duplicate notes. The surviving note retains the union of scopes and the most specific provenance. All inbound `[[wikilinks]]` are rewritten to target the survivor by leveraging [`graph.sh`](../woostack-init/scripts/graph.sh) `--backlinks` to identify and update references.
 - **replace**: Rewrite contradicted or stale notes to reflect the latest values, while preserving the original `source:` provenance information.
-- **drop**: Remove dead notes and notes with orphaned scope. Rewrite or remove inbound links pointing to dropped notes. Note that gitignored memory files are unrecoverable once deleted.
+- **drop**: Remove dead notes and notes with orphaned scope. Rewrite or remove inbound links pointing to dropped notes. (Overnight reports are unrecoverable — the Phase 3 gate shows their full body before any prune.)
 - **resolve**: Adjudicate each overlap cluster identified by `doctor.sh`. When a confident decision cannot be made, flag the conflict for the user instead of guessing.
-- **surface**: Consolidate a recurring pattern into a single new note. A recurring pattern may be a design decision recurring across the specs/plans/fixes corpus, consolidated into one tracked note. The `source:` must be derived from the contributing notes or the most-specific contributing artifact path and never fabricated. All new notes must pass the memory contract's section 7 distillation gate, which rejects new notes by default unless they represent generalized, high-value knowledge: cross-feature glob scope, provenance, store-wide dedupe, and an `updated:` stamp. Use a recall-eligible type (`decision`, `pattern`, or `convention`), never `spec` or `plan`. Dedupe is store-wide against `MEMORY.md` plus fuzzy hooks: a corroborated trend strengthens or rescopes the existing note rather than adding a duplicate. Superseded raw scratch is pruned through the `drop` operation, with the full-body gate.
+- **consolidate**: Roll a recurring pattern (a trend across the memory + overnight +
+  specs/plans/fixes corpora) into a single tracked **wisdom file** at `.woostack/wisdom/<slug>.md`,
+  per the wisdom contract [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md).
+  The wisdom file's `source:` records **all** contributing inputs (note names +
+  artifact paths) as permanent provenance. New wisdom must clear the wisdom contract's bar
+  (generalized, cross-cutting, high-value); dedupe store-wide against existing wisdom — a
+  corroborated trend strengthens or rescopes the existing wisdom file rather than adding a duplicate.
+  `woostack-dream` therefore no longer creates memory notes (those are written by woostack-execute
+  distillation); it consolidates, hygienes, and prunes them.
+- **prune**: Delete the **fully-absorbed** scratch inputs of a wisdom file — only memory notes and
+  overnight reports, never `fixes/specs/plans`. Compute a **prune list** = the subset of a wisdom
+  file's `source:` ledger whose value is *fully* captured by the finding (per-input agent judgment).
+  Inputs retaining independent value (e.g. a scope-specific memory note) are **partial** → kept or
+  rescoped, never pruned. **Any doubt → keep.** See the wisdom contract §5
+  [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md).
 - **doc recommendation**: Propose promoting a convention or correcting a contradicted claim in the documentation. This is subject to an evidence guard: every proposed documentation edit must cite a backing memory note. If no backing memory note is found, the documentation edit is prohibited.
 
 This synthesis pass is idempotent and does not mutate any files. A re-run with no new artifacts since the watermark is a no-op unless the user requests a full-corpus baseline.
@@ -38,7 +54,10 @@ This synthesis pass is idempotent and does not mutate any files. A re-run with n
 ### Phase 3 — Review gate (HARD)
 
 Present the complete changeset in the conversation transcript as a before-and-after diff or description. The presentation must follow these strict rules:
-- Show the full body of each note scheduled to be dropped, as gitignored memory is unrecoverable once applied.
+- Show the full body of each note scheduled to be dropped, as memory notes are git-tracked (recoverable), but `.woostack/overnight/` reports are gitignored and **unrecoverable once deleted** — so the gate shows their full body before any prune.
+- Show the **prune list**: each fully-absorbed input, its absorbing wisdom file, and a one-line
+  "why absorbed". Show the **full body** of every `.woostack/overnight/` report on the prune list
+  (gitignored → unrecoverable). `fixes/specs/plans` never appear on a prune list.
 - Explicitly flag any un-adjudicable conflicts for the user to resolve.
 - Show a diff for each recommended documentation edit, citing its backing note.
 
@@ -47,9 +66,10 @@ At this gate, no changes from the current synthesis pass have been applied yet. 
 ### Phase 4 — Apply (on approval)
 
 Upon receiving explicit user approval, perform the following actions:
-- **Memory**: Rewrite or delete the affected note files in place. Next, execute [`build-index.sh`](../woostack-init/scripts/build-index.sh) to regenerate the `MEMORY.md` index file. Finally, re-run [`doctor.sh`](../woostack-init/scripts/doctor.sh) to confirm a clean state, reporting any residual warnings (especially unresolved `[[wikilinks]]`).
+- **Memory**: Rewrite or delete the affected note files in place. Next, execute [`build-index.sh`](../woostack-init/scripts/build-index.sh) to regenerate the `MEMORY.md` index file. Finally, re-run [`doctor.sh`](../woostack-init/scripts/doctor.sh) to confirm a clean state, reporting any residual warnings (especially unresolved `[[wikilinks]]`). Execute the approved **prune list**: delete each fully-absorbed memory note (`.woostack/memory/<name>.md`) and overnight report (`.woostack/overnight/<file>.md`). Pruning memory notes is a memory mutation → re-run `build-index.sh` then `doctor.sh`; deleting overnight reports touches no index.
+- **Wisdom**: Write each new or updated wisdom file to `.woostack/wisdom/<slug>.md`.
 - **Docs**: Write the approved documentation edits directly to the working tree.
-- **Commit handoff**: Because memory notes are tracked shared knowledge, hand both curated memory changes and documentation edits to [`woostack-commit`](../woostack-commit/SKILL.md). `woostack-dream` itself never commits, pushes, merges, or advances the watermark before the approved run is successfully applied.
+- **Commit handoff**: Because memory notes and wisdom files are tracked shared knowledge, hand all curated memory changes, new/updated wisdom files, and documentation edits to [`woostack-commit`](../woostack-commit/SKILL.md). Pruned overnight reports are gitignored and require no commit. `woostack-dream` itself never commits, pushes, merges, or advances the watermark before the approved run is successfully applied.
 
 ### Phase 5 — Summarize & iterate
 
@@ -65,6 +85,8 @@ The tool degrades gracefully depending on the environment:
 - If a detected trend duplicates an existing note, update that note rather than adding a duplicate.
 - If no `.woostack/` directory exists, stop immediately; there is nothing to curate, and the tool must not scaffold a new store (defer to `/woostack-init`).
 - If individual memory scripts are missing (such as in an individual manual install), announce a manual fallback per section 10 of the memory contract [`../woostack-init/references/memory.md`](../woostack-init/references/memory.md). Perform recall and lint checks by hand, and never fail silently.
+- If `.woostack/wisdom/` is absent, create it on the first approved `consolidate` (or defer to `/woostack-init`); never error solely because it is missing.
+- If `.woostack/overnight/` is absent or empty, the overnight scan is a no-op; the rest of the pass proceeds.
 
 ## Hard constraints
 
@@ -76,5 +98,9 @@ The tool degrades gracefully depending on the environment:
 - **Full-body drop visibility**: Dropped notes must be shown full-body at the review gate.
 - **Inbound-link integrity**: Ensure that all inbound links are updated or removed when merging or dropping notes.
 - **Idempotent**: A re-run with no new artifacts since the watermark is a no-op.
-- **Reuse existing scripts**: Reuse the existing scripts under `skills/woostack-init/scripts/`; do not add new scripts or modify the memory contract.
+- **Reuse existing scripts at runtime**: a `woostack-dream` *run* reuses the scripts under
+  `skills/woostack-init/scripts/`, adds no new scripts, and does not edit the memory/wisdom contracts.
+  (Evolving those contracts or tooling is feature work, not a dream run.)
+- **Two stores, one writer**: dream is the only writer of `.woostack/wisdom/`. It consolidates into
+  wisdom and prunes absorbed scratch, but never deletes `fixes/specs/plans`.
 - **Standalone**: This command is not part of the gated build chain.


### PR DESCRIPTION
## Goal

Reshape the `woostack-dream` procedure around the two-tier knowledge model: it now mines the overnight corpus, consolidates recurring trends into the `.woostack/wisdom/` store (instead of memory notes), and prunes the scratch it fully absorbs — under the existing hard review gate. Second increment of the dream → wisdom feature (stacks on #328).

## Summary

- **Phase 1 scan** now includes `.woostack/overnight/*.md` (gitignored run reports), full-scanned each run (prune bounds the set); git-log watermark still covers only specs/plans/fixes.
- **`surface` → `consolidate`**: recurring trends now roll into `.woostack/wisdom/<slug>.md` with a `source:` contributor ledger, not memory notes. Dream no longer *creates* memory notes (execute distillation still does).
- **New gated `prune` op**: deletes only fully-absorbed memory notes + overnight reports (default-keep; partials kept; `fixes/specs/plans` exempt). Phase 3 gate shows the prune list + full body of every overnight report (gitignored → unrecoverable) before deletion; Phase 4 executes prune + rebuilds the index.
- **Corrected** the false "gitignored memory is unrecoverable" claim — memory is git-tracked/recoverable; `overnight/` is the unrecoverable surface.
- Updated `description`, Degradation (no-wisdom-dir / no-overnight no-ops), and Hard constraints (runtime-scoped reuse rule; dream as sole writer of `wisdom/`).

## Test plan

### Manual

**Before merge**

- [ ] Read `skills/woostack-dream/SKILL.md` end-to-end and confirm the reshaped Phases 1–4 (scan → consolidate → gated prune) are coherent and the recoverability claim is correct everywhere.

Spec: .woostack/specs/2026-06-13-dream-wisdom.md
