### PR TITLE
feat(doctor): add plan-source-link check (legacy bare-path → wikilink)

### DIFF
--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -39,6 +39,7 @@ overloaded):
 | `status-band` | status value in the other artifact's band (spec↔plan); skips `fixes/` | warn | report | — |
 | `plan-source` | plan missing the `**Source:**` join line | warn | auto (`source:` resolves) / report | `<root> <plan> source-line` |
 | `plan-source-sync` | plan `source:` basename ≠ `**Source:**` line basename, or `source:` absent while the line is present | warn | auto | `<root> <plan> source-sync` |
+| `plan-source-link` | plan's `**Source:**` line is a legacy bare-path, not the canonical `[[specs/<basename>]]` wikilink | warn | auto | `<root> <plan> source-link` |
 | `orphan-worktree` (present) | unregistered dir under `.woostack/worktrees/` (may hold work) | warn | report | — |
 | `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
 | `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |
@@ -51,8 +52,8 @@ job; doctor only surfaces the structural signals. The spec↔plan join reuses th
 
 ## Doc-template & status drift (static vs computed)
 
-The doc-template checks — `doc-type` and `status-enum` here, with `status-band`, `plan-source`, and
-`plan-source-sync` landing in later increments of this stack — repair specs/plans/fixes toward their
+The doc-template checks — `doc-type` and `status-enum` here, with `status-band`, `plan-source`,
+`plan-source-sync`, and `plan-source-link` landing in later increments of this stack — repair specs/plans/fixes toward their
 templates and the conventions enum using **only file content** — no `git`, no PR, no network. They cover **static,
 authoring-time** drift; the **computed**, git/PR-derived execute→done band
 (`executing`/`in-review`/`done`) is never written here. That band stays

--- a/skills/woostack-doctor/scripts/checks/plan-source.sh
+++ b/skills/woostack-doctor/scripts/checks/plan-source.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # plan-source.sh — plans carry the canonical **Source:** join line, and source: frontmatter
-# names the same spec. Two codes:
+# names the same spec. Three codes:
 #   plan-source       missing **Source:** line  (auto when source: resolves to a spec, else report)
 #   plan-source-sync  source: basename != line basename  (auto: sync source: ← the line)
+#   plan-source-link  **Source:** line is a legacy bare-path, not the [[specs/x]] wikilink (auto)
 #   diagnose:  plan-source.sh <WOO_ROOT>
 #   repair:    plan-source.sh --fix <WOO_ROOT> <plan> source-line
 #              plan-source.sh --fix <WOO_ROOT> <plan> source-sync
+#              plan-source.sh --fix <WOO_ROOT> <plan> source-link
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HERE/../../../woostack-init/scripts/lib.sh"
@@ -44,6 +46,15 @@ if [ "${1:-}" = "--fix" ]; then
       set_field "$plan" source ".woostack/specs/$lb.md" || { emit error plan-source-sync manual "${plan#"$root"/}" "no frontmatter fence; set source: manually"; exit 1; }
       [ "$(basename_of "$(field "$plan" source)")" = "$lb" ] || { emit error plan-source-sync manual "${plan#"$root"/}" "source: did not sync to '$lb'"; exit 1; }   # phantom-repair guard (spec §6)
       exit 0 ;;
+    source-link)
+      grep -E '^\*\*Source:\*\*' "$plan" | grep -qF '[[specs/' && exit 0   # already a wikilink → no-op
+      lb="$(line_base "$plan")"; [ -z "$lb" ] && exit 0                     # no **Source:** line → nothing to canonicalize
+      # Replace only the path token on the **Source:** line; preserve the prefix and any trailing text.
+      awk -v lb="$lb" '
+        d==0 && /^\*\*Source:\*\*/ { sub(/(\.woostack\/)?specs\/[A-Za-z0-9._-]+(\.md)?/, "[[specs/" lb "]]"); d=1 }
+        {print}' "$plan" > "$plan.t" && mv "$plan.t" "$plan" || { rm -f "$plan.t"; emit error plan-source-link manual "${plan#"$root"/}" "could not rewrite the **Source:** line"; exit 1; }
+      grep -E '^\*\*Source:\*\*' "$plan" | grep -qF "[[specs/$lb]]" || { emit error plan-source-link manual "${plan#"$root"/}" "**Source:** line did not canonicalize to [[specs/$lb]]"; exit 1; }   # phantom-repair guard
+      exit 0 ;;
     *) exit 2 ;;
   esac
 fi
