### PR TITLE
docs: register woostack-sweep on the public command surface (using-woostack routing + AGENTS list/map/counts)

### DIFF
--- a/.woostack/plans/2026-06-13-woostack-sweep.md
+++ b/.woostack/plans/2026-06-13-woostack-sweep.md
@@ -234,17 +234,17 @@ gt create -m "feat(sweep): woostack-sweep skill — single home of the drive-sta
 **Files:**
 - Modify: `skills/using-woostack/SKILL.md` (routing table, after the `woostack-execute-overnight` row)
 
-- [ ] **Step 1: Write the failing assertion**
+- [x] **Step 1: Write the failing assertion**
 
 Run: `grep -c 'woostack-sweep' skills/using-woostack/SKILL.md`
 Expected: `0` (no row yet).
 
-- [ ] **Step 2: Confirm it fails**
+- [x] **Step 2: Confirm it fails**
 
 Run: `grep -q 'woostack-sweep' skills/using-woostack/SKILL.md && echo PRESENT || echo ABSENT`
 Expected: `ABSENT`
 
-- [ ] **Step 3: Insert the routing row immediately after the `woostack-execute-overnight` row**
+- [x] **Step 3: Insert the routing row immediately after the `woostack-execute-overnight` row**
 
 Add this line after the `/woostack-execute-overnight …` table row (match the exact column shape of the adjacent rows):
 
