### PR TITLE
docs(woostack): migrate plan Source lines to [[specs/x]] wikilinks (44 plans)

### DIFF
--- a/.woostack/plans/2026-06-02-memory-distill-gate.md
+++ b/.woostack/plans/2026-06-02-memory-distill-gate.md
@@ -8,7 +8,7 @@ source: .woostack/specs/2026-06-02-memory-distill-gate.md
 status: done
 ---
 
-**Source:** .woostack/specs/2026-06-02-memory-distill-gate.md
+**Source:** [[specs/2026-06-02-memory-distill-gate]]
 
 
 # Memory Distillation Gate + updated: Coverage — Implementation Plan

--- a/.woostack/plans/2026-06-02-memory-distill.md
+++ b/.woostack/plans/2026-06-02-memory-distill.md
@@ -13,7 +13,7 @@ branch: feat/woostack-memory-distill
 
 **Architecture:** Agent-behavior + doc edits only. The build loop gains a post-execute distill step; bootstrap invokes `/woostack-init`; the memory contract documents the distill write-path.
 
-**Source:** specs/2026-06-02-memory-distill.md (Increment C of 4; shipped in #156).
+**Source:** [[specs/2026-06-02-memory-distill]] (Increment C of 4; shipped in #156).
 
 > Reconstructed after the fact: this increment shipped docs-only in PR #156 before plan-checkbox tracking existed. Tasks below mirror the spec's delivered scope and are checked to reflect the merged work.
 

--- a/.woostack/plans/2026-06-02-memory-obsidian.md
+++ b/.woostack/plans/2026-06-02-memory-obsidian.md
@@ -5,7 +5,7 @@ status: done
 branch: feat/woostack-memory-obsidian
 ---
 
-**Source:** .woostack/specs/2026-06-02-memory-obsidian.md
+**Source:** [[specs/2026-06-02-memory-obsidian]]
 
 
 # Obsidian layer (Increment D) Implementation Plan

--- a/.woostack/plans/2026-06-02-memory-overlap-clusters.md
+++ b/.woostack/plans/2026-06-02-memory-overlap-clusters.md
@@ -8,7 +8,7 @@ source: .woostack/specs/2026-06-02-memory-overlap-clusters.md
 status: done
 ---
 
-**Source:** .woostack/specs/2026-06-02-memory-overlap-clusters.md
+**Source:** [[specs/2026-06-02-memory-overlap-clusters]]
 
 
 # Memory Scope-Overlap Clusters + Recall Recency Tiebreak — Implementation Plan

--- a/.woostack/plans/2026-06-02-memory-recall.md
+++ b/.woostack/plans/2026-06-02-memory-recall.md
@@ -5,7 +5,7 @@ status: done
 branch: feat/woostack-memory-recall
 ---
 
-**Source:** .woostack/specs/2026-06-02-memory-recall.md
+**Source:** [[specs/2026-06-02-memory-recall]]
 
 
 # Memory recall + review scope-routing (Increment B) Implementation Plan

--- a/.woostack/plans/2026-06-02-memory-staleness-guard.md
+++ b/.woostack/plans/2026-06-02-memory-staleness-guard.md
@@ -5,7 +5,7 @@ status: done
 branch: memory-staleness-guard
 ---
 
-**Source:** .woostack/specs/2026-06-02-memory-staleness-guard.md
+**Source:** [[specs/2026-06-02-memory-staleness-guard]]
 
 
 # Memory Staleness Guard Implementation Plan

--- a/.woostack/plans/2026-06-02-review-metrics-overlap.md
+++ b/.woostack/plans/2026-06-02-review-metrics-overlap.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Bash + embedded Python 3 + `jq`; bash test harness under `skills/woostack-review/scripts/tests/` sourcing `skills/woostack-init/scripts/tests/assert.sh`.
 
-**Source:** specs/2026-06-02-review-metrics-tokens-overlap.md (Increment 1; tokens deferred per spec §8).
+**Source:** [[specs/2026-06-02-review-metrics-tokens-overlap]] (Increment 1; tokens deferred per spec §8).
 
 ---
 

--- a/.woostack/plans/2026-06-02-woostack-init.md
+++ b/.woostack/plans/2026-06-02-woostack-init.md
@@ -5,7 +5,7 @@ status: done
 branch: feat/woostack-init
 ---
 
-**Source:** .woostack/specs/2026-06-02-woostack-init.md
+**Source:** [[specs/2026-06-02-woostack-init]]
 
 
 # woostack-init (Increment A) Implementation Plan

--- a/.woostack/plans/2026-06-03-bounded-review-swarms.md
+++ b/.woostack/plans/2026-06-03-bounded-review-swarms.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/bounded-review-swarms
 ---
 
-**Source:** .woostack/specs/2026-06-03-bounded-review-swarms.md
+**Source:** [[specs/2026-06-03-bounded-review-swarms]]
 
 
 # Bounded Review Swarms Implementation Plan

--- a/.woostack/plans/2026-06-03-woostack-ideate.md
+++ b/.woostack/plans/2026-06-03-woostack-ideate.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/woostack-ideate
 ---
 
-**Source:** .woostack/specs/2026-06-03-woostack-ideate.md
+**Source:** [[specs/2026-06-03-woostack-ideate]]
 
 
 # woostack-ideate Skill Implementation Plan

--- a/.woostack/plans/2026-06-03-woostack-visualize.md
+++ b/.woostack/plans/2026-06-03-woostack-visualize.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/woostack-visualize
 ---
 
-**Source:** .woostack/specs/2026-06-03-woostack-visualize.md
+**Source:** [[specs/2026-06-03-woostack-visualize]]
 
 
 # woostack-visualize Skill Implementation Plan

--- a/.woostack/plans/2026-06-04-build-execution-handoff-gate.md
+++ b/.woostack/plans/2026-06-04-build-execution-handoff-gate.md
@@ -5,7 +5,7 @@ status: done
 branch: worktree-nested-wishing-hanrahan
 ---
 
-**Source:** .woostack/specs/2026-06-04-build-execution-handoff-gate.md
+**Source:** [[specs/2026-06-04-build-execution-handoff-gate]]
 
 
 # woostack-build Execution-Handoff Gate Implementation Plan

--- a/.woostack/plans/2026-06-04-commit-pr-goal-test-plan.md
+++ b/.woostack/plans/2026-06-04-commit-pr-goal-test-plan.md
@@ -5,7 +5,7 @@ status: done
 branch: worktree-delightful-pondering-thimble
 ---
 
-**Source:** .woostack/specs/2026-06-04-commit-pr-goal-test-plan.md
+**Source:** [[specs/2026-06-04-commit-pr-goal-test-plan]]
 
 
 # woostack-commit PR body: Goal + structured test plan — Implementation Plan

--- a/.woostack/plans/2026-06-04-execute-dual-mode-execution.md
+++ b/.woostack/plans/2026-06-04-execute-dual-mode-execution.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/execute-dual-mode
 ---
 
-**Source:** .woostack/specs/2026-06-04-execute-dual-mode-execution.md
+**Source:** [[specs/2026-06-04-execute-dual-mode-execution]]
 
 
 # woostack-execute Dual-Mode Execution Implementation Plan

--- a/.woostack/plans/2026-06-04-review-nit-comments.md
+++ b/.woostack/plans/2026-06-04-review-nit-comments.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/review-nit-comments
 ---
 
-**Source:** .woostack/specs/2026-06-04-review-nit-comments.md
+**Source:** [[specs/2026-06-04-review-nit-comments]]
 
 
 # Review Nit Comments Implementation Plan

--- a/.woostack/plans/2026-06-04-woostack-execute.md
+++ b/.woostack/plans/2026-06-04-woostack-execute.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/woostack-execute
 ---
 
-**Source:** .woostack/specs/2026-06-04-woostack-execute.md
+**Source:** [[specs/2026-06-04-woostack-execute]]
 
 
 # woostack-execute Skill Implementation Plan

--- a/.woostack/plans/2026-06-04-woostack-harden.md
+++ b/.woostack/plans/2026-06-04-woostack-harden.md
@@ -5,7 +5,7 @@ status: done
 branch: worktree-tender-exploring-swing
 ---
 
-**Source:** .woostack/specs/2026-06-04-woostack-harden.md
+**Source:** [[specs/2026-06-04-woostack-harden]]
 
 
 # woostack-harden Skill Implementation Plan

--- a/.woostack/plans/2026-06-04-woostack-status.md
+++ b/.woostack/plans/2026-06-04-woostack-status.md
@@ -9,7 +9,7 @@ branch: feature/woostack-status
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Source:** .woostack/specs/2026-06-04-woostack-status.md
+**Source:** [[specs/2026-06-04-woostack-status]]
 
 **Goal:** Ship `/woostack-status` — an on-demand, read-only shell deriver that prints a per-feature board (phase, plan progress, increment PRs, owner, age, next action) plus drift flags, backed by an enforced `spec : plan : PRs = 1 : 1 : N` invariant.
 

--- a/.woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
+++ b/.woostack/plans/2026-06-05-address-comments-fix-plan-gate.md
@@ -5,7 +5,7 @@ status: done
 branch: address-comments-fix-plan-gate
 ---
 
-**Source:** .woostack/specs/2026-06-05-address-comments-fix-plan-gate.md
+**Source:** [[specs/2026-06-05-address-comments-fix-plan-gate]]
 
 # woostack-address-comments: show the fix plan before approval — Implementation Plan
 

--- a/.woostack/plans/2026-06-05-execute-vary-subagent-model.md
+++ b/.woostack/plans/2026-06-05-execute-vary-subagent-model.md
@@ -7,7 +7,7 @@ branch: feature/execute-vary-subagent-model
 
 # Vary subagent model in woostack-execute — Implementation Plan
 
-**Source:** .woostack/specs/2026-06-05-execute-vary-subagent-model.md
+**Source:** [[specs/2026-06-05-execute-vary-subagent-model]]
 
 > **For agentic workers:** execute this plan with `/woostack-execute .woostack/plans/2026-06-05-execute-vary-subagent-model.md` — woostack-execute drives it as PR-sized stacked increments (one `woostack-commit` per increment, no per-task commit). Steps use checkbox (`- [x]`) syntax for tracking. This is a skill-collection (Markdown + Bash) change with **no app test runner**: every "test" is a concrete `grep` / link-check / `load-prompt.sh` dry-run, substituted for TDD per the inline-driver rule.
 

--- a/.woostack/plans/2026-06-05-skills-review-angle.md
+++ b/.woostack/plans/2026-06-05-skills-review-angle.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/skills-review-angle
 ---
 
-**Source:** .woostack/specs/2026-06-05-skills-review-angle.md
+**Source:** [[specs/2026-06-05-skills-review-angle]]
 
 # Skills Review Angle Implementation Plan
 

--- a/.woostack/plans/2026-06-05-woostack-debug.md
+++ b/.woostack/plans/2026-06-05-woostack-debug.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/woostack-debug
 ---
 
-**Source:** .woostack/specs/2026-06-05-woostack-debug.md
+**Source:** [[specs/2026-06-05-woostack-debug]]
 
 # woostack-debug Skill Implementation Plan
 

--- a/.woostack/plans/2026-06-05-woostack-plan.md
+++ b/.woostack/plans/2026-06-05-woostack-plan.md
@@ -5,7 +5,7 @@ status: executing
 branch: feature/woostack-plan
 ---
 
-**Source:** .woostack/specs/2026-06-05-woostack-plan.md
+**Source:** [[specs/2026-06-05-woostack-plan]]
 
 # woostack-plan Implementation Plan
 

--- a/.woostack/plans/2026-06-06-commit-memory-changes.md
+++ b/.woostack/plans/2026-06-06-commit-memory-changes.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/commit-memory-changes
 ---
 
-**Source:** .woostack/specs/2026-06-06-commit-memory-changes.md
+**Source:** [[specs/2026-06-06-commit-memory-changes]]
 
 # Commit memory changes unless gitignored — Implementation Plan
 

--- a/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
+++ b/.woostack/plans/2026-06-06-review-fail-fast-receipts.md
@@ -5,7 +5,7 @@ status: done
 branch: review-fail-fast-receipts
 ---
 
-**Source:** .woostack/specs/2026-06-06-review-fail-fast-receipts.md
+**Source:** [[specs/2026-06-06-review-fail-fast-receipts]]
 
 # woostack-review fail-fast on non-executing angle workers — Implementation Plan
 

--- a/.woostack/plans/2026-06-06-review-self-contained.md
+++ b/.woostack/plans/2026-06-06-review-self-contained.md
@@ -5,7 +5,7 @@ status: done
 branch: review-self-contained
 ---
 
-**Source:** .woostack/specs/2026-06-06-review-self-contained.md
+**Source:** [[specs/2026-06-06-review-self-contained]]
 
 # Make woostack-review self-contained (retire pr-review-toolkit) Implementation Plan
 

--- a/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
+++ b/.woostack/plans/2026-06-06-spec-acceptance-criteria.md
@@ -5,7 +5,7 @@ status: done
 branch: spec-acceptance-criteria
 ---
 
-**Source:** .woostack/specs/2026-06-06-spec-acceptance-criteria.md
+**Source:** [[specs/2026-06-06-spec-acceptance-criteria]]
 
 # Structured Acceptance Criteria in the spec template — Implementation Plan
 

--- a/.woostack/plans/2026-06-06-woostack-execute-overnight.md
+++ b/.woostack/plans/2026-06-06-woostack-execute-overnight.md
@@ -5,7 +5,7 @@ status: executing
 branch: feature/woostack-execute-overnight-skill
 ---
 
-**Source:** .woostack/specs/2026-06-06-woostack-execute-overnight.md
+**Source:** [[specs/2026-06-06-woostack-execute-overnight]]
 
 # woostack-execute-overnight Implementation Plan
 

--- a/.woostack/plans/2026-06-07-woostack-tdd.md
+++ b/.woostack/plans/2026-06-07-woostack-tdd.md
@@ -5,7 +5,7 @@ status: done
 branch: woostack-tdd
 ---
 
-**Source:** .woostack/specs/2026-06-07-woostack-tdd.md
+**Source:** [[specs/2026-06-07-woostack-tdd]]
 
 # woostack-tdd Implementation Plan
 

--- a/.woostack/plans/2026-06-08-address-comments-commit-integration.md
+++ b/.woostack/plans/2026-06-08-address-comments-commit-integration.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/address-comments-commit-integration
 ---
 
-**Source:** .woostack/specs/2026-06-08-address-comments-commit-integration.md
+**Source:** [[specs/2026-06-08-address-comments-commit-integration]]
 
 # woostack-address-comments: integrate the commit skill — Implementation Plan
 

--- a/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
+++ b/.woostack/plans/2026-06-08-generic-woostack-bootstrap.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/generic-woostack-bootstrap
 ---
 
-**Source:** .woostack/specs/2026-06-08-generic-woostack-bootstrap.md
+**Source:** [[specs/2026-06-08-generic-woostack-bootstrap]]
 
 # Dynamic, Requirements-Driven `woostack-bootstrap` Implementation Plan
 

--- a/.woostack/plans/2026-06-08-woostack-fix.md
+++ b/.woostack/plans/2026-06-08-woostack-fix.md
@@ -5,7 +5,7 @@ status: executing
 branch: feature/woostack-fix
 ---
 
-**Source:** .woostack/specs/2026-06-08-woostack-fix.md
+**Source:** [[specs/2026-06-08-woostack-fix]]
 
 # woostack-fix Skill and woostack-debug Refinement Implementation Plan
 

--- a/.woostack/plans/2026-06-09-readme-rewrite.md
+++ b/.woostack/plans/2026-06-09-readme-rewrite.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/readme-rewrite
 ---
 
-**Source:** .woostack/specs/2026-06-09-readme-rewrite.md
+**Source:** [[specs/2026-06-09-readme-rewrite]]
 
 # README Rewrite Implementation Plan
 

--- a/.woostack/plans/2026-06-09-review-stack-aware.md
+++ b/.woostack/plans/2026-06-09-review-stack-aware.md
@@ -5,7 +5,7 @@ status: executing
 branch: review-stack-aware-markers
 ---
 
-**Source:** .woostack/specs/2026-06-09-review-stack-aware.md
+**Source:** [[specs/2026-06-09-review-stack-aware]]
 
 # Stack-aware review (deferral markers) Implementation Plan
 

--- a/.woostack/plans/2026-06-09-woostack-dream.md
+++ b/.woostack/plans/2026-06-09-woostack-dream.md
@@ -5,7 +5,7 @@ status: executing
 branch: feature/woostack-dream
 ---
 
-**Source:** .woostack/specs/2026-06-09-woostack-dream.md
+**Source:** [[specs/2026-06-09-woostack-dream]]
 
 # woostack-dream Skill Implementation Plan
 

--- a/.woostack/plans/2026-06-10-parallel-worktrees.md
+++ b/.woostack/plans/2026-06-10-parallel-worktrees.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/parallel-worktrees
 ---
 
-**Source:** .woostack/specs/2026-06-10-parallel-worktrees.md
+**Source:** [[specs/2026-06-10-parallel-worktrees]]
 
 # Parallel worktree isolation + configurable base branch Implementation Plan
 

--- a/.woostack/plans/2026-06-11-overnight-review-sweep.md
+++ b/.woostack/plans/2026-06-11-overnight-review-sweep.md
@@ -5,7 +5,7 @@ status: executing
 branch: feature/overnight-review-sweep
 ---
 
-**Source:** .woostack/specs/2026-06-11-overnight-review-sweep.md
+**Source:** [[specs/2026-06-11-overnight-review-sweep]]
 
 # Overnight review sweep Implementation Plan
 

--- a/.woostack/plans/2026-06-11-woostack-dream-design-trends.md
+++ b/.woostack/plans/2026-06-11-woostack-dream-design-trends.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/woostack-dream-design-trends
 ---
 
-**Source:** .woostack/specs/2026-06-11-woostack-dream-design-trends.md
+**Source:** [[specs/2026-06-11-woostack-dream-design-trends]]
 
 # Shared Curated Memory + Design-Trend Consolidation Implementation Plan
 

--- a/.woostack/plans/2026-06-12-fumadocs-docs-site.md
+++ b/.woostack/plans/2026-06-12-fumadocs-docs-site.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/fumadocs-docs-site
 ---
 
-**Source:** .woostack/specs/2026-06-12-fumadocs-docs-site.md
+**Source:** [[specs/2026-06-12-fumadocs-docs-site]]
 
 # Fumadocs docs site for the woostack skills — Implementation Plan
 

--- a/.woostack/plans/2026-06-12-output-discipline.md
+++ b/.woostack/plans/2026-06-12-output-discipline.md
@@ -5,7 +5,7 @@ status: done
 branch: feature/output-discipline
 ---
 
-**Source:** .woostack/specs/2026-06-12-output-discipline.md
+**Source:** [[specs/2026-06-12-output-discipline]]
 
 # Native Output Discipline for Internal Comms — Implementation Plan
 

--- a/.woostack/plans/2026-06-13-dream-wisdom.md
+++ b/.woostack/plans/2026-06-13-dream-wisdom.md
@@ -5,7 +5,7 @@ status: executing
 branch: feature/dream-wisdom
 ---
 
-**Source:** .woostack/specs/2026-06-13-dream-wisdom.md
+**Source:** [[specs/2026-06-13-dream-wisdom]]
 
 # woostack-dream → wisdom consolidation Implementation Plan
 

--- a/.woostack/plans/2026-06-13-woostack-ask.md
+++ b/.woostack/plans/2026-06-13-woostack-ask.md
@@ -5,7 +5,7 @@ status: executing
 branch: feature/woostack-ask
 ---
 
-**Source:** .woostack/specs/2026-06-13-woostack-ask.md
+**Source:** [[specs/2026-06-13-woostack-ask]]
 
 # woostack-ask — read-only codebase Q&A — Implementation Plan
 

--- a/.woostack/plans/2026-06-13-woostack-doctor.md
+++ b/.woostack/plans/2026-06-13-woostack-doctor.md
@@ -5,7 +5,7 @@ status: in-review
 branch: feature/woostack-doctor
 ---
 
-**Source:** .woostack/specs/2026-06-13-woostack-doctor.md
+**Source:** [[specs/2026-06-13-woostack-doctor]]
 
 # /woostack-doctor — workspace health: diagnose + gated repair — Implementation Plan
 

--- a/.woostack/plans/2026-06-13-woostack-sweep.md
+++ b/.woostack/plans/2026-06-13-woostack-sweep.md
@@ -1,4 +1,4 @@
-**Source:** .woostack/specs/2026-06-13-woostack-sweep.md
+**Source:** [[specs/2026-06-13-woostack-sweep]]
 
 # woostack-sweep Implementation Plan
 


### PR DESCRIPTION
## Goal

Migrate the whole plan corpus onto the canonical `**Source:** [[specs/<basename>]]` wikilink join, so the Obsidian graph links plan→spec both ways and the legacy bare-path form is fully retired from this repo.

## Summary

- Ran `woostack-doctor`'s new `plan-source-link --fix` (PR #367) across all flagged plans: 44 `**Source:**` lines rewritten from legacy bare-path to `[[specs/<basename>]]`.
- Trailing annotations on the line preserved (e.g. `… [[specs/2026-06-02-review-metrics-tokens-overlap]] (Increment 1; tokens deferred per spec §8).`).
- Frontmatter `source:` untouched — plans keep the bare-path mirror by convention (a wikilink there would parse as a YAML nested flow sequence).

## Test plan

### Automated

- [x] `doctor.sh .` post-migration — `plan-source-link` findings 44 → 0; no Source line lacks `[[specs/`.
- [x] `doctor.sh . --check` — CI exit 0.

### Manual

**Before merge**

- [ ] Spot-check a plan with trailing text on its `**Source:**` line; confirm the wikilink replaced only the path token and the trailing text survives.
- [ ] Confirm no `.woostack/plans/*` frontmatter `source:` line changed (only the body `**Source:**` line).
