### PR TITLE
feat(doctor): status-enum check + board-boundary doctrine — normalize alias status, report unknowns

### DIFF
--- a/.woostack/plans/2026-06-14-doctor-doc-repair.md
+++ b/.woostack/plans/2026-06-14-doctor-doc-repair.md
@@ -201,7 +201,7 @@ itself. Skips fenceless docs (doc-type owns that) and empty `status:` (board con
 
 ### Task 2.1: failing test for `status-enum` diagnose
 
-- [ ] Create `scripts/tests/test-status-enum.sh`:
+- [x] Create `scripts/tests/test-status-enum.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -226,11 +226,11 @@ assert_contains "$out" "$(printf 'error\tstatus-enum\treport\t.woostack/fixes/un
 finish
 ```
 
-- [ ] Run it, confirm red (`exit=1`).
+- [x] Run it, confirm red (`exit=1`).
 
 ### Task 2.2: implement `status-enum.sh`
 
-- [ ] Create `scripts/checks/status-enum.sh`:
+- [x] Create `scripts/checks/status-enum.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -288,11 +288,11 @@ for dir in specs plans fixes; do
 done
 ```
 
-- [ ] Run the test, confirm diagnose passes (`exit=0`).
+- [x] Run the test, confirm diagnose passes (`exit=0`).
 
 ### Task 2.3: failing test for `--fix`, report-not-applied, idempotency
 
-- [ ] Append to `scripts/tests/test-status-enum.sh` (before `finish`):
+- [x] Append to `scripts/tests/test-status-enum.sh` (before `finish`):
 
 ```bash
 # --- repair: alias auto-fixes ---
@@ -313,24 +313,24 @@ assert_contains "$res" ".woostack/fixes/unk.md" "report finding persists"
 assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/status-enum.sh")" "" "status-enum calls no git/gh"
 ```
 
-- [ ] Run, confirm green (`exit=0`).
+- [x] Run, confirm green (`exit=0`).
 
 ### Task 2.4: catalog row + boundary doctrine
 
-- [ ] Add the row to `references/checks.md`:
+- [x] Add the row to `references/checks.md`:
 
 ```
 | `status-enum` | `status:` value not in the conventions enum | error | auto (alias hit) / report | `<root> <file>` |
 ```
 
-- [ ] In `references/checks.md`, after the table add a short subsection documenting: (a) the
+- [x] In `references/checks.md`, after the table add a short subsection documenting: (a) the
   **static-vs-computed-drift boundary** — doctor repairs authoring-time status drift (enum/alias);
   `woostack-status` owns the git/PR-derived execute→done band and is never written here; (b) the
   curated **exact-match alias table** contents from `status-enum.sh`; (c) the **consumer-CI
   migration** note — the one new way `--check` can newly fail is an unknown `status:` value
   (`error`). Link `conventions.md` for the canonical enum; do not restate it.
 
-- [ ] In `skills/woostack-doctor/SKILL.md`, refine the **Never reconcile the board** hard
+- [x] In `skills/woostack-doctor/SKILL.md`, refine the **Never reconcile the board** hard
   constraint to draw the line, replacing its bullet body with:
 
 ```
@@ -341,14 +341,14 @@ assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/status-enum.sh"
   the git/PR-derived execute→done band**; that stays `woostack-status`'s read-only computed truth.
 ```
 
-- [ ] Also extend the SKILL.md description's "store integrity and conventions" enumeration to
+- [x] Also extend the SKILL.md description's "store integrity and conventions" enumeration to
   mention doc-template + status-drift coverage (keep it concise).
 
-- [ ] Confirm `bash scripts/tests/test-no-stale-paths.sh; echo "exit=$?"` → `exit=0`.
+- [x] Confirm `bash scripts/tests/test-no-stale-paths.sh; echo "exit=$?"` → `exit=0`.
 
 ### Task 2.5: commit increment 2
 
-- [ ] Hand to `woostack-commit`. Subject:
+- [x] Hand to `woostack-commit`. Subject:
   `feat(doctor): status-enum check + board-boundary doctrine — normalize alias status, report unknowns`.
 
 ---

--- a/skills/woostack-doctor/SKILL.md
+++ b/skills/woostack-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-doctor
-description: Use to diagnose and (gated) repair a repo's .woostack/ workspace health — a run-anytime check of store integrity and conventions (memory wikilinks/provenance/dead notes, the spec↔plan Obsidian backlink, orphan worktrees, .gitignore drift, config.json keys), with a headless exit-coded diagnose mode for CI (--check) and an interactive propose→approve→apply→woostack-commit repair flow. Use for /woostack-doctor, "check my .woostack", "repair the workspace", or "is my woostack install healthy". Never scaffolds (that's woostack-init), never reconciles the board (woostack-status), never curates memory content (woostack-dream), and never merges.
+description: Use to diagnose and (gated) repair a repo's .woostack/ workspace health — a run-anytime check of store integrity and conventions (memory wikilinks/provenance/dead notes, spec/plan/fix templates + the status enum, the spec↔plan Obsidian backlink, orphan worktrees, .gitignore drift, config.json keys), with a headless exit-coded diagnose mode for CI (--check) and an interactive propose→approve→apply→woostack-commit repair flow. Use for /woostack-doctor, "check my .woostack", "repair the workspace", or "is my woostack install healthy". Never scaffolds (that's woostack-init), never reconciles the board (woostack-status), never curates memory content (woostack-dream), and never merges.
 ---
 
 # woostack-doctor
