### PR TITLE
feat(doctor): doc-type check — repair spec/plan/fix type: to match dir

### DIFF
--- a/.woostack/plans/2026-06-14-doctor-doc-repair.md
+++ b/.woostack/plans/2026-06-14-doctor-doc-repair.md
@@ -44,7 +44,7 @@ its test + its `checks.md` row. Independently shippable: auto-discovered, self-d
 
 ### Task 1.1: failing test for `doc-type` diagnose
 
-- [ ] Create `scripts/tests/test-doc-type.sh` with the diagnose cases (red — script absent):
+- [x] Create `scripts/tests/test-doc-type.sh` with the diagnose cases (red — script absent):
 
 ```bash
 #!/usr/bin/env bash
@@ -73,7 +73,7 @@ assert_contains "$out" "$(printf 'report\t.woostack/fixes/c.md')" "fenceless doc
 finish
 ```
 
-- [ ] Run it, confirm it fails because the script does not exist yet:
+- [x] Run it, confirm it fails because the script does not exist yet:
 
 ```
 bash scripts/tests/test-doc-type.sh; echo "exit=$?"
@@ -84,7 +84,7 @@ assertions on empty output fail). This is the red state.
 
 ### Task 1.2: implement `doc-type.sh`
 
-- [ ] Create `scripts/checks/doc-type.sh`:
+- [x] Create `scripts/checks/doc-type.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -132,7 +132,7 @@ for dir in specs plans fixes; do
 done
 ```
 
-- [ ] Run the test, confirm diagnose cases pass:
+- [x] Run the test, confirm diagnose cases pass:
 
 ```
 bash scripts/tests/test-doc-type.sh; echo "exit=$?"
@@ -142,7 +142,7 @@ Expected: `OK`/passed lines then `exit=0`.
 
 ### Task 1.3: failing test for `doc-type --fix` + idempotency
 
-- [ ] Append the repair cases to `scripts/tests/test-doc-type.sh` (before `finish`):
+- [x] Append the repair cases to `scripts/tests/test-doc-type.sh` (before `finish`):
 
 ```bash
 # --- repair ---
@@ -161,7 +161,7 @@ assert_contains "$res" ".woostack/fixes/c.md" "fenceless report persists"
 assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/doc-type.sh")" "" "doc-type calls no git/gh"
 ```
 
-- [ ] Run it, confirm everything passes:
+- [x] Run it, confirm everything passes:
 
 ```
 bash scripts/tests/test-doc-type.sh; echo "exit=$?"
@@ -171,13 +171,13 @@ Expected: all passed, `exit=0`.
 
 ### Task 1.4: catalog row in `references/checks.md`
 
-- [ ] Add a row to the check table in `references/checks.md`:
+- [x] Add a row to the check table in `references/checks.md`:
 
 ```
 | `doc-type` | spec/plan/fix `type:` missing or not matching its dir | warn | auto | `<root> <file>` |
 ```
 
-- [ ] Confirm the path-integrity test stays green:
+- [x] Confirm the path-integrity test stays green:
 
 ```
 bash scripts/tests/test-no-stale-paths.sh; echo "exit=$?"
@@ -187,7 +187,7 @@ Expected: `exit=0`.
 
 ### Task 1.5: commit increment 1
 
