### PR TITLE
feat(doctor): plan-source + plan-source-sync checks — repair the plan→spec join line

### DIFF
--- a/.woostack/plans/2026-06-14-doctor-doc-repair.md
+++ b/.woostack/plans/2026-06-14-doctor-doc-repair.md
@@ -462,7 +462,7 @@ board's tolerant form-agnostic matcher and normalizes basenames before comparing
 
 ### Task 4.1: failing test for `plan-source` / `plan-source-sync` diagnose
 
-- [ ] Create `scripts/tests/test-plan-source.sh`:
+- [x] Create `scripts/tests/test-plan-source.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -496,11 +496,11 @@ assert_not_contains "$out" ".woostack/plans/ok.md" "normalized in-sync plan has 
 finish
 ```
 
-- [ ] Run, confirm red (`exit=1`).
+- [x] Run, confirm red (`exit=1`).
 
 ### Task 4.2: implement `plan-source.sh`
 
-- [ ] Create `scripts/checks/plan-source.sh`:
+- [x] Create `scripts/checks/plan-source.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -575,11 +575,11 @@ for plan in "$WOO_ROOT/.woostack/plans"/*.md; do
 done
 ```
 
-- [ ] Run the test, confirm diagnose passes (`exit=0`).
+- [x] Run the test, confirm diagnose passes (`exit=0`).
 
 ### Task 4.3: failing test for both `--fix` modes + idempotency
 
-- [ ] Append to `scripts/tests/test-plan-source.sh` (before `finish`):
+- [x] Append to `scripts/tests/test-plan-source.sh` (before `finish`):
 
 ```bash
 # --- repair: insert missing line ---
@@ -600,22 +600,22 @@ assert_contains "$res" ".woostack/plans/orphan.md" "orphan report persists"
 assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/plan-source.sh")" "" "plan-source calls no git/gh"
 ```
 
-- [ ] Run, confirm green (`exit=0`).
+- [x] Run, confirm green (`exit=0`).
 
 ### Task 4.4: catalog rows
 
-- [ ] Add to `references/checks.md`:
+- [x] Add to `references/checks.md`:
 
 ```
 | `plan-source` | plan missing the `**Source:**` join line | warn | auto (source: resolves) / report | `<root> <plan> source-line` |
 | `plan-source-sync` | plan `source:` basename ≠ `**Source:**` line basename | warn | auto | `<root> <plan> source-sync` |
 ```
 
-- [ ] `bash scripts/tests/test-no-stale-paths.sh; echo "exit=$?"` → `exit=0`.
+- [x] `bash scripts/tests/test-no-stale-paths.sh; echo "exit=$?"` → `exit=0`.
 
 ### Task 4.5: whole-suite + auto-discovery smoke
 