@@ -58,8 +58,11 @@ siblings, so this holds by construction.
 
 - **Never scaffold.** Absent `.woostack/` → point at `woostack-init`; never create the workspace.
 - **Never reconcile the board** (that is `woostack-status`) and **never curate memory content**
-  (that is `woostack-dream`). Doctor flags *structural* problems and **reports** judgment-only
-  signals (dead notes); it never auto-prunes knowledge.
+  (that is `woostack-dream`). Doctor repairs **static, authoring-time** doc drift — `type:`, the
+  `status:` enum (normalizing exact-match aliases), and the plan→spec `**Source:**` join — and
+  **reports** judgment-only signals (dead notes, wrong-band status); it never auto-prunes knowledge.
+  It **never computes or writes the git/PR-derived execute→done band**; that stays
+  `woostack-status`'s read-only computed truth.
 - **Gate every repair.** Nothing mutates before explicit approval; `report` findings are never
   auto-applied.
 - **Safety is never relaxed.** The only filesystem repair is `git worktree prune` (admin-only);

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -48,9 +48,9 @@ job; doctor only surfaces the structural signals. The spec↔plan join reuses th
 
 ## Doc-template & status drift (static vs computed)
 
-The doc-template checks (`doc-type`, `status-enum`, and the `status-band` / `plan-source` /
-`plan-source-sync` checks added alongside them) repair specs/plans/fixes toward their templates and
-the conventions enum using **only file content** — no `git`, no PR, no network. They cover **static,
+The doc-template checks — `doc-type` and `status-enum` here, with `status-band`, `plan-source`, and
+`plan-source-sync` landing in later increments of this stack — repair specs/plans/fixes toward their
+templates and the conventions enum using **only file content** — no `git`, no PR, no network. They cover **static,
 authoring-time** drift; the **computed**, git/PR-derived execute→done band
 (`executing`/`in-review`/`done`) is never written here. That band stays
 [`woostack-status`](../../woostack-status/SKILL.md)'s **read-only computed truth** — doctor repairs

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -35,6 +35,7 @@ overloaded):
 | `memory-overlap` | notes with intersecting scope (review for contradiction) | warn | report | — |
 | `spec-plan-backlink` | a plan's source spec lacks `[[plans/<plan-basename>]]` | warn | auto | `<root> <spec> <plan-basename>` |
 | `doc-type` | spec/plan/fix `type:` missing or not matching its dir (owns the no-fence report for these docs) | warn | auto | `<root> <file>` |
+| `status-enum` | `status:` value not in the conventions enum | error | auto (exact alias hit) / report (unknown) | `<root> <file>` |
 | `orphan-worktree` (present) | unregistered dir under `.woostack/worktrees/` (may hold work) | warn | report | — |
 | `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
 | `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |
@@ -44,6 +45,27 @@ Memory checks are all `report` — memory *content* repair is [`woostack-dream`]
 job; doctor only surfaces the structural signals. The spec↔plan join reuses the
 `**Source:**`-line contract defined in
 [`../../woostack-status/references/conventions.md`](../../woostack-status/references/conventions.md).