-- [ ] Hand to `woostack-commit` (it cuts the Graphite branch + PR on top of the spec+plan PR).
+- [x] Hand to `woostack-commit` (it cuts the Graphite branch + PR on top of the spec+plan PR).
   Subject: `feat(doctor): doc-type check — repair spec/plan/fix type: to match dir`.
 
 ---

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -6,7 +6,9 @@ stdout, one per line, tab-delimited: `severity⇥code⇥fixable⇥path⇥message
 - **severity** — `error` (structural breakage; the orchestrator exits nonzero) or `warn`
   (hygiene/convention; exit stays 0). CI (`--check`) fails only on `error`.
 - **fixable** — `auto` (the check ships a `--fix` apply path) or `report` (judgment; surfaced for a
-  human, never auto-applied).
+  human, never auto-applied). An `auto` check's `--fix` path may additionally emit `manual` at
+  runtime for a single instance it cannot safely repair (e.g. a doc with no frontmatter fence):
+  surfaced for a human, never auto-applied.
 
 ## Calling convention
 

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -32,6 +32,7 @@ overloaded):
 | `memory-dead` | old + never recalled (prune candidate) | warn | report | — |
 | `memory-overlap` | notes with intersecting scope (review for contradiction) | warn | report | — |
 | `spec-plan-backlink` | a plan's source spec lacks `[[plans/<plan-basename>]]` | warn | auto | `<root> <spec> <plan-basename>` |
+| `doc-type` | spec/plan/fix `type:` missing or not matching its dir (owns the no-fence report for these docs) | warn | auto | `<root> <file>` |
 | `orphan-worktree` (present) | unregistered dir under `.woostack/worktrees/` (may hold work) | warn | report | — |
 | `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
 | `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |

--- a/skills/woostack-doctor/scripts/checks/doc-type.sh
+++ b/skills/woostack-doctor/scripts/checks/doc-type.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# doc-type.sh — every spec/plan/fix carries a type: matching its dir.
+# Owns the no-frontmatter-fence report for specs/plans/fixes (other doc checks skip fenceless docs).
+#   diagnose:  doc-type.sh <WOO_ROOT>
+#   repair:    doc-type.sh --fix <WOO_ROOT> <file>   (type self-derived from the file's dir)
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/lib.sh"
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+
+# want_for <file> → expected type from the parent dir, empty/non-zero if not a doc dir.
+want_for() {
+  case "$1" in
+    */.woostack/specs/*) echo spec ;;
+    */.woostack/plans/*) echo plan ;;
+    */.woostack/fixes/*) echo fix ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ "${1:-}" = "--fix" ]; then
+  root="$2"; file="$3"
+  want="$(want_for "$file")" || exit 0
+  set_field "$file" type "$want" || { emit error doc-type manual "${file#"$root"/}" "no frontmatter fence; add 'type: $want' manually"; exit 1; }
+  [ "$(field "$file" type)" = "$want" ] || { emit error doc-type manual "${file#"$root"/}" "type: did not update to '$want'"; exit 1; }
+  exit 0
+fi
+WOO_ROOT="${1:-.}"
+
+shopt -s nullglob
+for dir in specs plans fixes; do
+  case "$dir" in specs) want=spec ;; plans) want=plan ;; fixes) want=fix ;; esac
+  for f in "$WOO_ROOT/.woostack/$dir"/*.md; do
+    rp="${f#"$WOO_ROOT"/}"
+    if [ "$(head -1 "$f")" != "---" ]; then
+      emit warn doc-type report "$rp" "no frontmatter fence; cannot read/repair type: (expected '$want')"
+      continue
+    fi
+    t="$(field "$f" type)"
+    [ "$t" = "$want" ] && continue
+    emit warn doc-type auto "$rp" "type: '${t:-<missing>}' should be '$want' (dir implies it)"
+  done
+done

--- a/skills/woostack-doctor/scripts/tests/test-doc-type.sh
+++ b/skills/woostack-doctor/scripts/tests/test-doc-type.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+source "$HERE/../../../woostack-init/scripts/lib.sh"   # field() for reading frontmatter in asserts
+set +e
+C="$HERE/../checks"
+
+r="$(mktemp -d)"
+mkdir -p "$r/.woostack/specs" "$r/.woostack/plans" "$r/.woostack/fixes"
+# good spec (no finding)
+printf -- '---\nname: a\ntype: spec\nstatus: draft\n---\n\n# A\n' > "$r/.woostack/specs/a.md"
+# plan mis-typed as spec
+printf -- '---\ntype: spec\nstatus: planning\n---\n\n**Source:** [[specs/a]]\n\n# A Plan\n' > "$r/.woostack/plans/a.md"
+# spec missing type:
+printf -- '---\nname: b\nstatus: draft\n---\n\n# B\n' > "$r/.woostack/specs/b.md"
+# fenceless doc (report, not auto)
+printf -- '# C\nno frontmatter\n' > "$r/.woostack/fixes/c.md"
+
+out="$(bash "$C/doc-type.sh" "$r")"
+assert_eq "$(printf '%s\n' "$out" | grep -c 'doc-type')" "3" "three doc-type findings"
+assert_contains "$out" "$(printf 'auto\t.woostack/plans/a.md')" "mis-typed plan is auto"
+assert_contains "$out" "$(printf 'auto\t.woostack/specs/b.md')" "missing-type spec is auto"
+assert_contains "$out" "$(printf 'report\t.woostack/fixes/c.md')" "fenceless doc is report"
+
+# --- repair ---
+bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/plans/a.md"
+assert_eq "$(field "$r/.woostack/plans/a.md" type)" "plan" "mis-typed plan repaired"
+bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/specs/b.md"
+assert_eq "$(field "$r/.woostack/specs/b.md" type)" "spec" "missing-type spec repaired (inserted)"
+# idempotent re-fix
+bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/plans/a.md"
+assert_eq "$(grep -c '^type:' "$r/.woostack/plans/a.md")" "1" "re-fix is a no-op (single type: line)"
+# only the fenceless report remains
+res="$(bash "$C/doc-type.sh" "$r")"
+assert_eq "$(printf '%s\n' "$res" | grep -c 'auto')" "0" "no auto findings remain after repair"
+assert_contains "$res" ".woostack/fixes/c.md" "fenceless report persists"
+# no git/gh invocation in the check source
+assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/doc-type.sh")" "" "doc-type calls no git/gh"
+finish

--- a/skills/woostack-doctor/scripts/tests/test-doc-type.sh
+++ b/skills/woostack-doctor/scripts/tests/test-doc-type.sh
@@ -16,11 +16,14 @@ printf -- '---\ntype: spec\nstatus: planning\n---\n\n**Source:** [[specs/a]]\n\n
 printf -- '---\nname: b\nstatus: draft\n---\n\n# B\n' > "$r/.woostack/specs/b.md"
 # fenceless doc (report, not auto)
 printf -- '# C\nno frontmatter\n' > "$r/.woostack/fixes/c.md"
+# fenced fix mis-typed as spec (exercises the want_for→fix repair branch)
+printf -- '---\ntype: spec\nstatus: open\n---\n\n# D Fix\n' > "$r/.woostack/fixes/d.md"
 
 out="$(bash "$C/doc-type.sh" "$r")"
-assert_eq "$(printf '%s\n' "$out" | grep -c 'doc-type')" "3" "three doc-type findings"
+assert_eq "$(printf '%s\n' "$out" | grep -c 'doc-type')" "4" "four doc-type findings"
 assert_contains "$out" "$(printf 'auto\t.woostack/plans/a.md')" "mis-typed plan is auto"
 assert_contains "$out" "$(printf 'auto\t.woostack/specs/b.md')" "missing-type spec is auto"
+assert_contains "$out" "$(printf 'auto\t.woostack/fixes/d.md')" "mis-typed fenced fix is auto"
 assert_contains "$out" "$(printf 'report\t.woostack/fixes/c.md')" "fenceless doc is report"
 
 # --- repair ---
@@ -28,6 +31,8 @@ bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/plans/a.md"
 assert_eq "$(field "$r/.woostack/plans/a.md" type)" "plan" "mis-typed plan repaired"
 bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/specs/b.md"
 assert_eq "$(field "$r/.woostack/specs/b.md" type)" "spec" "missing-type spec repaired (inserted)"
+bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/fixes/d.md"
+assert_eq "$(field "$r/.woostack/fixes/d.md" type)" "fix" "mis-typed fenced fix repaired"
 # idempotent re-fix
 bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/plans/a.md"
 assert_eq "$(grep -c '^type:' "$r/.woostack/plans/a.md")" "1" "re-fix is a no-op (single type: line)"
@@ -41,4 +46,10 @@ assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/doc-type.sh")" 
 out_fx="$(bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/fixes/c.md")"; rc_fx=$?
 assert_exit 1 "$rc_fx" "--fix on fenceless file exits nonzero"
 assert_contains "$out_fx" "no frontmatter fence" "--fix on fenceless emits the error finding"
+assert_contains "$out_fx" "$(printf 'error\tdoc-type\tmanual\t')" "--fix on fenceless emits the documented 'manual' fixable value"
+# --fix on a file outside specs/plans/fixes: want_for returns 1 → silent no-op, exit 0
+printf -- '---\ntype: spec\n---\n\n# Outside\n' > "$r/.woostack/outside.md"
+out_nd="$(bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/outside.md")"; rc_nd=$?
+assert_exit 0 "$rc_nd" "--fix on a non-doc-dir file exits 0"
+assert_eq "$out_nd" "" "--fix on a non-doc-dir file emits nothing"
 finish

--- a/skills/woostack-doctor/scripts/tests/test-doc-type.sh
+++ b/skills/woostack-doctor/scripts/tests/test-doc-type.sh
@@ -37,4 +37,8 @@ assert_eq "$(printf '%s\n' "$res" | grep -c 'auto')" "0" "no auto findings remai
 assert_contains "$res" ".woostack/fixes/c.md" "fenceless report persists"
 # no git/gh invocation in the check source
 assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/doc-type.sh")" "" "doc-type calls no git/gh"
+# --fix on a fenceless file: the error path emits + exits nonzero (never silently swallowed)
+out_fx="$(bash "$C/doc-type.sh" --fix "$r" "$r/.woostack/fixes/c.md")"; rc_fx=$?
+assert_exit 1 "$rc_fx" "--fix on fenceless file exits nonzero"
+assert_contains "$out_fx" "no frontmatter fence" "--fix on fenceless emits the error finding"
 finish


### PR DESCRIPTION
## Goal

First increment of the doctor doc-template repair feature (spec+plan #355): a content-only `doc-type` check that flags and repairs a spec/plan/fix whose `type:` frontmatter is missing or doesn't match its directory.

## Summary

- New `scripts/checks/doc-type.sh` (warn/auto): emits `doc-type` for each spec/plan/fix whose `type:` ≠ its dir; `--fix` self-derives the type from the dir via `set_field`. Owns the no-frontmatter-fence `report` for these docs (other doc checks skip fenceless files). No git/PR/network.
- New `scripts/tests/test-doc-type.sh`: diagnose + repair + idempotency + no-git assertions (10 cases).
- `references/checks.md`: catalog row.

## Test plan

### Automated

- [x] `bash skills/woostack-doctor/scripts/tests/run-tests.sh` — all 7 suites pass (test-doc-type 10/10, nothing regressed).

### Manual

**Before merge**

- [ ] Eyeball `doc-type.sh`; confirm it calls no git/gh and reuses `lib.sh` `field`/`set_field`.

Spec: .woostack/specs/2026-06-14-doctor-doc-repair.md
