### PR TITLE
docs(fix): spec+plan — subagent debug + commit fix plan before the execute gate

### DIFF
--- a/.woostack/plans/2026-06-14-fix-subagent-debug-and-plan-pr.md
+++ b/.woostack/plans/2026-06-14-fix-subagent-debug-and-plan-pr.md
@@ -1,0 +1,408 @@
+---
+type: plan
+source: .woostack/specs/2026-06-14-fix-subagent-debug-and-plan-pr.md
+status: ready
+branch: feature/fix-subagent-debug-and-plan-pr
+---
+
+**Source:** [[specs/2026-06-14-fix-subagent-debug-and-plan-pr]]
+
+# Tighten the woostack-fix loop (subagent debug + plan PR before the execute gate) Implementation Plan
+
+**Goal:** Edit `skills/woostack-fix/SKILL.md` so the fix loop can run its step-1 debug investigation in a read-only subagent (smart default mirroring `woostack-execute`) and commits the fix plan as a docs-only PR before the approve-to-execute gate.
+
+**Architecture:** Two independent edits to a single markdown file, `skills/woostack-fix/SKILL.md`. Increment 1 adds a `## Debug investigation mode` section + a step-1 reference + a hard-constraint bullet. Increment 2 reorders the procedure (commit the fix plan before the gate, build-style 2-PR docs base) and updates the Overview diagram, the gate paragraph, the worktree prose, and Hard constraints. Cross-links target the *existing* `woostack-execute` "Execution mode" section and the worktree contract — no new files, and `woostack-debug`/`woostack-execute` SKILLs are untouched.
+
+**Tech Stack:** Markdown (skills repo). No code runner — every "test" is a `grep`/`grep -n` assertion over `skills/woostack-fix/SKILL.md` with exact expected output, plus `skills/woostack-init/scripts/build-index.sh` and `woostack-doctor` ending clean.
+
+> **Increments stack linearly:** Increment 2 branches off Increment 1's tip and sees its edits. The two touch disjoint regions of the file (Increment 1: a new section + step 1 + one constraint bullet; Increment 2: Overview diagram + gate paragraph + procedure steps + other constraint bullets), so each PR diff stands alone.
+
+> **Anchor note for the executor:** all `old_string` anchors below are quoted verbatim from `skills/woostack-fix/SKILL.md` at the increment's start. Re-grep before each Edit if the file has drifted.
+
+---
+
+## Increment 1: Add the `--inline` / `--subagent` debug driver to fix step 1
+
+> One independently shippable PR. Adds a `## Debug investigation mode` section, points step 1 at it, and adds one Hard-constraints bullet. Covers spec **AC1** and **AC2**.
+
+### Task 1: Add the `## Debug investigation mode` section
+
+**Files:**
+- Modify: `skills/woostack-fix/SKILL.md` (insert a new section between the Overview's gate paragraph and `## Procedure`)
+- Test: grep assertions over the same file
+
+- [ ] **Step 1: Write the failing test**
+  ```bash
+  # .woostack/tmp/inc1_section.sh — run from repo root
+  set -e
+  f=skills/woostack-fix/SKILL.md
+  grep -q '^## Debug investigation mode$' "$f" \
+    && grep -q 'Smart default (no flag): subagent where the host can spawn' "$f" \
+    && grep -q 'Passing both `--inline` and `--subagent` is an error' "$f" \
+    && grep -q 'no worktree and no cwd-pin' "$f" \
+    && grep -q 'returns a \*\*blocked status' "$f" \
+    && grep -q 'general-purpose' "$f"
+  echo "PASS"
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: `bash .woostack/tmp/inc1_section.sh; echo "exit=$?"`
+  Expected: FAIL — no `PASS` printed; `exit=1` (the `^## Debug investigation mode$` grep fails first).
+
+- [ ] **Step 3: Minimal implementation**
+  Edit `skills/woostack-fix/SKILL.md`. Insert the following section immediately **after** the Overview gate paragraph (the paragraph beginning `The skill has exactly **one** hard gate:`) and **before** `## Procedure`:
+  ```markdown
+  ## Debug investigation mode
+
+  Step 1's root-cause investigation runs through one of two drivers — the same `--inline` /
+  `--subagent` selection [`woostack-execute`](../woostack-execute/SKILL.md#execution-mode) uses
+  for its implement step; only *what* is delegated differs (here the read-only debug
+  investigation, not implementation). Pass the flag on the fix invocation; the flags are mutually
+  exclusive and an explicit flag always wins.
+
+  - **inline** — the fix orchestrator runs `/woostack-debug` itself, in this session (today's
+    behavior).
+  - **subagent** — dispatch a fresh `general-purpose` investigator subagent that runs the
+    `woostack-debug` four-phase analysis and returns **only** its Phase 4 handback (root-cause
+    summary + proposed minimal fix + TDD context). All the heavy investigation material — reading
+    errors, `git diff`, data-flow tracing — stays in the subagent, keeping the orchestrator
+    context small.
+
+  **Smart default (no flag): subagent where the host can spawn** a subagent (an `Agent`/`Task`
+  tool is available), else inline — the same rule `woostack-execute` uses. If `--subagent` is
+  requested but the host cannot spawn, fall back to inline (degraded — say so) or stop and ask;
+  never pretend subagent mode ran. Passing both `--inline` and `--subagent` is an error: stop and
+  ask which to use.
+
+  **The debug subagent is read-only and needs no worktree and no cwd-pin.** `woostack-debug`
+  never writes code, commits, or `.woostack/` artifacts, so the investigator — unlike
+  `woostack-execute`'s implementer subagent, which must self-pin to its worktree (see the
+  [worktree contract](../woostack-init/references/worktrees.md)) — pins to nothing. Step 1 also
+  runs **before** the fix worktree is created (step 2), so there is nothing to pin to.
+
+  **No root cause found.** In **inline** mode, `woostack-debug` stops and asks the user for hints,
+  as today. In **subagent** mode the subagent cannot prompt mid-run, so it returns a **blocked
+  status plus what it investigated**, and the orchestrator surfaces that to the user (mirroring
+  `woostack-execute`'s BLOCKED escalation) — never guess a fix plan from a failed investigation.
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  Run: `bash .woostack/tmp/inc1_section.sh`
+  Expected: PASS
+
+- [ ] **Step 5: Commit**
+  ```bash
+  # First commit in the increment:
+  gt create -m "feat(fix): add --inline/--subagent debug investigation mode"
+  ```
+
+### Task 2: Point step 1 at the driver
+
+**Files:**
+- Modify: `skills/woostack-fix/SKILL.md` step 1 (the `1. **Diagnose the root cause.**` block)
+- Test: grep assertions
+
+- [ ] **Step 1: Write the failing test**
+  ```bash
+  # .woostack/tmp/inc1_step1.sh — run from repo root
+  set -e
+  f=skills/woostack-fix/SKILL.md
+  grep -q 'through the selected driver' "$f" \
+    && grep -q 'see \[Debug investigation mode\](#debug-investigation-mode)' "$f"
+  echo "PASS"
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: `bash .woostack/tmp/inc1_step1.sh; echo "exit=$?"`
+  Expected: FAIL — `exit=1`; the phrase `through the selected driver` is absent.
+
+- [ ] **Step 3: Minimal implementation**
+  In `skills/woostack-fix/SKILL.md`, replace this exact block (step 1's lead-in + the fenced command):
+  ```markdown
+  1. **Diagnose the root cause.**
+     Run the systematic-debugging skill to find the root cause before proposing any code edits.
+     ```
+     /woostack-debug <target>
+     ```
+  ```
+  with:
+  ```markdown
+  1. **Diagnose the root cause.**
+     Run the systematic-debugging skill to find the root cause before proposing any code edits,
+     through the selected driver — inline, or a read-only subagent (see
+     [Debug investigation mode](#debug-investigation-mode)).
+     ```
+     /woostack-debug <target>   # inline, or dispatched to a read-only investigator subagent
+     ```
+  ```
+  Then replace the step's trailing sentence:
+  ```markdown
+  If it cannot find a root cause, do not guess: stop and ask the user for hints.
+  ```
+  with:
+  ```markdown
+  If it cannot find a root cause, do not guess: inline, stop and ask the user for hints; in
+  subagent mode the investigator returns a blocked status plus what it investigated, which you
+  surface to the user (see [Debug investigation mode](#debug-investigation-mode)).
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  Run: `bash .woostack/tmp/inc1_step1.sh`
+  Expected: PASS
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs(fix): route step 1 diagnosis through the debug driver"
+  ```
+
+### Task 3: Add the Hard-constraints `Debug driver` bullet + verify the store
+
+**Files:**
+- Modify: `skills/woostack-fix/SKILL.md` `## Hard constraints`
+- Verify: `skills/woostack-init/scripts/build-index.sh`, `woostack-doctor`
+
+- [ ] **Step 1: Write the failing test**
+  ```bash
+  # .woostack/tmp/inc1_constraint.sh — run from repo root
+  set -e
+  f=skills/woostack-fix/SKILL.md
+  grep -q '\*\*Debug driver\.\*\* Step 1' "$f"
+  echo "PASS"
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: `bash .woostack/tmp/inc1_constraint.sh; echo "exit=$?"`
+  Expected: FAIL — `exit=1`.
+
+- [ ] **Step 3: Minimal implementation**
+  In `skills/woostack-fix/SKILL.md`, insert this bullet into `## Hard constraints` immediately **after** the `- **No guess-and-check.** ...` bullet:
+  ```markdown
+  - **Debug driver.** Step 1's investigation runs inline or via a read-only `general-purpose` subagent (`--inline`/`--subagent`, smart default = subagent where the host can spawn, else inline); the subagent returns only `woostack-debug`'s Phase 4 handback and needs no worktree. See [Debug investigation mode](#debug-investigation-mode).
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  Run: `bash .woostack/tmp/inc1_constraint.sh`
+  Expected: PASS
+
+- [ ] **Step 5: Verify the store is clean**
+  Run:
+  ```bash
+  bash skills/woostack-init/scripts/build-index.sh
+  bash skills/woostack-doctor/scripts/doctor.sh --check
+  ```
+  Expected: build-index exits 0; `doctor.sh --check` exits 0 (no error). The `.woostack/tmp/inc1_*.sh` scratch scripts live in the gitignored `.woostack/tmp/` (root `.gitignore` line 63), so they never ride the PR — no cleanup step needed.
+
+- [ ] **Step 6: Commit**
+  ```bash
+  gt modify -c -m "docs(fix): add Debug driver hard constraint"
+  ```
+
+---
+
+## Increment 2: Commit the fix plan as a docs-only PR before the approve-to-execute gate
+
+> One independently shippable PR, stacked on Increment 1. Reorders the procedure so the fix plan is committed (docs-only PR, stack base) before the gate, build-style; updates the Overview diagram, the gate paragraph, the worktree prose, and Hard constraints. Covers spec **AC3** and **AC4**.
+
+### Task 1: Reorder the Overview diagram and rewrite the gate paragraph
+
+**Files:**
+- Modify: `skills/woostack-fix/SKILL.md` Overview (the fenced flow diagram + the gate paragraph)
+- Test: grep assertions
+
+- [ ] **Step 1: Write the failing test**
+  ```bash
+  # .woostack/tmp/inc2_overview.sh — run from repo root
+  set -e
+  f=skills/woostack-fix/SKILL.md
+  grep -q 'commit fix plan as a docs-only PR (stack base' "$f" \
+    && grep -q 'approve-to-execute (GATE)' "$f" \
+    && grep -q 'fresh code-increment worktree off' "$f" \
+    && grep -q 'two PRs (docs base + code increment)' "$f"
+  echo "PASS"
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: `bash .woostack/tmp/inc2_overview.sh; echo "exit=$?"`
+  Expected: FAIL — `exit=1`.
+
+- [ ] **Step 3: Minimal implementation**
+  In `skills/woostack-fix/SKILL.md`, replace the Overview diagram block:
+  ```
+  diagnose root cause (woostack-debug) → write fix plan (fixes/ markdown) → harden fix plan 
+    → approve fix plan (GATE) → execute via woostack-execute
+    (branch → TDD per task → tick → commit via woostack-commit → task review → distill)
+  ```
+  with:
+  ```
+  diagnose root cause (woostack-debug) → write fix plan (fixes/ markdown) → harden fix plan
+    → commit fix plan as a docs-only PR (stack base, via woostack-commit)
+    → approve-to-execute (GATE) → execute via woostack-execute
+    (fresh code-increment worktree off fix/<slug> tip → TDD per task → tick
+     → commit via woostack-commit → task review → distill)
+  ```
+  Then replace the gate paragraph:
+  ```markdown
+  The skill has exactly **one** hard gate: **fix plan approval**. Because the plan contains both the diagnosis (the spec part) and the steps (the plan part), a single approval stop protects the codebase from wrong fixes or poor plans before implementation begins. Delegation adds no gate: `woostack-execute` owns no approval gate and never merges, so the fix's one gate stays upstream of execution.
+  ```
+  with:
+  ```markdown
+  The skill has exactly **one** hard gate: **approve-to-execute**. The fix plan is first committed as a docs-only PR (the stack base) and *then* presented for approval — build-style (mirroring [`woostack-build`](../woostack-build/SKILL.md) steps 7-8), so the approved plan is a committed, reviewable artifact and the code increment stacks on top. The gate still protects the codebase: no implementation happens until it clears, and a fix is therefore **two PRs (docs base + code increment)**. Delegation adds no gate: `woostack-execute` owns no approval gate and never merges, so the fix's one gate stays upstream of execution.
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  Run: `bash .woostack/tmp/inc2_overview.sh`
+  Expected: PASS
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt create -m "feat(fix): commit the fix plan as a docs PR before the execute gate"
+  ```
+
+### Task 2: Reorder the procedure — commit the plan before the gate, with the worktree lifecycle
+
+**Files:**
+- Modify: `skills/woostack-fix/SKILL.md` procedure steps (the approval step, the execute step's worktree-reuse prose, the teardown step)
+- Test: grep + ordering assertion
+
+- [ ] **Step 1: Write the failing test**
+  ```bash
+  # .woostack/tmp/inc2_procedure.sh — run from repo root
+  set -e
+  f=skills/woostack-fix/SKILL.md
+  # required phrases
+  grep -q 'Commit the fix plan as a docs-only PR (stack base)' "$f"
+  grep -q 'Approve to execute (GATE)' "$f"
+  grep -q 'stays alive across the gate' "$f"
+  grep -q 'torn down only on Go' "$f"
+  grep -q 'cuts a fresh code-increment worktree' "$f"
+  grep -q '\*\*Revise\*\*' "$f" && grep -q '\*\*Abandon\*\*' "$f"
+  # ordering: the commit-the-plan step must appear BEFORE the gate step
+  commit_ln=$(grep -n 'Commit the fix plan as a docs-only PR (stack base)' "$f" | head -1 | cut -d: -f1)
+  gate_ln=$(grep -n 'Approve to execute (GATE)' "$f" | head -1 | cut -d: -f1)
+  test "$commit_ln" -lt "$gate_ln"
+  echo "PASS (commit@$commit_ln < gate@$gate_ln)"
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: `bash .woostack/tmp/inc2_procedure.sh; echo "exit=$?"`
+  Expected: FAIL — `exit=1`; `Commit the fix plan as a docs-only PR (stack base)` is absent.
+
+- [ ] **Step 3: Minimal implementation**
+  Apply these edits to `skills/woostack-fix/SKILL.md`.
+
+  > **Why one combined step, not a new numbered step:** inserting a new `5.` would force renumbering the existing execute (5) and track (6) steps and every `step 5`/`step 6` cross-reference in the file (e.g. "(run by `woostack-execute` in step 5)"). Folding commit + gate into step 4 (commit prose first, then the gate) keeps steps 5/6 and their references intact while still satisfying the commit-before-gate ordering assertion.
+
+  (a) Replace the approval step — the line `4. **Get explicit approval (GATE).**` plus its body paragraph (ending `When approved, set the frontmatter \`status: approved\`.`) — with this single combined step:
+  ```markdown
+  4. **Commit the fix plan as a docs-only PR (stack base), then approve to execute (GATE).**
+     First, **commit the fix plan**: with it hardened, commit via
+     [`woostack-commit`](../woostack-commit/SKILL.md) on the `fix/<slug>` branch from inside the
+     fix worktree — a **docs-only PR** carrying only the `.woostack/fixes/` markdown, no code; the
+     **stack base** (mirroring [`woostack-build`](../woostack-build/SKILL.md) step 7). Leave the
+     frontmatter at `status: hardened` — the lifecycle advances only at the gate.
+
+     Then the gate — **Approve to execute (GATE)**: **always present the committed fix-plan PR and
+     get explicit approval before executing** (the skill's single hard gate, build step-8 style).
+     Point the user at the PR and the fix-file path and wait for a clear yes:
+     - **Go** → set `status: approved` and proceed to step 5. The fix worktree **stays alive
+       across the gate** and is **torn down only on Go** — on Go, tear it down
+       (`git worktree remove "$WOOSTACK_ROOT/.woostack/worktrees/fix-<slug>"`), then step 5's
+       `woostack-execute` **cuts a fresh code-increment worktree** off the `fix/<slug>` tip.
+     - **Revise** → amend the fix plan in the still-alive fix worktree, re-push the docs PR, and
+       re-present at the gate.
+     - **Abandon** → close the docs PR, `git worktree remove --force` the fix worktree, and delete
+       the `fix/<slug>` branch; no code was implemented.
+     Never execute on inferred or assumed approval; silence is not a yes.
+  ```
+
+  (b) In the execute step (step 5, unchanged number), replace the worktree-reuse sentence:
+  ```markdown
+   step 2), so execute **verifies and reuses** that worktree rather than re-creating it, then
+  ```
+  with (factual correction only — the lifecycle tokens live in step 4):
+  ```markdown
+   step 2) but holds only the committed plan as the docs-PR stack base; the code increment runs in
+   the fresh worktree execute cut off the `fix/<slug>` tip at the Go transition (step 4), not the
+   step-2 fix-plan worktree, and execute then
+  ```
+
+  (c) In the track-and-lifecycle step (step 6, unchanged number), replace the teardown sentence:
+  ```markdown
+     After the PR is open and the frontmatter is set, **teardown** the fix worktree
+     (`git worktree remove "$WOOSTACK_ROOT/.woostack/worktrees/fix-<slug>"`); the branch/commits/PR
+     persist. **Leave it on failure** and report its path.
+  ```
+  with:
+  ```markdown
+     The fix-plan worktree was already torn down at the **Go** transition (step 4); the
+     code-increment worktree `woostack-execute` cut is torn down by execute after the code PR is
+     open. The branches/commits/PRs persist. **Leave a worktree on failure** and report its path.
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  Run: `bash .woostack/tmp/inc2_procedure.sh`
+  Expected: PASS (prints `PASS (commit@N < gate@M)`).
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "feat(fix): reorder procedure to commit plan before the gate; worktree lifecycle"
+  ```
+
+### Task 3: Update Hard constraints + verify the store
+
+**Files:**
+- Modify: `skills/woostack-fix/SKILL.md` `## Hard constraints`
+- Verify: `build-index.sh`, `woostack-doctor`
+
+- [ ] **Step 1: Write the failing test**
+  ```bash
+  # .woostack/tmp/inc2_constraint.sh — run from repo root
+  set -e
+  f=skills/woostack-fix/SKILL.md
+  grep -q '\*\*Commit the plan before the gate\.\*\*' "$f"
+  grep -q '\*\*Worktree lives across the gate\.\*\*' "$f"
+  # AC4 invariants still present
+  grep -q '\*\*Delegate execution\.\*\*' "$f"
+  grep -q '\*\*Never merge\.\*\*' "$f"
+  echo "PASS"
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: `bash .woostack/tmp/inc2_constraint.sh; echo "exit=$?"`
+  Expected: FAIL — `exit=1`; the two new bullets are absent (the `Delegate execution` / `Never merge` greps already pass, proving AC4 invariants are preserved).
+
+- [ ] **Step 3: Minimal implementation**
+  In `skills/woostack-fix/SKILL.md` `## Hard constraints`, insert these two bullets immediately **after** the `- **Wait for explicit approval.** ...` bullet:
+  ```markdown
+  - **Commit the plan before the gate.** The fix plan is committed as a docs-only PR (stack base) via `woostack-commit` **before** the approve-to-execute gate — build-style; a fix is two PRs (docs base + code increment).
+  - **Worktree lives across the gate.** The fix worktree stays alive across the approve-to-execute gate (so revise/abandon are cheap) and is torn down only on **Go**; `woostack-execute` then cuts a fresh code-increment worktree off the `fix/<slug>` tip — it does not reuse the step-2 worktree.
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  Run: `bash .woostack/tmp/inc2_constraint.sh`
+  Expected: PASS
+
+- [ ] **Step 5: Verify the store is clean**
+  Run:
+  ```bash
+  bash skills/woostack-init/scripts/build-index.sh
+  bash skills/woostack-doctor/scripts/doctor.sh --check
+  ```
+  Expected: build-index exits 0; `doctor.sh --check` exits 0 (no error). The `.woostack/tmp/inc2_*.sh` scratch scripts live in the gitignored `.woostack/tmp/`, so they never ride the PR — no cleanup step needed.
+
+- [ ] **Step 6: Commit**
+  ```bash
+  gt modify -c -m "docs(fix): add commit-before-gate and worktree-lifecycle constraints"
+  ```
+
+---
+
+## Plan Checks
+
+- **Spec coverage** — AC1 → Increment 1 Tasks 1-2 (flags, smart default, both-flags error, degrade); AC2 → Increment 1 Tasks 1-3 (handback-only, read-only/no-worktree, blocked path, general-purpose); AC3 → Increment 2 Tasks 1-2 (commit-before-gate ordering assertion, 2 PRs, fresh worktree off tip); AC4 → Increment 2 Task 3 (delegate/never-merge greps still pass) + the unchanged harden/lifecycle steps.
+- **AC coverage** — every filled happy/error/edge case in spec §7 maps to a grep above; no §7 case is whole-section `N/A`.
+- **No placeholders** — every Step carries the exact SKILL markdown to insert and the exact `grep`/command with expected output.
+- **Type consistency** — heading/token strings asserted by greps match the strings written in the implementation steps verbatim (`## Debug investigation mode`, `Commit the fix plan as a docs-only PR (stack base)`, `Approve to execute (GATE)`).
+- **No code edits outside `skills/woostack-fix/SKILL.md`** — cross-link targets (`woostack-execute#execution-mode`, the worktree contract) already exist; `woostack-debug`/`woostack-execute` SKILLs are not edited.
+- **No spec/plan status mutation in tasks** — these are edits to the *shipped* `woostack-fix` skill, not to this build's own `.woostack/` artifacts. No task touches this spec's or plan's frontmatter; this build's spec stays `approved` and the plan owns its own `planning`→`ready` band (set by the build loop, not by a task).
+- **Step numbering preserved** — Increment 2 folds commit+gate into step 4 (no new numbered step), so the execute (5) and track (6) steps and every `step 5`/`step 6` cross-reference in the SKILL stay valid.

--- a/.woostack/plans/2026-06-14-fix-subagent-debug-and-plan-pr.md
+++ b/.woostack/plans/2026-06-14-fix-subagent-debug-and-plan-pr.md
@@ -40,7 +40,7 @@ branch: feature/fix-subagent-debug-and-plan-pr
     && grep -q 'Smart default (no flag): subagent where the host can spawn' "$f" \
     && grep -q 'Passing both `--inline` and `--subagent` is an error' "$f" \
     && grep -q 'no worktree and no cwd-pin' "$f" \
-    && grep -q 'returns a \*\*blocked status' "$f" \
+    && grep -q 'it returns a \*\*blocked' "$f" \
     && grep -q 'general-purpose' "$f"
   echo "PASS"
   ```
@@ -330,13 +330,18 @@ branch: feature/fix-subagent-debug-and-plan-pr
   ```markdown
      After the PR is open and the frontmatter is set, **teardown** the fix worktree
      (`git worktree remove "$WOOSTACK_ROOT/.woostack/worktrees/fix-<slug>"`); the branch/commits/PR
-     persist. **Leave it on failure** and report its path.
+     persist. **Leave it on failure** and report its path. The memory distill (run by `woostack-execute`
+     in step 5) targets the primary tree via the `WOOSTACK_ROOT` export of the [worktree
+     contract](../woostack-init/references/worktrees.md) §5, so it survives teardown.
   ```
   with:
   ```markdown
      The fix-plan worktree was already torn down at the **Go** transition (step 4); the
      code-increment worktree `woostack-execute` cut is torn down by execute after the code PR is
-     open. The branches/commits/PRs persist. **Leave a worktree on failure** and report its path.
+     open. The branches/commits/PRs persist. **Leave a worktree on failure** and report its path. The
+     memory distill (run by `woostack-execute` in step 5) targets the primary tree via the
+     `WOOSTACK_ROOT` export of the [worktree contract](../woostack-init/references/worktrees.md) §5,
+     so it survives teardown.
   ```
 
 - [ ] **Step 4: Run the test, confirm it passes**

--- a/.woostack/specs/2026-06-14-fix-subagent-debug-and-plan-pr.md
+++ b/.woostack/specs/2026-06-14-fix-subagent-debug-and-plan-pr.md
@@ -1,0 +1,128 @@
+---
+name: 2026-06-14-fix-subagent-debug-and-plan-pr
+type: spec
+status: approved
+date: 2026-06-14
+branch: feature/fix-subagent-debug-and-plan-pr
+links:
+---
+
+# Tighten the woostack-fix loop: subagent debug + plan PR before the execute gate — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
+> **Plan:** [[plans/2026-06-14-fix-subagent-debug-and-plan-pr]]
+
+## 1. Problem
+
+The `woostack-fix` loop carries two structural rough edges, both in `skills/woostack-fix/SKILL.md`:
+
+1. **Debug bloats the orchestrator context.** Step 1 runs `woostack-debug` **inline** in the fix-loop session. Debug is a big read fan-out — read errors completely, `git diff`, trace data flow backward across components, pattern-compare working vs broken (`woostack-debug/SKILL.md:41-66`) — but its useful output is the small Phase 4 handback (root-cause summary + proposed minimal fix + TDD context, `woostack-debug/SKILL.md:78-82`). Running it inline leaves all the raw investigation material — file reads, greps, stack traces — resident in the orchestrator that owns the approval gate and the lifecycle, for no further use.
+
+2. **The fix plan is not committed before the execute gate.** Today fix's single hard gate (fix-plan approval, `woostack-fix/SKILL.md:62-63`) sits **before** any commit; the fix markdown stays uncommitted in the fix worktree until `woostack-execute` commits it together with the implementation code. There is no committed, reviewable record of the plan that was approved, and the shape diverges from `woostack-build`, where the spec+plan ship as their own docs-only PR (the stack base) *before* the execution-handoff gate (`woostack-build` steps 7-8).
+
+## 2. Goal
+
+Edit `skills/woostack-fix/SKILL.md` so the fix loop:
+
+1. Can dispatch its step-1 debug investigation to a **read-only investigator subagent** that returns only the Phase 4 handback, keeping the orchestrator context small — selected by a smart default that mirrors `woostack-execute`'s `--inline`/`--subagent` driver.
+2. **Commits the fix plan as its own docs-only PR** (the stack base) **before** the approval-to-execute gate, with the code increment stacking on top — mirroring `woostack-build` steps 7-8.
+
+Mode A change (skill-collection edit). No application code. The two changes are independent and ship as two increments under one plan.
+
+## 3. Non-goals
+
+- **Not** changing `woostack-debug` itself — it stays investigative-only, autonomous, no flag (`woostack-debug/SKILL.md:88-93`, `141-142`). Fix decides *where* debug runs; debug's own contract is untouched.
+- **Not** delegating `harden` (fix step 3, interactive + writes the fix file) or the lifecycle frontmatter — those stay orchestrator-owned.
+- **Not** re-inlining a TDD/commit/distill loop — execution still delegates to `woostack-execute` ([[fix-delegates-to-execute]]).
+- **Not** introducing a new shared mode-selection reference file — cross-link `woostack-execute`'s existing prose.
+- **Not** expanding fix's single gate into build's full Go / Overnight / Hand off triad — fix keeps one simple approve-to-execute gate.
+- **Never** merges.
+
+## 4. Approach
+
+### Increment 1 — delegate debug to a read-only subagent
+
+Rewrite fix step 1 so the debug investigation runs through one of two drivers, selecting with the **same vocabulary** as `woostack-execute`:
+
+- **Flags:** `--inline` / `--subagent`, mutually exclusive; explicit flag wins. **Smart default (no flag):** subagent where the host can spawn (an `Agent`/`Task` tool is available), else inline — the *same* rule as `woostack-execute`, chosen because the whole point is to keep the orchestrator context small (a trivial one-file bug pays a little spawn overhead; the user passes `--inline` to opt out). If `--subagent` is requested but the host cannot spawn, fall back to inline (degraded, say so) or stop — never pretend subagent mode ran. Cross-link `woostack-execute`'s [Execution mode](../woostack-execute/SKILL.md) prose rather than restating the selection logic.
+- **inline:** the orchestrator runs `/woostack-debug` itself, as today.
+- **subagent:** dispatch a fresh `general-purpose` investigator subagent that runs the `woostack-debug` four-phase analysis and returns **only** the Phase 4 handback (root-cause summary + proposed minimal fix + TDD context). The orchestrator carries that handback into the fix plan's `## 2. Proposed Fix`. `general-purpose` (not `Explore`) because debug must *read errors completely* and trace data flow — `Explore` is excerpt-only and would undercut that.
+- **Read-only / no worktree:** state explicitly that the debug subagent never writes code, commits, or `.woostack/` artifacts (governed by `woostack-debug`'s investigative-only contract), so — unlike `woostack-execute`'s implementer subagent — it needs **no worktree and no cwd-pin**. Step 1 runs *before* the fix worktree is created (fix step 2), so there is nothing to pin to. Contrast with [[subagent-self-pins-to-worktree]].
+- **No-root-cause wrinkle:** `woostack-debug` stops and asks the user for hints when it cannot find a root cause (`woostack-fix/SKILL.md:27`). A subagent cannot prompt mid-run, so the dispatched investigator must instead **return a blocked status plus what it investigated**, and the orchestrator surfaces that to the user (mirroring `woostack-execute`'s BLOCKED escalation, `woostack-execute/SKILL.md:214-215`).
+
+### Increment 2 — commit the fix plan before the execute gate (build-style docs PR)
+
+Reorder and rewrite the fix procedure so the committed plan PR is the stack base:
+
+```
+diagnose → write fix plan → harden
+  → commit fix plan as a docs-only PR (stack base) via woostack-commit
+  → approval-to-execute GATE
+  → execute: code increment stacks as a 2nd PR on top
+```
+
+- The fix-plan **docs-only PR** is committed (in the fix-plan worktree, on `fix/<slug>`) and opened *before* the gate. The gate stays fix's single hard gate, with semantics shifted to build's step-8 "approve to execute" (after the docs PR), not pre-commit plan approval.
+- **Worktree teardown happens after the gate clears, not right after the docs PR.** Because the approve-to-execute gate sits after the docs PR, the fix-plan worktree must stay **alive across the gate** so a reject/revise can amend the plan cheaply. Lifecycle:
+  - **Go** → teardown the fix-plan worktree; `woostack-execute` then **creates a fresh code-increment worktree** off the `fix/<slug>` branch tip (it no longer "verifies and reuses" the step-2 worktree), per the [worktree contract](../woostack-init/references/worktrees.md) §4 (stacked increment k → increment k-1 branch tip).
+  - **Revise** → amend the fix plan in the still-alive worktree, re-push the docs PR, re-present at the gate.
+  - **Abandon** → close the docs PR, `git worktree remove --force` the worktree, delete the `fix/<slug>` branch.
+  This is a deliberate, documented divergence from build's literal "teardown right after the PR" (build can teardown immediately because its gate — spec approval — is *upstream* of the docs PR, whereas fix's single gate is *downstream* of it).
+- **Branch shape.** `fix/<slug>` is the docs-PR stack base (holds only the fix markdown). The code-increment branch is created by `woostack-execute` under its normal per-increment naming, stacked on `fix/<slug>`. The fix markdown's `## 3. Implementation Plan` checkboxes are ticked by `woostack-execute` in the **code-increment** worktree (which branches off `fix/<slug>` and so *has* the committed plan), so the ticks ride the **code** PR while the docs PR carries the unticked plan — exactly as build commits the plan in the docs PR and ticks ride increment PRs.
+- A fix becomes **2 PRs**: docs base (fix plan) + code increment.
+
+## 5. Components & data flow
+
+Single file edited: `skills/woostack-fix/SKILL.md` (Overview diagram, step 1, steps 2-6 reorder, Hard constraints). Cross-links only — `woostack-execute` SKILL ([Execution mode]) and the worktree contract — no new files, no edits to `woostack-debug` or `woostack-execute`.
+
+Data flow (subagent debug): fix orchestrator → dispatch investigator subagent (target + recalled gotchas) → subagent runs debug Phases 1-4 → returns Phase 4 handback **or** blocked+findings → orchestrator writes Proposed Fix / surfaces blocker.
+
+Data flow (docs PR): fix plan markdown → `woostack-commit` on `fix/<slug>` (docs-only PR, base = resolved base) → approval gate → `woostack-execute` cuts code-increment worktree off `fix/<slug>` tip → code increment PR stacked on the docs PR.
+
+## 6. Error handling
+
+- **`--subagent` on a host that cannot spawn** → fall back to inline and say so, or stop; never silently pretend.
+- **Both flags passed** → error, stop and ask which (mirror execute).
+- **Debug subagent finds no root cause** → returns blocked + investigated-list; orchestrator surfaces to user and does not proceed to write a guessed fix plan.
+- **Docs-PR commit / push fails** → leave the fix-plan worktree, report its path (worktree contract §2 leave-on-failure); do not advance to the gate.
+- **Gate rejected → revise** → amend the plan in the still-alive fix-plan worktree, re-push the docs PR, re-present (do not teardown).
+- **Gate rejected → abandon** → close the docs PR, `git worktree remove --force` the fix-plan worktree, delete the `fix/<slug>` branch; no code was ever implemented.
+
+## 7. Acceptance criteria
+
+This is a SKILL.md markdown edit; ACs are grep-checkable assertions over `skills/woostack-fix/SKILL.md` plus a clean `woostack-doctor`/`build-index`.
+
+- **AC1 — fix step 1 offers an inline/subagent debug driver with a smart default**
+  - happy: the SKILL names both `--inline` and `--subagent` for the debug investigation and the no-flag smart default (subagent where the host can spawn, else inline — the same rule as `woostack-execute`).
+  - error: requesting `--subagent` where the host cannot spawn is documented to fall back to inline (stated) or stop — never pretend.
+  - edge: passing both flags is documented as an error (stop and ask).
+- **AC2 — the debug subagent is documented as read-only, no-worktree, returning only the handback**
+  - happy: SKILL states the debug subagent returns only the Phase 4 handback (root-cause + proposed fix + TDD context) and that it needs no worktree / no cwd-pin (runs before the fix worktree).
+  - error: SKILL states the no-root-cause case returns a blocked status + what-was-investigated and the orchestrator surfaces it to the user.
+  - edge: N/A — mode selection cross-links execute rather than restating (asserted by AC1 + a link presence check).
+- **AC3 — the fix procedure commits the fix plan before the approval-to-execute gate**
+  - happy: in the SKILL procedure, the "commit the fix plan" step appears **before** the approval-to-execute gate, and the gate is described as approve-to-execute after the docs PR.
+  - error: N/A — ordering is a static document property.
+  - edge: SKILL states a fix is 2 PRs (docs base + code increment); that the fix-plan worktree is torn down **after the gate clears (on Go)**, not right after the docs PR, with revise/abandon paths documented; and that `woostack-execute` cuts a fresh code-increment worktree off the `fix/<slug>` tip (no longer reuses the step-2 worktree).
+- **AC4 — invariants preserved**
+  - happy: SKILL still delegates execution to `woostack-execute`, keeps harden + lifecycle frontmatter orchestrator-owned, and states "never merge."
+  - error: N/A.
+  - edge: `woostack-debug` and `woostack-execute` SKILLs are unchanged by this work (no edits outside `woostack-fix/SKILL.md` except cross-link targets that already exist).
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+No code runner (markdown skills repo). Verification is grep-based assertions over `skills/woostack-fix/SKILL.md` for the tokens/orderings in §7, run as explicit shell checks per plan task, plus `woostack-init`'s `build-index.sh` and `woostack-doctor` (or `doctor.sh`) ending clean. Ordering ACs (AC3) verified by comparing line numbers of the "commit fix plan" step vs the gate via `grep -n`.
+
+## 9. Open questions
+
+Resolved during ideate: flag vocabulary = execute's `--inline`/`--subagent`; cross-link not a new ref file; `general-purpose` investigator; build-style 2-PR docs base.
+
+Resolved during spec harden:
+- **Worktree teardown timing** → teardown **after the gate clears (on Go)**, keeping the fix-plan worktree alive across the gate so reject/revise/abandon are cheap (a documented divergence from build's "teardown right after the PR", because fix's single gate is *downstream* of the docs PR while build's is upstream). See §4 increment 2 and §6.
+- **No-flag smart default** → **subagent where the host can spawn, else inline** — the same rule as `woostack-execute` (serves the context-bloat goal; `--inline` opts out). See §4 increment 1 and AC1.
+
+None remaining. Sequencing nuances are for the plan harden (build step 6).


### PR DESCRIPTION
## Goal

Ship the approved spec and ready plan for tightening the `woostack-fix` loop as the docs-only base of the stack, so the two implementation increments can stack on top during execute. No code in this PR.

## Summary

- Spec + plan to add an `--inline` / `--subagent` read-only-subagent driver to `woostack-fix` step 1's debug investigation (smart default mirroring `woostack-execute`): the subagent runs `woostack-debug` and returns only its Phase 4 handback, keeping the orchestrator context small.
- Spec + plan to commit the fix plan as a docs-only PR (stack base) **before** a build-style approve-to-execute gate, with the fix worktree kept alive across the gate and torn down only on Go (revise/abandon paths documented).
- Plan decomposes the work into two PR-sized increments, each a grep-TDD edit to `skills/woostack-fix/SKILL.md` only; no edits to `woostack-debug`/`woostack-execute`.

## Test plan

### Manual

**Before merge**

- [ ] Read the spec and plan; confirm the two increments are independently shippable and each grep assertion matches the SKILL text the implementation step inserts.

Spec: .woostack/specs/2026-06-14-fix-subagent-debug-and-plan-pr.md
