### PR TITLE
feat(doctor): orchestrator + finding contract; extract memory check

### DIFF
--- a/skills/woostack-doctor/scripts/checks/memory.sh
+++ b/skills/woostack-doctor/scripts/checks/memory.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# memory.sh — lint .woostack/memory; emit findings. Severities preserved from the
+# original doctor.sh (errors = malformed/missing-field/unknown-type/dup-name; rest warn).
+# All memory findings are fixable=report (content repair is woostack-dream's job).
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/lib.sh"
+WOO_ROOT="${1:-.}"
+MEM_DIR="$WOO_ROOT/.woostack/memory"
+[ -d "$MEM_DIR" ] || exit 0
+
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+err()  { emit error "$1" report "$2" "$3"; }
+warn() { emit warn  "$1" report "$2" "$3"; }
+
+VALID_TYPES=" decision pattern gotcha convention hotspot "
+seen="$(mktemp)"; overlap_pairs="$(mktemp)"
+paths="$(cd "$WOO_ROOT" && git ls-files 2>/dev/null || true)"
+
+shopt -s nullglob
+for f in "$MEM_DIR"/*.md; do
+  base="$(basename "$f")"; [ "$base" = "MEMORY.md" ] && continue
+  rp=".woostack/memory/$base"
+  if [ "$(head -1 "$f")" != "---" ]; then
+    err memory-malformed "$rp" "$base: malformed — missing opening '---' frontmatter fence"; continue
+  fi
+  name="$(field "$f" name)"; type="$(field "$f" type)"
+  body="$(note_body "$f" | tr -d '[:space:]')"
+  [ -z "$name" ] && err memory-field "$rp" "$base: missing required field: name"
+  [ -z "$type" ] && err memory-field "$rp" "$base: missing required field: type"
+  [ -z "$body" ] && err memory-field "$rp" "$base: empty body"
+  if [ -n "$type" ] && [ "${VALID_TYPES/ $type /}" = "$VALID_TYPES" ]; then
+    err memory-type "$rp" "$base: unknown type: $type"
+  fi
+  if [ -n "$name" ]; then
+    if grep -qxF "$name" "$seen"; then err memory-dup "$rp" "$base: duplicate name: $name"
+    else echo "$name" >> "$seen"; fi
+  fi
+  scope="$(field "$f" scope)"
+  if [ -n "$scope" ] && [ "$scope" != "*" ] && [ -n "$paths" ]; then
+    matches="$(printf '%s\n' "$paths" | bash "$HERE/../../../woostack-init/scripts/scope-match.sh" "$scope" 2>/dev/null)"
+    if [ -z "$matches" ]; then
+      warn memory-scope-stale "$rp" "$base: scope '$scope' matches no tracked files (stale)"
+    else
+      while IFS= read -r p; do [ -n "$p" ] && printf '%s\t%s\n' "$p" "$base" >> "$overlap_pairs"; done <<< "$matches"
+    fi
+  fi
+  source_path="$(field "$f" source)"
+  case "$source_path" in
+    .woostack/specs/*|.woostack/plans/*)
+      [ -f "$WOO_ROOT/$source_path" ] || warn memory-provenance "$rp" "$base: source '$source_path' is missing (stale provenance)" ;;
+  esac
+  [ -z "$source_path" ] && warn memory-provenance "$rp" "$base: missing source: (provenance required)"
+  case "$source_path" in pr-*|address-comments) is_review=1 ;; *) is_review= ;; esac
+  if [ -n "$scope" ] && [ "$scope" != "*" ] && [ -z "$is_review" ] && [ "${scope#*\*}" = "$scope" ]; then
+    warn memory-scope-trivia "$rp" "$base: non-glob scope '$scope' (possible trivia — prefer a glob)"
+  fi
+  while IFS= read -r link; do
+    [ -z "$link" ] && continue
+    [ -f "$MEM_DIR/$link.md" ] || warn memory-unresolved-link "$rp" "$base: unresolved [[$link]]"
+  done < <(grep -oE '\[\[[^]]+\]\]' "$f" 2>/dev/null | sed 's/\[\[//; s/\]\]//' | sort -u)
+  upd="$(field "$f" updated)"
+  if [ -n "$upd" ]; then
+    upd_e="$(_woo_epoch "$upd" || true)"
+    if [ -n "$upd_e" ]; then
+      now_e="$(_woo_epoch "$(_woo_now)")"
+      rc="$(tel_get "$MEM_DIR" "$name" recall_count)"; rc="${rc:-0}"
+      case "$rc" in (*[!0-9]*) rc=0 ;; esac
+      age=$(( ( now_e - upd_e ) / 86400 ))
+      if [ "$age" -gt "${WOOSTACK_DEAD_DAYS:-90}" ] && [ "$rc" -eq 0 ]; then
+        warn memory-dead "$rp" "$base: dead note — written ${age}d ago, never recalled (prune candidate)"
+      fi
+    fi
+  else
+    warn memory-no-updated "$rp" "$base: missing updated: (cannot be aged — add updated:)"
+  fi
+done
+
+if [ -s "$overlap_pairs" ]; then
+  clusters="$(awk -F'\t' '
+    function find(x,   r,t){ r=x; while(parent[r]!=r) r=parent[r];
+      while(parent[x]!=x){ t=parent[x]; parent[x]=r; x=t } return r }
+    function union(a,b,   ra,rb){ ra=find(a); rb=find(b); if(ra!=rb) parent[rb]=ra }
+    { note=$2; if(!(note in parent)) parent[note]=note;
+      f=$1; if(f in first) union(first[f], note); else first[f]=note }
+    END{ for(n in parent){ r=find(n); if(!(r in mn) || n < mn[r]) mn[r]=n }
+         for(n in parent){ r=find(n); print mn[r] "\t" n } }
+  ' "$overlap_pairs" | sort -u | awk -F'\t' '
+    { members[$1] = members[$1] (members[$1]==""?"":", ") $2; cnt[$1]++ }
+    END{ for(c in cnt) if(cnt[c] >= 2) print c "\t" members[c] }
+  ' | sort)"
+  if [ -n "$clusters" ]; then
+    while IFS="$(printf '\t')" read -r _cid _members; do
+      [ -n "$_members" ] && warn memory-overlap ".woostack/memory" "overlap cluster: $_members — intersecting scope, review for contradiction"
+    done <<< "$clusters"
+  fi
+fi
+rm -f "$seen" "$overlap_pairs"
+exit 0

--- a/skills/woostack-doctor/scripts/doctor.sh
+++ b/skills/woostack-doctor/scripts/doctor.sh
@@ -1,127 +1,43 @@
 #!/usr/bin/env bash
-# doctor.sh — lint the memory/ dir. Warnings exit 0; errors exit 1.
-# -e intentionally omitted: a linter must continue past per-note failures
-# to report every error in one run, not abort on the first.
+# doctor.sh — woostack workspace health orchestrator. Runs checks/*.sh, groups
+# findings, exits nonzero iff any error. --check = CI mode (annotations + exit only).
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$HERE/../../woostack-init/scripts/lib.sh"
 
-MEM_DIR="${1:-.woostack/memory}"
-VALID_TYPES=" decision pattern gotcha convention hotspot "
-errors=0; warnings=0
-seen="$(mktemp)"
-overlap_pairs="$(mktemp)"
-paths="$(git ls-files 2>/dev/null || true)"
-
-err()  { echo "::error:: $1" >&2; errors=$((errors+1)); }
-warn() { echo "::warning:: $1" >&2; warnings=$((warnings+1)); }
-
-shopt -s nullglob
-for f in "$MEM_DIR"/*.md; do
-  base="$(basename "$f")"
-  [ "$base" = "MEMORY.md" ] && continue
-
-  if [ "$(head -1 "$f")" != "---" ]; then
-    err "$base: malformed — missing opening '---' frontmatter fence"; continue
-  fi
-
-  name="$(field "$f" name)"; type="$(field "$f" type)"
-  body="$(note_body "$f" | tr -d '[:space:]')"
-
-  [ -z "$name" ] && err "$base: missing required field: name"
-  [ -z "$type" ] && err "$base: missing required field: type"
-  [ -z "$body" ] && err "$base: empty body"
-  if [ -n "$type" ] && [ "${VALID_TYPES/ $type /}" = "$VALID_TYPES" ]; then
-    err "$base: unknown type: $type"
-  fi
-
-  if [ -n "$name" ]; then
-    if grep -qxF "$name" "$seen"; then err "$base: duplicate name: $name"
-    else echo "$name" >> "$seen"; fi
-  fi
-
-  scope="$(field "$f" scope)"
-  if [ -n "$scope" ] && [ "$scope" != "*" ] && [ -n "$paths" ]; then
-    matches="$(printf '%s\n' "$paths" | bash "$HERE/../../woostack-init/scripts/scope-match.sh" "$scope" 2>/dev/null)"
-    if [ -z "$matches" ]; then
-      warn "$base: scope '$scope' matches no tracked files (stale)"
-    else
-      while IFS= read -r p; do
-        [ -n "$p" ] && printf '%s\t%s\n' "$p" "$base" >> "$overlap_pairs"
-      done <<< "$matches"
-    fi
-  fi
-
-  source_path="$(field "$f" source)"
-  case "$source_path" in
-    .woostack/specs/*|.woostack/plans/*)
-      [ -f "$source_path" ] || warn "$base: source '$source_path' is missing (stale provenance)"
-      ;;
+CHECK_ONLY=0; TARGET="."
+for a in "$@"; do
+  case "$a" in
+    --check) CHECK_ONLY=1 ;;
+    -*) echo "doctor: unknown flag: $a" >&2; exit 2 ;;
+    *)  TARGET="$a" ;;
   esac
-
-  # Distillation gate: every note needs provenance (§7).
-  [ -z "$source_path" ] && warn "$base: missing source: (provenance required)"
-
-  # Non-glob scope = trivia signal. Exempt global (*) and review-provenance notes
-  # (review records deliberately scope narrowly to suppress an accepted finding).
-  case "$source_path" in pr-*|address-comments) is_review=1 ;; *) is_review= ;; esac
-  if [ -n "$scope" ] && [ "$scope" != "*" ] && [ -z "$is_review" ] && [ "${scope#*\*}" = "$scope" ]; then
-    warn "$base: non-glob scope '$scope' (possible trivia — prefer a glob)"
-  fi
-
-  while IFS= read -r link; do
-    [ -z "$link" ] && continue
-    [ -f "$MEM_DIR/$link.md" ] || warn "$base: unresolved [[$link]]"
-  done < <(grep -oE '\[\[[^]]+\]\]' "$f" 2>/dev/null | sed 's/\[\[//; s/\]\]//' | sort -u)
-
-  # Dead-note signal: old (by updated:) AND never recalled → prune candidate.
-  # Requires updated: (no age basis otherwise). Warning only.
-  upd="$(field "$f" updated)"
-  if [ -n "$upd" ]; then
-    upd_e="$(_woo_epoch "$upd" || true)"
-    if [ -n "$upd_e" ]; then
-      now_e="$(_woo_epoch "$(_woo_now)")"
-      rc="$(tel_get "$MEM_DIR" "$name" recall_count)"; rc="${rc:-0}"
-      case "$rc" in (*[!0-9]*) rc=0 ;; esac
-      age=$(( ( now_e - upd_e ) / 86400 ))
-      if [ "$age" -gt "${WOOSTACK_DEAD_DAYS:-90}" ] && [ "$rc" -eq 0 ]; then
-        warn "$base: dead note — written ${age}d ago, never recalled (prune candidate)"
-      fi
-    fi
-  else
-    warn "$base: missing updated: (cannot be aged — add updated:)"
-  fi
 done
 
-# Overlap clusters: non-global notes sharing >=1 tracked file. awk union-find,
-# canonical cluster id = lexicographically smallest member name (deterministic
-# output regardless of git ls-files / glob ordering). Warning-only.
-if [ -s "$overlap_pairs" ]; then
-  # union-find (awk owns the assoc arrays — bash 3.2 has no `declare -A`),
-  # then group by canonical id and keep clusters of >=2 members.
-  clusters="$(awk -F'\t' '
-    function find(x,   r,t){ r=x; while(parent[r]!=r) r=parent[r];
-      while(parent[x]!=x){ t=parent[x]; parent[x]=r; x=t } return r }
-    function union(a,b,   ra,rb){ ra=find(a); rb=find(b); if(ra!=rb) parent[rb]=ra }
-    { note=$2; if(!(note in parent)) parent[note]=note;
-      f=$1; if(f in first) union(first[f], note); else first[f]=note }
-    END{
-      for(n in parent){ r=find(n); if(!(r in mn) || n < mn[r]) mn[r]=n }
-      for(n in parent){ r=find(n); print mn[r] "\t" n }
-    }
-  ' "$overlap_pairs" | sort -u | awk -F'\t' '
-    { members[$1] = members[$1] (members[$1]==""?"":", ") $2; cnt[$1]++ }
-    END{ for(c in cnt) if(cnt[c] >= 2) print c "\t" members[c] }
-  ' | sort)"
-  # Loop in the main shell (here-string, not a pipeline) so warn's counter sticks.
-  if [ -n "$clusters" ]; then
-    while IFS="$(printf '\t')" read -r _cid _members; do
-      [ -n "$_members" ] && warn "overlap cluster: $_members — intersecting scope, review for contradiction"
-    done <<< "$clusters"
-  fi
+WOO_ROOT="$(cd "$TARGET" 2>/dev/null && pwd)" \
+  || { echo "doctor: path not found: $TARGET" >&2; exit 2; }
+if [ ! -d "$WOO_ROOT/.woostack" ]; then
+  echo "doctor: no .woostack/ at $WOO_ROOT — run woostack-init first" >&2
+  exit 2
 fi
 
-rm -f "$seen" "$overlap_pairs"
+findings="$(mktemp)"
+shopt -s nullglob
+for chk in "$HERE"/checks/*.sh; do
+  bash "$chk" "$WOO_ROOT" >> "$findings" 2>/dev/null || true
+done
+
+errors=0; warnings=0
+TAB="$(printf '\t')"
+while IFS="$TAB" read -r sev code fixable path msg; do
+  [ -z "${sev:-}" ] && continue
+  case "$sev" in
+    error) errors=$((errors+1)); echo "::error:: [$code] $path: $msg" >&2 ;;
+    warn)  warnings=$((warnings+1)); echo "::warning:: [$code] $path: $msg" >&2 ;;
+  esac
+done < "$findings"
+
+[ "$CHECK_ONLY" -eq 0 ] && cat "$findings"
+rm -f "$findings"
 
 echo "doctor: $errors error(s), $warnings warning(s)" >&2
 [ "$errors" -eq 0 ]

--- a/skills/woostack-doctor/scripts/tests/test-doctor.sh
+++ b/skills/woostack-doctor/scripts/tests/test-doctor.sh
@@ -5,31 +5,35 @@ source "$DIR/../../woostack-init/scripts/tests/assert.sh"
 DOC="$DIR/doctor.sh"
 
 OUT=""; CODE=0
-run_doctor() { # memdir → captures stderr; sets OUT, CODE
+run_doctor() { # workspace-root → captures stderr+stdout; sets OUT, CODE
   set +e; OUT="$(bash "$DOC" "$1" 2>&1)"; CODE=$?; set -e
 }
+# mkws → echo a fresh workspace ROOT containing an empty .woostack/memory.
+# The orchestrator takes the workspace root (not the memdir); notes go in
+# "$root/.woostack/memory" and doctor is called with "$root".
+mkws() { local r; r="$(mktemp -d)"; mkdir -p "$r/.woostack/memory"; printf '%s\n' "$r"; }
 
 # clean store under a real git repo so scope-match has tracked files
 repo="$(mktemp -d)"; ( cd "$repo" && git -c user.email=t@t -c user.name=t init -q && mkdir -p packages/api && touch packages/api/x.ts && git add -A && git -c user.email=t@t -c user.name=t commit -qm init )
 md="$repo/.woostack/memory"; mkdir -p "$md"
 mk_note "$md" ok.md $'name: ok\ntype: pattern\nscope: packages/api/**' 'fine body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_exit 0 "$CODE" "clean store exits 0"
 
 # stale scope → warn, exit 0
 mk_note "$md" stale.md $'name: stale\ntype: gotcha\nscope: nope/**' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "stale" "stale scope warned"
 assert_exit 0 "$CODE" "warnings still exit 0"
 
 # missing .woostack source → warn, exit 0
 mk_note "$md" stale-source-spec.md $'name: stale-source-spec\ntype: pattern\nscope: packages/api/**\nsource: .woostack/specs/missing.md' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "source '.woostack/specs/missing.md' is missing" "missing spec source warned"
 assert_exit 0 "$CODE" "missing spec source is a warning"
 
 mk_note "$md" stale-source-plan.md $'name: stale-source-plan\ntype: pattern\nscope: packages/api/**\nsource: .woostack/plans/missing.md' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "source '.woostack/plans/missing.md' is missing" "missing plan source warned"
 assert_exit 0 "$CODE" "missing plan source is a warning"
 
@@ -38,7 +42,7 @@ touch "$repo/.woostack/specs/existing.md" "$repo/.woostack/plans/existing.md"
 mk_note "$md" live-source-spec.md $'name: live-source-spec\ntype: pattern\nscope: packages/api/**\nsource: .woostack/specs/existing.md\nupdated: 2026-06-02' 'body'
 mk_note "$md" live-source-plan.md $'name: live-source-plan\ntype: pattern\nscope: packages/api/**\nsource: .woostack/plans/existing.md\nupdated: 2026-06-02' 'body'
 mk_note "$md" pr-source.md $'name: pr-source\ntype: convention\nscope: packages/api/**\nsource: pr-165\nupdated: 2026-06-02' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 # Target the provenance warning specifically — these notes legitimately appear in
 # an overlap cluster (they share scope packages/api/** with other store notes),
 # so a bare-name check would false-fail. Intent: no stale-provenance warning.
@@ -49,125 +53,125 @@ assert_not_contains "$OUT" "pr-source.md: source" "PR source is not treated as a
 # --- distillation-gate backstop warnings ---
 # missing source: → warn, exit 0
 mk_note "$md" no-source.md $'name: no-source\ntype: pattern\nscope: packages/api/**\nupdated: 2026-06-02' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "no-source.md: missing source:" "note without source: is warned"
 assert_exit 0 "$CODE" "missing source: is a warning"
 
 # non-glob scope (single literal path), distill-origin → warn
 mk_note "$md" nonglob.md $'name: nonglob\ntype: pattern\nscope: packages/api/handler.ts\nupdated: 2026-06-02\nsource: .woostack/specs/existing.md' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "nonglob.md: non-glob scope" "single literal scope warned as possible trivia"
 assert_exit 0 "$CODE" "non-glob scope is a warning"
 
 # all-literal multi-scope (no * anywhere) → warn
 mk_note "$md" multilit.md $'name: multilit\ntype: pattern\nscope: a/b.ts, c/d.ts\nupdated: 2026-06-02\nsource: .woostack/specs/existing.md' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "multilit.md: non-glob scope" "all-literal multi-scope warned"
 
 # globbed scope → no warning
 mk_note "$md" globbed.md $'name: globbed\ntype: pattern\nscope: packages/api/**\nupdated: 2026-06-02\nsource: .woostack/specs/existing.md' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "globbed.md: non-glob scope" "a globbed scope is not flagged"
 
 # global scope (*) → no warning
 mk_note "$md" globalscope.md $'name: globalscope\ntype: pattern\nscope: *\nupdated: 2026-06-02\nsource: .woostack/specs/existing.md' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "globalscope.md: non-glob scope" "global scope is exempt"
 
 # multi-glob scope (contains *) → no warning
 mk_note "$md" multiglob.md $'name: multiglob\ntype: pattern\nscope: packages/api/**, apps/*/x.ts\nupdated: 2026-06-02\nsource: .woostack/specs/existing.md' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "multiglob.md: non-glob scope" "a multi-glob scope (contains *) is not flagged"
 
 # absent scope field → exempt (global)
 mk_note "$md" noscope.md $'name: noscope\ntype: pattern\nupdated: 2026-06-02\nsource: .woostack/specs/existing.md' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "noscope.md: non-glob scope" "absent scope is exempt from non-glob warning"
 
 # review-provenance (pr-*) with literal scope → exempt
 mk_note "$md" review-pr.md $'name: review-pr\ntype: convention\nscope: packages/api/handler.ts\nupdated: 2026-06-02\nsource: pr-42' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "review-pr.md: non-glob scope" "review-provenance note is exempt from non-glob warning"
 
 # review-provenance (address-comments) with literal scope → exempt
 mk_note "$md" review-ac.md $'name: review-ac\ntype: convention\nscope: packages/api/handler.ts\nupdated: 2026-06-02\nsource: address-comments' 'body'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "review-ac.md: non-glob scope" "address-comments note is exempt"
 
 # missing updated: → warn (cannot be aged), exit 0
