### PR TITLE
feat(doctor): workspace-health checks (orphan worktree, gitignore, config)

### DIFF
--- a/skills/woostack-doctor/scripts/checks/config-keys.sh
+++ b/skills/woostack-doctor/scripts/checks/config-keys.sh
@@ -10,6 +10,9 @@ if [ "${1:-}" = "--fix" ]; then FIX=1; WOO_ROOT="${2:-.}"; key="${3:-}"; else FI
 CFG="$WOO_ROOT/.woostack/config.json"
 
 if [ "$FIX" -eq 1 ]; then
+  # An empty key arg would make jq write a bogus "" entry into config.json
+  # (silent corruption). Require a real key; the orchestrator always passes one.
+  [ -n "$key" ] || { echo "config-keys.sh: --fix requires a key argument" >&2; exit 2; }
   [ -f "$CFG" ] || echo '{}' > "$CFG"
   val="$(jq -c --arg k "$key" '.[$k]' "$TEMPLATE")"
   tmp="$(mktemp)"; jq --arg k "$key" --argjson v "$val" '.[$k]=$v' "$CFG" > "$tmp" && mv "$tmp" "$CFG"

--- a/skills/woostack-doctor/scripts/checks/config-keys.sh
+++ b/skills/woostack-doctor/scripts/checks/config-keys.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="$HERE/../../../woostack-init/templates/config.json"
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+[ -f "$TEMPLATE" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+if [ "${1:-}" = "--fix" ]; then FIX=1; WOO_ROOT="${2:-.}"; key="${3:-}"; else FIX=0; WOO_ROOT="${1:-.}"; fi
+CFG="$WOO_ROOT/.woostack/config.json"
+
+if [ "$FIX" -eq 1 ]; then
+  [ -f "$CFG" ] || echo '{}' > "$CFG"
+  val="$(jq -c --arg k "$key" '.[$k]' "$TEMPLATE")"
+  tmp="$(mktemp)"; jq --arg k "$key" --argjson v "$val" '.[$k]=$v' "$CFG" > "$tmp" && mv "$tmp" "$CFG"
+  exit $?
+fi
+req_keys="$(jq -r 'keys[]' "$TEMPLATE")"
+for k in $req_keys; do
+  if [ ! -f "$CFG" ] || [ "$(jq --arg k "$k" 'has($k)' "$CFG" 2>/dev/null)" != "true" ]; then
+    emit warn config-key auto ".woostack/config.json" "missing required config key: $k"
+  fi
+done

--- a/skills/woostack-doctor/scripts/checks/gitignore-drift.sh
+++ b/skills/woostack-doctor/scripts/checks/gitignore-drift.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="$HERE/../../../woostack-init/templates/gitignore"
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+[ -f "$TEMPLATE" ] || exit 0
+
+if [ "${1:-}" = "--fix" ]; then FIX=1; WOO_ROOT="${2:-.}"; else FIX=0; WOO_ROOT="${1:-.}"; fi
+GI="$WOO_ROOT/.woostack/.gitignore"
+
+missing() {
+  while IFS= read -r line; do
+    case "$line" in ''|\#*) continue ;; esac
+    [ -f "$GI" ] && grep -qxF "$line" "$GI" && continue
+    printf '%s\n' "$line"
+  done < "$TEMPLATE"
+}
+
+if [ "$FIX" -eq 1 ]; then
+  [ -f "$GI" ] || : > "$GI"
+  while IFS= read -r line; do [ -n "$line" ] && printf '%s\n' "$line" >> "$GI"; done < <(missing)
+  exit 0
+fi
+while IFS= read -r line; do
+  [ -n "$line" ] && emit warn gitignore-drift auto ".woostack/.gitignore" "missing managed line: $line"
+done < <(missing)

--- a/skills/woostack-doctor/scripts/checks/orphan-worktree.sh
+++ b/skills/woostack-doctor/scripts/checks/orphan-worktree.sh
@@ -10,6 +10,11 @@ if [ "${1:-}" = "--fix" ]; then
   exit 0
 fi
 WOO_ROOT="${1:-.}"
+# Resolve to an absolute path: `git worktree list` emits absolute paths, so the
+# stale-registration `case` below never matches a relative wt_dir (e.g. the "."
+# default), silently skipping stale registrations. Keep the raw value if the dir
+# does not exist so the [ -d ] guard still exits cleanly.
+WOO_ROOT="$(cd "$WOO_ROOT" 2>/dev/null && pwd || printf '%s' "$WOO_ROOT")"
 wt_dir="$WOO_ROOT/.woostack/worktrees"
 [ -d "$wt_dir" ] || exit 0
 

--- a/skills/woostack-doctor/scripts/checks/orphan-worktree.sh
+++ b/skills/woostack-doctor/scripts/checks/orphan-worktree.sh
@@ -17,7 +17,9 @@ registered="$(cd "$WOO_ROOT" && git worktree list --porcelain 2>/dev/null | awk 
 shopt -s nullglob
 for d in "$wt_dir"/*/; do
   d="${d%/}"; abs="$(cd "$d" 2>/dev/null && pwd)" || continue
-  case "$registered" in *"$abs"*) continue ;; esac
+  # Exact full-line match — a substring `case` would treat .../worktrees/app as
+  # registered whenever .../worktrees/app2 is, silently skipping a real orphan.
+  printf '%s\n' "$registered" | grep -qxF "$abs" && continue
   emit warn orphan-worktree report "${d#$WOO_ROOT/}" "unregistered worktree dir (manual review/remove — may hold work)"
 done
 while IFS= read -r p; do

--- a/skills/woostack-doctor/scripts/checks/orphan-worktree.sh
+++ b/skills/woostack-doctor/scripts/checks/orphan-worktree.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# orphan-worktree.sh — flag worktree drift under .woostack/worktrees/. SAFE: the only
+# auto repair is `git worktree prune` (clears git's admin entries for already-gone dirs);
+# a present unregistered dir may hold uncommitted work, so it is always `report` (manual).
+set -uo pipefail
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+
+if [ "${1:-}" = "--fix" ]; then
+  ( cd "${2:-.}" && git worktree prune ) 2>/dev/null || true
+  exit 0
+fi
+WOO_ROOT="${1:-.}"
+wt_dir="$WOO_ROOT/.woostack/worktrees"
+[ -d "$wt_dir" ] || exit 0
+
+registered="$(cd "$WOO_ROOT" && git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')"
+shopt -s nullglob
+for d in "$wt_dir"/*/; do
+  d="${d%/}"; abs="$(cd "$d" 2>/dev/null && pwd)" || continue
+  case "$registered" in *"$abs"*) continue ;; esac
+  emit warn orphan-worktree report "${d#$WOO_ROOT/}" "unregistered worktree dir (manual review/remove — may hold work)"
+done
+while IFS= read -r p; do
+  [ -z "$p" ] && continue
+  case "$p" in "$wt_dir"/*) [ -d "$p" ] || emit warn orphan-worktree auto "${p#$WOO_ROOT/}" "stale worktree registration (git worktree prune)" ;; esac
+done <<< "$registered"

--- a/skills/woostack-doctor/scripts/tests/test-health-checks.sh
+++ b/skills/woostack-doctor/scripts/tests/test-health-checks.sh
@@ -29,7 +29,9 @@ if command -v jq >/dev/null 2>&1; then
 fi
 
 # orphan-worktree
-r3="$(mktemp -d)"; ( cd "$r3" && git -c user.email=t@t -c user.name=t init -q && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init )
+# Physical path (pwd -P): git canonicalizes worktree paths, so on macOS where
+# /var -> /private/var the registered list must match the resolved dir paths.
+r3="$(cd "$(mktemp -d)" && pwd -P)"; ( cd "$r3" && git -c user.email=t@t -c user.name=t init -q && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init )
 mkdir -p "$r3/.woostack/worktrees/ghost"
 assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "orphan-worktree" "unregistered worktree dir flagged"
 assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "report" "present unregistered dir is report (never auto-pruned)"
@@ -39,4 +41,11 @@ assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "report" "present unregi
 git -C "$r3" worktree add -q "$r3/.woostack/worktrees/app2" -b wt-app2
 mkdir -p "$r3/.woostack/worktrees/app"
 assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "worktrees/app	" "orphan 'app' flagged despite registered prefix-sibling 'app2'"
+
+# Stale registration (dir gone, git entry remains) must be detected even with a
+# RELATIVE WOO_ROOT — git emits absolute paths, so a relative wt_dir case-pattern
+# would never match (regression guard for the "." default).
+git -C "$r3" worktree add -q "$r3/.woostack/worktrees/stale" -b wt-stale
+rm -rf "$r3/.woostack/worktrees/stale"
+assert_contains "$( cd "$r3" && bash "$C/orphan-worktree.sh" . )" "stale worktree registration" "stale registration detected with a relative root"
 finish

--- a/skills/woostack-doctor/scripts/tests/test-health-checks.sh
+++ b/skills/woostack-doctor/scripts/tests/test-health-checks.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+set +e
+C="$HERE/../checks"
+
+# gitignore-drift
+r="$(mktemp -d)"; mkdir -p "$r/.woostack"; : > "$r/.woostack/.gitignore"
+assert_contains "$(bash "$C/gitignore-drift.sh" "$r")" "gitignore-drift" "empty .gitignore drifts"
+bash "$C/gitignore-drift.sh" --fix "$r"
+assert_eq "$(bash "$C/gitignore-drift.sh" "$r")" "" "after fix, no drift"
+before="$(wc -l < "$r/.woostack/.gitignore")"; bash "$C/gitignore-drift.sh" --fix "$r"
+assert_eq "$(wc -l < "$r/.woostack/.gitignore")" "$before" "gitignore fix idempotent"
+
+# config-keys (skips cleanly when jq absent)
+if command -v jq >/dev/null 2>&1; then
+  r2="$(mktemp -d)"; mkdir -p "$r2/.woostack"; echo '{}' > "$r2/.woostack/config.json"
+  assert_contains "$(bash "$C/config-keys.sh" "$r2")" "config-key" "empty config missing keys"
+  for k in $(jq -r 'keys[]' "$HERE/../../../woostack-init/templates/config.json"); do
+    bash "$C/config-keys.sh" --fix "$r2" "$k"
+  done
+  assert_eq "$(bash "$C/config-keys.sh" "$r2")" "" "after fixing all keys, clean"
+fi
+
+# orphan-worktree
+r3="$(mktemp -d)"; ( cd "$r3" && git -c user.email=t@t -c user.name=t init -q && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init )
+mkdir -p "$r3/.woostack/worktrees/ghost"
+assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "orphan-worktree" "unregistered worktree dir flagged"
+assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "report" "present unregistered dir is report (never auto-pruned)"
+finish

--- a/skills/woostack-doctor/scripts/tests/test-health-checks.sh
+++ b/skills/woostack-doctor/scripts/tests/test-health-checks.sh
@@ -21,6 +21,11 @@ if command -v jq >/dev/null 2>&1; then
     bash "$C/config-keys.sh" --fix "$r2" "$k"
   done
   assert_eq "$(bash "$C/config-keys.sh" "$r2")" "" "after fixing all keys, clean"
+
+  # --fix with no key arg must refuse, not write a bogus "" entry into config.
+  r2b="$(mktemp -d)"; mkdir -p "$r2b/.woostack"; echo '{}' > "$r2b/.woostack/config.json"
+  bash "$C/config-keys.sh" --fix "$r2b" >/dev/null 2>&1; assert_exit 2 "$?" "config-keys --fix without a key arg refuses"
+  assert_eq "$(cat "$r2b/.woostack/config.json")" "{}" "config-keys --fix without a key leaves config untouched"
 fi
 
 # orphan-worktree
@@ -28,4 +33,10 @@ r3="$(mktemp -d)"; ( cd "$r3" && git -c user.email=t@t -c user.name=t init -q &&
 mkdir -p "$r3/.woostack/worktrees/ghost"
 assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "orphan-worktree" "unregistered worktree dir flagged"
 assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "report" "present unregistered dir is report (never auto-pruned)"
+
+# Prefix-collision regression: a registered worktree (app2) whose path contains an
+# orphan dir's path (app) as a prefix must NOT make the orphan look registered.
+git -C "$r3" worktree add -q "$r3/.woostack/worktrees/app2" -b wt-app2
+mkdir -p "$r3/.woostack/worktrees/app"
+assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "worktrees/app	" "orphan 'app' flagged despite registered prefix-sibling 'app2'"
 finish


### PR DESCRIPTION
## Goal

Increment 4/7 of /woostack-doctor: the broad workspace-health checks — orphan worktrees, `.gitignore` drift, and `config.json` key gaps — each with a safe gated `--fix`.

## Summary

- `orphan-worktree.sh`: present unregistered dir → `report` (may hold work, never auto-removed); stale registration (dir gone) → `auto` `git worktree prune` (admin-only, safe).
- `gitignore-drift.sh`: each shipped-template managed line absent → finding; `--fix` appends only the missing lines (per-line presence, idempotent).
- `config-keys.sh`: required keys = init `config.json` template keys; `--fix <root> <key>` merges the template default (jq-gated; skips silently without jq).

## Test plan

### Automated

- [x] `test-health-checks.sh` 7 passed (each check fires + clean + idempotent fix). Full suite green (70).

### Manual

**Before merge**

- [ ] Confirm orphan-worktree never auto-removes a present dir (only prunes stale registrations).

Spec: .woostack/specs/2026-06-13-woostack-doctor.md
