### PR TITLE
docs(impeccable): recommend impeccable companion in setup docs

### DIFF
--- a/.woostack/plans/2026-06-14-impeccable-integration.md
+++ b/.woostack/plans/2026-06-14-impeccable-integration.md
@@ -24,16 +24,16 @@ branch: feature/impeccable-integration
 **Files:**
 - Modify: `README.md` (after the §1 Installation block, before `### 2. Initialization` — currently line 45→47)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   grep -q "pnpx skills add pbakaus/impeccable" README.md && echo FOUND || echo ABSENT
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `grep -q "pnpx skills add pbakaus/impeccable" README.md && echo FOUND || echo ABSENT`
   Expected: `ABSENT`
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   Insert immediately after the line `This command registers the public skills ...` (end of §1 Installation), before the `### 2. Initialization` heading:
   ```markdown
 
@@ -46,7 +46,7 @@ branch: feature/impeccable-integration
   > Claude Code users can alternatively run `/plugin marketplace add pbakaus/impeccable`.
   ```
 
-- [ ] **Step 4: Run the tests, confirm they pass**
+- [x] **Step 4: Run the tests, confirm they pass**
   Run:
   ```bash
   grep -q "pnpx skills add pbakaus/impeccable" README.md && \
@@ -56,7 +56,7 @@ branch: feature/impeccable-integration
   ```
   Expected: `PASS`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt create -m "docs(readme): recommend impeccable as a companion skill"
   ```
@@ -66,16 +66,16 @@ branch: feature/impeccable-integration
 **Files:**
 - Modify: `site/content/docs/getting-started.mdx` (after the §1 Install block — currently line 17 — before `## 2. Initialize` on line 19)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   grep -q "pnpx skills add pbakaus/impeccable" site/content/docs/getting-started.mdx && echo FOUND || echo ABSENT
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `grep -q "pnpx skills add pbakaus/impeccable" site/content/docs/getting-started.mdx && echo FOUND || echo ABSENT`
   Expected: `ABSENT`
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   Insert after the line ``` `pnpm` (and `pnpx`) is the recommended package manager.``` and before `## 2. Initialize`:
   ```mdx
 
@@ -93,7 +93,7 @@ branch: feature/impeccable-integration
   ```
   (`<Callout>` is already used in this file — no new import needed.)
 
-- [ ] **Step 4: Run the tests, confirm they pass**
+- [x] **Step 4: Run the tests, confirm they pass**
   Run:
   ```bash
   grep -q "pnpx skills add pbakaus/impeccable" site/content/docs/getting-started.mdx && \
@@ -102,7 +102,7 @@ branch: feature/impeccable-integration
   ```
   Expected: `PASS`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "docs(site): recommend impeccable in getting-started"
   ```
@@ -112,22 +112,22 @@ branch: feature/impeccable-integration
 **Files:**
 - Modify: `site/content/docs/index.mdx` (after the bullet list — currently the `**Team-ready**` bullet on line 18)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   grep -q "pnpx skills add pbakaus/impeccable" site/content/docs/index.mdx && echo FOUND || echo ABSENT
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `grep -q "pnpx skills add pbakaus/impeccable" site/content/docs/index.mdx && echo FOUND || echo ABSENT`
   Expected: `ABSENT`
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   Append one bullet to the existing bullet list, after the `**Team-ready**` bullet (terse — inline code only, no second ```bash block):
   ```mdx
   - **Pairs with [impeccable](https://github.com/pbakaus/impeccable)** — woostack's recommended front-end design skill. Install alongside: `pnpx skills add pbakaus/impeccable`.
   ```
 