-mu="$(mktemp -d)/m"; mkdir -p "$mu"
+muR="$(mkws)"; mu="$muR/.woostack/memory"
 mk_note "$mu" noupd2.md $'name: noupd2\ntype: pattern\nscope: *\nsource: pr-1' 'body'
-OUT="$(bash "$DOC" "$mu" 2>&1)"; CODE=$?
+run_doctor "$muR"
 assert_contains "$OUT" "noupd2.md: missing updated:" "note without updated: is warned"
 assert_exit 0 "$CODE" "missing updated: is a warning"
 assert_not_contains "$OUT" "dead note" "missing updated: does not also emit a dead-note signal"
-rm -rf "$mu"
+rm -rf "$muR"
 
 # unresolved wikilink → warn
 mk_note "$md" link.md $'name: link\ntype: pattern\nscope: packages/api/**' 'see [[ghost]] note'
-pushd "$repo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$repo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "ghost" "unresolved wikilink warned"
 
 # errors: dup name, bad type, missing field, malformed
-err="$(mktemp -d)/m"; mkdir -p "$err"
+errR="$(mkws)"; err="$errR/.woostack/memory"
 mk_note "$err" d1.md $'name: dup\ntype: pattern' 'b'
 mk_note "$err" d2.md $'name: dup\ntype: pattern' 'b'
