### PR TITLE
feat(ideate,execute): delegate front-end craft to impeccable (optional)

### DIFF
--- a/.woostack/plans/2026-06-14-impeccable-integration.md
+++ b/.woostack/plans/2026-06-14-impeccable-integration.md
@@ -149,16 +149,16 @@ branch: feature/impeccable-integration
 **Files:**
 - Modify: `skills/woostack-ideate/SKILL.md` §"Visual treatment, on demand" (currently lines 90-97)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   grep -q "impeccable" skills/woostack-ideate/SKILL.md && echo FOUND || echo ABSENT
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `grep -q "impeccable" skills/woostack-ideate/SKILL.md && echo FOUND || echo ABSENT`
   Expected: `ABSENT`
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   Append a paragraph to the end of the "## Visual treatment, on demand" section (after the sentence ending `...a UI topic is not automatically a visual question.`):
   ```markdown
 
@@ -171,7 +171,7 @@ branch: feature/impeccable-integration
   above is unchanged.
   ```
 
-- [ ] **Step 4: Run the tests, confirm they pass**
+- [x] **Step 4: Run the tests, confirm they pass**
   Run:
   ```bash
   grep -q "impeccable" skills/woostack-ideate/SKILL.md && \
@@ -182,7 +182,7 @@ branch: feature/impeccable-integration
   ```
   Expected: `PASS` (the last grep is the AC2-edge guard: the original no-browser-companion text is preserved)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt create -m "feat(ideate): delegate front-end craft to impeccable (optional)"
   ```
@@ -192,23 +192,23 @@ branch: feature/impeccable-integration
 **Files:**
 - Modify: `skills/woostack-execute/SKILL.md` §"Per-increment cadence", step 2 "Implement" (currently ends line 107)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   grep -q "impeccable" skills/woostack-execute/SKILL.md && echo FOUND || echo ABSENT
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `grep -q "impeccable" skills/woostack-execute/SKILL.md && echo FOUND || echo ABSENT`
   Expected: `ABSENT`
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   In step 2 ("**Implement** ... Follow each safe plan step exactly."), append the following as a new sentence on the same line, immediately after `Follow each safe plan step exactly.` — keep it inside step-2's list item (no blank line, so list numbering is preserved):
   ```text
    During a UI-touching increment, the implementer may optionally invoke [impeccable](https://github.com/pbakaus/impeccable) for front-end design craft (host-dependent; proceed normally if it is not installed) — the same optional-detour shape as the `woostack-debug` routing in "When to stop and ask".
   ```
   (The leading space is intentional: it separates the new sentence from the existing one on the same line.)
 
-- [ ] **Step 4: Run the tests, confirm they pass**
+- [x] **Step 4: Run the tests, confirm they pass**
   Run:
   ```bash
   grep -q "impeccable" skills/woostack-execute/SKILL.md && \
@@ -216,7 +216,7 @@ branch: feature/impeccable-integration
   ```
   Expected: `PASS`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "feat(execute): note optional impeccable craft on UI increments"
   ```

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -104,7 +104,7 @@ For each increment:
    [references/inline-driver.md](references/inline-driver.md) in inline mode, or
    [references/subagent-driver.md](references/subagent-driver.md) in subagent mode. Both follow
    TDD, run the verifications the plan specifies exactly, and check each task for spec compliance
-   and code quality before it is marked complete. Follow each safe plan step exactly.
+   and code quality before it is marked complete. Follow each safe plan step exactly. During a UI-touching increment, the implementer may optionally invoke [impeccable](https://github.com/pbakaus/impeccable) for front-end design craft (host-dependent; proceed normally if it is not installed) — the same optional-detour shape as the `woostack-debug` routing in "When to stop and ask".
 3. **Tick the plan's checkboxes in place.** Edit the markdown plan, `[ ]` → `[x]`, as each step
    or task completes, so the plan file is the live progress record.
 4. **Commit** via [`woostack-commit`](../woostack-commit/SKILL.md) on the increment's

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -96,6 +96,14 @@ seeing than reading — offer to render it with
 continue. Keep conceptual and requirements questions in the terminal; a UI topic is not
 automatically a visual question.
 
+For genuine front-end **craft** — typography, color, spacing, motion, component polish — rather
+than a view to *show*, defer to [impeccable](https://github.com/pbakaus/impeccable) when it is
+installed (its discipline commands, e.g. `/typeset`, `/colorize`, `/animate`). The split:
+`woostack-visualize` renders a view **to show the user**; impeccable **crafts the UI itself**.
+This is optional and host-dependent — if impeccable is not installed, proceed with built-in
+judgment. Its browser-based Live Mode stays out of this phase; the no-browser-companion rule
+above is unchanged.
+
 ## Key principles
 
 - **One question at a time.** Don't stack questions in a single message.


### PR DESCRIPTION
## Goal

Let the build loop lean on [impeccable](https://github.com/pbakaus/impeccable) for genuine front-end design craft, optionally and graceful-degrading, without weakening ideate's existing boundaries. Increment **C** of the impeccable integration.

## Summary

- `woostack-ideate` §"Visual treatment": defer real UI craft (type, color, spacing, motion, polish) to impeccable **when installed**. Keeps the distinction explicit — `woostack-visualize` renders a view *to show*; impeccable *crafts the UI*. Live Mode stays out; the no-browser-companion rule is unchanged.
- `woostack-execute` §"Per-increment cadence": implementer may optionally invoke impeccable on UI-touching increments — "proceed normally if it is not installed", mirroring the existing `woostack-debug` optional-detour.
- Both references are install-gated / host-dependent → no hard dependency.

## Test plan

### Automated

- [x] ideate greps: `impeccable` + `crafts the UI itself` + `optional and host-dependent` + `Live Mode stays out` + **`does not run a browser companion`** (AC2-edge guard: original boundary preserved) — PASS.
- [x] execute greps: `impeccable` + `proceed normally if it is not installed` — PASS.

### Manual

**Before merge**

- [ ] Read the ideate paragraph; confirm visualize-vs-impeccable split is clear and Live Mode is explicitly excluded.
- [ ] Confirm both references are optional (an absent impeccable is a no-op).

Spec: .woostack/specs/2026-06-14-impeccable-integration.md
