### PR TITLE
feat(status): track plan lifecycle separately

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -6,5 +6,8 @@
 				"standard": "gpt-5.4-mini"
 			}
 		}
+	},
+	"status": {
+		"staleDays": 14
 	}
 }

--- a/.woostack/fixes/2026-06-13-plan-frontmatter.md
+++ b/.woostack/fixes/2026-06-13-plan-frontmatter.md
@@ -1,0 +1,82 @@
+---
+type: fix
+status: in-review
+branch: fix/plan-frontmatter
+---
+
+# Fix: Track spec and plan lifecycle separately
+
+## 1. Root Cause
+
+The old feature-state contract put the whole build lifecycle on spec frontmatter and required plans
+to stay frontmatter-free. That made `/woostack-status` simple, but it mixed two different states:
+
+- specs answer whether the design has been written, hardened, and approved;
+- plans answer whether implementation is planned, ready, executing, in review, or done.
+
+This also blocked Obsidian from exposing plan properties and made the new `woostack-doctor`
+spec-plan checks depend only on the markdown `**Source:**` line.
+
+PR 342 adds `woostack-doctor`, including a spec-plan backlink check that reuses the existing
+`**Source:**` contract. The fix must preserve that line exactly while adding plan frontmatter.
+
+## 2. Proposed Fix
+
+Split lifecycle ownership:
+
+- Spec frontmatter owns design approval: `draft`, `hardened`, `approved`, `abandoned`.
+- Plan frontmatter owns implementation state: `planning`, `ready`, `executing`, `in-review`,
+  `done`, `abandoned`.
+- `/woostack-status` continues to show one row per spec/fix. Before a plan exists it reads spec
+  `status:`/`branch:`; after a plan resolves, it reads plan `status:`/`branch:`.
+- Plans start with Obsidian YAML properties and then keep the canonical join line:
+  ```yaml
+  ---
+  type: plan
+  source: .woostack/specs/<spec>.md
+  status: planning
+  branch: feature/<slug>
+  ---
+
+  **Source:** .woostack/specs/<spec>.md
+  ```
+
+Stack this fix on PR 342 (`feature/woostack-doctor-7-surface`) so the doctor skill and its
+spec-plan checks are present in the base.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Reproduce with failing contract checks**
+  - Run `skills/woostack-status/scripts/tests/run-tests.sh` after switching status to plan-owned
+    lifecycle.
+  - Expected before fixture updates: existing tests fail because plan fixtures default to
+    `planning` while old assertions expect spec-owned `ready`, `executing`, and `done`.
+
+- [x] **Step 2: Stack on PR 342**
+  - Fetch `feature/woostack-doctor-7-surface`.
+  - Rebase `fix/plan-frontmatter` onto it.
+  - Run `gt track --parent feature/woostack-doctor-7-surface`.
+
+- [x] **Step 3: Update `/woostack-status` behavior and tests**
+  - Teach `status.sh` to read spec lifecycle before a plan exists and plan lifecycle after a plan
+    resolves.
+  - Update status fixtures so generated plans carry `type`, `source`, `status`, and `branch`.
+  - Verification: `skills/woostack-status/scripts/tests/run-tests.sh`.
+
+- [x] **Step 4: Update contracts and skill guidance**
+  - Update `woostack-status` conventions for split lifecycle and doctor-compatible plan joins.
+  - Update `woostack-plan` and its template to generate plan frontmatter.
+  - Update `woostack-build`, `using-woostack`, and `woostack-commit` wording so status/branch
+    ownership is no longer spec-only.
+
+- [x] **Step 5: Migrate tracked plans**
+  - Add plan frontmatter to tracked `.woostack/plans/*.md` files.
+  - Preserve every existing `**Source:**` line exactly.
+  - For legacy plans without a source line, use the same-basename spec when it exists; otherwise
+    leave them untouched and let `woostack-doctor` report the pre-existing convention gap.
+
+- [x] **Step 6: Verify doctor compatibility**
+  - Run `skills/woostack-status/scripts/tests/run-tests.sh`.
+  - Run `skills/woostack-doctor/scripts/tests/test-spec-plan-backlink.sh`.
+  - Run `bash skills/woostack-doctor/scripts/doctor.sh . --check`.
+  - Run contract scans for stale `frontmatter-free` wording.

--- a/.woostack/plans/2026-06-02-memory-distill-gate.md
+++ b/.woostack/plans/2026-06-02-memory-distill-gate.md
@@ -4,7 +4,12 @@ type: plan
 date: 2026-06-02
 branch: feature/memory-distill-gate
 spec: .woostack/specs/2026-06-02-memory-distill-gate.md
+source: .woostack/specs/2026-06-02-memory-distill-gate.md
+status: done
 ---
+
+**Source:** .woostack/specs/2026-06-02-memory-distill-gate.md
+
 
 # Memory Distillation Gate + updated: Coverage — Implementation Plan
 

--- a/.woostack/plans/2026-06-02-memory-distill.md
+++ b/.woostack/plans/2026-06-02-memory-distill.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-02-memory-distill.md
+status: done
+branch: feat/woostack-memory-distill
+---
+
 # Memory distill + skill wiring (Increment C) — Implementation Plan
 
 > **For agentic workers:** Steps use checkbox (`- [ ]`) syntax. Docs-only increment — no new scripts; reuses A's `build-index`/`doctor` and B's `recall.sh`.

--- a/.woostack/plans/2026-06-02-memory-obsidian.md
+++ b/.woostack/plans/2026-06-02-memory-obsidian.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-02-memory-obsidian.md
+status: done
+branch: feat/woostack-memory-obsidian
+---
+
+**Source:** .woostack/specs/2026-06-02-memory-obsidian.md
+
+
 # Obsidian layer (Increment D) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox steps.

--- a/.woostack/plans/2026-06-02-memory-overlap-clusters.md
+++ b/.woostack/plans/2026-06-02-memory-overlap-clusters.md
@@ -4,7 +4,12 @@ type: plan
 date: 2026-06-02
 branch: feature/memory-overlap-clusters
 spec: .woostack/specs/2026-06-02-memory-overlap-clusters.md
+source: .woostack/specs/2026-06-02-memory-overlap-clusters.md
+status: done
 ---
+
+**Source:** .woostack/specs/2026-06-02-memory-overlap-clusters.md
+
 
 # Memory Scope-Overlap Clusters + Recall Recency Tiebreak — Implementation Plan
 

--- a/.woostack/plans/2026-06-02-memory-recall.md
+++ b/.woostack/plans/2026-06-02-memory-recall.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-02-memory-recall.md
+status: done
+branch: feat/woostack-memory-recall
+---
+
+**Source:** .woostack/specs/2026-06-02-memory-recall.md
+
+
 # Memory recall + review scope-routing (Increment B) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.

--- a/.woostack/plans/2026-06-02-memory-staleness-guard.md
+++ b/.woostack/plans/2026-06-02-memory-staleness-guard.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-02-memory-staleness-guard.md
+status: done
+branch: memory-staleness-guard
+---
+
+**Source:** .woostack/specs/2026-06-02-memory-staleness-guard.md
+
+
 # Memory Staleness Guard Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.

--- a/.woostack/plans/2026-06-02-woostack-init.md
+++ b/.woostack/plans/2026-06-02-woostack-init.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-02-woostack-init.md
+status: done
+branch: feat/woostack-init
+---
+
+**Source:** .woostack/specs/2026-06-02-woostack-init.md
+
+
 # woostack-init (Increment A) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-03-bounded-review-swarms.md
+++ b/.woostack/plans/2026-06-03-bounded-review-swarms.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-03-bounded-review-swarms.md
+status: done
+branch: feature/bounded-review-swarms
+---
+
+**Source:** .woostack/specs/2026-06-03-bounded-review-swarms.md
+
+
 # Bounded Review Swarms Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-03-woostack-ideate.md
+++ b/.woostack/plans/2026-06-03-woostack-ideate.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-03-woostack-ideate.md
+status: done
+branch: feature/woostack-ideate
+---
+
+**Source:** .woostack/specs/2026-06-03-woostack-ideate.md
+
+
 # woostack-ideate Skill Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-03-woostack-visualize.md
+++ b/.woostack/plans/2026-06-03-woostack-visualize.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-03-woostack-visualize.md
+status: done
+branch: feature/woostack-visualize
+---
+
+**Source:** .woostack/specs/2026-06-03-woostack-visualize.md
+
+
 # woostack-visualize Skill Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-04-build-execution-handoff-gate.md
+++ b/.woostack/plans/2026-06-04-build-execution-handoff-gate.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-04-build-execution-handoff-gate.md
+status: done
+branch: worktree-nested-wishing-hanrahan
+---
+
+**Source:** .woostack/specs/2026-06-04-build-execution-handoff-gate.md
+
+
 # woostack-build Execution-Handoff Gate Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. In the woostack loop this plan is executed by [`woostack-execute`](../../skills/woostack-execute/SKILL.md).