@@ -62,6 +73,14 @@ for plan in "$WOO_ROOT/.woostack/plans"/*.md; do
     fi
     continue
   fi
+  # The **Source:** line exists (lb non-empty). Its canonical form is the [[specs/<basename>]]
+  # wikilink — symmetric with the spec's [[plans/<basename>]] backlink, so the Obsidian graph
+  # links both ways. A legacy bare-path line still resolves (basename_of accepts it), so this is
+  # a gated nudge toward the wikilink, never a CI break.
+  case "$(grep -m1 -E '^\*\*Source:\*\*' "$plan")" in
+    *"[[specs/"*) : ;;
+    *) emit warn plan-source-link auto "$rp" "**Source:** line uses a legacy bare-path; canonicalize to the [[specs/$lb]] wikilink" ;;
+  esac
   sbase="$(basename_of "$(field "$plan" source)")"
   if [ -n "$sbase" ] && [ "$sbase" != "$lb" ]; then
     emit warn plan-source-sync auto "$rp" "source: names '$sbase' but **Source:** line names '$lb'; sync source: to the canonical line"

--- a/skills/woostack-doctor/scripts/tests/test-plan-source.sh
+++ b/skills/woostack-doctor/scripts/tests/test-plan-source.sh
@@ -29,7 +29,12 @@ assert_contains "$out" "$(printf 'warn\tplan-source\treport\t.woostack/plans/orp
 assert_contains "$out" "$(printf 'warn\tplan-source\treport\t.woostack/plans/gone.md')" "unresolvable source: is report, not auto"
 assert_contains "$out" "$(printf 'warn\tplan-source-sync\tauto\t.woostack/plans/sync.md')" "source/line basename mismatch"
 assert_contains "$out" "$(printf 'warn\tplan-source-sync\tauto\t.woostack/plans/line-no-key.md')" "line present, source: absent is auto sync"
-assert_not_contains "$out" ".woostack/plans/ok.md" "normalized in-sync plan has no finding"
+# ok.md is in sync (no plan-source-sync), but its **Source:** line is a legacy bare-path → plan-source-link
+assert_contains "$out" "$(printf 'warn\tplan-source-link\tauto\t.woostack/plans/ok.md')" "bare-path Source line flagged for wikilink canonicalization"
+assert_not_contains "$out" "$(printf 'plan-source-sync\tauto\t.woostack/plans/ok.md')" "in-sync bare-path plan is not a sync finding"
+# wikilink-form **Source:** lines are already canonical → never plan-source-link flagged
+assert_not_contains "$out" "$(printf 'plan-source-link\tauto\t.woostack/plans/line-no-key.md')" "wikilink Source line is not link-flagged"
+assert_not_contains "$out" "$(printf 'plan-source-link\tauto\t.woostack/plans/sync.md')" "wikilink Source line (sync mismatch) is not link-flagged"
 
 # --- repair: insert missing line ---
 bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/miss-auto.md" source-line
@@ -45,6 +50,13 @@ assert_eq "$(field "$r/.woostack/plans/sync.md" source)" ".woostack/specs/b.md" 
 # repair: sync source: ← line when source: frontmatter was absent
 bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/line-no-key.md" source-sync
 assert_eq "$(field "$r/.woostack/plans/line-no-key.md" source)" ".woostack/specs/a.md" "source: synced from the line when frontmatter absent"
+# --- repair: canonicalize a legacy bare-path **Source:** line to the [[specs/x]] wikilink ---
+bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/ok.md" source-link
+assert_eq "$(grep -m1 -E '^\*\*Source:\*\*' "$r/.woostack/plans/ok.md")" "**Source:** [[specs/a]] (shipped #1)" "bare-path line canonicalized, trailing text preserved"
+# idempotent
+bash "$C/plan-source.sh" --fix "$r" "$r/.woostack/plans/ok.md" source-link
+assert_eq "$(grep -cE '^\*\*Source:\*\*' "$r/.woostack/plans/ok.md")" "1" "re-canonicalize is a no-op"
+assert_eq "$(grep -m1 -E '^\*\*Source:\*\*' "$r/.woostack/plans/ok.md")" "**Source:** [[specs/a]] (shipped #1)" "idempotent canonicalization preserves trailing text"
 # clean diagnose after repairs (orphan report remains)
 res="$(bash "$C/plan-source.sh" "$r")"
 assert_eq "$(printf '%s\n' "$res" | grep -c 'auto')" "0" "no auto findings remain"


### PR DESCRIPTION
## Goal

Give woostack-doctor a way to surface — and, gated, migrate — plans whose `**Source:**` join line still uses the legacy bare-path form instead of the canonical `[[specs/<basename>]]` wikilink. The tolerance for legacy paths was deliberate (no CI break, no forced churn), but there was no lint nudging the upgrade; this adds the opt-in path.

## Summary

- New code `plan-source-link` (warn / auto), folded into `checks/plan-source.sh` — it already emits `plan-source` and `plan-source-sync`, so a third code is consistent and reuses `line_base`/`basename_of`.
- Diagnose: when a `**Source:**` line exists but lacks `[[specs/`, emit a `warn`. Wikilink-form lines and absent lines are never flagged.
- Repair `--fix <root> <plan> source-link`: rewrites only the path token to `[[specs/<basename>]]`, preserves the prefix and any trailing text, idempotent, with a phantom-repair guard.
- `warn` severity → never changes consumer `--check` CI exit (still 0). Migration stays gated and opt-in; `basename_of` already accepts both forms.
- Catalog row + doc-template-checks list updated in `references/checks.md`.

## Test plan

### Automated

- [x] `bash skills/woostack-doctor/scripts/tests/run-tests.sh` — all suites pass; `test-plan-source.sh` 19→29 asserts (diagnose flags bare-path / not wikilink-form; `--fix source-link` canonicalizes + preserves trailing text + idempotent).
- [x] `doctor.sh . --check` on this repo — exit 0 unchanged (new findings are `warn`).

### Manual

**Before merge**

- [ ] Run `/woostack-doctor` on a repo with legacy-form plans; confirm `plan-source-link` findings appear as gated auto-repairs (44 surface in this repo) and CI mode stays exit 0.
- [ ] Approve a `source-link` repair on a plan with trailing text on its `**Source:**` line; confirm the trailing text survives.
