### PR TITLE
docs(woostack): woostack-debug recalls wisdom + quarantines recall as hypotheses

### DIFF
--- a/.woostack/wisdom/lockstep-edit-sites.md
+++ b/.woostack/wisdom/lockstep-edit-sites.md
@@ -2,7 +2,7 @@
 name: lockstep-edit-sites
 type: wisdom
 category: process
-source: source-line-is-multi-reader-contract, memory-source-field-multi-reader, woostack-command-surface-bookkeeping, review-add-angle-sites, review-prompt-self-contained-blob, spec-template-md-html-mirror, plans/2026-06-04-woostack-status, plans/2026-06-06-review-self-contained
+source: source-line-is-multi-reader-contract, memory-source-field-multi-reader, woostack-command-surface-bookkeeping, review-add-angle-sites, review-prompt-self-contained-blob, spec-template-md-html-mirror, plans/2026-06-04-woostack-status, plans/2026-06-06-review-self-contained, pr-376
 updated: 2026-06-15
 ---
 
@@ -31,7 +31,14 @@ Known multi-site contracts:
   follow no relative links. ([[review-prompt-self-contained-blob]])
 - **spec-template `.md` / `.html`** — a hand-maintained 1:1 section pair, no generator.
   ([[spec-template-md-html-mirror]])
+- **Wisdom-consumer contract** — the set of skills that recall the wisdom store is enumerated in
+  N places: `wisdom.md` §6 (consumer list) + §7 (lifecycle diagram), each consuming skill's
+  `## Memory` recall section (review / ideate / plan / debug), **and the authored site page
+  `site/content/docs/concepts.mdx`** (the consumer table + wholesale-load flow diagram). The site
+  page is the easy-to-miss reader: per-skill `.mdx` is generated from `SKILL.md` and gitignored,
+  but `concepts.mdx` is hand-authored and tracked. (pr-376)
 
 How to apply: when a value is read/authored in more than one place, treat the **site-list
 itself** as the contract. Add a structural test that fails when the sites disagree, and review
-the easy-to-miss validators and whitelists last — they are where lockstep edits leak.
+the easy-to-miss validators and whitelists last — they are where lockstep edits leak — and remember
+authored site/docs pages mirror these contracts too.

--- a/site/content/docs/concepts.mdx
+++ b/site/content/docs/concepts.mdx
@@ -52,8 +52,8 @@ woostack keeps two stores under `.woostack/`, and they load in opposite ways.
   matches the files in play, plus any notes those link to (one hop out). A change that touches a
   few files pulls in a few notes, not the whole store.
 - **`wisdom/`** holds a small set of generalized, cross-cutting findings. These load *wholesale*:
-  every wisdom file, every time a skill gathers design, planning, or review context, with no scope
-  matching at all.
+  every wisdom file, every time a skill gathers design, planning, review, or root-cause
+  investigation context, with no scope matching at all.
 
 <Callout type="info">
   Wisdom is never scope-matched. It loads in full or not at all. Memory is the opposite: only the
@@ -67,7 +67,7 @@ Different skills reach for different stores, at different moments:
 | --- | :---: | :---: | --- |
 | [woostack-ideate](/docs/skills/woostack-ideate) | — | ✓ | exploring context, before proposing a design |
 | [woostack-plan](/docs/skills/woostack-plan) | — | ✓ | before writing the plan |
-| [woostack-debug](/docs/skills/woostack-debug) | ✓ | — | at the start, to surface known gotchas |
+| [woostack-debug](/docs/skills/woostack-debug) | ✓ | ✓ | at the start — known gotchas (scoped) and failure-class hints (wisdom), surfaced as hypotheses to test, never answers |
 | [woostack-review](/docs/skills/woostack-review) | ✓ | ✓ | prefetch, before the angle subagents run |
 | [woostack-execute](/docs/skills/woostack-execute) | writes | — | distills a note after each increment |
 | [woostack-dream](/docs/skills/woostack-dream) | reads & curates | reads & writes | consolidating trends into wisdom |
@@ -81,8 +81,8 @@ wisdom, and it rolls recurring trends up from memory and the decision corpus:
 woostack-execute        ── distill ─────►  memory/   (scoped, per-feature)
 woostack-dream          ── consolidate ─►  wisdom/   (generalized, cross-cutting)
 