--- a/.woostack/plans/2026-06-04-commit-pr-goal-test-plan.md
+++ b/.woostack/plans/2026-06-04-commit-pr-goal-test-plan.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
+status: done
+branch: worktree-delightful-pondering-thimble
+---
+
+**Source:** .woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
+
+
 # woostack-commit PR body: Goal + structured test plan — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-04-execute-dual-mode-execution.md
+++ b/.woostack/plans/2026-06-04-execute-dual-mode-execution.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-04-execute-dual-mode-execution.md
+status: done
+branch: feature/execute-dual-mode
+---
+
+**Source:** .woostack/specs/2026-06-04-execute-dual-mode-execution.md
+
+
 # woostack-execute Dual-Mode Execution Implementation Plan
 
 > **For agentic workers:** REQUIRED: execute this plan with `woostack-execute` (woostack-build

--- a/.woostack/plans/2026-06-04-review-nit-comments.md
+++ b/.woostack/plans/2026-06-04-review-nit-comments.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-04-review-nit-comments.md
+status: done
+branch: feature/review-nit-comments
+---
+
+**Source:** .woostack/specs/2026-06-04-review-nit-comments.md
+
+
 # Review Nit Comments Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-04-woostack-execute.md
+++ b/.woostack/plans/2026-06-04-woostack-execute.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-04-woostack-execute.md
+status: done
+branch: feature/woostack-execute
+---
+
+**Source:** .woostack/specs/2026-06-04-woostack-execute.md
+
+
 # woostack-execute Skill Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. (woostack-execute does not exist yet — it is what this plan ships — so this plan is executed via the current build step 6, i.e. superpowers:executing-plans, as a single PR.)

--- a/.woostack/plans/2026-06-04-woostack-harden.md
+++ b/.woostack/plans/2026-06-04-woostack-harden.md
@@ -1,3 +1,13 @@
+---
+type: plan
+source: .woostack/specs/2026-06-04-woostack-harden.md
+status: done
+branch: worktree-tender-exploring-swing
+---
+
+**Source:** .woostack/specs/2026-06-04-woostack-harden.md
+
+
 # woostack-harden Skill Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-04-woostack-status.md
+++ b/.woostack/plans/2026-06-04-woostack-status.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-04-woostack-status.md
+status: done
+branch: feature/woostack-status
+---
+
 # woostack-status: Derived Feature Board — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
+++ b/.woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
+status: done
+branch: address-comments-fix-plan-gate
+---
+
 **Source:** .woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
 
 # woostack-address-comments: show the fix plan before approval — Implementation Plan

--- a/.woostack/plans/2026-06-05-execute-vary-subagent-model.md
+++ b/.woostack/plans/2026-06-05-execute-vary-subagent-model.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-05-execute-vary-subagent-model.md
+status: done
+branch: feature/execute-vary-subagent-model
+---
+
 # Vary subagent model in woostack-execute — Implementation Plan
 
 **Source:** .woostack/specs/2026-06-05-execute-vary-subagent-model.md

--- a/.woostack/plans/2026-06-05-skills-review-angle.md
+++ b/.woostack/plans/2026-06-05-skills-review-angle.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-05-skills-review-angle.md
+status: done
+branch: feature/skills-review-angle
+---
+
 **Source:** .woostack/specs/2026-06-05-skills-review-angle.md
 
 # Skills Review Angle Implementation Plan

--- a/.woostack/plans/2026-06-05-woostack-debug.md
+++ b/.woostack/plans/2026-06-05-woostack-debug.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-05-woostack-debug.md
+status: done
+branch: feature/woostack-debug
+---
+
 **Source:** .woostack/specs/2026-06-05-woostack-debug.md
 
 # woostack-debug Skill Implementation Plan

--- a/.woostack/plans/2026-06-05-woostack-plan.md
+++ b/.woostack/plans/2026-06-05-woostack-plan.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-05-woostack-plan.md
+status: executing
+branch: feature/woostack-plan
+---
+
 **Source:** .woostack/specs/2026-06-05-woostack-plan.md
 
 # woostack-plan Implementation Plan

--- a/.woostack/plans/2026-06-06-commit-memory-changes.md
+++ b/.woostack/plans/2026-06-06-commit-memory-changes.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-06-commit-memory-changes.md
+status: done
+branch: feature/commit-memory-changes
+---
+
 **Source:** .woostack/specs/2026-06-06-commit-memory-changes.md
 
 # Commit memory changes unless gitignored — Implementation Plan

--- a/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
+++ b/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-06-review-fail-fast-receipts.md
+status: done
+branch: review-fail-fast-receipts
+---
+
 **Source:** .woostack/specs/2026-06-06-review-fail-fast-receipts.md
 
 # woostack-review fail-fast on non-executing angle workers — Implementation Plan

--- a/.woostack/plans/2026-06-06-review-self-contained.md
+++ b/.woostack/plans/2026-06-06-review-self-contained.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-06-review-self-contained.md
+status: done
+branch: review-self-contained
+---
+
 **Source:** .woostack/specs/2026-06-06-review-self-contained.md
 
 # Make woostack-review self-contained (retire pr-review-toolkit) Implementation Plan

--- a/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
+++ b/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-06-spec-acceptance-criteria.md
+status: done
+branch: spec-acceptance-criteria
+---
+
 **Source:** .woostack/specs/2026-06-06-spec-acceptance-criteria.md
 
 # Structured Acceptance Criteria in the spec template — Implementation Plan

--- a/.woostack/plans/2026-06-06-woostack-execute-overnight.md
+++ b/.woostack/plans/2026-06-06-woostack-execute-overnight.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-06-woostack-execute-overnight.md
+status: executing
+branch: feature/woostack-execute-overnight-skill
+---
+
 **Source:** .woostack/specs/2026-06-06-woostack-execute-overnight.md
 
 # woostack-execute-overnight Implementation Plan

--- a/.woostack/plans/2026-06-07-woostack-tdd.md
+++ b/.woostack/plans/2026-06-07-woostack-tdd.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-07-woostack-tdd.md
+status: done
+branch: woostack-tdd
+---
+
 **Source:** .woostack/specs/2026-06-07-woostack-tdd.md
 
 # woostack-tdd Implementation Plan

--- a/.woostack/plans/2026-06-08-address-comments-commit-integration.md
+++ b/.woostack/plans/2026-06-08-address-comments-commit-integration.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-08-address-comments-commit-integration.md
+status: done
+branch: feature/address-comments-commit-integration
+---
+
 **Source:** .woostack/specs/2026-06-08-address-comments-commit-integration.md
 
 # woostack-address-comments: integrate the commit skill — Implementation Plan

--- a/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
+++ b/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-08-generic-woostack-bootstrap.md
+status: done
+branch: feature/generic-woostack-bootstrap
+---
+
 **Source:** .woostack/specs/2026-06-08-generic-woostack-bootstrap.md
 
 # Dynamic, Requirements-Driven `woostack-bootstrap` Implementation Plan

--- a/.woostack/plans/2026-06-08-woostack-fix.md
+++ b/.woostack/plans/2026-06-08-woostack-fix.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-08-woostack-fix.md
+status: executing
+branch: feature/woostack-fix
+---
+
 **Source:** .woostack/specs/2026-06-08-woostack-fix.md
 
 # woostack-fix Skill and woostack-debug Refinement Implementation Plan

--- a/.woostack/plans/2026-06-09-readme-rewrite.md
+++ b/.woostack/plans/2026-06-09-readme-rewrite.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-09-readme-rewrite.md
+status: done
+branch: feature/readme-rewrite
+---
+
 **Source:** .woostack/specs/2026-06-09-readme-rewrite.md
 
 # README Rewrite Implementation Plan

--- a/.woostack/plans/2026-06-09-review-stack-aware.md
+++ b/.woostack/plans/2026-06-09-review-stack-aware.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-09-review-stack-aware.md
+status: executing
+branch: review-stack-aware-markers
+---
+
 **Source:** .woostack/specs/2026-06-09-review-stack-aware.md
 
 # Stack-aware review (deferral markers) Implementation Plan

--- a/.woostack/plans/2026-06-09-woostack-dream.md
+++ b/.woostack/plans/2026-06-09-woostack-dream.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-09-woostack-dream.md
+status: executing
+branch: feature/woostack-dream
+---
+
 **Source:** .woostack/specs/2026-06-09-woostack-dream.md
 
 # woostack-dream Skill Implementation Plan

--- a/.woostack/plans/2026-06-10-parallel-worktrees.md
+++ b/.woostack/plans/2026-06-10-parallel-worktrees.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-10-parallel-worktrees.md
+status: done
+branch: feature/parallel-worktrees
+---
+
 **Source:** .woostack/specs/2026-06-10-parallel-worktrees.md
 
 # Parallel worktree isolation + configurable base branch Implementation Plan

--- a/.woostack/plans/2026-06-11-overnight-review-sweep.md
+++ b/.woostack/plans/2026-06-11-overnight-review-sweep.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-11-overnight-review-sweep.md
+status: executing
+branch: feature/overnight-review-sweep
+---
+
 **Source:** .woostack/specs/2026-06-11-overnight-review-sweep.md
 
 # Overnight review sweep Implementation Plan

--- a/.woostack/plans/2026-06-11-woostack-dream-design-trends.md
+++ b/.woostack/plans/2026-06-11-woostack-dream-design-trends.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-11-woostack-dream-design-trends.md
+status: done
+branch: feature/woostack-dream-design-trends
+---
+
 **Source:** .woostack/specs/2026-06-11-woostack-dream-design-trends.md
 
 # Shared Curated Memory + Design-Trend Consolidation Implementation Plan

--- a/.woostack/plans/2026-06-12-fumadocs-docs-site.md
+++ b/.woostack/plans/2026-06-12-fumadocs-docs-site.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-12-fumadocs-docs-site.md
+status: done
+branch: feature/fumadocs-docs-site
+---
+
 **Source:** .woostack/specs/2026-06-12-fumadocs-docs-site.md
 
 # Fumadocs docs site for the woostack skills — Implementation Plan

--- a/.woostack/plans/2026-06-12-output-discipline.md
+++ b/.woostack/plans/2026-06-12-output-discipline.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-12-output-discipline.md
+status: done
+branch: feature/output-discipline
+---
+
 **Source:** .woostack/specs/2026-06-12-output-discipline.md
 
 # Native Output Discipline for Internal Comms — Implementation Plan

--- a/.woostack/plans/2026-06-13-dream-wisdom.md
+++ b/.woostack/plans/2026-06-13-dream-wisdom.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-13-dream-wisdom.md
+status: executing
+branch: feature/dream-wisdom
+---
+
 **Source:** .woostack/specs/2026-06-13-dream-wisdom.md
 
 # woostack-dream → wisdom consolidation Implementation Plan

--- a/.woostack/plans/2026-06-13-woostack-ask.md
+++ b/.woostack/plans/2026-06-13-woostack-ask.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-13-woostack-ask.md
+status: executing
+branch: feature/woostack-ask
+---
+
 **Source:** .woostack/specs/2026-06-13-woostack-ask.md
 
 # woostack-ask — read-only codebase Q&A — Implementation Plan

--- a/.woostack/plans/2026-06-13-woostack-doctor.md
+++ b/.woostack/plans/2026-06-13-woostack-doctor.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-13-woostack-doctor.md
+status: in-review
+branch: feature/woostack-doctor
+---
+
 **Source:** .woostack/specs/2026-06-13-woostack-doctor.md
 
 # /woostack-doctor — workspace health: diagnose + gated repair — Implementation Plan

--- a/.woostack/specs/2026-06-02-memory-distill-gate.md
+++ b/.woostack/specs/2026-06-02-memory-distill-gate.md
@@ -1,7 +1,7 @@
 ---
 name: memory-distill-gate
 type: spec
-status: done
+status: approved
 date: 2026-06-02
 branch: feature/memory-distill-gate
 links:

--- a/.woostack/specs/2026-06-02-memory-distill.md
+++ b/.woostack/specs/2026-06-02-memory-distill.md
@@ -1,7 +1,7 @@
 ---
 name: memory-distill
 type: spec
-status: done
+status: approved
 date: 2026-06-02
 branch: feat/woostack-memory-distill
 increment: C of 4

--- a/.woostack/specs/2026-06-02-memory-obsidian.md
+++ b/.woostack/specs/2026-06-02-memory-obsidian.md
@@ -1,7 +1,7 @@
 ---
 name: memory-obsidian
 type: spec
-status: done
+status: approved
 date: 2026-06-02
 branch: feat/woostack-memory-obsidian
 increment: D of 4

--- a/.woostack/specs/2026-06-02-memory-overlap-clusters.md
+++ b/.woostack/specs/2026-06-02-memory-overlap-clusters.md
@@ -1,7 +1,7 @@
 ---
 name: memory-overlap-clusters
 type: spec
-status: done
+status: approved
 date: 2026-06-02
 branch: feature/memory-overlap-clusters
 links:

--- a/.woostack/specs/2026-06-02-memory-recall.md
+++ b/.woostack/specs/2026-06-02-memory-recall.md
@@ -1,7 +1,7 @@
 ---
 name: memory-recall
 type: spec
-status: done
+status: approved
 date: 2026-06-02
 branch: feat/woostack-memory-recall
 increment: B of 4

--- a/.woostack/specs/2026-06-02-memory-staleness-guard.md
+++ b/.woostack/specs/2026-06-02-memory-staleness-guard.md
@@ -1,7 +1,7 @@
 ---
 name: memory-staleness-guard
 type: spec
-status: done
+status: approved
 date: 2026-06-02
 branch: memory-staleness-guard
 links:

--- a/.woostack/specs/2026-06-02-woostack-init.md
+++ b/.woostack/specs/2026-06-02-woostack-init.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-init
 type: spec
-status: done
+status: approved
 date: 2026-06-02
 branch: feat/woostack-init
 increment: A of 4

--- a/.woostack/specs/2026-06-03-bounded-review-swarms.md
+++ b/.woostack/specs/2026-06-03-bounded-review-swarms.md
@@ -1,7 +1,7 @@
 ---
 name: bounded-review-swarms
 type: spec
-status: done
+status: approved
 date: 2026-06-03
 branch: feature/bounded-review-swarms
 links:

--- a/.woostack/specs/2026-06-03-woostack-ideate.md
+++ b/.woostack/specs/2026-06-03-woostack-ideate.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-ideate
 type: spec
-status: done
+status: approved
 date: 2026-06-03
 branch: feature/woostack-ideate
 links:

--- a/.woostack/specs/2026-06-03-woostack-visualize.md
+++ b/.woostack/specs/2026-06-03-woostack-visualize.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-visualize
 type: spec
-status: done
+status: approved
 date: 2026-06-03
 branch: feature/woostack-visualize
 links:

--- a/.woostack/specs/2026-06-04-build-execution-handoff-gate.md
+++ b/.woostack/specs/2026-06-04-build-execution-handoff-gate.md
@@ -1,7 +1,7 @@
 ---
 name: build-execution-handoff-gate
 type: spec
-status: done
+status: approved
 date: 2026-06-04
 branch: worktree-nested-wishing-hanrahan
 links:

--- a/.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
+++ b/.woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
@@ -1,7 +1,7 @@
 ---
 name: commit-pr-goal-test-plan
 type: spec
-status: done
+status: approved
 date: 2026-06-04
 branch: worktree-delightful-pondering-thimble
 links:

--- a/.woostack/specs/2026-06-04-execute-dual-mode-execution.md
+++ b/.woostack/specs/2026-06-04-execute-dual-mode-execution.md
@@ -1,7 +1,7 @@
 ---
 name: execute-dual-mode-execution
 type: spec
-status: done
+status: approved
 date: 2026-06-04
 branch: feature/execute-dual-mode
 links:

--- a/.woostack/specs/2026-06-04-review-nit-comments.md
+++ b/.woostack/specs/2026-06-04-review-nit-comments.md
@@ -1,7 +1,7 @@
 ---
 name: review-nit-comments
 type: spec
-status: done
+status: approved
 date: 2026-06-04
 branch: feature/review-nit-comments
 links:

--- a/.woostack/specs/2026-06-04-woostack-execute.md
+++ b/.woostack/specs/2026-06-04-woostack-execute.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-execute
 type: spec
-status: done
+status: approved
 date: 2026-06-04
 branch: feature/woostack-execute
 links:

--- a/.woostack/specs/2026-06-04-woostack-harden.md
+++ b/.woostack/specs/2026-06-04-woostack-harden.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-harden
 type: spec
-status: done
+status: approved
 date: 2026-06-04
 branch: worktree-tender-exploring-swing
 links:

--- a/.woostack/specs/2026-06-04-woostack-status.md
+++ b/.woostack/specs/2026-06-04-woostack-status.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-status
 type: spec
-status: done
+status: approved
 date: 2026-06-04
 branch: feature/woostack-status
 links:

--- a/.woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
+++ b/.woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
@@ -1,7 +1,7 @@
 ---
 name: address-comments-fix-plan-gate
 type: spec
-status: planning
+status: approved
 date: 2026-06-05
 branch: address-comments-fix-plan-gate
 links:

--- a/.woostack/specs/2026-06-05-execute-vary-subagent-model.md
+++ b/.woostack/specs/2026-06-05-execute-vary-subagent-model.md
@@ -1,7 +1,7 @@
 ---
 name: execute-vary-subagent-model
 type: spec
-status: planning
+status: approved
 date: 2026-06-05
 branch: feature/execute-vary-subagent-model
 links:

--- a/.woostack/specs/2026-06-05-skills-review-angle.md
+++ b/.woostack/specs/2026-06-05-skills-review-angle.md
@@ -1,7 +1,7 @@
 ---
 name: skills-review-angle
 type: spec
-status: planning
+status: approved
 date: 2026-06-05
 branch: feature/skills-review-angle
 links:

--- a/.woostack/specs/2026-06-05-woostack-debug.md
+++ b/.woostack/specs/2026-06-05-woostack-debug.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-debug
 type: spec
-status: planning
+status: approved
 date: 2026-06-05
 branch: feature/woostack-debug
 links:

--- a/.woostack/specs/2026-06-05-woostack-plan.md
+++ b/.woostack/specs/2026-06-05-woostack-plan.md
@@ -1,7 +1,7 @@
 ---
 name: 2026-06-05-woostack-plan
 type: spec
-status: planning
+status: approved
 date: 2026-06-05
 branch: feature/woostack-plan
 links:

--- a/.woostack/specs/2026-06-06-commit-memory-changes.md
+++ b/.woostack/specs/2026-06-06-commit-memory-changes.md
@@ -1,7 +1,7 @@
 ---
 name: commit-memory-changes
 type: spec
-status: planning
+status: approved
 date: 2026-06-06
 branch: feature/commit-memory-changes
 links:

--- a/.woostack/specs/2026-06-06-review-fail-fast-receipts.md
+++ b/.woostack/specs/2026-06-06-review-fail-fast-receipts.md
@@ -1,7 +1,7 @@
 ---
 name: review-fail-fast-receipts
 type: spec
-status: planning
+status: approved
 date: 2026-06-06
 branch: review-fail-fast-receipts
 links:

--- a/.woostack/specs/2026-06-06-review-self-contained.md
+++ b/.woostack/specs/2026-06-06-review-self-contained.md
@@ -1,7 +1,7 @@
 ---
 name: review-self-contained
 type: spec
-status: planning
+status: approved
 date: 2026-06-06
 branch: review-self-contained
 links:

--- a/.woostack/specs/2026-06-06-spec-acceptance-criteria.md
+++ b/.woostack/specs/2026-06-06-spec-acceptance-criteria.md
@@ -1,7 +1,7 @@
 ---
 name: spec-acceptance-criteria
 type: spec
-status: planning
+status: approved
 date: 2026-06-06
 branch: spec-acceptance-criteria
 links:

--- a/.woostack/specs/2026-06-06-woostack-execute-overnight.md
+++ b/.woostack/specs/2026-06-06-woostack-execute-overnight.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-execute-overnight
 type: spec
-status: in-review
+status: approved
 date: 2026-06-06
 branch: feature/woostack-execute-overnight-skill
 links:

--- a/.woostack/specs/2026-06-07-woostack-tdd.md
+++ b/.woostack/specs/2026-06-07-woostack-tdd.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-tdd
 type: spec
-status: planning
+status: approved
 date: 2026-06-07
 branch: woostack-tdd
 links:

--- a/.woostack/specs/2026-06-08-address-comments-commit-integration.md
+++ b/.woostack/specs/2026-06-08-address-comments-commit-integration.md
@@ -1,7 +1,7 @@
 ---
 name: address-comments-commit-integration
 type: spec
-status: in-review
+status: approved
 date: 2026-06-08
 branch: feature/address-comments-commit-integration
 links:

--- a/.woostack/specs/2026-06-08-generic-woostack-bootstrap.md
+++ b/.woostack/specs/2026-06-08-generic-woostack-bootstrap.md
@@ -1,7 +1,7 @@
 ---
 name: generic-woostack-bootstrap
 type: spec
-status: in-review
+status: approved
 date: 2026-06-08
 branch: feature/generic-woostack-bootstrap
 links:

--- a/.woostack/specs/2026-06-08-woostack-fix.md
+++ b/.woostack/specs/2026-06-08-woostack-fix.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-fix
 type: spec
-status: in-review
+status: approved
 date: 2026-06-08
 branch: feature/woostack-fix
 links:

--- a/.woostack/specs/2026-06-09-readme-rewrite.md
+++ b/.woostack/specs/2026-06-09-readme-rewrite.md
@@ -1,7 +1,7 @@
 ---
 name: readme-rewrite
 type: spec
-status: planning
+status: approved
 date: 2026-06-09
 branch: feature/readme-rewrite
 links:

--- a/.woostack/specs/2026-06-09-review-stack-aware.md
+++ b/.woostack/specs/2026-06-09-review-stack-aware.md
@@ -1,7 +1,7 @@
 ---
 name: review-stack-aware
 type: spec
-status: planning
+status: approved
 date: 2026-06-09
 branch: review-stack-aware-markers
 links:

--- a/.woostack/specs/2026-06-09-woostack-dream.md
+++ b/.woostack/specs/2026-06-09-woostack-dream.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-dream
 type: spec
-status: planning
+status: approved
 date: 2026-06-09
 branch: feature/woostack-dream
 links:

--- a/.woostack/specs/2026-06-10-parallel-worktrees.md
+++ b/.woostack/specs/2026-06-10-parallel-worktrees.md
@@ -1,7 +1,7 @@
 ---
 name: 2026-06-10-parallel-worktrees
 type: spec
-status: planning
+status: approved
 date: 2026-06-10
 branch: feature/parallel-worktrees
 links:

--- a/.woostack/specs/2026-06-11-overnight-review-sweep.md
+++ b/.woostack/specs/2026-06-11-overnight-review-sweep.md
@@ -1,7 +1,7 @@
 ---
 name: overnight-review-sweep
 type: spec
-status: planning
+status: approved
 date: 2026-06-11
 branch: feature/overnight-review-sweep
 links:

--- a/.woostack/specs/2026-06-11-woostack-dream-design-trends.md
+++ b/.woostack/specs/2026-06-11-woostack-dream-design-trends.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-dream-design-trends
 type: spec
-status: planning
+status: approved
 date: 2026-06-11
 branch: feature/woostack-dream-design-trends
 links:

--- a/.woostack/specs/2026-06-12-fumadocs-docs-site.md
+++ b/.woostack/specs/2026-06-12-fumadocs-docs-site.md
@@ -1,7 +1,7 @@
 ---
 name: fumadocs-docs-site
 type: spec
-status: ready
+status: approved
 date: 2026-06-12
 branch: feature/fumadocs-docs-site
 links:

--- a/.woostack/specs/2026-06-12-output-discipline.md
+++ b/.woostack/specs/2026-06-12-output-discipline.md
@@ -1,7 +1,7 @@
 ---
 name: output-discipline
 type: spec
-status: ready
+status: approved
 date: 2026-06-12
 branch: feature/output-discipline
 links:

--- a/.woostack/specs/2026-06-13-dream-wisdom.md
+++ b/.woostack/specs/2026-06-13-dream-wisdom.md
@@ -1,7 +1,7 @@
 ---
 name: dream-wisdom
 type: spec
-status: ready
+status: approved
 date: 2026-06-13
 branch: feature/dream-wisdom
 links:

--- a/.woostack/specs/2026-06-13-woostack-ask.md
+++ b/.woostack/specs/2026-06-13-woostack-ask.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-ask
 type: spec
-status: ready
+status: approved
 date: 2026-06-13
 branch: feature/woostack-ask
 links:

--- a/.woostack/specs/2026-06-13-woostack-doctor.md
+++ b/.woostack/specs/2026-06-13-woostack-doctor.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-doctor
 type: spec
-status: ready
+status: approved
 date: 2026-06-13
 branch: feature/woostack-doctor
 links:

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -53,8 +53,8 @@ user explicitly asks for that behavior or the loaded task-specific skill require
 of an approved workflow.
 
 **Feature-state invariant:** in a woostack project, every spec has exactly one plan
-(`spec : plan : PRs = 1 : 1 : N`), and the spec's `status:`/`branch:` frontmatter is
-load-bearing for the `/woostack-status` board. The phase enum and the join contracts are
+(`spec : plan : PRs = 1 : 1 : N`), and the spec design `status:` plus plan implementation
+`status:`/`branch:` frontmatter is load-bearing for `/woostack-status` board.
 defined once in
 [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md);
 link it, never restate it.
@@ -96,7 +96,7 @@ These thoughts mean stop and load the relevant rules:
 | "I'll initialize `.woostack/` to be helpful." | This skill is adoption-only; mutate project state only when requested or required by the task skill. |
 | "This is only a review comment." | Review and address flows have posting, validation, and memory rules. |
 | "I'll write another plan for this spec." | Specs and plans are 1:1. A second plan breaks the board's join — amend the one existing plan instead. See [`conventions.md`](../woostack-status/references/conventions.md). |
-| "I'll just set `status:`/`branch:` by hand." | The build loop authors those fields and the `/woostack-status` board reads them; hand-editing or blanking them causes drift flags. |
+| "I'll just set `status:`/`branch:` by hand." | The build loop authors spec design status and plan implementation status/branch, and the `/woostack-status` board reads them; hand-editing or blanking them causes drift flags. |
 | "I'll rename or move this spec or plan." | Renames break the spec↔plan↔PR joins (the `**Source:**` line, `branch:`, the `Spec:` PR trailer). Avoid it, or update every join at once. |
 
 ## AGENTS.md Usage

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -54,8 +54,8 @@ of an approved workflow.
 
 **Feature-state invariant:** in a woostack project, every spec has exactly one plan
 (`spec : plan : PRs = 1 : 1 : N`), and the spec design `status:` plus plan implementation
-`status:`/`branch:` frontmatter is load-bearing for `/woostack-status` board.
-defined once in
+`status:`/`branch:` frontmatter is load-bearing for the `/woostack-status` board. The phase
+enum and the join contracts are defined once in
 [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md);
 link it, never restate it.
 

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -71,8 +71,7 @@ sits after that PR. So the chain has exactly the three hard gates above.
    approval; silence is not a yes.
 4. **Plan.** Once the spec is approved, invoke
    [`woostack-plan`](../woostack-plan/SKILL.md) with the approved spec path. It writes the
-   plan to `.woostack/plans/<spec-basename>.md` (same basename as the spec), opens with the
-plan to `.woostack/plans/<spec-basename>.md` with YAML frontmatter followed by the
+   plan to `.woostack/plans/<spec-basename>.md` with YAML frontmatter followed by the
    `**Source:** .woostack/specs/<file>.md` line so status and doctor join it 1:1, structures
    it as PR-sized increments, and sets the plan's `status: planning`. It writes the plan and
    ships in this collection, so the build loop has no external skill dependencies.

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -88,7 +88,7 @@ sits after that PR. So the chain has exactly the three hard gates above.
    owns none and hands straight back. The chain's last hard stop is the **execution-handoff
    gate (step 8)**, after the spec+plan PR — not a plan-*quality* gate here. Do not turn this
    harden into a plan-approval gate. When hardening stops producing new questions, set the
-   spec's `status: ready` — the [conventions.md](../woostack-status/references/conventions.md)
+   plan's `status: ready` — the [conventions.md](../woostack-status/references/conventions.md)
    value for "plan hardened, ready for execution" (mirroring step 3's `hardened`, but for the
    plan). Plans own implementation lifecycle, so this transition is authored on the **plan**, not the spec.
 7. **Commit the spec and plan as their own PR.** Before any implementation, commit the

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -72,9 +72,9 @@ sits after that PR. So the chain has exactly the three hard gates above.
 4. **Plan.** Once the spec is approved, invoke
    [`woostack-plan`](../woostack-plan/SKILL.md) with the approved spec path. It writes the
    plan to `.woostack/plans/<spec-basename>.md` (same basename as the spec), opens with the
-   `**Source:** .woostack/specs/<file>.md` line so the board joins it 1:1, stays
-   frontmatter-free, structures it as PR-sized increments, and sets the spec's
-   `status: planning`. It writes the plan and hands back, owning no gate. `woostack-plan`
+plan to `.woostack/plans/<spec-basename>.md` with YAML frontmatter followed by the
+   `**Source:** .woostack/specs/<file>.md` line so status and doctor join it 1:1, structures
+   it as PR-sized increments, and sets the plan's `status: planning`. It writes the plan and
    ships in this collection, so the build loop has no external skill dependencies.
 5. **Verify the increment decomposition.** `woostack-plan` already structures the plan as
    PR-sized increments; build confirms the increment boundaries are reviewable, independently
@@ -91,8 +91,7 @@ sits after that PR. So the chain has exactly the three hard gates above.
    harden into a plan-approval gate. When hardening stops producing new questions, set the
    spec's `status: ready` — the [conventions.md](../woostack-status/references/conventions.md)
    value for "plan hardened, ready for execution" (mirroring step 3's `hardened`, but for the
-   plan). Plans stay frontmatter-free, so this transition is authored on the **spec**, not the
-   plan. This is a status write, not a gate.
+   plan). Plans own implementation lifecycle, so this transition is authored on the **plan**, not the spec.
 7. **Commit the spec and plan as their own PR.** Before any implementation, commit the
    `.woostack/` spec and plan via [`woostack-commit`](../woostack-commit/SKILL.md) on a fresh
    Graphite branch and open a PR. This docs-only PR is the **base of the stack** — execution

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -146,13 +146,13 @@ unrelated dirty files, or user work from outside this session.
 
 ### 4.5 Invariant check (advisory)
 