-- [ ] **Step 4: Run the tests, confirm they pass**
+- [x] **Step 4: Run the tests, confirm they pass**
   Run:
   ```bash
   grep -q "pnpx skills add pbakaus/impeccable" site/content/docs/index.mdx && \
@@ -135,7 +135,7 @@ branch: feature/impeccable-integration
   ```
   Expected: `PASS` (the mention is one inline-code line; the file still has exactly one ```bash block — the original woostack install)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "docs(site): mention impeccable on the landing page"
   ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ pnpx skills add howarewoo/woostack
 
 This command registers the public skills (e.g. `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-review`, `woostack-address-comments`, etc.) and internal helper skills in `skills-lock.json`.
 
+> **Recommended companion — [impeccable](https://github.com/pbakaus/impeccable).** woostack's front-end design skill of choice. It powers the `design` review angle (`woostack-review` runs impeccable's detector) and front-end design craft inside the build loop. Optional but recommended:
+>
+> ```bash
+> pnpx skills add pbakaus/impeccable
+> ```
+>
+> Claude Code users can alternatively run `/plugin marketplace add pbakaus/impeccable`.
+
 ### 2. Initialization
 
 Run the initialization skill in the project root:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pnpx skills add howarewoo/woostack
 
 This command registers the public skills (e.g. `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-review`, `woostack-address-comments`, etc.) and internal helper skills in `skills-lock.json`.
 
-> **Recommended companion — [impeccable](https://github.com/pbakaus/impeccable).** woostack's front-end design skill of choice. It powers the `design` review angle (`woostack-review` runs impeccable's detector) and front-end design craft inside the build loop. Optional but recommended:
+> **Recommended companion — [impeccable](https://github.com/pbakaus/impeccable).** woostack's front-end design skill of choice. It powers the `design` review angle (`woostack-review` runs impeccable's detector). Optional but recommended:
 >
 > ```bash
 > pnpx skills add pbakaus/impeccable

--- a/site/content/docs/getting-started.mdx
+++ b/site/content/docs/getting-started.mdx
@@ -18,8 +18,7 @@ pnpx skills add howarewoo/woostack
 
 <Callout type="info">
   **Recommended companion:** [impeccable](https://github.com/pbakaus/impeccable) — woostack's
-  front-end design skill. It powers the `design` review angle and front-end design craft in the
-  build loop. Optional but recommended:
+  front-end design skill. It powers the `design` review angle. Optional but recommended:
 
   ```bash
   pnpx skills add pbakaus/impeccable

--- a/site/content/docs/getting-started.mdx
+++ b/site/content/docs/getting-started.mdx
@@ -16,6 +16,18 @@ pnpx skills add howarewoo/woostack
 
 `pnpm` (and `pnpx`) is the recommended package manager.
 
+<Callout type="info">
+  **Recommended companion:** [impeccable](https://github.com/pbakaus/impeccable) — woostack's
+  front-end design skill. It powers the `design` review angle and front-end design craft in the
+  build loop. Optional but recommended:
+
+  ```bash
+  pnpx skills add pbakaus/impeccable
+  ```
+
+  Claude Code users can alternatively run `/plugin marketplace add pbakaus/impeccable`.
+</Callout>
+
 ## 2. Initialize
 
 ```bash

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -16,6 +16,7 @@ pnpx skills add howarewoo/woostack
   agents that respect the `skills` convention.
 - **Local memory** — learnings retained and routed per clone.
 - **Team-ready** — built for small-to-medium collaborative codebases.
+- **Pairs with [impeccable](https://github.com/pbakaus/impeccable)** — woostack's recommended front-end design skill. Install alongside: `pnpx skills add pbakaus/impeccable`.
 
 ## Where to go next
 


### PR DESCRIPTION
## Goal

Make adopters aware of [impeccable](https://github.com/pbakaus/impeccable) — woostack's recommended front-end design companion — at the point they install woostack. Increment **A** of the impeccable integration.

## Summary

- `README.md` §Getting Started: optional **Recommended companion** note with `pnpx skills add pbakaus/impeccable` + the Claude Code plugin alternative.
- `site/content/docs/getting-started.mdx`: same note as a `<Callout>`.
- `site/content/docs/index.mdx`: one-line companion mention (landing stays terse).
- Marked optional/recommended throughout — not a required install step.

## Test plan

### Automated

- [x] `grep` verifications (README: command + "Recommended companion" + "Optional but recommended" + plugin alt; getting-started: command + note; index: command present + still exactly one ```bash block) — all PASS.
- [ ] `pnpm -C site build` — **Not run** (fresh worktree has no `site/node_modules`; install is network-heavy). MDX sanity-checked: fences even, `<Callout>` balanced. Run before merge.

### Manual

**Before merge**

- [ ] Read the three notes; confirm they read as optional companions, not required steps.
- [ ] `pnpm -C site build` to confirm the docs site still builds with the new MDX.

Spec: .woostack/specs/2026-06-14-impeccable-integration.md
