### PR TITLE
fix(woostack-status): exclude fenced example checkboxes from plan progress

### DIFF
--- a/skills/woostack-status/scripts/status.sh
+++ b/skills/woostack-status/scripts/status.sh
@@ -114,10 +114,29 @@ plan_for() {
 }
 
 plan_progress() {
-  local d t
-  d="$(grep -cE '^[[:space:]]*- \[[xX]\]' "$1" 2>/dev/null || true)"
-  t="$(grep -cE '^[[:space:]]*- \[[ xX]\]' "$1" 2>/dev/null || true)"
-  echo "${d:-0} ${t:-0}"
+  # Count task checkboxes, but NOT example boxes inside fenced code blocks
+  # (a plan that embeds a template/SKILL.md literal carries `- [ ]` lines that
+  # are content, not tasks). Fence rule (CommonMark): an opening fence is a run
+  # of >=3 backticks; the close must be a run >= the opening length, so the
+  # inner ``` of an embedded block never closes its enclosing ```` fence.
+  awk '
+    BEGIN { d=0; t=0; infence=0; flen=0 }
+    {
+      s=$0; sub(/^[[:space:]]+/,"",s)
+      if (substr(s,1,3)=="```") {
+        run=0; while (substr(s,run+1,1)=="`") run++
+        if (infence==0) { infence=1; flen=run }
+        else if (run>=flen) { infence=0; flen=0 }
+        next
+      }
+      if (infence) next
+      if ($0 ~ /^[[:space:]]*- \[[ xX]\]/) {
+        t++
+        if ($0 ~ /^[[:space:]]*- \[[xX]\]/) d++
+      }
+    }
+    END { printf "%d %d\n", d, t }
+  ' "$1" 2>/dev/null || echo "0 0"
 }
 
 prs_for_spec() {

--- a/skills/woostack-status/scripts/tests/test-status.sh
+++ b/skills/woostack-status/scripts/tests/test-status.sh
@@ -71,6 +71,27 @@ run_status "$p"
 assert_contains "$OUT" "3/10" "plan progress counted"
 assert_contains "$OUT" "harden the plan" "planning next-action"
 
+# Fenced example checkboxes (embedded template / SKILL.md literals) must NOT count
+# as tasks. Real: 3 done + 3 todo = 6. The 5 boxes inside the ```` fence (including
+# a nested ``` block, which must not close the enclosing fence) are ignored.
+fence="$(mktemp -d)/.woostack"
+mkspec "$fence" echo planning feature/echo
+mkdir -p "$fence/plans"
+{
+  printf -- '---\ntype: plan\nsource: .woostack/specs/2026-06-01-echo.md\nstatus: planning\nbranch: feature/echo\n---\n\n'
+  printf -- '**Source:** .woostack/specs/2026-06-01-echo.md\n\n'
+  printf -- '- [x] real done 1\n- [x] real done 2\n- [x] real done 3\n- [ ] real todo 1\n- [ ] real todo 2\n\n'
+  printf -- '````markdown\n'
+  printf -- '- [ ] embedded example a\n- [ ] embedded example b\n'
+  printf -- '```bash\n- [ ] nested fenced c\n```\n'
+  printf -- '- [ ] embedded example d\n- [ ] embedded example e\n'
+  printf -- '````\n\n'
+  printf -- '- [ ] real todo 3 after fence\n'
+} > "$fence/plans/2026-06-01-echo.md"
+run_status "$fence"
+assert_contains "$OUT" "3/6" "fenced example checkboxes excluded from progress"
+assert_not_contains "$OUT" "3/11" "fenced boxes not over-counted"
+
 # Source line as an Obsidian wikilink ([[specs/<basename>]]) resolves the plan, same as a
 # bare path. The plan basename intentionally differs from the spec slug so resolution can
 # only come from the **Source:** line, not the slug fallback.

--- a/skills/woostack-status/scripts/tests/test-status.sh
+++ b/skills/woostack-status/scripts/tests/test-status.sh
@@ -92,6 +92,48 @@ run_status "$fence"
 assert_contains "$OUT" "3/6" "fenced example checkboxes excluded from progress"
 assert_not_contains "$OUT" "3/11" "fenced boxes not over-counted"
 
+# A plain triple-backtick fence (the everyday variant) must also exclude its
+# example boxes. Outside the fence: 2 done + 1 todo = 3. The 2 boxes inside the
+# ``` block are ignored. Guards the flen=3 / `run>=flen` close path directly, so
+# a regression to `run==flen` (which still passes the 4-backtick test above)
+# fails here.
+tick3="$(mktemp -d)/.woostack"
+mkspec "$tick3" tick3 planning feature/tick3
+mkdir -p "$tick3/plans"
+{
+  printf -- '---\ntype: plan\nsource: .woostack/specs/2026-06-01-tick3.md\nstatus: planning\nbranch: feature/tick3\n---\n\n'
+  printf -- '**Source:** .woostack/specs/2026-06-01-tick3.md\n\n'
+  printf -- '- [x] real done 1\n- [x] real done 2\n- [ ] real todo 1\n\n'
+  printf -- '```markdown\n'
+  printf -- '- [ ] example a\n- [ ] example b\n'
+  printf -- '```\n'
+} > "$tick3/plans/2026-06-01-tick3.md"
+run_status "$tick3"
+assert_contains "$OUT" "2/3" "plain 3-backtick fence excludes example checkboxes"
+assert_not_contains "$OUT" "2/5" "3-backtick fenced boxes not over-counted"
+
+# Unclosed fence (a plausible state for a mid-write or agent-authored plan):
+# the opening ``` never closes, so `infence` stays 1 to EOF and every checkbox
+# after it is excluded. This pins CURRENT behavior — 1 done + 1 todo before the
+# fence count (1/2); the 2 real todos after the unclosed fence are swallowed.
+# Footgun: a malformed plan reads MORE complete than it is (denominator shrinks).
+# We characterize rather than fix it: counting post-unclosed-fence boxes would
+# need EOF-buffering of every pending-fence line, not worth it for malformed
+# input. If the awk ever changes, this assert makes the behavior shift visible.
+nofence="$(mktemp -d)/.woostack"
+mkspec "$nofence" nofence planning feature/nofence
+mkdir -p "$nofence/plans"
+{
+  printf -- '---\ntype: plan\nsource: .woostack/specs/2026-06-01-nofence.md\nstatus: planning\nbranch: feature/nofence\n---\n\n'
+  printf -- '**Source:** .woostack/specs/2026-06-01-nofence.md\n\n'
+  printf -- '- [x] real done 1\n- [ ] real todo 1\n\n'
+  printf -- '```markdown\n'
+  printf -- '- [ ] swallowed todo a\n- [ ] swallowed todo b\n'
+} > "$nofence/plans/2026-06-01-nofence.md"
+run_status "$nofence"
+assert_contains "$OUT" "1/2" "unclosed fence swallows trailing checkboxes (characterized)"
+assert_not_contains "$OUT" "1/4" "post-unclosed-fence boxes are not counted"
+
 # Source line as an Obsidian wikilink ([[specs/<basename>]]) resolves the plan, same as a
 # bare path. The plan basename intentionally differs from the spec slug so resolution can
 # only come from the **Source:** line, not the slug fallback.


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
