### PR TITLE
chore(obsidian): ignore review-tmp and tmp directories

### DIFF
--- a/.woostack/.obsidian/app.json
+++ b/.woostack/.obsidian/app.json
@@ -1,1 +1,6 @@
-{}
+{
+  "userIgnoreFilters": [
+    "review-tmp/",
+    "tmp/"
+  ]
+}


### PR DESCRIPTION
## Goal

This PR updates the Obsidian configuration to ignore temporary and review directories. This prevents temporary files generated during automated reviews (`review-tmp/`) or general tasks (`tmp/`) from cluttering the Obsidian workspace and search index.

## Summary

- Add `review-tmp/` and `tmp/` to `userIgnoreFilters` in `.woostack/.obsidian/app.json`.

## Test plan

### Manual

**Before merge**

- [ ] Inspect `.woostack/.obsidian/app.json` diff and verify that `review-tmp/` and `tmp/` are added under `userIgnoreFilters`.
- [ ] Open the workspace in Obsidian and verify that the `tmp` and `review-tmp` directories are excluded from search results and the file explorer.