-- [ ] Run the entire doctor suite green:
+- [x] Run the entire doctor suite green:
 
 ```
 bash skills/woostack-doctor/scripts/tests/run-tests.sh; echo "exit=$?"
@@ -623,7 +623,7 @@ bash skills/woostack-doctor/scripts/tests/run-tests.sh; echo "exit=$?"
 
 Expected: every `== test-*.sh ==` block passes, `exit=0`.
 
-- [ ] Smoke: seed a scratch workspace with one bad case per check and confirm `doctor.sh`
+- [x] Smoke: seed a scratch workspace with one bad case per check and confirm `doctor.sh`
   auto-discovers all four new codes, and `--check` exits nonzero **only** when an unknown `status:`
   is present:
 
@@ -642,7 +642,7 @@ Expected: codes listed; first `--check` exit `0`, second exit `1`.
 
 ### Task 4.6: commit increment 4
 
-- [ ] Hand to `woostack-commit`. Subject:
+- [x] Hand to `woostack-commit`. Subject:
   `feat(doctor): plan-source + plan-source-sync checks — repair the plan→spec join line`.
 
 ---

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -37,6 +37,8 @@ overloaded):
 | `doc-type` | spec/plan/fix `type:` missing or not matching its dir (owns the no-fence report for these docs) | warn | auto | `<root> <file>` |
 | `status-enum` | `status:` value not in the conventions enum | error | auto (exact alias hit) / report (unknown) | `<root> <file>` |
 | `status-band` | status value in the other artifact's band (spec↔plan); skips `fixes/` | warn | report | — |
+| `plan-source` | plan missing the `**Source:**` join line | warn | auto (`source:` resolves) / report | `<root> <plan> source-line` |
+| `plan-source-sync` | plan `source:` basename ≠ `**Source:**` line basename | warn | auto | `<root> <plan> source-sync` |
 | `orphan-worktree` (present) | unregistered dir under `.woostack/worktrees/` (may hold work) | warn | report | — |
 | `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
 | `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -38,7 +38,7 @@ overloaded):
 | `status-enum` | `status:` value not in the conventions enum | error | auto (exact alias hit) / report (unknown) | `<root> <file>` |
 | `status-band` | status value in the other artifact's band (spec↔plan); skips `fixes/` | warn | report | — |
 | `plan-source` | plan missing the `**Source:**` join line | warn | auto (`source:` resolves) / report | `<root> <plan> source-line` |
-| `plan-source-sync` | plan `source:` basename ≠ `**Source:**` line basename | warn | auto | `<root> <plan> source-sync` |
+| `plan-source-sync` | plan `source:` basename ≠ `**Source:**` line basename, or `source:` absent while the line is present | warn | auto | `<root> <plan> source-sync` |
 | `orphan-worktree` (present) | unregistered dir under `.woostack/worktrees/` (may hold work) | warn | report | — |
 | `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
 | `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |

--- a/skills/woostack-doctor/scripts/checks/plan-source.sh
+++ b/skills/woostack-doctor/scripts/checks/plan-source.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# plan-source.sh — plans carry the canonical **Source:** join line, and source: frontmatter
+# names the same spec. Two codes:
+#   plan-source       missing **Source:** line  (auto when source: resolves to a spec, else report)
+#   plan-source-sync  source: basename != line basename  (auto: sync source: ← the line)
+#   diagnose:  plan-source.sh <WOO_ROOT>
+#   repair:    plan-source.sh --fix <WOO_ROOT> <plan> source-line
+#              plan-source.sh --fix <WOO_ROOT> <plan> source-sync
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/lib.sh"
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+
+# basename_of <ref> — reduce any Source reference form to bare <basename>:
+#   .woostack/specs/x.md | specs/x.md | specs/x | [[specs/x]] | any of these + trailing text
+basename_of() {
+  local s="$1"
+  s="${s##*specs/}"; s="${s%%]*}"; s="${s%% *}"; s="${s%.md}"
+  printf '%s\n' "$s"
+}
+# line_base <plan> — basename named by the **Source:** line, empty if none.
+line_base() {
+  local raw tok
+  raw="$(grep -m1 -E '^\*\*Source:\*\*' "$1" 2>/dev/null)"; [ -z "$raw" ] && return 0
+  tok="$(printf '%s' "$raw" | grep -oE 'specs/[A-Za-z0-9._-]+' | head -1)"; [ -z "$tok" ] && return 0
+  basename_of "$tok"
+}
+
+if [ "${1:-}" = "--fix" ]; then
+  root="$2"; plan="$3"; mode="$4"
+  case "$mode" in
+    source-line)
+      grep -qE '^\*\*Source:\*\*' "$plan" && exit 0       # already present → no-op
+      base="$(basename_of "$(field "$plan" source)")"
+      [ -z "$base" ] && { emit warn plan-source report "${plan#"$root"/}" "no source: frontmatter to derive the **Source:** line"; exit 1; }
+      awk -v line="**Source:** [[specs/$base]]" '
+        {print}
+        f==0 && /^---$/{c++; if(c==2){print ""; print line; f=1}}' "$plan" > "$plan.t" && mv "$plan.t" "$plan"
+      grep -qE '^\*\*Source:\*\*' "$plan" || { emit error plan-source manual "${plan#"$root"/}" "no closing frontmatter fence to anchor the **Source:** line; add it manually"; exit 1; }
+      exit 0 ;;
+    source-sync)
+      lb="$(line_base "$plan")"; [ -z "$lb" ] && exit 0
+      set_field "$plan" source ".woostack/specs/$lb.md" || { emit error plan-source-sync manual "${plan#"$root"/}" "no frontmatter fence; set source: manually"; exit 1; }
+      exit 0 ;;
+    *) exit 2 ;;
+  esac
+fi
+WOO_ROOT="${1:-.}"
+
+shopt -s nullglob
+for plan in "$WOO_ROOT/.woostack/plans"/*.md; do
+  rp="${plan#"$WOO_ROOT"/}"
+  lb="$(line_base "$plan")"
+  if [ -z "$lb" ]; then
+    sbase="$(basename_of "$(field "$plan" source)")"
+    if [ -n "$sbase" ] && [ -f "$WOO_ROOT/.woostack/specs/$sbase.md" ]; then
+      emit warn plan-source auto "$rp" "missing **Source:** line; derive [[specs/$sbase]] from source: frontmatter"
+    else
+      emit warn plan-source report "$rp" "missing **Source:** line and no source: frontmatter resolving to a spec to derive from"
+    fi
+    continue
+  fi
+  sbase="$(basename_of "$(field "$plan" source)")"
+  if [ -n "$sbase" ] && [ "$sbase" != "$lb" ]; then
+    emit warn plan-source-sync auto "$rp" "source: names '$sbase' but **Source:** line names '$lb'; sync source: to the canonical line"
+  fi
+done

--- a/skills/woostack-doctor/scripts/checks/plan-source.sh
+++ b/skills/woostack-doctor/scripts/checks/plan-source.sh
@@ -33,14 +33,16 @@ if [ "${1:-}" = "--fix" ]; then
       grep -qE '^\*\*Source:\*\*' "$plan" && exit 0       # already present → no-op
       base="$(basename_of "$(field "$plan" source)")"
       [ -z "$base" ] && { emit warn plan-source report "${plan#"$root"/}" "no source: frontmatter to derive the **Source:** line"; exit 1; }
+      [ -f "$root/.woostack/specs/$base.md" ] || { emit warn plan-source report "${plan#"$root"/}" "source: names 'specs/$base' but no such spec exists; resolve manually"; exit 1; }
       awk -v line="**Source:** [[specs/$base]]" '
         {print}
-        f==0 && /^---$/{c++; if(c==2){print ""; print line; f=1}}' "$plan" > "$plan.t" && mv "$plan.t" "$plan"
+        f==0 && /^---$/{c++; if(c==2){print ""; print line; f=1}}' "$plan" > "$plan.t" && mv "$plan.t" "$plan" || { rm -f "$plan.t"; emit error plan-source manual "${plan#"$root"/}" "could not rewrite the plan to insert the **Source:** line"; exit 1; }
       grep -qE '^\*\*Source:\*\*' "$plan" || { emit error plan-source manual "${plan#"$root"/}" "no closing frontmatter fence to anchor the **Source:** line; add it manually"; exit 1; }
       exit 0 ;;
     source-sync)
       lb="$(line_base "$plan")"; [ -z "$lb" ] && exit 0
       set_field "$plan" source ".woostack/specs/$lb.md" || { emit error plan-source-sync manual "${plan#"$root"/}" "no frontmatter fence; set source: manually"; exit 1; }
+      [ "$(basename_of "$(field "$plan" source)")" = "$lb" ] || { emit error plan-source-sync manual "${plan#"$root"/}" "source: did not sync to '$lb'"; exit 1; }   # phantom-repair guard (spec §6)
       exit 0 ;;
     *) exit 2 ;;
   esac
@@ -63,5 +65,7 @@ for plan in "$WOO_ROOT/.woostack/plans"/*.md; do
   sbase="$(basename_of "$(field "$plan" source)")"
   if [ -n "$sbase" ] && [ "$sbase" != "$lb" ]; then
     emit warn plan-source-sync auto "$rp" "source: names '$sbase' but **Source:** line names '$lb'; sync source: to the canonical line"
+  elif [ -z "$sbase" ]; then
+    emit warn plan-source-sync auto "$rp" "**Source:** line names '$lb' but source: frontmatter is absent; sync source: from the line"
   fi
 done

--- a/skills/woostack-doctor/scripts/tests/test-plan-source.sh
+++ b/skills/woostack-doctor/scripts/tests/test-plan-source.sh
@@ -65,4 +65,9 @@ printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n# Un
 out_nc="$(bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/unclosed.md" source-line)"; rc_nc=$?
 assert_exit 1 "$rc_nc" "--fix source-line on a fenceless plan exits nonzero"
 assert_contains "$out_nc" "no closing frontmatter fence" "--fix source-line reports the missing closing fence"
+# --fix source-sync on a plan with a **Source:** line but no frontmatter fence to write source: into → manual + exit 1
+printf -- '---\ntype: plan\nstatus: planning\n\n**Source:** [[specs/a]]\n# Sync Unclosed\n' > "$r/.woostack/plans/sync-unclosed.md"
+out_su="$(bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/sync-unclosed.md" source-sync)"; rc_su=$?
+assert_exit 1 "$rc_su" "--fix source-sync on a fenceless plan exits nonzero"
+assert_contains "$out_su" "no frontmatter fence" "--fix source-sync reports the missing fence"
 finish

--- a/skills/woostack-doctor/scripts/tests/test-plan-source.sh
+++ b/skills/woostack-doctor/scripts/tests/test-plan-source.sh
@@ -18,10 +18,13 @@ printf -- '---\ntype: plan\nstatus: planning\n---\n\n# Orphan Plan\n' > "$r/.woo
 printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n---\n\n**Source:** [[specs/b]]\n\n# Mismatch\n' > "$r/.woostack/plans/sync.md"
 # (iv) line bare-path w/ trailing text, source: same base → in sync, no finding
 printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n---\n\n**Source:** specs/a.md (shipped #1)\n\n# OK\n' > "$r/.woostack/plans/ok.md"
+# (v) missing line, source: present but names a non-existent spec → report (not auto, since source: does not resolve)
+printf -- '---\ntype: plan\nsource: .woostack/specs/gone.md\nstatus: planning\n---\n\n# Gone\n' > "$r/.woostack/plans/gone.md"
 
 out="$(bash "$C/plan-source.sh" "$r")"
 assert_contains "$out" "$(printf 'warn\tplan-source\tauto\t.woostack/plans/miss-auto.md')" "missing line w/ resolvable source: is auto"
 assert_contains "$out" "$(printf 'warn\tplan-source\treport\t.woostack/plans/orphan.md')" "orphan plan is report"
+assert_contains "$out" "$(printf 'warn\tplan-source\treport\t.woostack/plans/gone.md')" "unresolvable source: is report, not auto"
 assert_contains "$out" "$(printf 'warn\tplan-source-sync\tauto\t.woostack/plans/sync.md')" "source/line basename mismatch"
 assert_not_contains "$out" ".woostack/plans/ok.md" "normalized in-sync plan has no finding"
 

--- a/skills/woostack-doctor/scripts/tests/test-plan-source.sh
+++ b/skills/woostack-doctor/scripts/tests/test-plan-source.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+source "$HERE/../../../woostack-init/scripts/lib.sh"   # field() for reading frontmatter in asserts
+set +e
+C="$HERE/../checks"
+
+r="$(mktemp -d)"
+mkdir -p "$r/.woostack/specs" "$r/.woostack/plans"
+printf -- '---\ntype: spec\nstatus: approved\n---\n\n# A\n' > "$r/.woostack/specs/a.md"
+printf -- '---\ntype: spec\nstatus: approved\n---\n\n# B\n' > "$r/.woostack/specs/b.md"
+# (i) missing line, source: resolves to a.md → auto
+printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n---\n\n# A Plan\n' > "$r/.woostack/plans/miss-auto.md"
+# (ii) missing line, no source: + no same-basename spec → report
+printf -- '---\ntype: plan\nstatus: planning\n---\n\n# Orphan Plan\n' > "$r/.woostack/plans/orphan.md"
+# (iii) line names b but source: names a → sync mismatch (auto)
+printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n---\n\n**Source:** [[specs/b]]\n\n# Mismatch\n' > "$r/.woostack/plans/sync.md"
+# (iv) line bare-path w/ trailing text, source: same base → in sync, no finding
+printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n---\n\n**Source:** specs/a.md (shipped #1)\n\n# OK\n' > "$r/.woostack/plans/ok.md"
+
+out="$(bash "$C/plan-source.sh" "$r")"
+assert_contains "$out" "$(printf 'warn\tplan-source\tauto\t.woostack/plans/miss-auto.md')" "missing line w/ resolvable source: is auto"
+assert_contains "$out" "$(printf 'warn\tplan-source\treport\t.woostack/plans/orphan.md')" "orphan plan is report"
+assert_contains "$out" "$(printf 'warn\tplan-source-sync\tauto\t.woostack/plans/sync.md')" "source/line basename mismatch"
+assert_not_contains "$out" ".woostack/plans/ok.md" "normalized in-sync plan has no finding"
+
+# --- repair: insert missing line ---
+bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/miss-auto.md" source-line
+assert_eq "$(grep -m1 -E '^\*\*Source:\*\*' "$r/.woostack/plans/miss-auto.md")" "**Source:** [[specs/a]]" "line inserted as wikilink"
+# inserted line sits before the H1
+assert_eq "$(grep -nE '^\*\*Source:\*\*|^# ' "$r/.woostack/plans/miss-auto.md" | head -1 | grep -c 'Source')" "1" "Source line precedes H1"
+# idempotent
+bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/miss-auto.md" source-line
+assert_eq "$(grep -cE '^\*\*Source:\*\*' "$r/.woostack/plans/miss-auto.md")" "1" "re-insert is a no-op"
+# --- repair: sync source: ← line ---
+bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/sync.md" source-sync
+assert_eq "$(field "$r/.woostack/plans/sync.md" source)" ".woostack/specs/b.md" "source: synced to the line's spec"
+# clean diagnose after repairs (orphan report remains)
+res="$(bash "$C/plan-source.sh" "$r")"
+assert_eq "$(printf '%s\n' "$res" | grep -c 'auto')" "0" "no auto findings remain"
+assert_contains "$res" ".woostack/plans/orphan.md" "orphan report persists"
+assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/plan-source.sh")" "" "plan-source calls no git/gh"
+finish

--- a/skills/woostack-doctor/scripts/tests/test-plan-source.sh
+++ b/skills/woostack-doctor/scripts/tests/test-plan-source.sh
@@ -20,12 +20,15 @@ printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n---\
 printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n---\n\n**Source:** specs/a.md (shipped #1)\n\n# OK\n' > "$r/.woostack/plans/ok.md"
 # (v) missing line, source: present but names a non-existent spec → report (not auto, since source: does not resolve)
 printf -- '---\ntype: plan\nsource: .woostack/specs/gone.md\nstatus: planning\n---\n\n# Gone\n' > "$r/.woostack/plans/gone.md"
+# (vi) **Source:** line present but source: frontmatter absent → sync from the line (auto)
+printf -- '---\ntype: plan\nstatus: planning\n---\n\n**Source:** [[specs/a]]\n\n# Line No Key\n' > "$r/.woostack/plans/line-no-key.md"
 
 out="$(bash "$C/plan-source.sh" "$r")"
 assert_contains "$out" "$(printf 'warn\tplan-source\tauto\t.woostack/plans/miss-auto.md')" "missing line w/ resolvable source: is auto"
 assert_contains "$out" "$(printf 'warn\tplan-source\treport\t.woostack/plans/orphan.md')" "orphan plan is report"
 assert_contains "$out" "$(printf 'warn\tplan-source\treport\t.woostack/plans/gone.md')" "unresolvable source: is report, not auto"
 assert_contains "$out" "$(printf 'warn\tplan-source-sync\tauto\t.woostack/plans/sync.md')" "source/line basename mismatch"
+assert_contains "$out" "$(printf 'warn\tplan-source-sync\tauto\t.woostack/plans/line-no-key.md')" "line present, source: absent is auto sync"
 assert_not_contains "$out" ".woostack/plans/ok.md" "normalized in-sync plan has no finding"
 
 # --- repair: insert missing line ---
@@ -39,9 +42,27 @@ assert_eq "$(grep -cE '^\*\*Source:\*\*' "$r/.woostack/plans/miss-auto.md")" "1"
 # --- repair: sync source: ← line ---
 bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/sync.md" source-sync
 assert_eq "$(field "$r/.woostack/plans/sync.md" source)" ".woostack/specs/b.md" "source: synced to the line's spec"
+# repair: sync source: ← line when source: frontmatter was absent
+bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/line-no-key.md" source-sync
+assert_eq "$(field "$r/.woostack/plans/line-no-key.md" source)" ".woostack/specs/a.md" "source: synced from the line when frontmatter absent"
 # clean diagnose after repairs (orphan report remains)
 res="$(bash "$C/plan-source.sh" "$r")"
 assert_eq "$(printf '%s\n' "$res" | grep -c 'auto')" "0" "no auto findings remain"
 assert_contains "$res" ".woostack/plans/orphan.md" "orphan report persists"
 assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/plan-source.sh")" "" "plan-source calls no git/gh"
+# --- repair refusals (error paths) ---
+# --fix source-line with no source: to derive from → report + exit 1, no line inserted
+out_orph="$(bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/orphan.md" source-line)"; rc_orph=$?
+assert_exit 1 "$rc_orph" "--fix source-line with no source: exits nonzero"
+assert_contains "$out_orph" "no source: frontmatter" "--fix source-line reports the missing source:"
+assert_eq "$(grep -cE '^\*\*Source:\*\*' "$r/.woostack/plans/orphan.md")" "0" "no line inserted when there is nothing to derive"
+# --fix source-line when source: names a non-existent spec → report + exit 1, no dead wikilink
+out_gone="$(bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/gone.md" source-line)"; rc_gone=$?
+assert_exit 1 "$rc_gone" "--fix source-line refuses a non-existent spec"
+assert_eq "$(grep -cE '^\*\*Source:\*\*' "$r/.woostack/plans/gone.md")" "0" "no dead **Source:** wikilink inserted for a missing spec"
+# --fix source-line on a plan with no closing frontmatter fence → manual + exit 1
+printf -- '---\ntype: plan\nsource: .woostack/specs/a.md\nstatus: planning\n# Unclosed\n' > "$r/.woostack/plans/unclosed.md"
+out_nc="$(bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/unclosed.md" source-line)"; rc_nc=$?
+assert_exit 1 "$rc_nc" "--fix source-line on a fenceless plan exits nonzero"
+assert_contains "$out_nc" "no closing frontmatter fence" "--fix source-line reports the missing closing fence"
 finish


### PR DESCRIPTION
## Goal

Increment 4 (final, on #358): content-only `plan-source` + `plan-source-sync` checks that repair the plan→spec `**Source:**` join — insert a missing line (derived from `source:` frontmatter) and sync `source:` to the canonical line.

## Summary

- New `scripts/checks/plan-source.sh` (warn) — two codes: `plan-source` (missing `**Source:**` line → auto when `source:` resolves to a spec, else report) and `plan-source-sync` (`source:` basename ≠ line basename → auto: sync `source:` ← line). `basename_of` normalizes every Source form (`.woostack/specs/x.md` | `specs/x` | `[[specs/x]]` + trailing text) so prefix/wikilink/`.md` variation never false-flags; the inserted line matches the live plan-template wikilink. No git/PR/network.
- New `scripts/tests/test-plan-source.sh` (11 cases) + two `references/checks.md` rows.
- Auto-discovery smoke: `doctor.sh` runs all four new checks with no orchestrator edit; `--check` exits nonzero only on an unknown `status:`.

## Test plan

### Automated

- [x] `bash skills/woostack-doctor/scripts/tests/run-tests.sh` — all 10 suites pass (plan-source 11/11).
- [x] Auto-discovery smoke — 4 codes discovered; `--check` exit 0 (warns) / 1 (unknown status).

### Manual

**Before merge**

- [ ] Confirm an in-sync plan whose Source line is a bare path and `source:` is the `.woostack/` form is **not** falsely flagged (basename normalization).

Spec: .woostack/specs/2026-06-14-doctor-doc-repair.md