-When the staged changes touch `.woostack/specs/*.md`, `.woostack/plans/*.md`, or `.woostack/fixes/*.md`, run the cheap feature-state invariant checks on every affected spec/fix so the `/woostack-status` board stays honest. The affected set is every directly touched spec/fix plus the spec named by each touched plan's `**Source:** .woostack/specs/<file>.md` line. These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
+When the staged changes touch `.woostack/specs/*.md`, `.woostack/plans/*.md`, or `.woostack/fixes/*.md`, run the cheap feature-state invariant checks on every affected spec/fix so the `/woostack-status` board stays honest. The affected set is every directly touched spec/fix plus the spec named by each touched plan's `source:` frontmatter or `**Source:** .woostack/specs/<file>.md` line. These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
 
 For each affected spec/fix, check:
 
 - **1:1 plan** — exactly one plan resolves to it (for specs). (For fixes under `fixes/`, they are self-contained plans and this check is skipped).
-- **`branch:` present** — the frontmatter `branch:` is non-empty and not the literal `unknown`.
-- **`status:` in the enum** — the frontmatter `status:` is one of `draft｜hardened｜approved｜planning｜ready｜executing｜in-review｜done｜abandoned`.
+- **`branch:` present** — the active lifecycle artifact frontmatter (`spec` before planning, `plan` after planning, `fix` for fixes) is non-empty and not the literal `unknown`.
+- **`status:` in the enum** — spec frontmatter uses `draft|hardened|approved|abandoned`; plan frontmatter uses `planning|ready|executing|in-review|done|abandoned`; fix frontmatter uses the full fix lifecycle.
 
 The phase enum and the join contracts are defined once in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) — do not restate them here. If the `woostack-status` skill is not installed, skip this check silently.
 

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-plan
-description: "Use to write the implementation plan for an approved woostack spec — a comprehensive, bite-sized TDD plan structured as PR-sized increments, saved frontmatter-free to .woostack/plans/<spec-basename>.md, opening with a `**Source:**` line that joins it 1:1 to the spec, and setting the spec's status: planning. This is the plan phase of the woostack build loop (woostack-build step 4); also usable standalone via /woostack-plan <spec-path>. One plan per spec. Writes the plan and hands back — never executes, commits, or merges."
+description: "Use to write the implementation plan for an approved woostack spec -- a comprehensive, bite-sized TDD plan structured as PR-sized increments, saved with Obsidian YAML frontmatter to .woostack/plans/<spec-basename>.md, preserving the `**Source:**` line that joins it 1:1 to the spec, and setting the plan status: planning. This is the plan phase of the woostack build loop (woostack-build step 4); also usable standalone via /woostack-plan <spec-path>. One plan per spec. Writes the plan and hands back -- never executes, commits, or merges."
 ---
 
 # woostack-plan