-run_doctor "$err"; assert_exit 1 "$CODE" "duplicate name errors"; assert_contains "$OUT" "duplicate" "dup msg"
+run_doctor "$errR"; assert_exit 1 "$CODE" "duplicate name errors"; assert_contains "$OUT" "duplicate" "dup msg"
 
-err2="$(mktemp -d)/m"; mkdir -p "$err2"
+err2R="$(mkws)"; err2="$err2R/.woostack/memory"
 mk_note "$err2" bad.md $'name: x\ntype: bogus' 'b'
-run_doctor "$err2"; assert_exit 1 "$CODE" "bad type errors"
+run_doctor "$err2R"; assert_exit 1 "$CODE" "bad type errors"
 
-err3="$(mktemp -d)/m"; mkdir -p "$err3"
+err3R="$(mkws)"; err3="$err3R/.woostack/memory"
 mk_note "$err3" nofield.md $'type: pattern' 'b'
-run_doctor "$err3"; assert_exit 1 "$CODE" "missing name errors"
+run_doctor "$err3R"; assert_exit 1 "$CODE" "missing name errors"
 
-err4="$(mktemp -d)/m"; mkdir -p "$err4"
+err4R="$(mkws)"; err4="$err4R/.woostack/memory"
 printf 'no frontmatter here\n' > "$err4/malformed.md"
