### PR TITLE
feat: load wisdom wholesale in build/ideate/plan design+planning phases

### DIFF
--- a/.woostack/plans/2026-06-13-dream-wisdom.md
+++ b/.woostack/plans/2026-06-13-dream-wisdom.md
@@ -639,12 +639,12 @@ gt modify -c -m "docs(dream): update description, degradation, constraints for w
 - Modify: `skills/woostack-ideate/SKILL.md` (Process step 1 "Explore project context")
 - Modify: `skills/woostack-build/SKILL.md` (step 1 Ideate)
 
-- [ ] **Step 1: Confirm neither loads wisdom today (red)**
+- [x] **Step 1: Confirm neither loads wisdom today (red)**
 
 Run: `grep -c 'wisdom' skills/woostack-ideate/SKILL.md skills/woostack-build/SKILL.md || true`
 Expected: `0` for both files.
 
-- [ ] **Step 2: Add a wisdom-load instruction to ideate's context exploration**
+- [x] **Step 2: Add a wisdom-load instruction to ideate's context exploration**
 
 In `skills/woostack-ideate/SKILL.md`, Process step 1 ("Explore project context"), append:
 
@@ -655,7 +655,7 @@ In `skills/woostack-ideate/SKILL.md`, Process step 1 ("Explore project context")
    An empty or absent `wisdom/` is a no-op.
 ```
 
-- [ ] **Step 3: Note the wisdom load in `woostack-build` step 1**
+- [x] **Step 3: Note the wisdom load in `woostack-build` step 1**
 
 In `skills/woostack-build/SKILL.md`, step 1 (Ideate), append a sentence:
 
@@ -665,7 +665,7 @@ context exploration); see the wisdom contract
 [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md).
 ```
 
-- [ ] **Step 4: Verify (green)**
+- [x] **Step 4: Verify (green)**
 
 Run:
 ```bash
@@ -686,12 +686,12 @@ gt create -m "feat(build): load wisdom wholesale in the design phase"
 **Files:**
 - Modify: `skills/woostack-plan/SKILL.md` ("Read and check the spec" section)
 
-- [ ] **Step 1: Confirm plan does not load wisdom today (red)**
+- [x] **Step 1: Confirm plan does not load wisdom today (red)**
 
 Run: `grep -c 'wisdom' skills/woostack-plan/SKILL.md || true`
 Expected: `0`
 
-- [ ] **Step 2: Add a wisdom-load step**
+- [x] **Step 2: Add a wisdom-load step**
 
 In `skills/woostack-plan/SKILL.md`, in the "Read and check the spec" section, add as a new first
 sub-step:
@@ -703,7 +703,7 @@ sub-step:
    `wisdom/` is a no-op.
 ```
 
-- [ ] **Step 3: Verify (green)**
+- [x] **Step 3: Verify (green)**
 
 Run: `grep -q 'Load wisdom' skills/woostack-plan/SKILL.md && grep -q 'references/wisdom.md' skills/woostack-plan/SKILL.md && echo OK`
 Expected: `OK`

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -37,6 +37,9 @@ sits after that PR. So the chain has exactly the three hard gates above.
    the problem and converge on a design. Let it run its own approval gate. It hands back an
    approved design and stops there — it writes no spec and chains no plan, so the next steps
    are yours to drive.
+   The design phase loads `.woostack/wisdom/*.md` wholesale as guidance (via `woostack-ideate`'s
+   context exploration); see the wisdom contract
+   [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md).
 2. **Write the spec as markdown.** When the design is approved, do **not** write to a generic
    `docs/specs/` location. **First create the spec+plan worktree** (the first write of this run,
    per the [worktree contract](../woostack-init/references/worktrees.md)): pick the branch

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -49,6 +49,10 @@ Work the steps in order. Ask **one question per message** so you never overwhelm
 1. **Explore project context.** Read the relevant files, docs, and recent commits before
    asking anything. In an existing codebase, learn the current structure and follow its
    patterns rather than proposing greenfield shapes.
+   Also read every `.woostack/wisdom/*.md` file (wholesale — they are generalized, cross-cutting
+   guidance, not scope-routed) and treat them as house-rules the design should respect. See the
+   wisdom contract [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md).
+   An empty or absent `wisdom/` is a no-op.
 2. **Check scope first.** If the request bundles multiple independent subsystems ("a platform
    with chat, billing, and analytics"), flag it immediately. Don't refine details of
    something that needs decomposing first — help split it into independent pieces, note how

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -34,6 +34,10 @@ step 2/3.
 
 ## Read and check the spec
 
+0. **Load wisdom.** Read every `.woostack/wisdom/*.md` file (wholesale) before planning, and respect
+   those generalized findings when shaping increments and tasks. See the wisdom contract
+   [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md). Empty/absent
+   `wisdom/` is a no-op.
 1. Read the spec file end to end — it is the source of truth for *what* to build; the plan is
    *how*.
 2. **Scope check.** If the spec covers multiple independent subsystems, suggest splitting into


### PR DESCRIPTION
## Goal

Make wisdom actually guide development: the design and planning phases now load the `.woostack/wisdom/` store wholesale before they work. Third increment of the dream → wisdom feature (stacks on #330).

## Summary

- `skills/woostack-ideate/SKILL.md` — "Explore project context" now reads every `.woostack/wisdom/*.md` wholesale as house-rules the design must respect (cross-links the wisdom contract; empty/absent = no-op).
- `skills/woostack-build/SKILL.md` — step 1 notes the design phase loads wisdom via ideate's context exploration.
- `skills/woostack-plan/SKILL.md` — "Read and check the spec" gains a "Load wisdom" sub-step before planning.

## Test plan

### Manual

**Before merge**

- [ ] Confirm each of ideate / build / plan SKILL.md instructs a wholesale `.woostack/wisdom/*.md` load at the right phase, with a resolving `references/wisdom.md` cross-link.

Spec: .woostack/specs/2026-06-13-dream-wisdom.md