@@ -10,7 +10,7 @@ increments. This is woostack's own planning phase — [`woostack-build`](../woos
 step 4. It keeps the discipline that makes plans worth executing (file-structure first,
 bite-sized TDD tasks, no placeholders, a self-review pass) and adds the woostack conventions:
 markdown plans under `.woostack/plans/`, an opening `**Source:**` line that joins the plan 1:1 to
-its spec, frontmatter-free, decomposed into independently shippable increments, and a
+its spec, backed by YAML frontmatter, decomposed into independently shippable increments, and a
 `status: planning` transition on the spec. It writes the plan and hands back; it owns no approval
 gate and never executes, commits, or merges.
 
@@ -134,12 +134,12 @@ them:
 
 Exact file paths always. Complete code in every code step. Exact commands with expected output.
 
-## Board join: Source line, frontmatter-free, filename
+## Board join: YAML frontmatter, Source line, filename
 
 - **Filename:** save to `.woostack/plans/<spec-basename>.md` — the **same** `YYYY-MM-DD-<slug>`
   basename as the spec (reuse the spec's date; **not** today's). The shared basename is the
   slug-match fallback join.
-- **Opening line:** the plan's first line is `**Source:** .woostack/specs/<file>.md` — the
+- **Frontmatter:** the plan starts with YAML properties: `type: plan`, `source: .woostack/specs/<file>.md`, `status: planning`, and `branch: <feature branch>`.
   primary spec→plan join the `/woostack-status` board reads.
 - **Frontmatter-free:** plans carry no YAML frontmatter and no `REQUIRED SUB-SKILL` banner. The
   header is the `**Source:**` line plus Goal / Architecture / Tech Stack.
