### PR TITLE
feat(doctor): skill shell + gated repair layer + check catalog

### DIFF
--- a/skills/woostack-doctor/SKILL.md
+++ b/skills/woostack-doctor/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: woostack-doctor
+description: Use to diagnose and (gated) repair a repo's .woostack/ workspace health — a run-anytime check of store integrity and conventions (memory wikilinks/provenance/dead notes, the spec↔plan Obsidian backlink, orphan worktrees, .gitignore drift, config.json keys), with a headless exit-coded diagnose mode for CI (--check) and an interactive propose→approve→apply→woostack-commit repair flow. Use for /woostack-doctor, "check my .woostack", "repair the workspace", or "is my woostack install healthy". Never scaffolds (that's woostack-init), never reconciles the board (woostack-status), never curates memory content (woostack-dream), and never merges.
+---
+
+# woostack-doctor
+
+Diagnose — and, with your approval, repair — the health of a repo's `.woostack/` workspace.
+This is the 17th public command and the **store-integrity + convention** quadrant of woostack
+health: `woostack-init` scaffolds (creates missing structure), `woostack-status` reconciles the
+feature board, `woostack-dream` curates memory *content*, and **`woostack-doctor` lints and repairs
+existing content and conventions**.
+
+It has two layers:
+
+- A **headless diagnose engine** (`scripts/doctor.sh`) — pure bash, **exit-coded** (0 = no errors,
+  nonzero = at least one `error` finding). Drop it into consumer CI with `--check`.
+- An **interactive repair layer** (this skill's procedure) — proposes a changeset for the
+  auto-fixable findings, mutates **nothing** before you approve, applies the approved repairs, and
+  hands file changes to [`woostack-commit`](../woostack-commit/SKILL.md). It **never merges**.
+
+## Commands
+
+- `/woostack-doctor [path]` — diagnose the workspace at `path` (default: current repo), then
+  **offer** a gated repair changeset for the auto-fixable findings.
+- `/woostack-doctor [path] --check` — **CI mode**: diagnose only. Prints GitHub-style annotations
+  and sets the exit code (nonzero iff any `error`); suppresses the machine-readable findings dump.
+  Mutates nothing.
+
+The engine depends on [`woostack-init`](../woostack-init/SKILL.md) being installed (it sources the
+shared libs and reads the `templates/` it ships); the woostack collection installs both as
+siblings, so this holds by construction.
+
+## Procedure
+
+1. **Diagnose.** Run `bash <doctor>/scripts/doctor.sh [path]`. Read the machine-readable findings
+   on stdout — one per line, `severity⇥code⇥fixable⇥path⇥message`. Severity is `error`
+   (structural breakage — fails CI) or `warn` (hygiene/convention). `fixable` is `auto`
+   (the owning check ships a `--fix`) or `report` (judgment — surfaced, never auto-applied). The
+   full catalog is in [references/checks.md](references/checks.md).
+2. **No workspace?** If the engine exits 2 with "no `.woostack/`", **stop** and tell the user to
+   run [`woostack-init`](../woostack-init/SKILL.md). Doctor never scaffolds.
+3. **Propose a changeset.** Group the `fixable=auto` findings into a proposed repair set — one line
+   per repair: the `code`, the `path`, and exactly what will change. List the `report`-only
+   findings separately as "manual / judgment" items. Present both.
+4. **HARD GATE — approval.** Mutate nothing until the user approves. Silence is not a yes. The user
+   may approve all, a subset, or none. `report`-only findings are never auto-applied.
+5. **Apply.** For each approved finding, invoke the owning check's `--fix` path with the uniform
+   convention `<check> --fix <WOO_ROOT> <extra-args...>` (see [references/checks.md](references/checks.md)
+   for each check's args). File repairs mutate the working tree; the filesystem-only repair
+   (`orphan-worktree --fix`, a safe `git worktree prune`) runs directly.
+6. **Commit.** After file repairs, hand to [`woostack-commit`](../woostack-commit/SKILL.md) — it
+   creates a fresh `feature/*` branch and opens a PR (respects branch protection; **never merges**).
+   Filesystem-only repairs need no commit.
+7. **Confirm.** Re-run the engine and report any residual findings.
+
+## Hard constraints
+
+- **Never scaffold.** Absent `.woostack/` → point at `woostack-init`; never create the workspace.
+- **Never reconcile the board** (that is `woostack-status`) and **never curate memory content**
+  (that is `woostack-dream`). Doctor flags *structural* problems and **reports** judgment-only
+  signals (dead notes); it never auto-prunes knowledge.
+- **Gate every repair.** Nothing mutates before explicit approval; `report` findings are never
+  auto-applied.
+- **Safety is never relaxed.** The only filesystem repair is `git worktree prune` (admin-only);
+  a present worktree dir that may hold work is always `report`, never auto-removed.
+- **Never merge.** Approved file repairs land via `woostack-commit` (branch + PR), never a merge.
+- **Cross-link, don't restate.** The spec↔plan join contract lives in
+  [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md);
+  link it.

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -1,0 +1,52 @@
+# woostack-doctor check catalog
+
+Each check is a script under [`../scripts/checks/`](../scripts/checks/) that emits findings to
+stdout, one per line, tab-delimited: `severity⇥code⇥fixable⇥path⇥message`.
+
+- **severity** — `error` (structural breakage; the orchestrator exits nonzero) or `warn`
+  (hygiene/convention; exit stays 0). CI (`--check`) fails only on `error`.
+- **fixable** — `auto` (the check ships a `--fix` apply path) or `report` (judgment; surfaced for a
+  human, never auto-applied).
+
+## Calling convention
+
+Every check is invoked two ways. Resolve the mode **before** deriving any path (`$1` is
+overloaded):
+
+- **diagnose:** `bash checks/<name>.sh <WOO_ROOT>` → emits findings.
+- **repair:** `bash checks/<name>.sh --fix <WOO_ROOT> <extra-args...>` → applies the fix.
+
+## Checks
+
+| code | check | severity | fixable | `--fix` args |
+|---|---|---|---|---|
+| `memory-malformed` | memory note missing opening `---` fence | error | report | — |
+| `memory-field` | memory note missing `name`/`type` or empty body | error | report | — |
+| `memory-type` | memory note has an unknown `type:` | error | report | — |
+| `memory-dup` | duplicate memory note `name:` | error | report | — |
+| `memory-scope-stale` | `scope:` matches no tracked files | warn | report | — |
+| `memory-provenance` | missing `source:`, or `source:` points at a missing spec/plan | warn | report | — |
+| `memory-scope-trivia` | non-glob `scope:` (possible trivia) | warn | report | — |
+| `memory-unresolved-link` | unresolved `[[wikilink]]` in a memory note (kept `warn` to not break consumer CI) | warn | report | — |
+| `memory-no-updated` | memory note missing `updated:` (cannot be aged) | warn | report | — |
+| `memory-dead` | old + never recalled (prune candidate) | warn | report | — |
+| `memory-overlap` | notes with intersecting scope (review for contradiction) | warn | report | — |
+| `spec-plan-backlink` | a plan's source spec lacks `[[plans/<plan-basename>]]` | warn | auto | `<root> <spec> <plan-basename>` |
+| `orphan-worktree` (present) | unregistered dir under `.woostack/worktrees/` (may hold work) | warn | report | — |
+| `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
+| `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |
+| `config-key` | a required `config.json` key (per the init template) is absent | warn | auto | `<root> <key>` (merges template default) |
+
+Memory checks are all `report` — memory *content* repair is [`woostack-dream`](../../woostack-dream/SKILL.md)'s
+job; doctor only surfaces the structural signals. The spec↔plan join reuses the
+`**Source:**`-line contract defined in
+[`../../woostack-status/references/conventions.md`](../../woostack-status/references/conventions.md).
+
+## Adding a check
+
+1. Drop `checks/<name>.sh` following the calling convention above (resolve `--fix` mode first; for a
+   check in `checks/`, sibling-skill libs/templates are `$HERE/../../../woostack-init/...`).
+2. Emit findings with a stable `code`.
+3. Add `tests/test-<name>.sh` (fires on a drifted fixture, silent on a clean one; idempotent
+   `--fix`).
+4. Add the row here.

--- a/skills/woostack-doctor/scripts/tests/test-repair-apply.sh
+++ b/skills/woostack-doctor/scripts/tests/test-repair-apply.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+set +e
+D="$HERE/../doctor.sh"; C="$HERE/../checks"
+
+r="$(mktemp -d)"; ( cd "$r" && git -c user.email=t@t -c user.name=t init -q && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init )
+mkdir -p "$r/.woostack/specs" "$r/.woostack/plans" "$r/.woostack/memory"
+: > "$r/.woostack/.gitignore"
+printf -- '---\nname: x\ntype: spec\n---\n\n# X\n## 1. Problem\n' > "$r/.woostack/specs/2026-06-13-x.md"
+printf -- '**Source:** .woostack/specs/2026-06-13-x.md\n\n# X Plan\n' > "$r/.woostack/plans/2026-06-13-x.md"
+
+bash "$D" "$r" >/dev/null 2>&1; assert_exit 0 "$?" "warn-only diagnose exits 0"
+found="$(bash "$D" "$r" 2>/dev/null)"
+assert_contains "$found" "spec-plan-backlink" "backlink finding present pre-repair"
+assert_contains "$found" "gitignore-drift" "gitignore finding present pre-repair"
+
+bash "$C/spec-plan-backlink.sh" --fix "$r" "$r/.woostack/specs/2026-06-13-x.md" "2026-06-13-x"
+bash "$C/gitignore-drift.sh" --fix "$r"
+residue="$(bash "$D" "$r" 2>/dev/null | grep -E 'spec-plan-backlink|gitignore-drift')"
+assert_eq "$residue" "" "after applying auto fixes, those findings clear"
+finish


### PR DESCRIPTION
## Goal

Increment 5/7 of /woostack-doctor: the public skill surface + the gated repair procedure that drives the checks' `--fix` paths to a `woostack-commit` handoff.

## Summary

- `SKILL.md`: `/woostack-doctor [path] [--check]`, the diagnose→propose→**approve gate**→apply→`woostack-commit` procedure, and the sharp init/status/dream boundary. Never scaffolds, never merges.
- `references/checks.md`: full catalog (code, severity, fixable, `--fix` args) + an "adding a check" guide.
- `test-repair-apply.sh`: diagnose→apply round-trip clears the auto findings (backlink + gitignore).

## Test plan

### Automated

- [x] `test-repair-apply.sh` 4 passed. Full suite green (74).

### Manual

**Before merge**

- [ ] Read SKILL.md — confirm the approval gate wording + that repair never auto-applies `report` findings and never merges.

Spec: .woostack/specs/2026-06-13-woostack-doctor.md
