### PR TITLE
feat(doctor): dogfood spec↔plan backlink — template + backfill 42 specs

### DIFF
--- a/.woostack/specs/2026-06-02-memory-distill-gate.md
+++ b/.woostack/specs/2026-06-02-memory-distill-gate.md
@@ -9,6 +9,8 @@ links:
 
 # Memory: distillation gate + updated: coverage (#167 + #161) — Design Spec
 
+> **Plan:** [[plans/2026-06-02-memory-distill-gate]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-02-memory-distill.md
+++ b/.woostack/specs/2026-06-02-memory-distill.md
@@ -9,6 +9,8 @@ increment: C of 4
 
 # Memory distill + skill wiring — Design Spec
 
+> **Plan:** [[plans/2026-06-02-memory-distill]]
+
 > Increment C of 4. Stacks on B ([[memory-recall]]). Wires the remaining three skills to the memory system. **Docs-only** — no new scripts; reuses A's `build-index`/`doctor` and B's `recall.sh`. Runs a lighter loop (no TDD) because it ships no code.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-02-memory-obsidian.md
+++ b/.woostack/specs/2026-06-02-memory-obsidian.md
@@ -9,6 +9,8 @@ increment: D of 4
 
 # Obsidian layer — Design Spec
 
+> **Plan:** [[plans/2026-06-02-memory-obsidian]]
+
 > Increment D of 4 (final). Stacks on C ([[memory-distill]]). The optional Obsidian layer over the memory vault. Hard reality: `obsidian eval` needs the desktop app running, so it is **never a dependency** — the grep-wikilink path (already in `recall.sh`/`doctor.sh`) stays the headless workhorse. This increment adds opt-in vault config + an optional graph helper that falls back to grep.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-02-memory-overlap-clusters.md
+++ b/.woostack/specs/2026-06-02-memory-overlap-clusters.md
@@ -9,6 +9,8 @@ links:
 
 # Memory: scope-overlap clusters + recall recency tiebreak (#162) — Design Spec
 
+> **Plan:** [[plans/2026-06-02-memory-overlap-clusters]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-02-memory-recall.md
+++ b/.woostack/specs/2026-06-02-memory-recall.md
@@ -9,6 +9,8 @@ increment: B of 4
 
 # Memory recall + review scope-routing — Design Spec
 
+> **Plan:** [[plans/2026-06-02-memory-recall]]
+
 > Increment B of 4. Stacks on increment A ([[woostack-init]]). Builds the read path: the `recall.sh` orchestration A deferred, wired into the review pipeline so workers get scope-matched notes instead of the whole flat dump.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-02-memory-staleness-guard.md
+++ b/.woostack/specs/2026-06-02-memory-staleness-guard.md
@@ -9,6 +9,8 @@ links:
 
 # Memory Staleness Guard — Design Spec
 
+> **Plan:** [[plans/2026-06-02-memory-staleness-guard]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
+++ b/.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
@@ -9,6 +9,8 @@ links:
 
 # Review metrics: cross-angle overlap (+ deferred token cost) — Design Spec
 
+> **Plan:** [[plans/2026-06-02-review-metrics-overlap]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-02-woostack-init.md
+++ b/.woostack/specs/2026-06-02-woostack-init.md
@@ -9,6 +9,8 @@ increment: A of 4
 
 # woostack-init — Design Spec
 
+> **Plan:** [[plans/2026-06-02-woostack-init]]
+
 > Increment A of 4. Hardened via grill-me 2026-06-02. Visualize on demand: render this file with `spec-template.html` if a rich view is wanted.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-03-bounded-review-swarms.md
+++ b/.woostack/specs/2026-06-03-bounded-review-swarms.md
@@ -10,6 +10,8 @@ links:
 
 # Bounded Review Swarms — Design Spec
 
+> **Plan:** [[plans/2026-06-03-bounded-review-swarms]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-03-woostack-ideate.md
+++ b/.woostack/specs/2026-06-03-woostack-ideate.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-ideate: a woostack-native ideation skill — Design Spec
 
+> **Plan:** [[plans/2026-06-03-woostack-ideate]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-03-woostack-visualize.md
+++ b/.woostack/specs/2026-06-03-woostack-visualize.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-visualize Skill — Design Spec
 
+> **Plan:** [[plans/2026-06-03-woostack-visualize]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-04-build-execution-handoff-gate.md
+++ b/.woostack/specs/2026-06-04-build-execution-handoff-gate.md
@@ -11,6 +11,8 @@ links:
 
 # woostack-build: execution-handoff gate — Design Spec
 
+> **Plan:** [[plans/2026-06-04-build-execution-handoff-gate]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
+++ b/.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-commit: PR body with Goal and structured test plan — Design Spec
 
+> **Plan:** [[plans/2026-06-04-commit-pr-goal-test-plan]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-04-execute-dual-mode-execution.md
+++ b/.woostack/specs/2026-06-04-execute-dual-mode-execution.md
@@ -10,6 +10,8 @@ links:
 
 # woostack-execute dual-mode execution (inline + subagent-driven) — Design Spec
 
+> **Plan:** [[plans/2026-06-04-execute-dual-mode-execution]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-04-review-nit-comments.md
+++ b/.woostack/specs/2026-06-04-review-nit-comments.md
@@ -9,6 +9,8 @@ links:
 
 # Review Nit Comments (below-floor findings surface as nits) — Design Spec
 
+> **Plan:** [[plans/2026-06-04-review-nit-comments]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-04-woostack-execute.md
+++ b/.woostack/specs/2026-06-04-woostack-execute.md
@@ -11,6 +11,8 @@ links:
 
 # woostack-execute: a woostack-native plan-execution command — Design Spec
 
+> **Plan:** [[plans/2026-06-04-woostack-execute]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-04-woostack-harden.md
+++ b/.woostack/specs/2026-06-04-woostack-harden.md
@@ -10,6 +10,8 @@ links:
 
 # woostack-harden: a woostack-native hardening skill — Design Spec
 
+> **Plan:** [[plans/2026-06-04-woostack-harden]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-04-woostack-status.md
+++ b/.woostack/specs/2026-06-04-woostack-status.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-status: a derived feature board — Design Spec
 
+> **Plan:** [[plans/2026-06-04-woostack-status]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 ## 1. Problem

--- a/.woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
+++ b/.woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-address-comments: show the fix plan before approval — Design Spec
 
+> **Plan:** [[plans/2026-06-05-address-comments-fix-plan-gate]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-05-execute-vary-subagent-model.md
+++ b/.woostack/specs/2026-06-05-execute-vary-subagent-model.md
@@ -11,6 +11,8 @@ links:
 
 # woostack-execute: vary subagent model per task (quality / speed / cost) — Design Spec
 
+> **Plan:** [[plans/2026-06-05-execute-vary-subagent-model]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-05-skills-review-angle.md
+++ b/.woostack/specs/2026-06-05-skills-review-angle.md
@@ -9,6 +9,8 @@ links:
 
 # Skills Review Angle — Design Spec
 
+> **Plan:** [[plans/2026-06-05-skills-review-angle]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-05-woostack-debug.md
+++ b/.woostack/specs/2026-06-05-woostack-debug.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-debug: a woostack-native systematic-debugging skill — Design Spec
 
+> **Plan:** [[plans/2026-06-05-woostack-debug]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-05-woostack-plan.md
+++ b/.woostack/specs/2026-06-05-woostack-plan.md
@@ -12,6 +12,8 @@ links:
 
 # woostack-plan: a woostack-native plan-writing command — Design Spec
 
+> **Plan:** [[plans/2026-06-05-woostack-plan]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-06-commit-memory-changes.md
+++ b/.woostack/specs/2026-06-06-commit-memory-changes.md
@@ -9,6 +9,8 @@ links:
 
 # Commit memory changes unless gitignored — Design Spec
 
+> **Plan:** [[plans/2026-06-06-commit-memory-changes]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-06-review-fail-fast-receipts.md
+++ b/.woostack/specs/2026-06-06-review-fail-fast-receipts.md
@@ -10,6 +10,8 @@ links:
 
 # woostack-review: fail fast when angle workers cannot execute — Design Spec
 
+> **Plan:** [[plans/2026-06-06-review-fail-fast-receipts]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-06-review-self-contained.md
+++ b/.woostack/specs/2026-06-06-review-self-contained.md
@@ -9,6 +9,8 @@ links:
 
 # Make woostack-review self-contained (retire pr-review-toolkit) — Design Spec
 
+> **Plan:** [[plans/2026-06-06-review-self-contained]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-06-spec-acceptance-criteria.md
+++ b/.woostack/specs/2026-06-06-spec-acceptance-criteria.md
@@ -9,6 +9,8 @@ links:
 
 # Structured Acceptance Criteria in the spec template — Design Spec
 
+> **Plan:** [[plans/2026-06-06-spec-acceptance-criteria]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-06-woostack-execute-overnight.md
+++ b/.woostack/specs/2026-06-06-woostack-execute-overnight.md
@@ -11,6 +11,8 @@ links:
 
 # woostack-execute-overnight: unattended autonomous plan execution — Design Spec
 
+> **Plan:** [[plans/2026-06-06-woostack-execute-overnight]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-07-woostack-tdd.md
+++ b/.woostack/specs/2026-06-07-woostack-tdd.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-tdd: TDD doctrine home + add-tests command — Design Spec
 
+> **Plan:** [[plans/2026-06-07-woostack-tdd]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-08-address-comments-commit-integration.md
+++ b/.woostack/specs/2026-06-08-address-comments-commit-integration.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-address-comments: integrate the commit skill — Design Spec
 
+> **Plan:** [[plans/2026-06-08-address-comments-commit-integration]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-08-generic-woostack-bootstrap.md
+++ b/.woostack/specs/2026-06-08-generic-woostack-bootstrap.md
@@ -9,6 +9,8 @@ links:
 
 # Dynamic, Requirements-Driven `woostack-bootstrap` Skill — Design Spec
 
+> **Plan:** [[plans/2026-06-08-generic-woostack-bootstrap]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-08-woostack-fix.md
+++ b/.woostack/specs/2026-06-08-woostack-fix.md
@@ -9,6 +9,8 @@ links:
 
 # Create `woostack-fix` Skill and Refine `woostack-debug` — Design Spec
 
+> **Plan:** [[plans/2026-06-08-woostack-fix]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-09-readme-rewrite.md
+++ b/.woostack/specs/2026-06-09-readme-rewrite.md
@@ -9,6 +9,8 @@ links:
 
 # README Rewrite — Design Spec
 
+> **Plan:** [[plans/2026-06-09-readme-rewrite]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-09-review-stack-aware.md
+++ b/.woostack/specs/2026-06-09-review-stack-aware.md
@@ -14,6 +14,8 @@ links:
 
 # Stack-aware review — Design Spec
 
+> **Plan:** [[plans/2026-06-09-review-stack-aware]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-09-woostack-dream.md
+++ b/.woostack/specs/2026-06-09-woostack-dream.md
@@ -9,6 +9,8 @@ links:
 
 # Create `woostack-dream` Skill — Agent-Agnostic Memory & Docs Curation — Design Spec
 
+> **Plan:** [[plans/2026-06-09-woostack-dream]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-10-parallel-worktrees.md
+++ b/.woostack/specs/2026-06-10-parallel-worktrees.md
@@ -9,6 +9,8 @@ links:
 
 # Parallel worktree isolation + configurable base branch — Design Spec
 
+> **Plan:** [[plans/2026-06-10-parallel-worktrees]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-11-overnight-review-sweep.md
+++ b/.woostack/specs/2026-06-11-overnight-review-sweep.md
@@ -11,6 +11,8 @@ links:
 
 # Overnight review sweep — Design Spec
 
+> **Plan:** [[plans/2026-06-11-overnight-review-sweep]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-11-woostack-dream-design-trends.md
+++ b/.woostack/specs/2026-06-11-woostack-dream-design-trends.md
@@ -9,6 +9,8 @@ links:
 
 # Shared Curated Memory + Design-Trend Consolidation in `woostack-dream` — Design Spec
 
+> **Plan:** [[plans/2026-06-11-woostack-dream-design-trends]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view, or hand it to `woostack-visualize` (audience `engineer`). Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-12-fumadocs-docs-site.md
+++ b/.woostack/specs/2026-06-12-fumadocs-docs-site.md
@@ -9,6 +9,8 @@ links:
 
 # Fumadocs docs site for the woostack skills — Design Spec
 
+> **Plan:** [[plans/2026-06-12-fumadocs-docs-site]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-12-output-discipline.md
+++ b/.woostack/specs/2026-06-12-output-discipline.md
@@ -9,6 +9,8 @@ links:
 
 # Native Output Discipline for Internal Comms — Design Spec
 
+> **Plan:** [[plans/2026-06-12-output-discipline]]
+
 > Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-13-dream-wisdom.md
+++ b/.woostack/specs/2026-06-13-dream-wisdom.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-dream → wisdom consolidation — Design Spec
 
+> **Plan:** [[plans/2026-06-13-dream-wisdom]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/.woostack/specs/2026-06-13-woostack-ask.md
+++ b/.woostack/specs/2026-06-13-woostack-ask.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-ask — read-only codebase Q&A — Design Spec
 
+> **Plan:** [[plans/2026-06-13-woostack-ask]]
+
 > Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).

--- a/skills/woostack-build/references/spec-template.md
+++ b/skills/woostack-build/references/spec-template.md
@@ -13,6 +13,8 @@ links:
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
 
+> **Plan:** [[plans/{{DATE}}-{{SLUG}}]]
+
 ## 1. Problem
 
 {{PROBLEM}}


### PR DESCRIPTION
## Goal

Increment 6/7 of /woostack-doctor: dogfood the spec↔plan backlink convention on this repo — make new specs born-linked and backfill every existing spec. Resolves the original "specs are isolated nodes in Obsidian" report.

## Summary

- `spec-template.md`: adds `> **Plan:** [[plans/{{DATE}}-{{SLUG}}]]` (date-prefixed basename — not `{{SLUG}}` — so the wikilink resolves to the plan file).
- Backfilled 42 existing specs with their `[[plans/<basename>]]` backlink via the `spec-plan-backlink --fix` path (idempotent; the doctor spec was already linked).
- `bash skills/woostack-doctor/scripts/doctor.sh .` now reports **0** `spec-plan-backlink` findings.

## Test plan

### Automated

- [x] Full doctor suite green (6/6 test files). `doctor.sh .` → 0 spec-plan-backlink findings.

### Manual

**Before merge**

- [ ] Open `.woostack/` in Obsidian → a previously-isolated spec now shows an edge to its plan.
- [ ] Confirm the 42-spec backfill diff is one `> **Plan:** [[...]]` line each (no other content touched).

Spec: .woostack/specs/2026-06-13-woostack-doctor.md