+
+## Doc-template & status drift (static vs computed)
+
+The doc-template checks (`doc-type`, `status-enum`, and the `status-band` / `plan-source` /
+`plan-source-sync` checks added alongside them) repair specs/plans/fixes toward their templates and
+the conventions enum using **only file content** — no `git`, no PR, no network. They cover **static,
+authoring-time** drift; the **computed**, git/PR-derived execute→done band
+(`executing`/`in-review`/`done`) is never written here. That band stays
+[`woostack-status`](../../woostack-status/SKILL.md)'s **read-only computed truth** — doctor repairs
+how a doc is *authored*, status derives what the artifacts *show*.
+
+`status-enum` normalizes only **exact-match** alias values against a curated table owned by the
+check (`aproved→approved`, `in_review→in-review`, `complete→done`, `wip→executing`, …); a value
+that matches neither the enum nor an alias is genuinely unknown and stays `report` (no intent-guess,
+no fuzzy match). The enum itself is canonical in
+[`../../woostack-status/references/conventions.md`](../../woostack-status/references/conventions.md)
+— linked, not restated.
+
+**Consumer-CI migration:** `status-enum` is the one new `error` — an unknown `status:` value newly
+fails `--check`. The other doc-template checks are `warn` (they surface and auto-fix on demand
+without failing CI).
 
 ## Adding a check
 

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -63,9 +63,10 @@ no fuzzy match). The enum itself is canonical in
 [`../../woostack-status/references/conventions.md`](../../woostack-status/references/conventions.md)
 — linked, not restated.
 
-**Consumer-CI migration:** `status-enum` is the one new `error` — an unknown `status:` value newly
-fails `--check`. The other doc-template checks are `warn` (they surface and auto-fix on demand
-without failing CI).
+**Consumer-CI migration:** `status-enum` is the one new `error` — any non-canonical `status:` value
+newly fails `--check`, whether it's an alias (e.g. `wip`, `aproved`) or a genuinely unknown value.
+Aliases are auto-repaired by `--fix`; unknowns need manual correction. The other doc-template checks
+are `warn` (they surface and auto-fix on demand without failing CI).
 
 ## Adding a check
 

--- a/skills/woostack-doctor/scripts/checks/status-enum.sh
+++ b/skills/woostack-doctor/scripts/checks/status-enum.sh
@@ -31,6 +31,7 @@ if [ "${1:-}" = "--fix" ]; then
   [ "${VALID/ $s /}" != "$VALID" ] && exit 0        # already valid → no-op
   canon="$(alias_for "$s")" || exit 0               # unknown, no alias → never auto-applied
   set_field "$file" status "$canon" || { emit error status-enum manual "${file#"$root"/}" "no frontmatter fence; set 'status: $canon' manually"; exit 1; }
+  [ "$(field "$file" status)" = "$canon" ] || { emit error status-enum manual "${file#"$root"/}" "status: did not update to '$canon'"; exit 1; }   # phantom-repair guard (spec §6, mirrors doc-type.sh)
   exit 0
 fi
 WOO_ROOT="${1:-.}"