-ideate · plan · review  ── load wholesale ─►  wisdom/
-debug · review          ── scope-match ────►  memory/
+ideate · plan · review · debug  ── load wholesale ─►  wisdom/
+debug · review                  ── scope-match ────►  memory/
 ```
 
 ### Scripts compute, agents read

--- a/skills/woostack-debug/SKILL.md
+++ b/skills/woostack-debug/SKILL.md
@@ -97,17 +97,25 @@ hands the findings back and never applies the fix itself.
 
 ## Memory
 
-woostack-debug reads and writes the scoped `.woostack/memory/` store. The note schema, the
-recall procedure, the reject-by-default distillation gate, and the degradation contract are
-defined once in [memory.md](../woostack-init/references/memory.md) — this section says only how
-debugging uses them.
+woostack-debug reads and writes the scoped `.woostack/memory/` store and **reads** the
+wholesale-loaded `.woostack/wisdom/` store. The note schema, the recall procedure, the
+reject-by-default distillation gate, and the degradation contract are defined once in
+[memory.md](../woostack-init/references/memory.md) (the wisdom contract in
+[wisdom.md](../woostack-init/references/wisdom.md)) — this section says only how debugging uses
+them.
 
 - **Recall (start).** Compute the working set — the target's files: the failing test file and
   the code under suspicion. Run the recall procedure: `recall.sh` when the `woostack-init`
   scripts are present, the manual procedure (load `MEMORY.md` + the flat `memory.md`, scope-
-  match, one-hop link expand) otherwise. Surface matching `gotcha`/`hotspot`/`pattern` notes
-  before investigating — a matching note may already name the root cause. State whether recall
-  was script-assisted or manual; never fail silently.
+  match, one-hop link expand) otherwise. Also **wholesale-load every `.woostack/wisdom/*.md`**
+  when that store is present; skip silently when absent. Surface the matching scoped
+  `gotcha`/`hotspot`/`pattern` notes **and** the wisdom findings before investigating — a scoped
+  note names a *specific* trap, wisdom names a recurring failure *class*, and either may point at
+  the root cause. Treat both as **candidate hypotheses, never answers**: a recalled note seeds a
+  Phase 3 hypothesis that must still survive its test (the Iron Law holds), and you **verify any
+  file, line, or symbol the note names still exists** before trusting it — notes reflect what was
+  true when written and can be stale. State whether recall was script-assisted or manual; never
+  fail silently.
 - **Distill (end).** `woostack-debug` does not write code, so it does not distill gotcha notes directly. Memory note distillation is owned by the caller (such as `woostack-fix` or `woostack-execute`) once the minimal fix has been implemented and verified.
 
 ## Red flags — stop and return to Phase 1
@@ -137,6 +145,7 @@ external: document what you investigated and log findings for future investigati
 ## Hard constraints
 
 - **Iron Law.** No fix proposed or applied before Phase 1 is complete. Keep this prominent so it survives summarization.
+- **Recall primes, never concludes.** A recalled scoped note or wisdom finding enters as a candidate Phase 3 hypothesis that must survive its test — never as the root-cause verdict, and never trusted before verifying the file/line/symbol it names still exists. The Iron Law is not satisfied by a recalled note.
 - **Owns no spec/plan/status.** Never writes a `.woostack/specs/`, `.woostack/plans/`, or `.woostack/fixes/` file. The phase enum and join contracts live in [conventions.md](../woostack-status/references/conventions.md) — link, never restate.
 - **Never writes code, commits, or merges.** Hands the findings back; does not touch repository code files.
 - **Always autonomous.** Runs the four phases end to end without a user gate and hands back; owns no `--auto` flag (autonomous is the only mode) and never runs interactively. Investigative only — it never applies the fix.

--- a/skills/woostack-init/references/wisdom.md
+++ b/skills/woostack-init/references/wisdom.md
@@ -117,7 +117,7 @@ note triggers `build-index.sh` regeneration; deleting an overnight report touche
 ## 6. Consumption (wholesale-load)
 
 Wisdom guides future work by being loaded **in full** (every `wisdom/*.md` body) wherever design,
-planning, or review context is gathered:
+planning, review, or root-cause investigation context is gathered:
 
 - **`woostack-review`** — `prefetch.sh` composes a `$OUTDIR/wisdom.md` artifact via
   [`compose-wisdom.sh`](../../woostack-review/scripts/compose-wisdom.sh) (the wisdom analogue of
@@ -126,6 +126,13 @@ planning, or review context is gathered:
 - **`woostack-build` / `woostack-ideate`** — the design phase reads all `wisdom/*.md` before
   proposing a design.
 - **`woostack-plan`** — reads all `wisdom/*.md` before writing the plan.
+- **`woostack-debug`** — recalls all `wisdom/*.md` at investigation start, alongside its scoped
+  `.woostack/memory/` recall, surfacing wisdom as recurring failure-*class* hints. Both tiers are
+  quarantined as **candidate hypotheses, never answers** — subject to the Iron Law and the Phase 3
+  test (see [`woostack-debug/SKILL.md`](../../woostack-debug/SKILL.md#memory)). Debug is the natural
+  first **selective** consumer should the store grow: it would load the diagnostic categories
+  (`testing`, `process`) and drop the prescriptive ones (`review`, `planning`) via the per-note
+  `category` hook (§3).
 
 An empty or absent `wisdom/` makes every load a no-op (no consumer error).
 
@@ -138,7 +145,7 @@ woostack-execute distills ──► memory/ note (scoped scratch)
 woostack-execute-overnight ──► overnight/ report (gitignored scratch)
 woostack-dream consolidates recurring trends across memory + overnight + fixes/specs/plans
         └──► wisdom/<slug>.md   (durable, generalized)   + gated prune of fully-absorbed scratch
-review / build / plan ──► wholesale-load wisdom/ as guidance
+review / build / plan / debug ──► wholesale-load wisdom/ as guidance
 ```
 
 `woostack-dream` no longer **creates** memory notes (its old `surface` op is now `consolidate`,


### PR DESCRIPTION
## Goal

woostack-debug recalled scoped memory but never the wisdom store, and its recall framing leaned toward "a matching note may already name the root cause" — an answer, not a hypothesis. This gives debug the generalized failure-*class* tier of the corpus while keeping the Iron Law intact, and syncs the authored docs + wisdom store that mirror the wisdom-consumer contract.

## Summary

- **debug recall now wholesale-loads `.woostack/wisdom/*.md`** at investigation start, alongside scoped `gotcha`/`hotspot`/`pattern` recall (skips silently when the store is absent).
- **Recall reframed as priming, not conclusion**: a recalled scoped note or wisdom finding enters as a candidate Phase 3 hypothesis that must survive its test; added a stale-note guard (verify the file/line/symbol a note names still exists before trusting it).
- New Hard constraint **"Recall primes, never concludes"** so the rule survives summarization (barrier + hard constraint, per the autonomy-needs-structural-proof wisdom).
- **Wired `woostack-debug` into the wisdom consumer contract**: `wisdom.md` §6 framing widened to include root-cause investigation, new debug consumer entry, and §7 lifecycle diagram updated (in-file lockstep). Noted debug as the natural first *selective* consumer (`testing`+`process` only) via the per-note `category` hook should the store grow.
- **Synced the authored site docs** (`site/content/docs/concepts.mdx`, a committed lockstep reader): widened the wholesale-load framing, flipped debug's "reads wisdom" column to ✓, and added debug to the wholesale-load flow diagram. (Per-skill `.mdx` pages are generated from `SKILL.md` and gitignored, so the debug reference page regenerates on build.)
- **Recorded the contract in wisdom** (`/woostack-dream`): added the **wisdom-consumer contract** as a known multi-site lockstep contract in `.woostack/wisdom/lockstep-edit-sites.md`, naming `concepts.mdx` as the easy-to-miss authored reader so a future wisdom-consumer change catches it.

## Test plan

### Automated

- [x] No test or doctor check asserts the changed skill prose — `grep -rln` over `skills/*/scripts/tests/` and `skills/woostack-doctor/` returned nothing; all edits verified present by grep. (Doc-only skill/site/wisdom edits; repo has no harness for this prose.)

### Manual

**Before merge**

- [ ] Read the diff: `skills/woostack-debug/SKILL.md` Recall bullet wholesale-loads wisdom + quarantines both tiers as hypotheses + stale-note verify; intro sentence and new "Recall primes, never concludes" Hard constraint present.
- [ ] `skills/woostack-init/references/wisdom.md` §6 lists `woostack-debug` with the category escape-valve note; §6 framing line and §7 lifecycle diagram both include debug.
- [ ] `site/content/docs/concepts.mdx` consumer table shows debug as `✓` under "Reads wisdom"; framing line and flow diagram include root-cause investigation / debug. (Optional: `pnpm --dir site build` renders without error.)
- [ ] `.woostack/wisdom/lockstep-edit-sites.md` lists the wisdom-consumer contract with `concepts.mdx` as the easy-to-miss reader; `source:` ledger includes `pr-376`.
