### PR TITLE
feat(doctor): spec<->plan backlink check + repair

### DIFF
--- a/skills/woostack-doctor/scripts/checks/spec-plan-backlink.sh
+++ b/skills/woostack-doctor/scripts/checks/spec-plan-backlink.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# spec-plan-backlink.sh — every plan's source spec must carry [[plans/<plan-basename>]].
+# Calling convention (uniform across all checks):
+#   diagnose:  <check> <WOO_ROOT>
+#   repair:    <check> --fix <WOO_ROOT> <extra-args...>
+# $1 is overloaded (root or "--fix"), so resolve mode BEFORE deriving any path.
+set -uo pipefail
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+
+if [ "${1:-}" = "--fix" ]; then
+  # --fix <root> <spec> <plan-basename> : insert the callout after the first H1 (idempotent).
+  spec="$3"; pbase="$4"
+  grep -qF "[[plans/$pbase]]" "$spec" 2>/dev/null && exit 0
+  awk -v line="> **Plan:** [[plans/$pbase]]" '
+    {print} d==0 && /^# /{print ""; print line; d=1}' "$spec" > "$spec.t" \
+    && mv "$spec.t" "$spec"
+  exit $?
+fi
+WOO_ROOT="${1:-.}"
+
+# spec_for <plan-file> → absolute spec path (Source line, else same-basename), empty if none.
+spec_for() {
+  local plan="$1" pbase src
+  pbase="$(basename "$plan")"
+  src="$(grep -m1 -E '^\*\*Source:\*\*' "$plan" 2>/dev/null | grep -oE 'specs/[^])[:space:]]+\.md' | head -1)"
+  if [ -n "$src" ] && [ -f "$WOO_ROOT/.woostack/$src" ]; then
+    printf '%s\n' "$WOO_ROOT/.woostack/$src"; return
+  fi
+  [ -f "$WOO_ROOT/.woostack/specs/$pbase" ] && printf '%s\n' "$WOO_ROOT/.woostack/specs/$pbase"
+}
+
+shopt -s nullglob
+for plan in "$WOO_ROOT"/.woostack/plans/*.md; do
+  pbase="$(basename "$plan" .md)"
+  spec="$(spec_for "$plan")"
+  [ -z "$spec" ] && continue
+  grep -qF "[[plans/$pbase]]" "$spec" \
+    || emit warn spec-plan-backlink auto "${spec#$WOO_ROOT/}" \
+         "spec missing Obsidian backlink [[plans/$pbase]] to its plan"
+done

--- a/skills/woostack-doctor/scripts/checks/spec-plan-backlink.sh
+++ b/skills/woostack-doctor/scripts/checks/spec-plan-backlink.sh
@@ -9,12 +9,21 @@ emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
 
 if [ "${1:-}" = "--fix" ]; then
   # --fix <root> <spec> <plan-basename> : insert the callout after the first H1 (idempotent).
-  spec="$3"; pbase="$4"
+  root="$2"; spec="$3"; pbase="$4"
   grep -qF "[[plans/$pbase]]" "$spec" 2>/dev/null && exit 0
   awk -v line="> **Plan:** [[plans/$pbase]]" '
     {print} d==0 && /^# /{print ""; print line; d=1}' "$spec" > "$spec.t" \
     && mv "$spec.t" "$spec"
-  exit $?
+  # The awk anchors the callout to the first H1; a spec with no H1 heading leaves
+  # the file unchanged, so the backlink is never inserted. Confirm it actually
+  # landed instead of reporting a phantom-successful repair (the orchestrator
+  # reads exit 0 as "fixed" and would otherwise re-warn on the next diagnose).
+  if ! grep -qF "[[plans/$pbase]]" "$spec"; then
+    emit error spec-plan-backlink manual "${spec#"$root"/}" \
+      "no H1 heading to anchor backlink [[plans/$pbase]]; add it to the spec manually"
+    exit 1
+  fi
+  exit 0
 fi
 WOO_ROOT="${1:-.}"
 

--- a/skills/woostack-doctor/scripts/tests/test-spec-plan-backlink.sh
+++ b/skills/woostack-doctor/scripts/tests/test-spec-plan-backlink.sh
@@ -29,4 +29,12 @@ assert_contains "$(bash "$CHK" "$r2")" "y-long.md" "slug-mismatch resolves via S
 r3="$(mktemp -d)"; mkdir -p "$r3/.woostack/specs" "$r3/.woostack/plans"
 printf -- '**Source:** .woostack/specs/missing.md\n\n# Z Plan\n' > "$r3/.woostack/plans/2026-06-13-z.md"
 assert_eq "$(bash "$CHK" "$r3")" "" "spec-less plan is not flagged"
+
+# --fix on a spec with no H1 cannot anchor the callout; it must fail loudly
+# (exit non-zero + error finding) rather than report a phantom-successful repair.
+r4="$(mktemp -d)"; mkdir -p "$r4/.woostack/specs"
+printf -- '---\nname: w\ntype: spec\n---\n\nBody only, no H1 heading.\n' > "$r4/.woostack/specs/2026-06-13-w.md"
+out4="$(bash "$CHK" --fix "$r4" "$r4/.woostack/specs/2026-06-13-w.md" "2026-06-13-w")"; rc4=$?
+assert_exit 1 "$rc4" "--fix on a no-H1 spec exits non-zero"
+assert_contains "$out4" "no H1 heading to anchor" "--fix on a no-H1 spec emits an error finding"
 finish

--- a/skills/woostack-doctor/scripts/tests/test-spec-plan-backlink.sh
+++ b/skills/woostack-doctor/scripts/tests/test-spec-plan-backlink.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+set +e
+CHK="$HERE/../checks/spec-plan-backlink.sh"
+
+mk() { local root; root="$(mktemp -d)"; mkdir -p "$root/.woostack/specs" "$root/.woostack/plans"
+  printf -- '---\nname: x\ntype: spec\n---\n\n# X — Design Spec\n\n## 1. Problem\n' > "$root/.woostack/specs/2026-06-13-x.md"
+  printf -- '**Source:** .woostack/specs/2026-06-13-x.md\n\n# X Plan\n' > "$root/.woostack/plans/2026-06-13-x.md"
+  printf '%s\n' "$root"; }
+
+r="$(mk)"
+out="$(bash "$CHK" "$r")"
+assert_contains "$out" "spec-plan-backlink" "isolated spec is flagged"
+assert_contains "$out" "[[plans/2026-06-13-x]]" "message names the expected backlink"
+
+bash "$CHK" --fix "$r" "$r/.woostack/specs/2026-06-13-x.md" "2026-06-13-x"
+assert_contains "$(cat "$r/.woostack/specs/2026-06-13-x.md")" "> **Plan:** [[plans/2026-06-13-x]]" "fix inserts the callout"
+assert_eq "$(bash "$CHK" "$r")" "" "after fix, no finding"
+bash "$CHK" --fix "$r" "$r/.woostack/specs/2026-06-13-x.md" "2026-06-13-x"
+assert_eq "$(grep -cF "[[plans/2026-06-13-x]]" "$r/.woostack/specs/2026-06-13-x.md")" "1" "fix is idempotent"
+
+r2="$(mktemp -d)"; mkdir -p "$r2/.woostack/specs" "$r2/.woostack/plans"
+printf -- '---\nname: y\ntype: spec\n---\n\n# Y\n' > "$r2/.woostack/specs/2026-06-13-y-long.md"
+printf -- '**Source:** .woostack/specs/2026-06-13-y-long.md\n\n# Y Plan\n' > "$r2/.woostack/plans/2026-06-13-y.md"
+assert_contains "$(bash "$CHK" "$r2")" "y-long.md" "slug-mismatch resolves via Source line"
+
+r3="$(mktemp -d)"; mkdir -p "$r3/.woostack/specs" "$r3/.woostack/plans"
+printf -- '**Source:** .woostack/specs/missing.md\n\n# Z Plan\n' > "$r3/.woostack/plans/2026-06-13-z.md"
+assert_eq "$(bash "$CHK" "$r3")" "" "spec-less plan is not flagged"
+finish


### PR DESCRIPTION
## Goal

Increment 3/7 of /woostack-doctor: the seed convention check — every plan's source spec must carry an Obsidian backlink to its plan, with a gated repair. This is the original "specs are isolated nodes" fix, now a doctor check.

## Summary

- `checks/spec-plan-backlink.sh`: warns `spec-plan-backlink` (fixable=auto) when a spec lacks `[[plans/<plan-basename>]]`; reuses the `status.sh` Source-line join + same-basename fallback; folder-qualified to disambiguate the shared basename.
- `--fix <root> <spec> <pbase>` inserts `> **Plan:** [[plans/<pbase>]]` after the first H1, idempotently.

## Test plan

### Automated

- [x] `test-spec-plan-backlink.sh` 7 passed (flag, fix, idempotent, slug-mismatch, spec-less). Full suite green.

### Manual

**Before merge**

- [ ] Confirm folder-qualified `[[plans/...]]` (shared basename) + the uniform `--fix <root> ...` arg order.

Spec: .woostack/specs/2026-06-13-woostack-doctor.md