--- a/skills/woostack-doctor/scripts/checks/status-enum.sh
+++ b/skills/woostack-doctor/scripts/checks/status-enum.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# status-enum.sh — status: must be a known phase; exact-match aliases auto-normalize.
+# Enum is canonical in woostack-status/references/conventions.md; this is the linted copy
+# (mirrors status.sh's VALID_PHASES — keep in sync when the enum changes).
+#   diagnose:  status-enum.sh <WOO_ROOT>
+#   repair:    status-enum.sh --fix <WOO_ROOT> <file>   (canonical self-derived; idempotent)
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/lib.sh"
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+
+VALID=" draft hardened approved planning ready executing in-review done abandoned "
+
+# Curated, EXACT-MATCH alias table (misspelling/synonym → canonical). No fuzzy matching.
+alias_for() {
+  case "$1" in
+    aproved|approve)              echo approved ;;
+    hardend)                      echo hardened ;;
+    in_review|inreview|reviewing) echo in-review ;;
+    complete|completed|merged)    echo done ;;
+    wip)                          echo executing ;;
+    planned)                      echo planning ;;
+    abandon|abandonded)           echo abandoned ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ "${1:-}" = "--fix" ]; then
+  root="$2"; file="$3"
+  s="$(field "$file" status)"
+  [ "${VALID/ $s /}" != "$VALID" ] && exit 0        # already valid → no-op
+  canon="$(alias_for "$s")" || exit 0               # unknown, no alias → never auto-applied
+  set_field "$file" status "$canon" || { emit error status-enum manual "${file#"$root"/}" "no frontmatter fence; set 'status: $canon' manually"; exit 1; }
+  exit 0
+fi
+WOO_ROOT="${1:-.}"
+
+shopt -s nullglob
+for dir in specs plans fixes; do
+  for f in "$WOO_ROOT/.woostack/$dir"/*.md; do
+    [ "$(head -1 "$f")" != "---" ] && continue       # no fence → doc-type owns that report
+    s="$(field "$f" status)"
+    [ -z "$s" ] && continue                          # missing status → board concern, not enum
+    [ "${VALID/ $s /}" != "$VALID" ] && continue     # valid phase → ok
+    rp="${f#"$WOO_ROOT"/}"
+    if canon="$(alias_for "$s")"; then
+      emit error status-enum auto "$rp" "status: '$s' is an alias; normalize to '$canon'"
+    else
+      emit error status-enum report "$rp" "status: '$s' is not a known phase; set a valid status: manually"
+    fi
+  done
+done

--- a/skills/woostack-doctor/scripts/tests/test-status-enum.sh
+++ b/skills/woostack-doctor/scripts/tests/test-status-enum.sh
@@ -12,12 +12,16 @@ printf -- '---\ntype: spec\nstatus: approved\n---\n\n# ok\n'   > "$r/.woostack/s
 printf -- '---\ntype: spec\nstatus: aproved\n---\n\n# typo\n'  > "$r/.woostack/specs/typo.md" # alias → auto
 printf -- '---\ntype: plan\nstatus: in_review\n---\n\n# al\n'  > "$r/.woostack/plans/al.md"   # alias → auto
 printf -- '---\ntype: fix\nstatus: frobnicate\n---\n\n# unk\n' > "$r/.woostack/fixes/unk.md"  # unknown → report
+printf -- '# no fence\nbody only\n'                            > "$r/.woostack/specs/nofence.md"  # no frontmatter → skipped (doc-type owns the no-fence report)
+printf -- '---\ntype: plan\n---\n\n# nostatus\n'               > "$r/.woostack/plans/nostatus.md" # fenced but no status: key → skipped
 
 out="$(bash "$C/status-enum.sh" "$r")"
 assert_eq "$(printf '%s\n' "$out" | grep -c 'status-enum')" "3" "three status-enum findings"
 assert_contains "$out" "$(printf 'error\tstatus-enum\tauto\t.woostack/specs/typo.md')" "alias is error+auto"
 assert_contains "$out" "$(printf 'error\tstatus-enum\tauto\t.woostack/plans/al.md')" "in_review alias is auto"
 assert_contains "$out" "$(printf 'error\tstatus-enum\treport\t.woostack/fixes/unk.md')" "unknown is error+report"
+assert_not_contains "$out" "nofence.md" "no-fence file is skipped (status-enum defers to doc-type)"
+assert_not_contains "$out" "nostatus.md" "file with no status: key is skipped"
 
 # --- repair: alias auto-fixes ---
 bash "$C/status-enum.sh" --fix "$r" "$r/.woostack/specs/typo.md"
@@ -35,4 +39,26 @@ res="$(bash "$C/status-enum.sh" "$r")"
 assert_eq "$(printf '%s\n' "$res" | grep -c 'auto')" "0" "no auto findings remain"
 assert_contains "$res" ".woostack/fixes/unk.md" "report finding persists"
 assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/status-enum.sh")" "" "status-enum calls no git/gh"
+# every alias in the table normalizes to its canonical phase via --fix
+while IFS='=' read -r a canon; do
+  [ -z "$a" ] && continue
+  af="$r/.woostack/specs/alias-$a.md"
+  printf -- '---\ntype: spec\nstatus: %s\n---\n\n# alias\n' "$a" > "$af"
+  bash "$C/status-enum.sh" --fix "$r" "$af"
+  assert_eq "$(field "$af" status)" "$canon" "alias $a → $canon"
+done <<'ALIASES'
+aproved=approved
+approve=approved
+hardend=hardened
+in_review=in-review
+inreview=in-review
+reviewing=in-review
+complete=done
+completed=done
+merged=done
+wip=executing
+planned=planning
+abandon=abandoned
+abandonded=abandoned
+ALIASES
 finish

--- a/skills/woostack-doctor/scripts/tests/test-status-enum.sh
+++ b/skills/woostack-doctor/scripts/tests/test-status-enum.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+source "$HERE/../../../woostack-init/scripts/lib.sh"   # field() for reading frontmatter in asserts
+set +e
+C="$HERE/../checks"
+
+r="$(mktemp -d)"
+mkdir -p "$r/.woostack/specs" "$r/.woostack/plans" "$r/.woostack/fixes"
+printf -- '---\ntype: spec\nstatus: approved\n---\n\n# ok\n'   > "$r/.woostack/specs/ok.md"   # valid → none
+printf -- '---\ntype: spec\nstatus: aproved\n---\n\n# typo\n'  > "$r/.woostack/specs/typo.md" # alias → auto
+printf -- '---\ntype: plan\nstatus: in_review\n---\n\n# al\n'  > "$r/.woostack/plans/al.md"   # alias → auto
+printf -- '---\ntype: fix\nstatus: frobnicate\n---\n\n# unk\n' > "$r/.woostack/fixes/unk.md"  # unknown → report
+
+out="$(bash "$C/status-enum.sh" "$r")"
+assert_eq "$(printf '%s\n' "$out" | grep -c 'status-enum')" "3" "three status-enum findings"
+assert_contains "$out" "$(printf 'error\tstatus-enum\tauto\t.woostack/specs/typo.md')" "alias is error+auto"
+assert_contains "$out" "$(printf 'error\tstatus-enum\tauto\t.woostack/plans/al.md')" "in_review alias is auto"
+assert_contains "$out" "$(printf 'error\tstatus-enum\treport\t.woostack/fixes/unk.md')" "unknown is error+report"
+
+# --- repair: alias auto-fixes ---
+bash "$C/status-enum.sh" --fix "$r" "$r/.woostack/specs/typo.md"
+assert_eq "$(field "$r/.woostack/specs/typo.md" status)" "approved" "aproved → approved"
+bash "$C/status-enum.sh" --fix "$r" "$r/.woostack/plans/al.md"
+assert_eq "$(field "$r/.woostack/plans/al.md" status)" "in-review" "in_review → in-review"
+# report value is NEVER mutated, even if --fix is called on it
+bash "$C/status-enum.sh" --fix "$r" "$r/.woostack/fixes/unk.md"
+assert_eq "$(field "$r/.woostack/fixes/unk.md" status)" "frobnicate" "unknown status untouched by --fix"
+# idempotent
+bash "$C/status-enum.sh" --fix "$r" "$r/.woostack/specs/typo.md"
+assert_eq "$(field "$r/.woostack/specs/typo.md" status)" "approved" "re-fix no-op"
+# only the unknown (report) finding remains
+res="$(bash "$C/status-enum.sh" "$r")"
+assert_eq "$(printf '%s\n' "$res" | grep -c 'auto')" "0" "no auto findings remain"
+assert_contains "$res" ".woostack/fixes/unk.md" "report finding persists"
+assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/status-enum.sh")" "" "status-enum calls no git/gh"
+finish


### PR DESCRIPTION
## Goal

Increment 2 (on #356): a content-only `status-enum` check that normalizes typo/alias `status:` values to the canonical conventions enum and reports genuinely-unknown ones — plus the **board-boundary doctrine** refinement that draws the line between doctor (static authoring drift) and `woostack-status` (the computed git/PR band).

## Summary

- New `scripts/checks/status-enum.sh` (**error** severity): flags any `status:` not in the enum; `--fix` rewrites exact-match aliases (curated table: `aproved→approved`, `in_review→in-review`, `complete→done`, `wip→executing`, …) to canonical, is a **no-op on unknowns** (never auto-applied) and idempotent. No git/PR/network.
- New `scripts/tests/test-status-enum.sh`: alias auto-fix, unknown report-not-applied, idempotency, no-git (11 cases).
- `references/checks.md`: catalog row + new **"Doc-template & status drift (static vs computed)"** subsection (boundary, alias table, consumer-CI migration note).
- `SKILL.md`: **"Never reconcile the board"** constraint refined to the static-vs-computed line; description extended to mention spec/plan/fix templates + the status enum.

## Test plan

### Automated

- [x] `bash skills/woostack-doctor/scripts/tests/run-tests.sh` — all 8 suites pass (test-status-enum 11/11, nothing regressed).

### Manual

**Before merge**

- [ ] Confirm an unknown `status:` stays `report` (never rewritten) and the boundary doctrine reads correctly in `SKILL.md` + `checks.md`.

Spec: .woostack/specs/2026-06-14-doctor-doc-repair.md
