### PR TITLE
docs(plans): mark completed plans as done and check off tasks

### DIFF
--- a/.woostack/plans/2026-06-05-woostack-plan.md
+++ b/.woostack/plans/2026-06-05-woostack-plan.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-05-woostack-plan.md
-status: executing
+status: done
 branch: feature/woostack-plan
 ---
 

--- a/.woostack/plans/2026-06-06-woostack-execute-overnight.md
+++ b/.woostack/plans/2026-06-06-woostack-execute-overnight.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-06-woostack-execute-overnight.md
-status: executing
+status: done
 branch: feature/woostack-execute-overnight-skill
 ---
 

--- a/.woostack/plans/2026-06-09-woostack-dream.md
+++ b/.woostack/plans/2026-06-09-woostack-dream.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-09-woostack-dream.md
-status: executing
+status: done
 branch: feature/woostack-dream
 ---
 
@@ -252,10 +252,10 @@ gt modify -c -m "docs: reconcile woostack-dream surface counts"
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — AC1 (Inc1 T1 + T2 S1), AC2 (Inc1 T1 Phase 3 + T2 S2), AC3 (Inc1 T1 Phase 2/4 + T2 S2), AC4 (Phase 2 doc-recommendation + T2 S2 `evidence guard`), AC5 (Degradation + T2 S2), AC6 (Hard constraints + T2 S2), AC7 (Inc2 all tasks), AC8 (Phase 5), AC9 (Phase 2 merge/drop link rewrite + idempotent language + Inc1 T2 S3). All mapped.
-- [ ] **AC coverage** — each AC's happy/edge/error case maps to a grep/test assertion or an authored-section requirement above.
-- [ ] **No placeholders** — exact paths, exact commands, expected output in every step; SKILL.md content specified section-by-section.
-- [ ] **Type consistency** — phase names (Gather/Synthesize/Review gate/Apply/Summarize), op names (merge/replace/drop/resolve/surface/doc), and script names (`doctor.sh`/`build-index.sh`/`graph.sh`) are used identically across plan and skill.
+- [x] **Spec coverage** — AC1 (Inc1 T1 + T2 S1), AC2 (Inc1 T1 Phase 3 + T2 S2), AC3 (Inc1 T1 Phase 2/4 + T2 S2), AC4 (Phase 2 doc-recommendation + T2 S2 `evidence guard`), AC5 (Degradation + T2 S2), AC6 (Hard constraints + T2 S2), AC7 (Inc2 all tasks), AC8 (Phase 5), AC9 (Phase 2 merge/drop link rewrite + idempotent language + Inc1 T2 S3). All mapped.
+- [x] **AC coverage** — each AC's happy/edge/error case maps to a grep/test assertion or an authored-section requirement above.
+- [x] **No placeholders** — exact paths, exact commands, expected output in every step; SKILL.md content specified section-by-section.
+- [x] **Type consistency** — phase names (Gather/Synthesize/Review gate/Apply/Summarize), op names (merge/replace/drop/resolve/surface/doc), and script names (`doctor.sh`/`build-index.sh`/`graph.sh`) are used identically across plan and skill.
 
 > woostack plan conventions (kept):
 > - Frontmatter-free; opens with the `**Source:**` line.

--- a/.woostack/plans/2026-06-11-overnight-review-sweep.md
+++ b/.woostack/plans/2026-06-11-overnight-review-sweep.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-11-overnight-review-sweep.md
-status: executing
+status: done
 branch: feature/overnight-review-sweep
 ---
 