@@ -165,7 +165,7 @@ Fix issues inline; no re-review needed.
 
 ## Status: planning
 
-When the plan file exists, set the spec's `status: planning` (the conventions.md value for "plan
+When the plan file exists, set the plan's `status: planning` (the conventions.md value for "plan
 exists, 0 boxes done"). Doing it here means a standalone `/woostack-plan` also advances the board.
 Do not tick any plan checkbox yet — execution owns checkbox progress.
 
@@ -197,5 +197,5 @@ execute, commit, or merge. It writes the plan and hands back — preserving `woo
   flag and split oversized ones.
 - **Bite-sized TDD tasks, no placeholders.** One action per step; complete code, exact commands,
   expected output.
-- **Set `status: planning`; tick no checkbox.** Execution owns checkbox progress.
+- **Set plan `status: planning`; tick no checkbox.** Execution owns checkbox progress.
 - **Own no gate; never execute, commit, or merge.** Write the plan and hand back.

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -11,7 +11,7 @@ step 4. It keeps the discipline that makes plans worth executing (file-structure
 bite-sized TDD tasks, no placeholders, a self-review pass) and adds the woostack conventions:
 markdown plans under `.woostack/plans/`, an opening `**Source:**` line that joins the plan 1:1 to
 its spec, backed by YAML frontmatter, decomposed into independently shippable increments, and a
-`status: planning` transition on the spec. It writes the plan and hands back; it owns no approval
+`status: planning` transition on the plan. It writes the plan and hands back; it owns no approval
 gate and never executes, commits, or merges.
 
 It internalizes the plan-writing discipline as a native phase — the same move
@@ -139,10 +139,8 @@ Exact file paths always. Complete code in every code step. Exact commands with e
 - **Filename:** save to `.woostack/plans/<spec-basename>.md` — the **same** `YYYY-MM-DD-<slug>`
   basename as the spec (reuse the spec's date; **not** today's). The shared basename is the
   slug-match fallback join.
-- **Frontmatter:** the plan starts with YAML properties: `type: plan`, `source: .woostack/specs/<file>.md`, `status: planning`, and `branch: <feature branch>`.
-  primary spec→plan join the `/woostack-status` board reads.
-- **Frontmatter-free:** plans carry no YAML frontmatter and no `REQUIRED SUB-SKILL` banner. The
-  header is the `**Source:**` line plus Goal / Architecture / Tech Stack.
+- **Frontmatter:** the plan starts with YAML properties: `type: plan`, `source: .woostack/specs/<file>.md`, `status: planning`, and `branch: <feature branch>`. The `source:` field is the primary spec→plan join the `/woostack-status` board reads.
+- **Header:** after the frontmatter, the body opens with the `**Source:**` line plus Goal / Architecture / Tech Stack — no `REQUIRED SUB-SKILL` banner.
 
 The phase enum and join contracts are defined once in
 [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) —

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -139,7 +139,7 @@ Exact file paths always. Complete code in every code step. Exact commands with e
 - **Filename:** save to `.woostack/plans/<spec-basename>.md` — the **same** `YYYY-MM-DD-<slug>`
   basename as the spec (reuse the spec's date; **not** today's). The shared basename is the
   slug-match fallback join.
-- **Frontmatter:** the plan starts with YAML properties: `type: plan`, `source: .woostack/specs/<file>.md`, `status: planning`, and `branch: <feature branch>`. The `source:` field is the primary spec→plan join the `/woostack-status` board reads.
+- **Frontmatter:** the plan starts with YAML properties: `type: plan`, `source: .woostack/specs/<file>.md`, `status: planning`, and `branch: <feature branch>`. The `source:` property mirrors the spec path for Obsidian; the canonical spec→plan join the `/woostack-status` board reads is the `**Source:**` line below.
 - **Header:** after the frontmatter, the body opens with the `**Source:**` line plus Goal / Architecture / Tech Stack — no `REQUIRED SUB-SKILL` banner.
 
 The phase enum and join contracts are defined once in

--- a/skills/woostack-plan/references/plan-template.md
+++ b/skills/woostack-plan/references/plan-template.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/{{SPEC_BASENAME}}.md
+status: planning
+branch: {{FEATURE_BRANCH}}
+---
+
 **Source:** .woostack/specs/{{SPEC_BASENAME}}.md
 
 # {{FEATURE_NAME}} Implementation Plan
@@ -8,11 +15,9 @@
 
 **Tech Stack:** {{KEY_TECHNOLOGIES}}
 
----
-
 ## Increment 1: {{PR_SIZED_SLICE_NAME}}
 
-> One independently shippable PR (≤500 LOC soft target) — its own Graphite-stacked branch.
+> One independently shippable PR (<=500 LOC soft target) -- its own Graphite-stacked branch.
 
 ### Task 1: {{COMPONENT_NAME}}
 
@@ -22,49 +27,45 @@
 - Test: `{{exact/path/to/test.ext}}`
 
 - [ ] **Step 1: Write the failing test**
-
-```{{lang}}
-{{actual test code — never a placeholder}}
-```
+  ```{{lang}}
+  {{actual test code - never a placeholder}}
+  ```
 
 - [ ] **Step 2: Run the test, confirm it fails**
-
-Run: `{{exact command}}`
-Expected: FAIL — `{{exact expected failure}}`
+  Run: `{{exact command}}`
+  Expected: FAIL - `{{exact expected failure}}`
 
 - [ ] **Step 3: Minimal implementation**
-
-```{{lang}}
-{{actual implementation code}}
-```
+  ```{{lang}}
+  {{actual implementation code}}
+  ```
 
 - [ ] **Step 4: Run the test, confirm it passes**
-
-Run: `{{exact command}}`
-Expected: PASS
+  Run: `{{exact command}}`
+  Expected: PASS
 
 - [ ] **Step 5: Commit**
+  ```bash
+  # First commit in the increment:
+  gt create -m "{{type}}: {{subject}}"
 