@@ -252,12 +252,12 @@ Add this line after the `/woostack-execute-overnight …` table row (match the e
 | `/woostack-sweep [PR#] [--base R] [--interactive]`, drive a stack of PRs to a clean review | `woostack-sweep` |
 ```
 
-- [ ] **Step 4: Confirm it passes**
+- [x] **Step 4: Confirm it passes**
 
 Run: ``grep -q '`/woostack-sweep' skills/using-woostack/SKILL.md && echo PRESENT``
 Expected: `PRESENT`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "docs(using-woostack): route /woostack-sweep to the woostack-sweep skill"
@@ -270,7 +270,7 @@ gt create -m "docs(using-woostack): route /woostack-sweep to the woostack-sweep 
 
 > `AGENTS.md` is the source of truth; `.claude/CLAUDE.md` is a symlink to it, so editing `AGENTS.md` updates both. The count bump is **relative** — increment whatever number the file currently states by one; do **not** also fold in `woostack-ask` / `woostack-doctor` (separate in-flight work that hasn't updated these counts on this branch). Assert *list length == spelled count*, not a hardcoded word.
 
-- [ ] **Step 1: Capture the current count + list length (the assertion baseline)**
+- [x] **Step 1: Capture the current count + list length (the assertion baseline)**
 
 Run:
 ```bash
@@ -279,12 +279,12 @@ grep -cE '^- \[`(using-)?woostack-[a-z-]+`\]\(skills/' AGENTS.md
 ```
 Expected: prints the current count word (e.g. `sixteen`) and the current bullet count (e.g. `16`). Record both; the list must equal the spelled count, and after the edit both rise by exactly 1.
 
-- [ ] **Step 2: Confirm woostack-sweep is absent from the list**
+- [x] **Step 2: Confirm woostack-sweep is absent from the list**
 
 Run: ``grep -q '^- \[`woostack-sweep`\]' AGENTS.md && echo PRESENT || echo ABSENT``
 Expected: `ABSENT`
 
-- [ ] **Step 3: Add the bullet, bump the counts, add the file-map entry**
+- [x] **Step 3: Add the bullet, bump the counts, add the file-map entry**
 
 1. After the `- [`woostack-dream`](skills/woostack-dream/SKILL.md)` bullet, add:
 ```
@@ -298,7 +298,7 @@ Expected: `ABSENT`
   [`skills/woostack-sweep/SKILL.md`](skills/woostack-sweep/SKILL.md)
 ```
 
-- [ ] **Step 4: Confirm list == count and the entry resolves**
+- [x] **Step 4: Confirm list == count and the entry resolves**
 
 Run:
 ```bash
@@ -310,7 +310,7 @@ echo "REGISTERED — list=$n spelled=$word (must match, and = baseline+1)"
 ```
 Expected: `REGISTERED`, with `list=` exactly one more than the Step-1 baseline and the spelled word naming that same number (e.g. `list=17 spelled=seventeen`).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "docs(agents): register woostack-sweep on the public command surface + file map"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `pnpx skills add howarewoo/woostack`.
 
-The public command/adoption surface has seventeen skills:
+The public command/adoption surface has eighteen skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -33,12 +33,13 @@ The public command/adoption surface has seventeen skills:
 - [`woostack-tdd`](skills/woostack-tdd/SKILL.md)
 - [`woostack-dream`](skills/woostack-dream/SKILL.md)
 - [`woostack-doctor`](skills/woostack-doctor/SKILL.md)
+- [`woostack-sweep`](skills/woostack-sweep/SKILL.md)
 
 The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the seventeen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+`/woostack-*` commands: they have no routing row and are absent from the eighteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
 There is no application source code, app lockfile, build, or CI for this repo's own
@@ -70,7 +71,7 @@ do not add application code, app build configs, or app lockfiles **outside the s
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
 `/woostack-bootstrap`, `/woostack-build`, `/woostack-fix`, `/woostack-plan`, `/woostack-execute`, `/woostack-execute-overnight`, `/woostack-commit`,
 `/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, `/woostack-dream`,
-`/woostack-tdd`, or `/woostack-doctor`, including intent-equivalent wording. Load the matching skill
+`/woostack-tdd`, `/woostack-doctor`, or `/woostack-sweep`, including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
 directory, not in this repo.
 
@@ -92,7 +93,7 @@ directory, not in this repo.
   incompatibility forces an exact version.
 - Keep `SKILL.md` descriptions accurate and concise. The description drives discovery; the
   workflow belongs in referenced docs.
-- Do not move or rename any of the nineteen `SKILL.md` files (the seventeen public command/adoption
+- Do not move or rename any of the twenty `SKILL.md` files (the eighteen public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -116,6 +117,8 @@ directory, not in this repo.
   [`skills/woostack-execute/SKILL.md`](skills/woostack-execute/SKILL.md)
 - Overnight (unattended, autonomous) plan-execution engine (public command):
   [`skills/woostack-execute-overnight/SKILL.md`](skills/woostack-execute-overnight/SKILL.md)
+- Stack review-sweep engine (public command + delegated-to by execute-overnight):
+  [`skills/woostack-sweep/SKILL.md`](skills/woostack-sweep/SKILL.md)
 - Ideate phase engine for the build loop (internal sub-skill):
   [`skills/woostack-ideate/SKILL.md`](skills/woostack-ideate/SKILL.md)
 - Harden phase engine for the build loop (internal sub-skill):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, `woostack-debug`, `woostack-tdd`, and `woostack-dream`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, `woostack-debug`, `woostack-tdd`, `woostack-dream`, `woostack-doctor`, and `woostack-sweep`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 
@@ -25,6 +25,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Change the plan phase (the build loop's planning step) | `skills/woostack-plan/SKILL.md` |
 | Change the execute phase (the build loop's implementation step) | `skills/woostack-execute/SKILL.md` |
 | Change the overnight execute phase (unattended autonomous run, morning report) | `skills/woostack-execute-overnight/SKILL.md` |
+| Change the stack review-sweep engine (`/woostack-sweep`) | `skills/woostack-sweep/SKILL.md` |
 | Change the commit / PR update workflow | `skills/woostack-commit/SKILL.md` |
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |
 | Change the systematic-debugging behavior (`/woostack-debug`) | `skills/woostack-debug/SKILL.md` |
@@ -32,6 +33,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Change the memory/docs curation engine (`/woostack-dream`) | `skills/woostack-dream/SKILL.md` |
 | Change the address-comments delegator | `skills/woostack-address-comments/SKILL.md` |
 | Change the status board / feature-state conventions | `skills/woostack-status/SKILL.md`, `skills/woostack-status/references/conventions.md`, `skills/woostack-status/scripts/` |
+| Change the workspace-health diagnose/repair (`/woostack-doctor`) | `skills/woostack-doctor/SKILL.md` |
 | Update agent instructions (Claude or any) | `AGENTS.md` (`.claude/CLAUDE.md` is a symlink to it) |
 
 ## Workflow

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -70,6 +70,7 @@ link it, never restate it.
 | `/woostack-plan <spec-path>`, write the implementation plan for an approved spec as PR-sized increments | `woostack-plan` |
 | `/woostack-execute <plan-path> [--inline\|--subagent]`, execute an approved plan as PR-sized stacked increments (inline or subagent-driven) | `woostack-execute` |
 | `/woostack-execute-overnight <plan-path> [--inline\|--subagent]`, execute an approved plan unattended overnight (autonomous, morning report) | `woostack-execute-overnight` |
+| `/woostack-sweep [PR#] [--base R] [--interactive]`, drive a stack of PRs to a clean review | `woostack-sweep` |
 | `/woostack-commit`, commit session-relevant changes and update PR fields | `woostack-commit` |
 | `/woostack-review [PR#]`, review a PR or local diff | `woostack-review` |
 | `/woostack-address-comments [PR#]`, address unresolved review threads | `woostack-address-comments` |


### PR DESCRIPTION
## Goal

Register the new `woostack-sweep` skill on the public command surface so it is discoverable and routable as the 18th public command.

## Summary

- `skills/using-woostack/SKILL.md`: routing row for `/woostack-sweep [PR#] [--base R] [--interactive]`.
- `AGENTS.md` (and its `.claude/CLAUDE.md` symlink): added `woostack-sweep` to the public-skill list and the quick file map; bumped every count for consistency — public skills `seventeen`→`eighteen`, total SKILL files `nineteen`→`twenty`, the "absent from the N-skill surface" line, and the Mode B command enumeration.

## Test plan

### Manual

**Before merge**

- [ ] Confirm the public-skill list length equals the spelled count (`18` == `eighteen`) and the routing row + file-map entry resolve to `skills/woostack-sweep/SKILL.md`.

Spec: .woostack/specs/2026-06-13-woostack-sweep.md