### PR TITLE
feat(doctor): status-band check — report status authored on the wrong artifact

### DIFF
--- a/.woostack/plans/2026-06-14-doctor-doc-repair.md
+++ b/.woostack/plans/2026-06-14-doctor-doc-repair.md
@@ -360,7 +360,7 @@ the enum-sites memory-note update (both enum-consuming checks now exist → no f
 
 ### Task 3.1: failing test for `status-band`
 
-- [ ] Create `scripts/tests/test-status-band.sh`:
+- [x] Create `scripts/tests/test-status-band.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -390,11 +390,11 @@ assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/status-band.sh"
 finish
 ```
 
-- [ ] Run, confirm red (`exit=1`).
+- [x] Run, confirm red (`exit=1`).
 
 ### Task 3.2: implement `status-band.sh`
 
-- [ ] Create `scripts/checks/status-band.sh`:
+- [x] Create `scripts/checks/status-band.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -428,28 +428,28 @@ scan plans "$SPEC_BAND" "plan carries spec-band status; plans own planning..done
 # fixes/ intentionally not scanned.
 ```
 
-- [ ] Run the test, confirm green (`exit=0`).
+- [x] Run the test, confirm green (`exit=0`).
 
 ### Task 3.3: catalog row
 
-- [ ] Add to `references/checks.md`:
+- [x] Add to `references/checks.md`:
 
 ```
 | `status-band` | status value in the other artifact's band (spec↔plan); skips fixes/ | warn | report | — |
 ```
 
-- [ ] `bash scripts/tests/test-no-stale-paths.sh; echo "exit=$?"` → `exit=0`.
+- [x] `bash scripts/tests/test-no-stale-paths.sh; echo "exit=$?"` → `exit=0`.
 
 ### Task 3.4: update the enum-sites memory note (distill)
 
-- [ ] Update the user memory note `woostack-add-phase-enum-value.md`: add doctor's `status-enum.sh`
+- [x] Update the user memory note `woostack-add-phase-enum-value.md`: add doctor's `status-enum.sh`
   (`VALID`) and `status-band.sh` (`SPEC_BAND`/`PLAN_BAND`) as new sites that must change when the
   phase enum changes, bump `updated:`, and refresh the MEMORY.md hook line if it cites a site
   count. `woostack-execute` writes this during the increment.
 
 ### Task 3.5: commit increment 3
 
-- [ ] Hand to `woostack-commit`. Subject:
+- [x] Hand to `woostack-commit`. Subject:
   `feat(doctor): status-band check — report status authored on the wrong artifact`.
 
 ---

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -36,6 +36,7 @@ overloaded):
 | `spec-plan-backlink` | a plan's source spec lacks `[[plans/<plan-basename>]]` | warn | auto | `<root> <spec> <plan-basename>` |
 | `doc-type` | spec/plan/fix `type:` missing or not matching its dir (owns the no-fence report for these docs) | warn | auto | `<root> <file>` |
 | `status-enum` | `status:` value not in the conventions enum | error | auto (exact alias hit) / report (unknown) | `<root> <file>` |
+| `status-band` | status value in the other artifact's band (spec↔plan); skips `fixes/` | warn | report | — |
 | `orphan-worktree` (present) | unregistered dir under `.woostack/worktrees/` (may hold work) | warn | report | — |
 | `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
 | `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |

--- a/skills/woostack-doctor/scripts/checks/status-band.sh
+++ b/skills/woostack-doctor/scripts/checks/status-band.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# status-band.sh — report-only. specs own draft/hardened/approved; plans own
+# planning/ready/executing/in-review/done. 'abandoned' is terminal for both. fixes/ skipped
+# (a fix is its own spec+plan, no opposite band). Never repairs — can't pick the right value.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/lib.sh"
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+[ "${1:-}" = "--fix" ] && exit 0          # report-only: --fix is a no-op
+WOO_ROOT="${1:-.}"
+
+SPEC_BAND=" draft hardened approved "
+PLAN_BAND=" planning ready executing in-review done "
+
+scan() {                                  # scan <dir> <opposite-band> <msg>
+  local dir="$1" band="$2" msg="$3" f s rp
+  shopt -s nullglob
+  for f in "$WOO_ROOT/.woostack/$dir"/*.md; do
+    [ "$(head -1 "$f")" != "---" ] && continue
+    s="$(field "$f" status)"; [ -z "$s" ] && continue
+    if [ "${band/ $s /}" != "$band" ]; then
+      rp="${f#"$WOO_ROOT"/}"
+      emit warn status-band report "$rp" "$msg '$s'"
+    fi
+  done
+}
+scan specs "$PLAN_BAND" "spec carries plan-band status; specs own draft/hardened/approved, move lifecycle to the plan:"
+scan plans "$SPEC_BAND" "plan carries spec-band status; plans own planning..done, set a plan-lifecycle status:"
+# fixes/ intentionally not scanned.

--- a/skills/woostack-doctor/scripts/tests/test-status-band.sh
+++ b/skills/woostack-doctor/scripts/tests/test-status-band.sh
@@ -13,12 +13,16 @@ printf -- '---\ntype: spec\nstatus: executing\n---\n\n# x\n'  > "$r/.woostack/sp
 printf -- '---\ntype: plan\nstatus: executing\n---\n\n# ok\n' > "$r/.woostack/plans/ok.md"  # in-band → none
 printf -- '---\ntype: plan\nstatus: hardened\n---\n\n# y\n'   > "$r/.woostack/plans/y.md"   # spec-band on plan → report
 printf -- '---\ntype: fix\nstatus: executing\n---\n\n# f\n'   > "$r/.woostack/fixes/f.md"   # fixes skipped → none
+printf -- '---\ntype: spec\nstatus: abandoned\n---\n\n# sa\n' > "$r/.woostack/specs/sa.md"  # terminal both bands → none
+printf -- '---\ntype: plan\nstatus: abandoned\n---\n\n# pa\n' > "$r/.woostack/plans/pa.md"  # terminal both bands → none
 
 out="$(bash "$C/status-band.sh" "$r")"
-assert_eq "$(printf '%s\n' "$out" | grep -c 'status-band')" "2" "exactly two band findings"
+assert_eq "$(printf '%s\n' "$out" | grep -c 'status-band')" "2" "exactly two band findings (abandoned never flagged)"
 assert_contains "$out" "$(printf 'warn\tstatus-band\treport\t.woostack/specs/x.md')" "plan-band value on spec"
 assert_contains "$out" "$(printf 'warn\tstatus-band\treport\t.woostack/plans/y.md')" "spec-band value on plan"
 assert_not_contains "$out" ".woostack/fixes/f.md" "fixes/ skipped"
+assert_not_contains "$out" ".woostack/specs/sa.md" "abandoned spec not flagged (terminal for both bands)"
+assert_not_contains "$out" ".woostack/plans/pa.md" "abandoned plan not flagged (terminal for both bands)"
 # --fix is a no-op for a report check
 bash "$C/status-band.sh" --fix "$r" "$r/.woostack/specs/x.md"; assert_exit 0 "$?" "--fix no-op exits 0"
 assert_eq "$(field "$r/.woostack/specs/x.md" status)" "executing" "report check never mutates"

--- a/skills/woostack-doctor/scripts/tests/test-status-band.sh
+++ b/skills/woostack-doctor/scripts/tests/test-status-band.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+source "$HERE/../../../woostack-init/scripts/lib.sh"   # field() for reading frontmatter in asserts
+set +e
+C="$HERE/../checks"
+
+r="$(mktemp -d)"
+mkdir -p "$r/.woostack/specs" "$r/.woostack/plans" "$r/.woostack/fixes"
+printf -- '---\ntype: spec\nstatus: approved\n---\n\n# ok\n'  > "$r/.woostack/specs/ok.md"  # in-band → none
+printf -- '---\ntype: spec\nstatus: executing\n---\n\n# x\n'  > "$r/.woostack/specs/x.md"   # plan-band on spec → report
+printf -- '---\ntype: plan\nstatus: executing\n---\n\n# ok\n' > "$r/.woostack/plans/ok.md"  # in-band → none
+printf -- '---\ntype: plan\nstatus: hardened\n---\n\n# y\n'   > "$r/.woostack/plans/y.md"   # spec-band on plan → report
+printf -- '---\ntype: fix\nstatus: executing\n---\n\n# f\n'   > "$r/.woostack/fixes/f.md"   # fixes skipped → none
+
+out="$(bash "$C/status-band.sh" "$r")"
+assert_eq "$(printf '%s\n' "$out" | grep -c 'status-band')" "2" "exactly two band findings"
+assert_contains "$out" "$(printf 'warn\tstatus-band\treport\t.woostack/specs/x.md')" "plan-band value on spec"
+assert_contains "$out" "$(printf 'warn\tstatus-band\treport\t.woostack/plans/y.md')" "spec-band value on plan"
+assert_not_contains "$out" ".woostack/fixes/f.md" "fixes/ skipped"
+# --fix is a no-op for a report check
+bash "$C/status-band.sh" --fix "$r" "$r/.woostack/specs/x.md"; assert_exit 0 "$?" "--fix no-op exits 0"
+assert_eq "$(field "$r/.woostack/specs/x.md" status)" "executing" "report check never mutates"
+assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/status-band.sh")" "" "status-band calls no git/gh"
+finish


### PR DESCRIPTION
## Goal

Increment 3 (on #357): a report-only `status-band` check that flags a `status:` value authored on the **wrong artifact** — a plan-lifecycle value on a spec, or a spec value on a plan — so the lifecycle lands where it belongs.

## Summary

- New `scripts/checks/status-band.sh` (warn/report): specs own `draft/hardened/approved`, plans own `planning…done`; `abandoned` is terminal for both; **skips `fixes/`** (a fix is its own spec+plan). Never repairs (can't mechanically pick the right value) — `--fix` is a no-op. No git/PR/network.
- New `scripts/tests/test-status-band.sh` (7 cases) + `references/checks.md` row.
- Distill: updated the `woostack-add-phase-enum-value` memory note (now **8 sites** — added doctor's `status-enum` `VALID` + `status-band` `SPEC_BAND`/`PLAN_BAND`).

## Test plan

### Automated

- [x] `bash skills/woostack-doctor/scripts/tests/run-tests.sh` — all 9 suites pass (status-band 7/7, nothing regressed).

### Manual

**Before merge**

- [ ] Confirm a spec with `status: executing` reports `status-band`, a plan with `status: hardened` reports it, and a `fix` is never flagged.

Spec: .woostack/specs/2026-06-14-doctor-doc-repair.md
