### PR TITLE
docs(woostack): seed .woostack/wisdom store from first dream run (3 findings) + fix review-action-trigger-gates provenance

### DIFF
--- a/.woostack/memory/review-action-trigger-gates.md
+++ b/.woostack/memory/review-action-trigger-gates.md
@@ -5,6 +5,7 @@ scope: .github/workflows/**
 tags: github-actions, review, security
 hook: Review-trigger workflows must actor+phrase gate issue_comment and avoid automatic secret-dependent fork PR runs.
 updated: 2026-06-11
+source: pr-306
 ---
 
 When enabling woostack-review in GitHub Actions, `issue_comment` triggers run in the

--- a/.woostack/wisdom/autonomy-needs-structural-proof.md
+++ b/.woostack/wisdom/autonomy-needs-structural-proof.md
@@ -1,0 +1,30 @@
+---
+name: autonomy-needs-structural-proof
+type: wisdom
+category: process
+source: gate-needs-hard-barrier, delegated-review-no-silent-downgrade, fanout-empty-needs-receipt, fixes/2026-06-11-address-comments-verdict-gate, fixes/2026-06-14-overnight-sweep-downgrade, plans/2026-06-06-review-fail-fast-receipts
+updated: 2026-06-15
+---
+
+A load-bearing gate, verdict, or quality step survives an **autonomous or low-effort/fast
+driver** only if it is **structurally enforced and backed by proof-of-execution**. Soft body
+prose gets collapsed, skipped, or downgraded by a model optimizing for completion. Three
+layers of the same law:
+
+- **Gates** — a load-bearing approval gate needs a prominent STOP barrier **and** a
+  restatement in `## Hard constraints` ("Silence is not a yes"). A gate that exists only as a
+  mid-procedure sentence is skippable. ([[gate-needs-hard-barrier]])
+- **Verdicts** — a delegated review/verify `clean` is valid **only** with an execution receipt
+  from the real engine on the current HEAD. No receipt ⇒ `blocked`, never a pass. Decide
+  feasibility at pre-flight; a mid-run failure is its own outcome, never a downgraded `clean`.
+  ([[delegated-review-no-silent-downgrade]])
+- **Fan-out** — an empty aggregate is ambiguous: *clean* vs *never ran* look identical. Each
+  worker writes a **separate execution receipt as its last action**; do not pre-initialize the
+  receipt to a benign value, or a swallowed worker masquerades as a PASS.
+  ([[fanout-empty-needs-receipt]])
+
+How to apply: state every load-bearing rule as a barrier **and** as a Hard constraint; make
+"no silent downgrade" a safety-class invariant the driver cannot relax; let one
+single-authority gate/aggregator script own the receipt contract so the autonomous path and
+the test path cannot drift. The same instinct catches side-effect failures — e.g. confirm a
+`gt submit` actually opened the PR before tearing down its worktree.

--- a/.woostack/wisdom/lockstep-edit-sites.md
+++ b/.woostack/wisdom/lockstep-edit-sites.md
@@ -1,0 +1,37 @@
+---
+name: lockstep-edit-sites
+type: wisdom
+category: process
+source: source-line-is-multi-reader-contract, memory-source-field-multi-reader, woostack-command-surface-bookkeeping, review-add-angle-sites, review-prompt-self-contained-blob, spec-template-md-html-mirror, plans/2026-06-04-woostack-status, plans/2026-06-06-review-self-contained
+updated: 2026-06-15
+---
+
+Several woostack values are parsed or authored in **N places at once**. Touching one site
+without the others half-works or silently desyncs — and the missed site is usually a config
+validator, an attribution/footer whitelist, or a committed gating test, not the obvious one.
+Before changing such a value, **enumerate every reader/author, move them in lockstep, and
+verify the test that pins the joint.**
+
+Known multi-site contracts:
+
+- **Plan `**Source:**` line** — 2 parser regexes (`status.sh` plan-for, `spec-plan-backlink.sh`
+  spec-for) + ~5 authoring/contract docs; readers must stay back-compatible with on-disk
+  path-form plans. ([[source-line-is-multi-reader-contract]])
+- **Memory note `source:`** — parsed by 2 doctor checks (provenance + unresolved-link).
+  ([[memory-source-field-multi-reader]])
+- **Public command surface** — AGENTS.md (count line, public list, N-skill phrasing,
+  rename-constraint, file-map, Mode B) + README + `using-woostack` routing + CONTRIBUTING
+  (2 sites) + bootstrap `development.md`. ([[woostack-command-surface-bookkeeping]])
+- **A review angle** — ~11 sites: `detect-angles.sh` (predicate + push + header catalog),
+  worker prompt, `load-config.sh` VALID_ANGLES, `_header.md` (count word + catalog row +
+  Python footer whitelist + findings schema), SKILL.md (conditional + tier), `anthropic.md`
+  per-angle tier (+ openai/google/opencode), and the detect-angles test.
+  ([[review-add-angle-sites]])
+- **Review prompt shared content** — must be **inlined** into the composed blob; CI runners
+  follow no relative links. ([[review-prompt-self-contained-blob]])
+- **spec-template `.md` / `.html`** — a hand-maintained 1:1 section pair, no generator.
+  ([[spec-template-md-html-mirror]])
+
+How to apply: when a value is read/authored in more than one place, treat the **site-list
+itself** as the contract. Add a structural test that fails when the sites disagree, and review
+the easy-to-miss validators and whitelists last — they are where lockstep edits leak.

--- a/.woostack/wisdom/review-ci-local-asymmetry.md
+++ b/.woostack/wisdom/review-ci-local-asymmetry.md
@@ -1,0 +1,32 @@
+---
+name: review-ci-local-asymmetry
+type: wisdom
+category: review
+source: review-marker-trust-asymmetry, review-prefetch-findings-guard-ci-gated, review-model-resolution-two-paths, fixes/2026-06-11-review-marker-self-trust, fixes/2026-06-12-review-outdir-per-run, fixes/2026-06-11-review-local-model-resolution
+updated: 2026-06-15
+---
+
+woostack-review runs in two contexts — CI (single-session, GitHub Actions) and local
+(per-call) — and many of its values must behave *differently* in each. A change wired for one
+context silently regresses the other. Before editing any review value, ask: **does this path
+run in CI, local, or both — and is the gate/resolver shaped for every context that reads or
+writes it?**
+
+Cases, each of which cost a fix:
+
+- **Marker trust** — the SHA watermark is written in both contexts, but the read-side trust
+  gate was bot-author-only, so a local re-review never trusted its own marker. Widen to
+  `bot OR (local AND author==self)`, gated `not-in-CI`. ([[review-marker-trust-asymmetry]])
+- **Findings guard** — CI re-runs `prefetch.sh` with pre-downloaded `findings.*` present
+  (warn + preserve); local treats the same state as a hard-stop. Don't collapse the branch.
+  ([[review-prefetch-findings-guard-ci-gated]])
+- **Model resolution** — two paths (`load-prompt.sh` in CI's single session;
+  `resolve-model.sh` per-call locally) must share one tier→model precedence. A resolver wired
+  to one path regresses the other. ([[review-model-resolution-two-paths]])
+- **OUTDIR shape** — CI wants a stable per-project dir; local wants per-run (ts+pid) so
+  concurrent local runs don't clobber. ([[woostack-paths-anchor-to-repo-root]])
+
+How to apply: extract the context-split logic into a single-authority resolver script
+(`resolve-marker.sh` / `resolve-model.sh` / `resolve-root.sh`) so the unit test and the
+production filter cannot drift, and gate CI-only safety clauses on `GITHUB_ACTIONS`. Treat
+"works locally" and "works in CI" as two separate proofs.


### PR DESCRIPTION
## Goal

First `/woostack-dream` consolidation run: seed the `.woostack/wisdom/` store with the recurring cross-cutting findings mined from the memory + overnight + specs/plans/fixes corpus, so future review/build/plan passes wholesale-load them as house-rules. Also clear the lone `doctor.sh` missing-provenance warning.

## Summary

- Create `.woostack/wisdom/` (first wisdom files) with 3 dense, wholesale-loaded findings:
  - `review-ci-local-asymmetry.md` (review) — woostack-review values behave differently in CI vs local; wire every context, extract single-authority resolvers.
  - `lockstep-edit-sites.md` (process) — values parsed/authored in N places (plan Source line, memory source:, command surface, review angle 11-site set, inlined prompt blob, spec-template .md/.html) must move in lockstep.
  - `autonomy-needs-structural-proof.md` (process) — gates/verdicts/fan-out under autonomous or low-effort drivers need a structural barrier + execution receipt, never soft prose.
- Add `source: pr-306` provenance to `review-action-trigger-gates.md` (the only note with no `source:`), clearing the `doctor.sh` missing-provenance warn (2 → 1; remaining warn is the coarse adjudicated overlap cluster).
- No memory notes pruned: each contributing note keeps scope-specific recall (partial absorption, contract §5.4 "any doubt → keep"); the wisdom `source:` ledgers record them as permanent provenance.
- (Out of band, not in this diff) 9 fully-absorbed gitignored `.woostack/overnight/` reports pruned; 1 kept for an un-captured `gt submit` gotcha.

## Test plan

### Automated

- [x] `bash skills/woostack-init/scripts/build-index.sh` — regenerated `MEMORY.md`; wisdom excluded from recall (`grep -c wisdom MEMORY.md` = 0).
- [x] `bash skills/woostack-doctor/scripts/doctor.sh` — 0 errors, 1 warning (down from 2; remaining is the expected single-domain overlap cluster).

### Manual

**Before merge**

- [ ] Read the 3 wisdom bodies under `.woostack/wisdom/` — confirm each is generalized/cross-cutting (clears the contract bar) and the `[[wikilinks]]` resolve to real memory notes.
- [ ] Confirm `.woostack/wisdom/` is tracked (not gitignored) and `review-action-trigger-gates.md` now carries `source: pr-306`.
