### PR TITLE
feat(ideate): load impeccable DESIGN.md as design house-rules

### DIFF
--- a/.woostack/plans/2026-06-14-impeccable-integration.md
+++ b/.woostack/plans/2026-06-14-impeccable-integration.md
@@ -230,16 +230,16 @@ branch: feature/impeccable-integration
 **Files:**
 - Modify: `skills/woostack-ideate/SKILL.md` step 1 "Explore project context" (currently lines 49-54)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   grep -q "DESIGN.md" skills/woostack-ideate/SKILL.md && echo FOUND || echo ABSENT
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `grep -q "DESIGN.md" skills/woostack-ideate/SKILL.md && echo FOUND || echo ABSENT`
   Expected: `ABSENT`
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   Insert after the wisdom sentence (`An empty or absent \`wisdom/\` is a no-op.`) inside step 1:
   ```markdown
    For front-end work, also read impeccable's `DESIGN.md` if present (at the repo root, where
@@ -249,7 +249,7 @@ branch: feature/impeccable-integration
    An absent `DESIGN.md` is a no-op.
   ```
 
-- [ ] **Step 4: Run the tests, confirm they pass**
+- [x] **Step 4: Run the tests, confirm they pass**
   Run:
   ```bash
   grep -q "DESIGN.md" skills/woostack-ideate/SKILL.md && \
@@ -258,7 +258,7 @@ branch: feature/impeccable-integration
   ```
   Expected: `PASS`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt create -m "feat(ideate): load impeccable DESIGN.md as design house-rules"
   ```
@@ -270,11 +270,11 @@ branch: feature/impeccable-integration
 
 > No file change. These are assertions, not edits — the only write is ticking these checkboxes, which rides Increment 3 Task 1's commit. If either guard FAILs, **stop**: an increment violated a non-goal (made impeccable required, or touched the shipped design angle).
 
-- [ ] **Step 1: Guard AC4-edge — no-dep property still true**
+- [x] **Step 1: Guard AC4-edge — no-dep property still true**
   Run: `grep -q "no external skill dependencies" skills/woostack-build/SKILL.md && echo PASS || echo FAIL`
   Expected: `PASS` (no increment converted impeccable into a required dependency; the sentence survives)
 
-- [ ] **Step 2: Guard AC5 — B (design angle) untouched and still wired to impeccable**
+- [x] **Step 2: Guard AC5 — B (design angle) untouched and still wired to impeccable**
   Run: `grep -q "impeccable" skills/woostack-review/prompts/angles/design.md && echo PASS || echo FAIL`
   Expected: `PASS` (the already-shipped detector wiring is intact; these increments did not touch it)
 

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -52,6 +52,11 @@ Work the steps in order. Ask **one question per message** so you never overwhelm
    Also read every `.woostack/wisdom/*.md` file (wholesale — they are generalized, cross-cutting
    guidance, not scope-routed) and treat them as house-rules the design should respect. See the
    wisdom contract [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md).
+   For front-end work, also read impeccable's `DESIGN.md` if present (at the repo root, where
+   `/impeccable init` writes it) and treat it as design house-rules. Single home: `DESIGN.md` is
+   the design-system source of truth, `@infrastructure/ui` tokens are its implementation, and
+   `.woostack/wisdom/` holds general house-rules — read `DESIGN.md`, never copy it into `wisdom/`.
+   An absent `DESIGN.md` is a no-op.
    An empty or absent `wisdom/` is a no-op.
 2. **Check scope first.** If the request bundles multiple independent subsystems ("a platform
    with chat, billing, and analytics"), flag it immediately. Don't refine details of


### PR DESCRIPTION
## Goal

Let an ideated front-end design inherit the project's visual system by reading impeccable's `DESIGN.md` as design house-rules, with a single-home rule that prevents drift. Increment **D** (final) of the impeccable integration.

## Summary

- `woostack-ideate` step 1 (already loads `.woostack/wisdom/*.md`): also reads `DESIGN.md` at the repo root **if present**, as design house-rules.
- **Single home** stated to kill drift: `DESIGN.md` = design-system source of truth · `@infrastructure/ui` tokens = its implementation · `.woostack/wisdom/` = general house-rules. ideate *reads* `DESIGN.md`, never copies it into `wisdom/`.
- Absent `DESIGN.md` is a no-op (graceful-degrade, like an absent `wisdom/`).
- **Non-goal guards** (read-only): the build loop's "no external skill dependencies" sentence survives (AC4-edge), and the shipped `design` review angle still wires impeccable's detector (AC5).

## Test plan

### Automated

- [x] ideate greps: `DESIGN.md` + `design-system source of truth` + `never copy it into` — PASS.
- [x] AC4-edge guard: `no external skill dependencies` still in `woostack-build/SKILL.md` — PASS.
- [x] AC5 guard: `impeccable` still in `woostack-review/prompts/angles/design.md` — PASS.

### Manual

**Before merge**

- [ ] Read the ideate step-1 addition; confirm the single-home rule is unambiguous and the DESIGN.md load is optional.

Spec: .woostack/specs/2026-06-14-impeccable-integration.md