-run_doctor "$err4"; assert_exit 1 "$CODE" "malformed frontmatter errors"
+run_doctor "$err4R"; assert_exit 1 "$CODE" "malformed frontmatter errors"
 
-err5="$(mktemp -d)/m"; mkdir -p "$err5"
+err5R="$(mkws)"; err5="$err5R/.woostack/memory"
 mk_note "$err5" notype.md $'name: x' 'b'
-run_doctor "$err5"; assert_exit 1 "$CODE" "missing type errors"
+run_doctor "$err5R"; assert_exit 1 "$CODE" "missing type errors"
 
-err6="$(mktemp -d)/m"; mkdir -p "$err6"
+err6R="$(mkws)"; err6="$err6R/.woostack/memory"
 mk_note "$err6" nobody.md $'name: x\ntype: pattern' ''
-run_doctor "$err6"; assert_exit 1 "$CODE" "empty body errors"
+run_doctor "$err6R"; assert_exit 1 "$CODE" "empty body errors"
 
 # --- dead-note check ---
 # old + never recalled → dead warning, exit 0
-dd1="$(mktemp -d)/m"; mkdir -p "$dd1"
+dd1R="$(mkws)"; dd1="$dd1R/.woostack/memory"
 mk_note "$dd1" old.md $'name: old\ntype: pattern\nscope: *\nupdated: 2026-01-01' 'stale body'
-OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd1" 2>&1)"; CODE=$?
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd1R" 2>&1)"; CODE=$?
 assert_contains "$OUT" "dead note" "old + zero recalls flagged as dead"
 assert_exit 0 "$CODE" "dead note is a warning (exit 0)"
 
 # old but recalled → not flagged
-dd2="$(mktemp -d)/m"; mkdir -p "$dd2"
+dd2R="$(mkws)"; dd2="$dd2R/.woostack/memory"
 mk_note "$dd2" old.md $'name: old\ntype: pattern\nscope: *\nupdated: 2026-01-01' 'body'
 printf 'old\t3\t2026-05-01\n' > "$dd2/.telemetry.tsv"
-OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd2" 2>&1)"
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd2R" 2>&1)"
 assert_not_contains "$OUT" "dead note" "a note recalled per the sidecar is never flagged dead"
 
 # fresh updated → not flagged
-dd3="$(mktemp -d)/m"; mkdir -p "$dd3"
+dd3R="$(mkws)"; dd3="$dd3R/.woostack/memory"
 mk_note "$dd3" fresh.md $'name: fresh\ntype: pattern\nscope: *\nupdated: 2026-05-30' 'body'
-OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd3" 2>&1)"
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd3R" 2>&1)"
 assert_not_contains "$OUT" "dead note" "a fresh note is not flagged"
 
 # no updated: → not aged by the dead-note check, but does warn "missing updated:"