-```bash
-# first commit in this increment:
-gt create -m "{{type}}: {{subject}}"
-# later commits in the same increment:
-gt modify -c -m "{{type}}: {{subject}}"
-```
+  # Later commits in the same increment:
+  gt modify -c -m "{{type}}: {{subject}}"
+  ```
 
-<!-- Repeat Task N for each unit in this increment. Add Increment 2, 3, … for each PR-sized slice. -->
+## Plan Checks
 
----
+- **Spec coverage** - every spec requirement maps to a task.
+- **AC coverage** - each spec section 7 acceptance criterion maps to a test; a `N/A` is
+  sanity-checked against the spec body.
+- **No placeholders** - no TBD/TODO; complete code, exact commands, and expected output.
+- **Type consistency** - types, signatures, and names match the current codebase.
 
-## Self-review (run before handing back)
+This file starts with YAML frontmatter for Obsidian properties, then preserves the `**Source:**`
+line as the canonical spec -> plan join used by `/woostack-status` and `woostack-doctor`.
 
-- [ ] **Spec coverage** — every spec requirement maps to a task above.
-- [ ] **AC coverage** — each spec §7 acceptance criterion (and its filled happy/error/edge cases) maps to a test; a whole-section `N/A` is sanity-checked against the spec body.
-- [ ] **No placeholders** — no TBD/TODO; complete code, exact commands, and expected output in every step.
-- [ ] **Type consistency** — types, signatures, and names match across tasks.
+> Filename mirrors spec basename: `.woostack/plans/<spec-basename>.md`.
 
-> woostack plan conventions (keep them):
-> - This file is **frontmatter-free** and **opens with** the `**Source:**` line.
-> - Filename mirrors the spec basename: `.woostack/plans/<spec-basename>.md` (the spec's date, not today's).
-> - **No** required sub-skill banner — execution is `woostack-execute`'s (woostack-build step 8, or `/woostack-execute <plan>`).
-> - In a target without a test runner, a "failing test" step is a concrete verification command (grep, `bash -n`, an existing test) with exact expected output.
+**No required-sub-skill banner.** Plans are executable by `woostack-execute` directly. In this
+skills repo, a "failing test" step can be a concrete verification command such as `grep`,
+`bash -n`, an existing test, or a `python3 -c` parser check with exact expected output.

--- a/skills/woostack-status/references/conventions.md
+++ b/skills/woostack-status/references/conventions.md
@@ -1,69 +1,51 @@
 # woostack feature-state conventions
 
-Canonical definitions for the `/woostack-status` board. Other skills link here;
-they do not restate these rules (cross-link, do not duplicate).
+These definitions are the source of truth for the `/woostack-status` board and the
+`woostack-doctor` spec-plan checks.
 
-## Invariant: spec : plan : PRs = 1 : 1 : N
+- `spec : plan : PRs = 1 : 1 : N`
+- Every spec has exactly one plan. The plan owns N independently shippable increment PRs.
+- Spec frontmatter owns design approval only: `draft -> hardened -> approved`, plus terminal
+  `abandoned`.
+- Plan frontmatter owns implementation lifecycle after spec approval:
+  `planning -> ready -> executing -> in-review -> done`, plus terminal `abandoned`.
+- Before a plan exists, `/woostack-status` displays the spec's `status:` and `branch:`.
+  Once a plan resolves to the spec, the board displays the plan's `status:` and `branch:`.
+- spec -> plan join: the plan carries YAML frontmatter followed by a `**Source:**` line of the
+  exact form `**Source:** .woostack/specs/<file>.md`. The `source:` frontmatter property must
+  match the same spec path for Obsidian, but the `**Source:**` line remains the canonical join
+  for `/woostack-status`, `woostack-doctor`, and legacy compatibility. Slug-match is the legacy
+  fallback.
+- plan -> PR join: every PR body carries a trailer line `Spec: .woostack/specs/<file>.md`.
+  The board narrows candidates with `gh pr list --search`, then **exact-matches** the trailer
+  value in each PR body to avoid fuzzy cross-matches.
+- Plan frontmatter shape:
+  ```yaml
+  ---
+  type: plan
+  source: .woostack/specs/<file>.md
+  status: planning
+  branch: feature/<slug>
+  ---
 
