### PR TITLE
chore(obsidian): ignore overnight/ in userIgnoreFilters

### DIFF
--- a/.woostack/.obsidian/app.json
+++ b/.woostack/.obsidian/app.json
@@ -1,6 +1,7 @@
 {
   "userIgnoreFilters": [
     "review-tmp/",
-    "tmp/"
+    "tmp/",
+    "overnight/"
   ]
 }


### PR DESCRIPTION
## Goal

Prevent Obsidian from scanning or listing files in the `overnight/` directory, keeping the workspace view and search clean.

## Summary

- Add `"overnight/"` to `userIgnoreFilters` in `.woostack/.obsidian/app.json`.

## Test plan

### Manual

**Before merge**

- [ ] Verify that `.woostack/.obsidian/app.json` has `"overnight/"` in the list of ignored directories.
- [ ] Confirm Obsidian ignores the `overnight/` directory in search results and file views.