-dd4="$(mktemp -d)/m"; mkdir -p "$dd4"
+dd4R="$(mkws)"; dd4="$dd4R/.woostack/memory"
 mk_note "$dd4" noupd.md $'name: noupd\ntype: pattern\nscope: *' 'body'
-OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd4" 2>&1)"
+OUT="$(WOOSTACK_NOW=2026-06-02 bash "$DOC" "$dd4R" 2>&1)"
 assert_not_contains "$OUT" "dead note" "a note without updated: gets no dead-note signal"
 assert_contains "$OUT" "noupd.md: missing updated:" "a note without updated: is warned (cannot be aged)"
 
 # WOOSTACK_DEAD_DAYS tightens the window
-dd5="$(mktemp -d)/m"; mkdir -p "$dd5"
+dd5R="$(mkws)"; dd5="$dd5R/.woostack/memory"
 mk_note "$dd5" recent.md $'name: recent\ntype: pattern\nscope: *\nupdated: 2026-05-30' 'body'
-OUT="$(WOOSTACK_NOW=2026-06-02 WOOSTACK_DEAD_DAYS=1 bash "$DOC" "$dd5" 2>&1)"
+OUT="$(WOOSTACK_NOW=2026-06-02 WOOSTACK_DEAD_DAYS=1 bash "$DOC" "$dd5R" 2>&1)"
 assert_contains "$OUT" "dead note" "DEAD_DAYS=1 flags a 3-day-old never-recalled note"
