### PR TITLE
docs(doctor): register woostack-doctor as the 17th public command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,8 @@ do not add application code, app build configs, or app lockfiles **outside the s
 
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
 `/woostack-bootstrap`, `/woostack-build`, `/woostack-fix`, `/woostack-plan`, `/woostack-execute`, `/woostack-execute-overnight`, `/woostack-commit`,
-`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, `/woostack-dream`, or
-`/woostack-tdd`, including intent-equivalent wording. Load the matching skill
+`/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, `/woostack-dream`,
+`/woostack-tdd`, or `/woostack-doctor`, including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
 directory, not in this repo.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `pnpx skills add howarewoo/woostack`.
 
-The public command/adoption surface has sixteen skills:
+The public command/adoption surface has seventeen skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -32,12 +32,13 @@ The public command/adoption surface has sixteen skills:
 - [`woostack-debug`](skills/woostack-debug/SKILL.md)
 - [`woostack-tdd`](skills/woostack-tdd/SKILL.md)
 - [`woostack-dream`](skills/woostack-dream/SKILL.md)
+- [`woostack-doctor`](skills/woostack-doctor/SKILL.md)
 
 The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the sixteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+`/woostack-*` commands: they have no routing row and are absent from the seventeen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
 There is no application source code, app lockfile, build, or CI for this repo's own
@@ -91,7 +92,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the eighteen `SKILL.md` files (the sixteen public command/adoption
+- Do not move or rename any of the nineteen `SKILL.md` files (the seventeen public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -129,6 +130,8 @@ directory, not in this repo.
   [`skills/woostack-visualize/SKILL.md`](skills/woostack-visualize/SKILL.md)
 - Memory & docs curation engine (public command; agent-agnostic "dreams"):
   [`skills/woostack-dream/SKILL.md`](skills/woostack-dream/SKILL.md)
+- Workspace health — diagnose + gated repair of `.woostack/` (the 17th public command):
+  [`skills/woostack-doctor/SKILL.md`](skills/woostack-doctor/SKILL.md)
 - TDD doctrine home and add-tests command (public command):
   [`skills/woostack-tdd/SKILL.md`](skills/woostack-tdd/SKILL.md)
 - Address-comments delegator:

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -78,6 +78,7 @@ link it, never restate it.
 | `/woostack-debug <target>`, run an autonomous root-cause analysis before fixing (investigative only — hands back the root cause and a proposed fix) | `woostack-debug` |
 | `/woostack-tdd <target>`, add appropriate tests to a code block, PR, spec, or plan (gate-light; TDD doctrine home) | `woostack-tdd` |
 | `/woostack-dream [instructions]`, curate the memory store and recommend doc updates (gated) | `woostack-dream` |
+| `/woostack-doctor [path] [--check]`, diagnose + gated-repair `.woostack/` workspace health (store integrity + conventions; `--check` is CI-friendly exit-coded) | `woostack-doctor` |
 
 
 If the user asks for the behavior without using the exact command name, route by intent.

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-init
-description: Use when initializing, scaffolding, or repairing the .woostack/ workspace — creates the memory store, specs and plans directories, config.json, and .gitignore from canonical templates, then runs the index builder and store linter. Invoke at project setup (brownfield) or from woostack-bootstrap (greenfield).
+description: Use when initializing, scaffolding, or repairing the .woostack/ workspace — creates the memory store, specs and plans directories, config.json, and .gitignore from canonical templates, then runs the index builder and the `woostack-doctor` store linter. For ongoing workspace-health checks and convention repair, use [`woostack-doctor`](../woostack-doctor/SKILL.md). Invoke at project setup (brownfield) or from woostack-bootstrap (greenfield).
 ---
 
 # woostack-init


### PR DESCRIPTION
## Goal

Increment 7/7 of /woostack-doctor: register the new command across the adoption surface (16 → 17) and trim woostack-init's repair claim to scaffold-only.

## Summary

- `AGENTS.md`: "sixteen"→"seventeen" skills (and "eighteen"→"nineteen" SKILL.md files), surface bullet, and a Quick-file-map entry.
- `using-woostack`: `/woostack-doctor [path] [--check]` routing row.
- `woostack-init`: description + overview now point to `woostack-doctor` for store-integrity + convention lint/repair (init stays scaffold/create).
- Docs site: `gen-skills.mjs` discovers skills via `readdir`, so `woostack-doctor` is auto-included — no nav edit.

## Test plan

### Automated

- [x] Full doctor suite green (6/6). `grep "sixteen skills" AGENTS.md skills` → none (count consistent).

### Manual

**Before merge**

- [ ] Confirm the surface count is consistent (seventeen public / nineteen SKILL.md) and the routing row resolves.

Spec: .woostack/specs/2026-06-13-woostack-doctor.md