@@ -137,7 +137,7 @@ Expected: `1`, then `bottom-up: ok`, `full: ok`, `no-gt-sync: ok`, `config-key: 
 Run: `grep -n "^## \(Tracks & halt policy\|Post-implementation review sweep\|Morning report\)" skills/woostack-execute-overnight/SKILL.md`
 Expected: the three headings appear in that order (Tracks & halt policy < Post-implementation review sweep < Morning report).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "feat(execute-overnight): post-implementation review sweep section"
@@ -233,7 +233,7 @@ Expected: `override2-xref: ok`, `hard-constraint: ok`, `terminal-state: ok`, `de
 Run: `grep -q "woostack-review --fast" skills/woostack-execute-overnight/SKILL.md && echo "override2-fast: still present"`
 Expected: `override2-fast: still present` (the augment invariant — sweep did not remove or alter override #2).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(execute-overnight): wire sweep into override #2, terminal state, constraints, description"
@@ -312,7 +312,7 @@ Expected: `sweep-section: ok`, `sweep-column: ok`, `decision-log: ok`.
 Run: `grep -n "^## \(Per-increment\|Review sweep\|Decision log\)" skills/woostack-execute-overnight/references/report-template.md`
 Expected: the three headings in that order (Per-increment < Review sweep < Decision log).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "feat(execute-overnight): report-template Review sweep section + sweep column"

--- a/.woostack/plans/2026-06-13-dream-wisdom.md
+++ b/.woostack/plans/2026-06-13-dream-wisdom.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-13-dream-wisdom.md
-status: executing
+status: done
 branch: feature/dream-wisdom
 ---
 
@@ -682,7 +682,7 @@ grep -q 'wisdom' skills/woostack-ideate/SKILL.md \
 ```
 Expected: `OK`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt create -m "feat(build): load wisdom wholesale in the design phase"
@@ -715,7 +715,7 @@ sub-step:
 Run: `grep -q 'Load wisdom' skills/woostack-plan/SKILL.md && grep -q 'references/wisdom.md' skills/woostack-plan/SKILL.md && echo OK`
 Expected: `OK`
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "feat(plan): load wisdom wholesale before planning"
@@ -819,7 +819,7 @@ grep -q 'woostack-defer' skills/woostack-init/references/wisdom.md && echo "STIL
 ```
 Expected: `MARKER REMOVED`
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 gt create -m "feat(review): add compose-wisdom.sh wholesale wisdom loader"
@@ -872,7 +872,7 @@ rm -rf "$tmp"
 ```
 Expected: `SYNTAX_OK` then `ARTIFACT_OK`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 gt modify -c -m "feat(review): compose \$OUTDIR/wisdom.md guidance in prefetch"
@@ -918,7 +918,7 @@ grep -q 'Wisdom guidance' skills/woostack-review/prompts/_header.md \
 ```
 Expected: `OK`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 gt modify -c -m "docs(review): document wisdom.md guidance artifact in shared contract"
@@ -928,7 +928,7 @@ gt modify -c -m "docs(review): document wisdom.md guidance artifact in shared co
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — every spec requirement maps to a task:
+- [x] **Spec coverage** — every spec requirement maps to a task:
   - AC1 (scaffold `wisdom/`) → Inc 1 Task 3.
   - AC2 (wisdom tracked, overnight ignored) → Inc 1 Task 4.
   - AC3 (structural recall exclusion) → Inc 1 Task 1 §4 + Task 2 §3 (doc) + **Task 5 build-index regression test** (concrete no-leak proof; no recall.sh change, per §9 Q1).
@@ -936,8 +936,8 @@ gt modify -c -m "docs(review): document wisdom.md guidance artifact in shared co
   - AC5 (dream procedure reshape + correction) → Inc 2 Tasks 1–4.
   - AC6 (consumers load wisdom wholesale) → Inc 3 Tasks 1–2 (build/ideate/plan) + Inc 4 Tasks 1–3 (review).
   - AC7 (gated default-keep prune; overnight full-body) → Inc 2 Task 3.
-- [ ] **AC coverage** — each happy/error/edge case maps to a verification step (greps, the gitignore guard's bite-test, the compose-wisdom absent/empty/populated cases, the prefetch artifact check).
-- [ ] **No placeholders** — every step has the actual file path, exact content/edit, exact command, and expected output; no TBD/TODO.
-- [ ] **Type consistency** — names match across tasks: `compose-wisdom.sh`, `$OUTDIR/wisdom.md`, `type: wisdom`, `.woostack/wisdom/<slug>.md`, `source:` ledger / prune list — used identically in the spec, `wisdom.md`, dream, and review wiring.
+- [x] **AC coverage** — each happy/error/edge case maps to a verification step (greps, the gitignore guard's bite-test, the compose-wisdom absent/empty/populated cases, the prefetch artifact check).
+- [x] **No placeholders** — every step has the actual file path, exact content/edit, exact command, and expected output; no TBD/TODO.
+- [x] **Type consistency** — names match across tasks: `compose-wisdom.sh`, `$OUTDIR/wisdom.md`, `type: wisdom`, `.woostack/wisdom/<slug>.md`, `source:` ledger / prune list — used identically in the spec, `wisdom.md`, dream, and review wiring.
 
 > woostack plan conventions (kept): frontmatter-free; opens with the `**Source:**` line; basename mirrors the spec (`2026-06-13-dream-wisdom`); no required-sub-skill banner; in this runner-less skill repo, each "failing test" is a concrete grep / `bash -n` / self-contained bash test with exact expected output.

--- a/.woostack/plans/2026-06-13-woostack-doctor.md
+++ b/.woostack/plans/2026-06-13-woostack-doctor.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-13-woostack-doctor.md
-status: in-review
+status: done
 branch: feature/woostack-doctor
 ---
 
@@ -46,14 +46,14 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 - Move: `skills/woostack-init/scripts/tests/test-doctor.sh` → `skills/woostack-doctor/scripts/tests/test-doctor.sh`
 - Create: `skills/woostack-doctor/scripts/tests/run-tests.sh`
 
-- [ ] Create the new dirs and move with git (preserves history):
+- [x] Create the new dirs and move with git (preserves history):
   ```bash
   cd "$(git rev-parse --show-toplevel)"
   mkdir -p skills/woostack-doctor/scripts/checks skills/woostack-doctor/scripts/tests skills/woostack-doctor/references
   git mv skills/woostack-init/scripts/doctor.sh skills/woostack-doctor/scripts/doctor.sh
   git mv skills/woostack-init/scripts/tests/test-doctor.sh skills/woostack-doctor/scripts/tests/test-doctor.sh
   ```
-- [ ] Fix the two cross-skill source/call lines in `skills/woostack-doctor/scripts/doctor.sh`
+- [x] Fix the two cross-skill source/call lines in `skills/woostack-doctor/scripts/doctor.sh`
   (was `"$HERE/lib.sh"` / `"$HERE/scope-match.sh"`, now in `woostack-init`):
   ```bash
   # line 7:
@@ -61,7 +61,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   # line 45 (inside the loop):
   matches="$(printf '%s\n' "$paths" | bash "$HERE/../../woostack-init/scripts/scope-match.sh" "$scope" 2>/dev/null)"
   ```
-- [ ] Point the moved test at the cross-skill `assert.sh`. The test header is
+- [x] Point the moved test at the cross-skill `assert.sh`. The test header is
   `DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"` (= `scripts/`), then
   `source "$DIR/tests/assert.sh"` and `DOC="$DIR/doctor.sh"`. `DOC` already resolves after the
   move; `assert.sh` stays in `woostack-init`, so only line 4's source path changes:
@@ -71,7 +71,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   The rest of the body (`run_doctor`, `mk_note`, the assertions) is unchanged in this increment —
   Inc 1's `doctor.sh` is still the verbatim memory linter (takes the memdir as `$1`, emits the old
   `::warning::`/`::error::` format), so every existing assertion passes.
-- [ ] Create `skills/woostack-doctor/scripts/tests/run-tests.sh` (mirror of init's runner):
+- [x] Create `skills/woostack-doctor/scripts/tests/run-tests.sh` (mirror of init's runner):
   ```bash
   #!/usr/bin/env bash
   set -euo pipefail
@@ -84,12 +84,12 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   done
   exit "$rc"
   ```
-- [ ] Verify the moved suite is green from its new home:
+- [x] Verify the moved suite is green from its new home:
   ```bash
   bash skills/woostack-doctor/scripts/tests/run-tests.sh
   ```
   Expected: ends `0 failed` (all existing memory-linter assertions pass unchanged).
-- [ ] Verify the init suite still passes with `test-doctor.sh` gone from it:
+- [x] Verify the init suite still passes with `test-doctor.sh` gone from it:
   ```bash
   bash skills/woostack-init/scripts/tests/run-tests.sh
   ```
@@ -100,7 +100,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Modify: `skills/woostack-init/SKILL.md` (lines ~13–14, 80, 83, 87, 115, 118)
 
-- [ ] In `skills/woostack-init/SKILL.md`, change the invocation from
+- [x] In `skills/woostack-init/SKILL.md`, change the invocation from
   `bash scripts/doctor.sh .woostack/memory` to the new path and note the cross-skill dependency:
   ```
   bash ../woostack-doctor/scripts/doctor.sh .woostack/memory
@@ -108,7 +108,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   Update the surrounding prose (lines 13–14, 83, 87) so "runs `doctor.sh`" reads "runs
   `woostack-doctor`'s `doctor.sh` engine"; in the headless-tooling list (115, 118) keep `doctor`
   but point to its new home.
-- [ ] Confirm no stale path remains in init:
+- [x] Confirm no stale path remains in init:
   ```bash
   grep -rn "woostack-init/scripts/doctor" skills/woostack-init/ ; echo "exit=$?"
   ```
@@ -119,11 +119,11 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Modify: `skills/woostack-dream/SKILL.md` (lines 8, 20, 69)
 
-- [ ] Replace all `../woostack-init/scripts/doctor.sh` with `../woostack-doctor/scripts/doctor.sh`:
+- [x] Replace all `../woostack-init/scripts/doctor.sh` with `../woostack-doctor/scripts/doctor.sh`:
   ```bash
   sed -i.bak 's#\.\./woostack-init/scripts/doctor\.sh#../woostack-doctor/scripts/doctor.sh#g' skills/woostack-dream/SKILL.md && rm -f skills/woostack-dream/SKILL.md.bak
   ```
-- [ ] Confirm the move left no dangling reference anywhere in the repo:
+- [x] Confirm the move left no dangling reference anywhere in the repo:
   ```bash
   grep -rn "woostack-init/scripts/doctor" skills/ .github/ action.yml 2>/dev/null ; echo "exit=$?"
   ```
@@ -135,7 +135,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/tests/test-no-stale-paths.sh`
 
-- [ ] Write the failing test first:
+- [x] Write the failing test first:
   ```bash
   #!/usr/bin/env bash
   set -euo pipefail
@@ -146,7 +146,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   assert_eq "$hits" "" "no skill references the old woostack-init/scripts/doctor.sh path"
   finish
   ```
-- [ ] Run it; expect green (Tasks 1.2–1.3 already removed the references):
+- [x] Run it; expect green (Tasks 1.2–1.3 already removed the references):
   ```bash
   bash skills/woostack-doctor/scripts/tests/test-no-stale-paths.sh
   ```
@@ -164,7 +164,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/checks/memory.sh`
 
-- [ ] Create `checks/memory.sh` by moving the per-note loop + overlap-cluster block from the old
+- [x] Create `checks/memory.sh` by moving the per-note loop + overlap-cluster block from the old
   `doctor.sh` **verbatim**, with two mechanical substitutions: (a) source libs cross-skill; (b)
   replace `err`/`warn` with a finding emitter. Header + helpers:
   ```bash
@@ -183,7 +183,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   err()  { emit error "$1" report "$2" "$3"; }
   warn() { emit warn  "$1" report "$2" "$3"; }
   ```
-- [ ] Move the body of the old `for f in "$MEM_DIR"/*.md` loop and the overlap-cluster `awk`
+- [x] Move the body of the old `for f in "$MEM_DIR"/*.md` loop and the overlap-cluster `awk`
   block **verbatim**, rewriting each `err "<msg>"` / `warn "<msg>"` call to the 3-arg
   `err <code> <path> <msg>` / `warn <code> <path> <msg>` form, using these codes (path = `$base`,
   or `MEM_DIR` for the cluster line):
@@ -209,7 +209,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Modify: `skills/woostack-doctor/scripts/doctor.sh` (replace contents — it is now the orchestrator)
 
-- [ ] Replace `doctor.sh` with the orchestrator:
+- [x] Replace `doctor.sh` with the orchestrator:
   ```bash
   #!/usr/bin/env bash
   # doctor.sh — woostack workspace health orchestrator. Runs checks/*.sh, groups
@@ -263,12 +263,12 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 - Modify: `skills/woostack-doctor/scripts/tests/test-doctor.sh`
 - Create: `skills/woostack-doctor/scripts/tests/test-orchestrator.sh`
 
-- [ ] In `test-doctor.sh`, the memory-lint assertions still hold but the annotation lines now carry
+- [x] In `test-doctor.sh`, the memory-lint assertions still hold but the annotation lines now carry
   a `[code]` prefix. Where a test asserted `::warning::` + a message substring, it still passes
   (substring match). Add `WOO=` fixture wrapping: the engine now takes a repo root, so build
   fixtures as `$WOO/.woostack/memory/...` and call `bash "$DOCTOR" "$WOO"`. Update the harness
   helper calls accordingly (memory dir → `"$WOO/.woostack/memory"`).
-- [ ] Write `test-orchestrator.sh` (red first — orchestrator behaviors):
+- [x] Write `test-orchestrator.sh` (red first — orchestrator behaviors):
   ```bash
   #!/usr/bin/env bash
   set -uo pipefail
@@ -299,7 +299,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   assert_eq "$dump" "" "--check suppresses machine dump on stdout"
   finish
   ```
-- [ ] Run the suite; iterate `memory.sh`/orchestrator until green:
+- [x] Run the suite; iterate `memory.sh`/orchestrator until green:
   ```bash
   bash skills/woostack-doctor/scripts/tests/run-tests.sh
   ```
@@ -316,7 +316,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/checks/spec-plan-backlink.sh`
 
-- [ ] Write the check (diagnose default; `--fix <spec> <plan-basename>` apply path). It reuses the
+- [x] Write the check (diagnose default; `--fix <spec> <plan-basename>` apply path). It reuses the
   `status.sh` join (Source line → spec; else same-basename fallback) and requires the spec to carry
   a folder-qualified `[[plans/<plan-basename>]]`:
   ```bash
@@ -367,7 +367,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/tests/test-spec-plan-backlink.sh`
 
-- [ ] Write the test (red first):
+- [x] Write the test (red first):
   ```bash
   #!/usr/bin/env bash
   set -uo pipefail
@@ -408,7 +408,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   assert_eq "$(bash "$CHK" "$r3")" "" "spec-less plan is not flagged by this check"
   finish
   ```
-- [ ] Run; iterate until green:
+- [x] Run; iterate until green:
   ```bash
   bash skills/woostack-doctor/scripts/tests/test-spec-plan-backlink.sh
   ```
@@ -425,7 +425,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/checks/orphan-worktree.sh`
 
-- [ ] Write it — flag dirs under `.woostack/worktrees/` not registered with git; `auto` only when
+- [x] Write it — flag dirs under `.woostack/worktrees/` not registered with git; `auto` only when
   prunable (clean), else `report`:
   ```bash
   #!/usr/bin/env bash
@@ -464,7 +464,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/checks/gitignore-drift.sh`
 
-- [ ] Write it — each shipped-template line absent from the consumer `.woostack/.gitignore` is a
+- [x] Write it — each shipped-template line absent from the consumer `.woostack/.gitignore` is a
   finding; `--fix` appends only the missing lines (per-line presence, no reorder):
   ```bash
   #!/usr/bin/env bash
@@ -502,7 +502,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/checks/config-keys.sh`
 
-- [ ] Write it — required keys = the keys in the shipped init `config.json` template; missing →
+- [x] Write it — required keys = the keys in the shipped init `config.json` template; missing →
   finding; `--fix` adds the missing top-level key with its template default (jq when present, else a
   reported manual edit):
   ```bash
@@ -538,7 +538,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/tests/test-health-checks.sh`
 
-- [ ] Write the test (red first) covering each check's fire + clean + idempotent fix:
+- [x] Write the test (red first) covering each check's fire + clean + idempotent fix:
   ```bash
   #!/usr/bin/env bash
   set -uo pipefail
@@ -569,7 +569,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   assert_contains "$(bash "$C/orphan-worktree.sh" "$r3")" "orphan-worktree" "unregistered worktree dir flagged"
   finish
   ```
-- [ ] Run; iterate until green:
+- [x] Run; iterate until green:
   ```bash
   bash skills/woostack-doctor/scripts/tests/test-health-checks.sh
   ```
@@ -588,7 +588,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 - Create: `skills/woostack-doctor/SKILL.md`
 - Create: `skills/woostack-doctor/references/checks.md`
 
-- [ ] Write `SKILL.md` with: a concise `description:` (run-anytime diagnose + gated repair of
+- [x] Write `SKILL.md` with: a concise `description:` (run-anytime diagnose + gated repair of
   `.woostack/`; the 17th command; never merges); the command forms `/woostack-doctor [path]`
   (default = diagnose then offer repair) and `/woostack-doctor [path] --check` (CI: diagnose-only,
   exit-coded); the procedure:
@@ -606,7 +606,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   reconcile the board (that is `woostack-status`); never curate memory content (that is
   `woostack-dream`); never auto-apply; never merge. Cross-link `conventions.md` for the spec↔plan
   join; do not restate it.
-- [ ] Write `references/checks.md`: a table of every check — `code`, what it flags, severity,
+- [x] Write `references/checks.md`: a table of every check — `code`, what it flags, severity,
   `fixable` (auto/report), and the `--fix` contract. Link it from `SKILL.md`.
 
 ### Task 5.2: Repair-composition integration test
@@ -614,7 +614,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Create: `skills/woostack-doctor/scripts/tests/test-repair-apply.sh`
 
-- [ ] Test that the diagnose→apply round-trip clears findings across all auto checks at once (the
+- [x] Test that the diagnose→apply round-trip clears findings across all auto checks at once (the
   agent's apply loop, exercised mechanically — the `woostack-commit` handoff is asserted at the
   boundary, not by opening a real PR):
   ```bash
@@ -643,7 +643,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
   assert_eq "$residue" "" "after applying auto fixes, those findings clear"
   finish
   ```
-- [ ] Run the full doctor suite green:
+- [x] Run the full doctor suite green:
   ```bash
   bash skills/woostack-doctor/scripts/tests/run-tests.sh
   ```
@@ -661,12 +661,12 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Modify: `skills/woostack-build/references/spec-template.md`
 
-- [ ] Add the callout below the existing `> status:` callout (use `{{DATE}}-{{SLUG}}`, the plan
+- [x] Add the callout below the existing `> status:` callout (use `{{DATE}}-{{SLUG}}`, the plan
   basename — **not** `{{SLUG}}` alone):
   ```
   > **Plan:** [[plans/{{DATE}}-{{SLUG}}]]
   ```
-- [ ] Verify the placeholder reconstructs the basename (the spec file is `{{DATE}}-{{SLUG}}.md`):
+- [x] Verify the placeholder reconstructs the basename (the spec file is `{{DATE}}-{{SLUG}}.md`):
   ```bash
   grep -n "Plan:.*\[\[plans/{{DATE}}-{{SLUG}}\]\]" skills/woostack-build/references/spec-template.md
   ```
@@ -677,7 +677,7 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Modify: all `.woostack/specs/*.md` with a plan (40 same-basename + 3 slug-mismatch via Source)
 
-- [ ] Run the backfill (reuses the check's join + idempotent `--fix`):
+- [x] Run the backfill (reuses the check's join + idempotent `--fix`):
   ```bash
   cd "$(git rev-parse --show-toplevel)"
   CHK=skills/woostack-doctor/scripts/checks/spec-plan-backlink.sh
@@ -689,12 +689,12 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
     bash "$CHK" --fix . "$spec" "$pbase"   # --fix <root> <spec> <pbase>; root=. (repo cwd)
   done
   ```
-- [ ] Confirm the engine reports no `spec-plan-backlink` finding on the real store:
+- [x] Confirm the engine reports no `spec-plan-backlink` finding on the real store:
   ```bash
   bash skills/woostack-doctor/scripts/doctor.sh . 2>&1 | grep spec-plan-backlink ; echo "exit=$?"
   ```
   Expected: no matches (`exit=1`).
-- [ ] Spot-check one previously-isolated spec now carries the callout:
+- [x] Spot-check one previously-isolated spec now carries the callout:
   ```bash
   grep -n "Plan:.*\[\[plans/2026-06-12-output-discipline\]\]" .woostack/specs/2026-06-12-output-discipline.md
   ```
@@ -711,14 +711,14 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Modify: `AGENTS.md` (the "sixteen skills" surface, file map, Modes B list)
 
-- [ ] Change "sixteen skills" → "seventeen skills" and add the
+- [x] Change "sixteen skills" → "seventeen skills" and add the
   [`woostack-doctor`](skills/woostack-doctor/SKILL.md) bullet to the command-surface list.
-- [ ] Add a Quick file map entry:
+- [x] Add a Quick file map entry:
   ```
   - Workspace health (diagnose + gated repair) engine:
     [`skills/woostack-doctor/SKILL.md`](skills/woostack-doctor/SKILL.md)
   ```
-- [ ] Add `/woostack-doctor` to the Modes B command list. Note the engine move: the line about
+- [x] Add `/woostack-doctor` to the Modes B command list. Note the engine move: the line about
   init "runs the index builder and store linter" now points at `woostack-doctor`'s engine.
 
 ### Task 7.2: using-woostack routing + init trim
@@ -727,9 +727,9 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 - Modify: `skills/using-woostack/SKILL.md` (routing table)
 - Modify: `skills/woostack-init/SKILL.md` (description + repair claim)
 
-- [ ] Add a `/woostack-doctor` row to the using-woostack routing table (intent: "check/repair my
+- [x] Add a `/woostack-doctor` row to the using-woostack routing table (intent: "check/repair my
   .woostack workspace health").
-- [ ] Trim `woostack-init`'s description/SKILL so its "repair" reads **scaffold-only** (create
+- [x] Trim `woostack-init`'s description/SKILL so its "repair" reads **scaffold-only** (create
   missing structure) and points to `woostack-doctor` for lint/repair of existing content.
 
 ### Task 7.3: Docs site nav + framing
@@ -737,13 +737,13 @@ contract → checks → repair → dogfood → surface). No `## Track:` headings
 **Files:**
 - Modify: `site/` nav config + framing page listing the skills (locate with the grep below)
 
-- [ ] Find where the site enumerates skills and add `woostack-doctor`:
+- [x] Find where the site enumerates skills and add `woostack-doctor`:
   ```bash
   grep -rln "woostack-dream\|woostack-tdd\|sixteen" site/ --include=*.ts --include=*.tsx --include=*.mdx --include=*.json
   ```
   Add the doctor entry to each match (nav + any authored framing list). Per-skill reference pages
   are generated from `SKILL.md`, so no page authoring is needed.
-- [ ] Confirm the surface count is consistent across the repo:
+- [x] Confirm the surface count is consistent across the repo:
   ```bash
   grep -rn "sixteen skills\|sixteen public" . --include=*.md ; echo "exit=$?"
   ```

--- a/.woostack/plans/2026-06-13-woostack-sweep.md
+++ b/.woostack/plans/2026-06-13-woostack-sweep.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-13-woostack-sweep.md
-status: ready
+status: done
 branch: feature/woostack-sweep
 ---
 
@@ -465,14 +465,14 @@ gt modify -c -m "refactor(overnight): collapse the sweep hard-constraint bullet;
 
 ## Self-review (run before handing back)
 
-- [ ] **Spec coverage** — every spec section maps to a task:
+- [x] **Spec coverage** — every spec section maps to a task:
   - §4 new skill / engine / command surface / config / outcomes → Increment 1.
   - §4 delegation seam (overnight, **both** the section and the hard-constraint bullet) + config promotion → Increment 3.
   - §4 registration surface → Increment 2.
   - §6 error handling (no-PR skip, exit-0, protected-OK, raw-git, bad-config) → Increment 1 SKILL body.
-- [ ] **AC coverage** — AC1 (skill exists + engine) → Inc 1 Steps 4–5; AC2 (overnight delegates, no restate — section + bullet) → Inc 3 Task 1 Step 4 **and** Task 2 Step 4 (`! grep restack`); AC3 (single config key) → Inc 3 Task 2 Step 4; AC4 (standalone terminal incl. no-PR skip + exit 0) → Inc 1 SKILL body (Blocker & terminal state, Resolve the stack); AC5 (registered) → Inc 2 Step 4 of both tasks; AC6 (safety invariants) → Inc 1 Step 4 `Never merge` + Hard constraints.
-- [ ] **No placeholders** — every step has the exact file, the full SKILL.md / replacement content, exact grep/`gh`/`gt` commands, and expected output.
-- [ ] **Type consistency** — the per-PR outcome vocabulary (`clean` / `done-with-findings` / `blocked`), the key name `review_sweep.max_rounds`, the flag names (`--base`, `--interactive`), and the skill name `woostack-sweep` are spelled identically across the new SKILL, the overnight delegation (section + bullet), the routing row, and AGENTS.md.
+- [x] **AC coverage** — AC1 (skill exists + engine) → Inc 1 Steps 4–5; AC2 (overnight delegates, no restate — section + bullet) → Inc 3 Task 1 Step 4 **and** Task 2 Step 4 (`! grep restack`); AC3 (single config key) → Inc 3 Task 2 Step 4; AC4 (standalone terminal incl. no-PR skip + exit 0) → Inc 1 SKILL body (Blocker & terminal state, Resolve the stack); AC5 (registered) → Inc 2 Step 4 of both tasks; AC6 (safety invariants) → Inc 1 Step 4 `Never merge` + Hard constraints.
+- [x] **No placeholders** — every step has the exact file, the full SKILL.md / replacement content, exact grep/`gh`/`gt` commands, and expected output.
+- [x] **Type consistency** — the per-PR outcome vocabulary (`clean` / `done-with-findings` / `blocked`), the key name `review_sweep.max_rounds`, the flag names (`--base`, `--interactive`), and the skill name `woostack-sweep` are spelled identically across the new SKILL, the overnight delegation (section + bullet), the routing row, and AGENTS.md.
 
 > woostack plan conventions (keep them):
 > - This file is **frontmatter-free** and **opens with** the `**Source:**` line.

--- a/.woostack/plans/2026-06-15-core-concepts-context-economy.md
+++ b/.woostack/plans/2026-06-15-core-concepts-context-economy.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-15-core-concepts-context-economy.md
-status: executing
+status: done
 branch: feature/core-concepts-context-economy
 ---
 


### PR DESCRIPTION
## Goal

Synchronize the status of completed development plans in `.woostack/plans/` and ensure the status board reflects reality by updating their frontmatter to `status: done` and checking off completed task lists.

## Summary

- Mark 8 completed development plans in `.woostack/plans/` as `status: done` (specifically `woostack-plan`, `woostack-execute-overnight`, `woostack-dream`, `overnight-review-sweep`, `dream-wisdom`, `woostack-doctor`, `woostack-sweep`, and `core-concepts-context-economy`).
- Check off the completed task list checkboxes in the affected plan files.

## Test plan

### Automated

- [ ] `bash skills/woostack-doctor/scripts/doctor.sh .` (passed with 0 errors, 1 warning)

### Manual

**Before merge**

- [ ] Inspect the diff of the plan files to verify all updated plans are correctly transitioned to `status: done`.
- [ ] Run `bash skills/woostack-doctor/scripts/doctor.sh .` locally and confirm there are no errors.