-rm -rf "$dd1" "$dd2" "$dd3" "$dd4" "$dd5"
+rm -rf "$dd1R" "$dd2R" "$dd3R" "$dd4R" "$dd5R"
 
 # --- overlap clusters (own git repo: needs tracked files) ---
 orepo="$(mktemp -d)"
@@ -179,24 +183,24 @@ omd="$orepo/.woostack/memory"; mkdir -p "$omd"
 # two notes matching the same tracked file → one cluster naming both (min-name order)
 mk_note "$omd" c1.md $'name: c1\ntype: pattern\nscope: packages/api/**\nupdated: 2026-06-02\nsource: pr-1' 'b'
 mk_note "$omd" c2.md $'name: c2\ntype: gotcha\nscope: packages/api/orpc/**, packages/api/x.ts\nupdated: 2026-06-02\nsource: pr-2' 'b'
-pushd "$orepo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$orepo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "overlap cluster: c1.md, c2.md" "two notes on a shared file form one cluster"
 assert_exit 0 "$CODE" "overlap cluster is a warning (exit 0)"
 
 # add a disjoint note (apps/web only) → not in the api cluster
 mk_note "$omd" web.md $'name: web\ntype: pattern\nscope: apps/web/**\nupdated: 2026-06-02\nsource: pr-3' 'b'
-pushd "$orepo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$orepo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "web.md" "a disjoint-scope note is not clustered"
 assert_contains "$OUT" "overlap cluster: c1.md, c2.md" "disjoint note does not disturb the api cluster"
 
 # add a global note → never clustered
 mk_note "$omd" g.md $'name: g\ntype: convention\nscope: *\nupdated: 2026-06-02\nsource: pr-4' 'b'
-pushd "$orepo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$orepo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "overlap cluster: c1.md, c2.md, g.md" "global note is exempt from clustering"
 
 # add a third api note → single cluster of three, sorted
 mk_note "$omd" c3.md $'name: c3\ntype: pattern\nscope: packages/api/**\nupdated: 2026-06-02\nsource: pr-5' 'b'
-pushd "$orepo" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$orepo" >/dev/null; run_doctor "."; popd >/dev/null
 assert_contains "$OUT" "overlap cluster: c1.md, c2.md, c3.md" "three notes on a shared file form one sorted cluster"
 
 # a stale note (matches no tracked file) is never clustered, only stale-warned
@@ -207,7 +211,7 @@ ostale="$(mktemp -d)"
 osmd="$ostale/.woostack/memory"; mkdir -p "$osmd"
 mk_note "$osmd" real.md  $'name: real\ntype: pattern\nscope: packages/api/**\nupdated: 2026-06-02\nsource: pr-1' 'b'
 mk_note "$osmd" ghost.md $'name: ghost\ntype: pattern\nscope: zzz/**\nupdated: 2026-06-02\nsource: pr-2' 'b'