-- Every spec has exactly one plan. The plan owns N independently shippable
-  increment PRs.
-- spec -> plan join: the plan carries, in its first ~5 lines, a line of the exact
-  form `**Source:** .woostack/specs/<file>.md`. Slug-match is the legacy fallback.
-  Plans stay frontmatter-free.
-- plan -> PR join: every PR body carries a trailer line
-  `Spec: .woostack/specs/<file>.md` (written by woostack-commit). The board narrows
-  candidates with `gh pr list --search`, then **exact-matches** the trailer against each PR
-  body (`specs/<basename>`) — `gh --search` is fuzzy and would otherwise cross-match
-  look-alike specs, so an untrailered or sibling PR never attaches to the wrong spec. When no
-  trailered PR resolves, it falls back to the active `spec.branch:` head PR (marked partial).
-- fix PRs (from [`woostack-fix`](../../woostack-fix/SKILL.md)) carry a parallel
-  `Spec: .woostack/fixes/<file>.md` trailer (also written by woostack-commit), but a fix is
-  **not** a spec increment: that trailer attaches the PR to its fix file, and a fix's lifecycle
-  is tracked by the fix file's own frontmatter `status:`, not by attaching to a spec. Because the
-  spec trailer search exact-matches `specs/<basename>`, a `fixes/` trailer never cross-matches a
-  spec; surfacing fixes on the board from their `.woostack/fixes/*.md` files is owned by the
-  status board's fix integration, separate from this spec-trailer join.
-- `spec.branch:` names the active increment's branch.
-- An overnight run ([`woostack-execute-overnight`](../../woostack-execute-overnight/SKILL.md)) may
-  produce **tree-stacked** increment PRs — multiple `## Track:`s branched off the common base, so a
-  spec can have several independent increment branches rather than one linear chain. The
-  `1 : 1 : N` count, the `**Source:**` join, and the `Spec:` PR trailer are unaffected, and this
-  adds **no** new phase-enum value; a blocked/partial overnight run is visible via its
-  `.woostack/overnight/` report.
+  **Source:** .woostack/specs/<file>.md
+  ```
+- Feature states:
+  - `draft` — spec written, not hardened
+  - `hardened` — spec grilled, needs user approval
+  - `approved` — spec gate cleared, no plan yet
+  - `planning` — plan written, not yet hardened, 0 boxes done
+  - `ready` — plan hardened, 0 boxes done, spec+plan PR should be opened before execution
+  - `executing` — branch + commits, plan partial
+  - `in-review` — increment PR open
+  - `done` — 100% + all PRs merged
+  - `abandoned` — intentionally stopped
 
-## Phase enum (spec frontmatter `status:`)
+`/woostack-status` derives truth from artifacts and flags drift instead of rewriting it:
 
-`draft -> hardened -> approved -> planning -> ready -> executing -> in-review -> done`,
-plus the terminal `abandoned`. The build loop authors every transition; the board
-displays the authored value for head states and computes the execute/review/done
-band from artifacts (truth table below).
-
-| phase | meaning | authored at build step |
-|---|---|---|
-| draft | spec written, not hardened | 2 |
-| hardened | grilled, awaiting approval gate | 3 |
-| approved | gate cleared, no plan yet | 3 |
-| planning | plan written, not yet hardened, 0 boxes done | 4 |
-| ready | plan hardened, 0 boxes done, ready for execution | 6 |
-| executing | branch + commits, plan partial | 9 (execute) |
-| in-review | an increment PR is open | 9 (execute) |
-| done | plan 100% + all PRs merged, or trusted legacy authored `done` with no active branch commits/PR | post-merge |
-| abandoned | shelved (terminal, hidden) | manual |
-
-## Truth table (execute -> review -> done band)
-
-- any increment PR open -> `in-review`
-- plan partial, no open PR, branch has commits -> `executing`
-- plan 100% + all increment PRs merged + >=1 merged -> `done`
-- authored `done` + plan 100% + no discovered increment PR + no active branch commits -> `done`
-  (trusts an explicit terminal assertion for legacy/untrailered features whose PRs can't be
-  discovered)
-
-A disagreeing authored value in this band is a FLAG, not displayed truth.
-
-## Reconcile flags
-
-0 or >=2 plans for a spec; `branch:` empty/`unknown` at phase >= executing;
-unknown `status:` value; head-state phase while a PR already exists; executing
-spec older than `status.staleDays` (config, default 14); two in-flight specs on
-the same branch.
+- unknown `status:` values;
+- missing, duplicate, or slug-fallback plans;
+- missing `branch:` for execution phases;
+- head-state phases while PRs already exist;
+- executing rows older than `status.staleDays` (config, default 14);
+- two in-flight rows on the same branch.

--- a/skills/woostack-status/scripts/status.sh
+++ b/skills/woostack-status/scripts/status.sh
@@ -232,7 +232,8 @@ abandoned_count=0
 rows=""
 
 for f in "${specs[@]}"; do
-  phase="$(field "$f" status)"; [ -n "$phase" ] || phase="unknown"
+  spec_phase="$(field "$f" status)"; [ -n "$spec_phase" ] || spec_phase="unknown"
+  phase="$spec_phase"
   raw_phase="$phase"
 
   plan_cell="-"; done=0; total=0; planfile=""
@@ -254,6 +255,11 @@ for f in "${specs[@]}"; do
     else
       planfile="${plans[0]}"
     fi
+
+    if [ -n "$planfile" ]; then
+      phase="$(field "$planfile" status)"; [ -n "$phase" ] || phase="unknown"
+      raw_phase="$phase"
+    fi
   fi
 
   if [ "${VALID_PHASES/ $phase /}" = "$VALID_PHASES" ]; then
@@ -265,7 +271,11 @@ for f in "${specs[@]}"; do
     read -r done total < <(plan_progress "$planfile")
     [ "$total" -gt 0 ] && plan_cell="$done/$total"
   fi
-  br="$(field "$f" branch)"
+  if [[ "$f" == *"/fixes/"* ]] || [ -z "$planfile" ]; then
+    br="$(field "$f" branch)"
+  else
+    br="$(field "$planfile" branch)"
+  fi
   open=0; merged=0; prcount=0; inc_cell="-"; inc_parts=""
   last_author=""; last_upd_date=""
   while IFS=$'\t' read -r num state head author upd; do

--- a/skills/woostack-status/scripts/tests/test-status.sh
+++ b/skills/woostack-status/scripts/tests/test-status.sh
@@ -23,9 +23,11 @@ mkspec() {
 }
 
 mkplan() {
-  local n
+  local n status branch
+  status="${6:-planning}"
+  branch="${7:-feature/$2}"
   mkdir -p "$1/plans"
-  { printf '# %s Plan\n\n**Source:** .woostack/specs/%s\n\n' "$2" "$3"
+  { printf -- '---\ntype: plan\nsource: .woostack/specs/%s\nstatus: %s\nbranch: %s\n---\n\n**Source:** .woostack/specs/%s\n\n' "$3" "$status" "$branch" "$3"
     n=1; while [ "$n" -le "$4" ]; do echo "- [x] done $n"; n=$((n+1)); done
     n=1; while [ "$n" -le "$5" ]; do echo "- [ ] todo $n"; n=$((n+1)); done
   } > "$1/plans/2026-06-01-$2.md"
@@ -82,7 +84,7 @@ assert_contains "$OUT" "no plan" "0-plan flagged"
 # `ready` = plan hardened, 0 boxes done, ready for execution (build step 6).
 rdy="$(mktemp -d)/.woostack"
 mkspec "$rdy" mike ready feature/mike
-mkplan "$rdy" mike 2026-06-01-mike.md 0 5
+mkplan "$rdy" mike 2026-06-01-mike.md 0 5 ready feature/mike
 run_status "$rdy"
 assert_contains "$OUT" "ready" "ready phase rendered"
 assert_contains "$OUT" "open spec+plan PR, then execute" "ready next-action"
@@ -122,7 +124,7 @@ assert_exit 0 "$CODE" "band compute exits 0"
 exec_repo="$(mktemp -d)"
 ( cd "$exec_repo" && git -c user.email=t@t -c user.name=Tess init -q && git checkout -qb main )
 mkspec "$exec_repo/.woostack" sierra planning feature/sierra
-mkplan "$exec_repo/.woostack" sierra 2026-06-01-sierra.md 1 2
+mkplan "$exec_repo/.woostack" sierra 2026-06-01-sierra.md 1 2 executing feature/sierra
 ( cd "$exec_repo" && git add -A && git -c user.email=t@t -c user.name=Tess commit -qm "add sierra plan" )
 ( cd "$exec_repo" && git checkout -qb feature/sierra && printf 'work\n' > work.txt && git add work.txt && git -c user.email=t@t -c user.name=Tess commit -qm "start sierra" )
 ( cd "$exec_repo" && FAKE_GH_JSON='[]' PATH="$g/bin:$PATH" WOO_DIR=.woostack bash "$ST" > /tmp/sierra.out 2>&1 )
@@ -133,7 +135,7 @@ assert_not_contains "$OUT" "sierra                 planning" "commit-backed plan
 
 h="$(mktemp -d)/.woostack"
 mkspec "$h" hotel executing feature/hotel
-mkplan "$h" hotel 2026-06-01-hotel.md 5 5
+mkplan "$h" hotel 2026-06-01-hotel.md 5 5 executing feature/hotel
 export FAKE_GH_JSON='[{"number":181,"state":"MERGED","headRefName":"feature/hotel-1","author":{"login":"adam"},"updatedAt":"2026-06-02T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-hotel.md"},{"number":190,"state":"OPEN","headRefName":"feature/hotel-2","author":{"login":"adam"},"updatedAt":"2026-06-03T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-hotel.md"}]'
 PATH="$g/bin:$PATH" run_status "$h"
 assert_contains "$OUT" "#181" "merged increment listed"
@@ -161,7 +163,7 @@ assert_contains "$OUT" "Tess" "pre-PR owner from spec git log"
 assert_contains "$OUT" "15d" "pre-PR age from spec git log"
 
 k="$(mktemp -d)/.woostack"; mkspec "$k" kilo executing unknown
-mkplan "$k" kilo 2026-06-01-kilo.md 1 9
+mkplan "$k" kilo 2026-06-01-kilo.md 1 9 executing unknown
 FAKE_GH_JSON='[]' PATH="$g/bin:$PATH" run_status "$k"
 assert_contains "$OUT" "branch is 'unknown'" "unknown branch flagged"
 
@@ -189,7 +191,7 @@ assert_contains "$OUT" "oscar" "done shown with --all"
 unset FAKE_GH_JSON
 
 oc="$(mktemp -d)/.woostack"; mkspec "$oc" oscar executing feature/oscar
-mkplan "$oc" oscar 2026-06-01-oscar.md 5 0
+mkplan "$oc" oscar 2026-06-01-oscar.md 5 0 done feature/oscar
 export FAKE_GH_JSON='[{"number":9,"state":"MERGED","headRefName":"feature/oscar","author":{"login":"a"},"updatedAt":"2026-06-02T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-oscar.md"},{"number":10,"state":"CLOSED","headRefName":"feature/oscar","author":{"login":"a"},"updatedAt":"2026-06-03T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-oscar.md"}]'
 PATH="$g/bin:$PATH" run_status "$oc"
 assert_contains "$OUT" "oscar" "closed-unmerged increment keeps row visible"
@@ -198,7 +200,7 @@ assert_contains "$OUT" "0 done" "closed-unmerged increment not counted done"
 unset FAKE_GH_JSON
 
 ocd="$(mktemp -d)/.woostack"; mkspec "$ocd" oscardone done feature/oscardone
-mkplan "$ocd" oscardone 2026-06-01-oscardone.md 5 0
+mkplan "$ocd" oscardone 2026-06-01-oscardone.md 5 0 done feature/oscardone done feature/oscardone
 export FAKE_GH_JSON='[{"number":11,"state":"MERGED","headRefName":"feature/oscardone","author":{"login":"a"},"updatedAt":"2026-06-02T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-oscardone.md"},{"number":12,"state":"CLOSED","headRefName":"feature/oscardone","author":{"login":"a"},"updatedAt":"2026-06-03T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-oscardone.md"}]'
 PATH="$g/bin:$PATH" run_status "$ocd"
 assert_contains "$OUT" "oscardone" "authored done with closed-unmerged increment stays visible"
@@ -233,7 +235,7 @@ assert_contains "$(cat /tmp/r.out)" "stale" "staleDays:3 makes 5d spec stale"
 # PR (same fuzzy tokens, different spec) must NOT cross-match a sibling.
 xm="$(mktemp -d)/.woostack"
 mkspec "$xm" xalpha executing feature/xalpha
-mkplan "$xm" xalpha 2026-06-01-xalpha.md 1 9
+mkplan "$xm" xalpha 2026-06-01-xalpha.md 1 9 executing feature/xalpha
 mkspec "$xm" xbeta executing feature/xbeta
 mkplan "$xm" xbeta 2026-06-01-xbeta.md 1 9
 export FAKE_GH_JSON='[{"number":300,"state":"OPEN","headRefName":"feature/xalpha","author":{"login":"z"},"updatedAt":"2026-06-03T00:00:00Z","body":"work done.\nSpec: .woostack/specs/2026-06-01-xalpha.md"}]'
@@ -276,7 +278,7 @@ unset FAKE_GH_JSON FAKE_GH_HEAD_JSON
 # not executing — an explicit terminal assertion plus a complete plan is trusted.
 ld="$(mktemp -d)/.woostack"
 mkspec "$ld" legdone done feature/legdone
-mkplan "$ld" legdone 2026-06-01-legdone.md 4 0
+mkplan "$ld" legdone 2026-06-01-legdone.md 4 0 done feature/legdone
 FAKE_GH_JSON='[]' PATH="$g/bin:$PATH" run_status "$ld"
 assert_contains "$OUT" "1 done" "authored done + 100% plan + no PR counts as done"
 assert_not_contains "$OUT" "legdone " "legacy done hidden by default"
@@ -285,7 +287,7 @@ assert_not_contains "$OUT" "legdone " "legacy done hidden by default"
 active_done_repo="$(mktemp -d)"
 ( cd "$active_done_repo" && git -c user.email=t@t -c user.name=Tess init -q && git checkout -qb main )
 mkspec "$active_done_repo/.woostack" activedone done feature/activedone
-mkplan "$active_done_repo/.woostack" activedone 2026-06-01-activedone.md 4 0
+mkplan "$active_done_repo/.woostack" activedone 2026-06-01-activedone.md 4 0 done feature/activedone
 ( cd "$active_done_repo" && git add -A && git -c user.email=t@t -c user.name=Tess commit -qm "add active done plan" )
 ( cd "$active_done_repo" && git checkout -qb feature/activedone && printf 'work\n' > work.txt && git add work.txt && git -c user.email=t@t -c user.name=Tess commit -qm "active work" )
 ( cd "$active_done_repo" && FAKE_GH_JSON='[]' PATH="$g/bin:$PATH" WOO_DIR=.woostack bash "$ST" --all > /tmp/active-done.out 2>&1 )
@@ -298,7 +300,7 @@ assert_contains "$OUT" "executing" "active branch work overrides legacy authored
 merged_done_repo="$(mktemp -d)"
 ( cd "$merged_done_repo" && git -c user.email=t@t -c user.name=Tess init -q && git checkout -qb main )
 mkspec "$merged_done_repo/.woostack" mergeddone done feature/mergeddone
-mkplan "$merged_done_repo/.woostack" mergeddone 2026-06-01-mergeddone.md 4 0
+mkplan "$merged_done_repo/.woostack" mergeddone 2026-06-01-mergeddone.md 4 0 done feature/mergeddone
 ( cd "$merged_done_repo" && git add -A && git -c user.email=t@t -c user.name=Tess commit -qm "add merged done plan" )
 ( cd "$merged_done_repo" && git checkout -qb feature/mergeddone && printf 'work\n' > work.txt && git add work.txt && git -c user.email=t@t -c user.name=Tess commit -qm "merged work" )
 ( cd "$merged_done_repo" && git checkout -q main && git merge --no-ff -q feature/mergeddone -m "merge work" )


### PR DESCRIPTION
## Goal
Split woostack feature-state tracking so specs own design approval while plans own implementation lifecycle, with Obsidian-readable plan frontmatter that still preserves the doctor/status `**Source:**` join.

## Summary
- Adds plan frontmatter (`type`, `source`, `status`, `branch`) and updates status parsing to read plan lifecycle after a plan resolves.
- Updates plan/build/status/commit guidance and the plan template for the new lifecycle contract.
- Migrates tracked historical plans/spec statuses and keeps PR 342's doctor plan in review so the stacked board stays coherent.
- Adds the missing `status.staleDays` config key expected by `woostack-doctor`.

## Test plan
### Automated
- `bash skills/woostack-status/scripts/tests/run-tests.sh` — 64 passed, 0 failed.
- `find skills/woostack-doctor/scripts/tests -type f -name 'test-*.sh' -maxdepth 1 -print -exec bash {} \;` — all doctor test scripts passed.
- `bash skills/woostack-doctor/scripts/doctor.sh . --check` — 0 errors, 1 existing memory-overlap warning.
- `git diff --check` — passed.

### Manual
- Ran `/woostack-status --all`; PR 342 doctor drift is gone, leaving only the unrelated legacy `review-metrics-tokens-overlap` unknown-phase flag.

Spec: .woostack/fixes/2026-06-13-plan-frontmatter.md
