### PR TITLE
docs(woostack): repair plan source: + spec→plan backlink joins

### DIFF
--- a/.woostack/plans/2026-06-02-review-metrics-overlap.md
+++ b/.woostack/plans/2026-06-02-review-metrics-overlap.md
@@ -20,6 +20,7 @@
 - **Create** `skills/woostack-review/scripts/tests/test-intersect-overlap.sh` — drives `intersect-findings.sh` over fixtures, asserts overlap shape.
 - **Create** `skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh` — drives `metrics-fold.sh`, asserts accumulation + v1→v2 reseed.
 
+source: .woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
 ---
 
 ## Task 1: Overlap computation in `emit_angle_metrics`

--- a/.woostack/plans/2026-06-13-woostack-sweep.md
+++ b/.woostack/plans/2026-06-13-woostack-sweep.md
@@ -223,6 +223,7 @@ Expected: opens with `---`, `name: woostack-sweep`, a `description:` line, `---`
 gt create -m "feat(sweep): woostack-sweep skill — single home of the drive-stack-to-clean review loop"
 ```
 
+source: .woostack/specs/2026-06-13-woostack-sweep.md
 ---
 
 ## Increment 2: Register `woostack-sweep` on the public command surface

--- a/.woostack/specs/2026-06-13-woostack-sweep.md
+++ b/.woostack/specs/2026-06-13-woostack-sweep.md
@@ -9,6 +9,8 @@ links:
 
 # woostack-sweep — Design Spec
 
+> **Plan:** [[plans/2026-06-13-woostack-sweep]]
+
 > Visualize on demand: render this file with [spec-template.html](../../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
 
 > `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).


### PR DESCRIPTION
## Goal

Clear three `fixable=auto` woostack-doctor findings so the `.woostack/` store passes its store-integrity lint without auto-fixable drift.

## Summary

- `plan-source-sync`: add `source:` frontmatter to `plans/2026-06-02-review-metrics-overlap.md` and `plans/2026-06-13-woostack-sweep.md`, synced from each plan's existing `**Source:**` line.
- `spec-plan-backlink`: add the `[[plans/2026-06-13-woostack-sweep]]` Obsidian backlink to `specs/2026-06-13-woostack-sweep.md` (post-H1 callout).
- Workspace-hygiene only; no skill behavior change.

## Test plan

### Automated

- [x] `bash woostack-doctor/scripts/doctor.sh .` re-run after repairs — both `plan-source-sync` findings and the `spec-plan-backlink` finding cleared; 0 errors, residual warnings are pre-existing report-only items.

### Manual

**Before merge**

- [ ] Inspect the diff: two `source:` lines + one `> **Plan:** [[plans/...]]` callout, 4 insertions total.
- [ ] Re-run `/woostack-doctor` and confirm the three auto findings no longer appear.