-pushd "$ostale" >/dev/null; run_doctor ".woostack/memory"; popd >/dev/null
+pushd "$ostale" >/dev/null; run_doctor "."; popd >/dev/null
 assert_not_contains "$OUT" "overlap cluster" "a lone real note + a stale note form no cluster"
 assert_contains "$OUT" "ghost.md: scope 'zzz/**' matches no tracked files (stale)" "stale note still stale-warned"
 

--- a/skills/woostack-doctor/scripts/tests/test-orchestrator.sh
+++ b/skills/woostack-doctor/scripts/tests/test-orchestrator.sh
@@ -24,6 +24,8 @@ bash "$DOC" "$errws" >/dev/null 2>&1; assert_exit 1 "$?" "error finding exits 1"
 dump="$(bash "$DOC" --check "$warnws" 2>/dev/null)"
 assert_eq "$dump" "" "--check suppresses machine dump on stdout"
 
+bash "$DOC" --check "$errws" >/dev/null 2>&1; assert_exit 1 "$?" "--check with errors still exits 1"
+
 dump2="$(bash "$DOC" "$warnws" 2>/dev/null)"
 assert_contains "$dump2" "memory-unresolved-link" "default mode dumps machine findings on stdout"
 

--- a/skills/woostack-doctor/scripts/tests/test-orchestrator.sh
+++ b/skills/woostack-doctor/scripts/tests/test-orchestrator.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+set +e   # assert.sh enables -e; we capture doctor exit codes manually
+DOC="$HERE/../doctor.sh"
+
+empty="$(mktemp -d)"
+out="$(bash "$DOC" "$empty" 2>&1)"; code=$?
+assert_exit 2 "$code" "missing .woostack exits 2"
+assert_contains "$out" "run woostack-init" "missing-workspace message points to init"
+
+clean="$(mktemp -d)"; mkdir -p "$clean/.woostack/memory"
+bash "$DOC" "$clean" >/dev/null 2>&1; assert_exit 0 "$?" "clean workspace exits 0"
+
+warnws="$(mktemp -d)"; mkdir -p "$warnws/.woostack/memory"
+printf -- '---\nname: n\ntype: gotcha\nscope: *\nsource: .woostack/specs/x.md\nupdated: 2099-01-01\n---\nbody [[ghost]]\n' > "$warnws/.woostack/memory/n.md"
+bash "$DOC" "$warnws" >/dev/null 2>&1; assert_exit 0 "$?" "warn-only exits 0"
+
+errws="$(mktemp -d)"; mkdir -p "$errws/.woostack/memory"
+printf 'no fence\n' > "$errws/.woostack/memory/bad.md"
+bash "$DOC" "$errws" >/dev/null 2>&1; assert_exit 1 "$?" "error finding exits 1"
+
+dump="$(bash "$DOC" --check "$warnws" 2>/dev/null)"
+assert_eq "$dump" "" "--check suppresses machine dump on stdout"
+
+dump2="$(bash "$DOC" "$warnws" 2>/dev/null)"
+assert_contains "$dump2" "memory-unresolved-link" "default mode dumps machine findings on stdout"
+
+bad="$(bash "$DOC" --bogus "$warnws" 2>&1)"; bc=$?
+assert_exit 2 "$bc" "unknown flag exits 2"
+finish


### PR DESCRIPTION
## Goal

Increment 2/7 of /woostack-doctor: turn the moved engine into a check **orchestrator** with a stable finding contract and CI-friendly exit codes, so later increments add checks as `checks/*.sh`.

## Summary

- `doctor.sh` now runs `checks/*.sh`, groups findings (`severity⇥code⇥fixable⇥path⇥message`), prints `::error::`/`::warning::` annotations, dumps machine findings on stdout, exits nonzero iff any `error`. `--check` = CI mode (annotations + exit only).
- Memory lint extracted verbatim into `checks/memory.sh` (severities preserved; all `fixable=report`).
- `test-doctor.sh` reworked to the workspace-root contract; new `test-orchestrator.sh` (missing-`.woostack`→exit 2, clean→0, warn-only→0, error→1, `--check` suppresses dump, unknown flag→2).

## Test plan

### Automated

- [x] `run-tests.sh` → test-doctor 47, test-orchestrator 8, test-no-stale-paths 1 — all pass.
- [x] init suite still green; orchestrator on the real store exits 0.

### Manual

**Before merge**

- [ ] Confirm `checks/memory.sh` preserves the original lint flags + severities (diff vs the pre-move `doctor.sh`).

Spec: .woostack/specs/2026-06-13-woostack-doctor.md
