### PR TITLE
docs(woostack): repair plan/spec frontmatter, status-band & memory link integrity (woostack-doctor)

### DIFF
--- a/.woostack/memory/review-action-trigger-gates.md
+++ b/.woostack/memory/review-action-trigger-gates.md
@@ -5,7 +5,6 @@ scope: .github/workflows/**
 tags: github-actions, review, security
 hook: Review-trigger workflows must actor+phrase gate issue_comment and avoid automatic secret-dependent fork PR runs.
 updated: 2026-06-11
-source: [[fixes/2026-06-11-enable-repo-review-action]]
 ---
 
 When enabling woostack-review in GitHub Actions, `issue_comment` triggers run in the

--- a/.woostack/memory/status-ready-phase-pr-not-drift.md
+++ b/.woostack/memory/status-ready-phase-pr-not-drift.md
@@ -14,7 +14,7 @@ source: [[fixes/2026-06-14-status-ready-pr-drift]]
 [[woostack-feature-state-invariant]] / conventions.md, the spec+plan handoff PR
 is opened *at* `ready`, so a PR there is expected, not drift. Including `ready`
 contradicts its own `next_action` ("open spec+plan PR, then execute"). Rule when
-adding a plan phase (see [[woostack-add-phase-enum-value]] wiring sites): if the
+adding a plan phase (see the add-a-phase-enum-value wiring sites): if the
 phase legitimately has an open PR, keep it out of the lag `case`.
 
 Test pitfall that hid this: the status tests' `mkplan` helper defaults the plan

--- a/.woostack/plans/2026-05-31-woostack-skill-collection.md
+++ b/.woostack/plans/2026-05-31-woostack-skill-collection.md
@@ -1,3 +1,9 @@
+---
+type: plan
+source: .woostack/specs/2026-05-31-woostack-skill-collection-design.md
+status: done
+---
+
 # woostack Skill Collection Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -8,7 +14,7 @@
 
 **Tech Stack:** Bash scripts (ported woo-review), Markdown SKILL.md files, a self-contained HTML spec template. Verification is by static checks (`bash -n`, `jq`, link resolution, `grep`), not unit tests.
 
-**Source spec:** [`.woostack/specs/2026-05-31-woostack-skill-collection-design.html`](../specs/2026-05-31-woostack-skill-collection-design.html)
+**Source:** [[specs/2026-05-31-woostack-skill-collection-design]]
 
 **PR slicing (honors the ≤500 LOC ethos):** Tasks are grouped into five independently shippable PRs — A: rename bootstrap; B: port woo-review; C: add build; D: add address-comments; E: docs reframe. Commit at the end of each task; open a PR at each group boundary.
 

--- a/.woostack/plans/2026-06-02-memory-recall-telemetry.md
+++ b/.woostack/plans/2026-06-02-memory-recall-telemetry.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-02-memory-recall-telemetry.md
+status: done
+branch: feat/memory-recall-telemetry
+---
+
 # Memory Recall Telemetry Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
@@ -8,7 +15,7 @@
 
 **Tech Stack:** POSIX-ish bash (3.2 / macOS BSD compatible), awk, the existing `tests/assert.sh` harness. No new dependencies.
 
-Spec: [.woostack/specs/2026-06-02-memory-recall-telemetry.html](../specs/2026-06-02-memory-recall-telemetry.html) · Issue #159.
+**Source:** [[specs/2026-06-02-memory-recall-telemetry]] · Issue #159.
 
 **Conventions to respect:**
 - All scripts live in `skills/woostack-init/scripts/`. `lib.sh` is sourced by `recall.sh`, `doctor.sh`, `build-index.sh`.

--- a/.woostack/plans/2026-06-02-review-metrics-overlap.md
+++ b/.woostack/plans/2026-06-02-review-metrics-overlap.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
+status: done
+branch: feature/review-metrics-overlap
+---
+
 # Cross-Angle Overlap Metric — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/.woostack/plans/2026-06-13-woostack-sweep.md
+++ b/.woostack/plans/2026-06-13-woostack-sweep.md
@@ -1,3 +1,10 @@
+---
+type: plan
+source: .woostack/specs/2026-06-13-woostack-sweep.md
+status: ready
+branch: feature/woostack-sweep
+---
+
 **Source:** [[specs/2026-06-13-woostack-sweep]]
 
 # woostack-sweep Implementation Plan

--- a/.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
+++ b/.woostack/specs/2026-06-02-review-metrics-tokens-overlap.md
@@ -1,7 +1,7 @@
 ---
 name: review-metrics-tokens-overlap
 type: spec
-status: done
+status: approved
 date: 2026-06-02
 branch: feature/review-metrics-overlap
 links:

--- a/.woostack/specs/2026-06-13-woostack-sweep.md
+++ b/.woostack/specs/2026-06-13-woostack-sweep.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-sweep
 type: spec
-status: ready
+status: approved
 date: 2026-06-13
 branch: feature/woostack-sweep
 links:


### PR DESCRIPTION
## Goal

`/woostack-doctor` flagged 12 authoring-time `.woostack/` convention warnings. Repair the mechanically-fixable drift so the store lints clean (the 2 residuals are memory-content judgment, deferred to `/woostack-dream`).

## Summary

- **4 plans** — added missing `---` frontmatter with `type: plan` (+ `source:`/`status:`/`branch:`): `2026-05-31-woostack-skill-collection`, `2026-06-02-memory-recall-telemetry`, `2026-06-02-review-metrics-overlap`, `2026-06-13-woostack-sweep`.
- **2 plans** — converted legacy bare-path/`Spec:` lines to the canonical `**Source:**` `[[specs/…]]` wikilink and synced `source:` basename (skill-collection, memory-recall-telemetry).
- **2 specs** — moved plan-band `status:` to spec-band `approved`; the lifecycle value now lives on the paired plan (`review-metrics-tokens-overlap`, `woostack-sweep`).
- **2 memory notes** — link integrity: dropped a `source:` pointing at a fix that never existed (`review-action-trigger-gates`), de-linked an unresolvable `[[woostack-add-phase-enum-value]]` (`status-ready-phase-pr-not-drift`).

## Test plan

### Automated

- [x] `bash <doctor>/scripts/doctor.sh` — 12 warnings → **2 warnings, 0 errors** (exit 0). Residuals are both `report`-only memory-content findings (provenance + 40-note overlap cluster) owned by `/woostack-dream`, not doctor.

### Manual

**Before merge**

- [ ] Confirm the 2 status-band specs read `status: approved` and their paired plans carry the relocated lifecycle (`done` / `ready`).
- [ ] Confirm the 4 plans now open with a valid `---` plan frontmatter block.
