### PR TITLE
docs: humanize authored site docs (drop em-dash AI tells)

### DIFF
--- a/site/content/docs/concepts.mdx
+++ b/site/content/docs/concepts.mdx
@@ -67,7 +67,7 @@ Different skills reach for different stores, at different moments:
 | --- | :---: | :---: | --- |
 | [woostack-ideate](/docs/skills/woostack-ideate) | — | ✓ | exploring context, before proposing a design |
 | [woostack-plan](/docs/skills/woostack-plan) | — | ✓ | before writing the plan |
-| [woostack-debug](/docs/skills/woostack-debug) | ✓ | ✓ | at the start — known gotchas (scoped) and failure-class hints (wisdom), surfaced as hypotheses to test, never answers |
+| [woostack-debug](/docs/skills/woostack-debug) | ✓ | ✓ | at the start: known gotchas (scoped) and failure-class hints (wisdom), surfaced as hypotheses to test rather than answers |
 | [woostack-review](/docs/skills/woostack-review) | ✓ | ✓ | prefetch, before the angle subagents run |
 | [woostack-execute](/docs/skills/woostack-execute) | writes | — | distills a note after each increment |
 | [woostack-dream](/docs/skills/woostack-dream) | reads & curates | reads & writes | consolidating trends into wisdom |

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -6,14 +6,14 @@ description: Every key in the .woostack/config.json file, what it tunes, its typ
 woostack reads optional settings from `.woostack/config.json` at the repository root.
 [woostack-init](/docs/skills/woostack-init) creates the file, and every key is optional: when a
 key is absent, the skill that reads it falls back to a built-in default. The init template ships
-only two top-level namespaces — an empty `review` and a `status` block — and
+only two top-level namespaces (an empty `review` and a `status` block), and
 [woostack-doctor](/docs/skills/woostack-doctor) checks that those two are present.
 
 There are five top-level namespaces:
 
 | Namespace | Read by | Tunes |
 | --- | --- | --- |
-| `review` | [woostack-review](/docs/skills/woostack-review) | the PR review engine — angles, noise, models, validation |
+| `review` | [woostack-review](/docs/skills/woostack-review) | the PR review engine: angles, noise, models, validation |
 | `review_sweep` | [woostack-sweep](/docs/skills/woostack-sweep) | how many review rounds a stack sweep runs |
 | `commit` | [woostack-commit](/docs/skills/woostack-commit) | a pre-commit hook command |
 | `status` | [woostack-status](/docs/skills/woostack-status) | when the board flags a spec as stale |
@@ -72,7 +72,7 @@ finding explicitly marked blocking always surfaces regardless of the floor.
 
 Angles are auto-detected from the diff. Force an angle to run it regardless of detection; skip one
 to keep it off. `force` wins when an angle appears in both. The `bugs` and `security` angles can
-never be skipped — they are silently kept even if listed.
+never be skipped. They are silently kept even if listed.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
@@ -93,7 +93,7 @@ The valid angles are: `aeo`, `api`, `architecture`, `bugs`, `comments`, `convent
 ### Skipping PRs automatically
 
 Some PRs should short-circuit the whole review with a skip comment. By default, three bot authors
-are skipped — `dependabot[bot]`, `renovate[bot]`, and `github-actions[bot]` — and PR titles
+are skipped (`dependabot[bot]`, `renovate[bot]`, and `github-actions[bot]`), and PR titles
 matching the release-rollup pattern `^(staging\|release\|chore\(release\))` are skipped. Set either
 to opt out: an empty array for `authors_skip`, or an empty string for the pattern.
 
@@ -104,7 +104,7 @@ to opt out: an empty array for `authors_skip`, or an empty string for the patter
 
 ### Model selection
 
-Each review subagent runs at a tier — `fast`, `standard`, or `deep` — and each tier maps to a
+Each review subagent runs at a tier (`fast`, `standard`, or `deep`), and each tier maps to a
 concrete model per provider. Override a single tier for one provider with
 `review.models.<provider>.<tier>`, or set a provider-agnostic fallback with the flat
 `review.models.<tier>`. `review.force_tier` pins every subagent to one tier, the config-file
@@ -134,7 +134,7 @@ PR → the action's `force_tier` input → `review.force_tier` → the action's 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `review.chunking.max_loc` | integer ≥ 0 | `4000` | Changed-line threshold; a larger diff is split into chunks and each angle fans out across them. `0` disables chunking. |
-| `review.disable_adversarial` | boolean | `false` | `true` skips the skeptical prosecutor pass and uses the defender pass alone — a cost opt-out. |
+| `review.disable_adversarial` | boolean | `false` | `true` skips the skeptical prosecutor pass and uses the defender pass alone, a cost opt-out. |
 | `review.defer_markers` | boolean | `true` | `true` honors inline `woostack-defer(<ref>)` markers, demoting a matching finding to a non-blocking nit. `security` findings are never deferred. |
 | `review.metrics` | boolean | `false` | `true` writes a per-angle signal/noise breakdown and folds a rolling local `.woostack/metrics.json`. |
 | `review.fix_commands` | array of string | `[]` | Reserved for a future loop mode; parsed but not yet consumed. |
@@ -150,7 +150,7 @@ review → address-comments per PR.
 
 ## Commit hook
 
-[woostack-commit](/docs/skills/woostack-commit) can run a command before it stages anything — a
+[woostack-commit](/docs/skills/woostack-commit) can run a command before it stages anything: a
 formatter, linter, or test runner.
 
 | Key | Type | Default | Meaning |
@@ -180,7 +180,7 @@ worktrees are cut from.
 <Callout type="info">
   Every key is optional. The init template ships only `review` and `status`; everything else takes
   its built-in default when absent. [woostack-doctor](/docs/skills/woostack-doctor) validates that
-  the two template top-level keys are present and can repair a missing one — the remaining keys are
+  the two template top-level keys are present and can repair a missing one. The remaining keys are
   validated at review time by woostack-review.
 </Callout>
 

--- a/site/content/docs/getting-started.mdx
+++ b/site/content/docs/getting-started.mdx
@@ -17,7 +17,7 @@ pnpx skills add howarewoo/woostack
 `pnpm` (and `pnpx`) is the recommended package manager.
 
 <Callout type="info">
-  **Recommended companion:** [impeccable](https://github.com/pbakaus/impeccable) — woostack's
+  **Recommended companion:** [impeccable](https://github.com/pbakaus/impeccable), woostack's
   front-end design skill. It powers the `design` review angle. Optional but recommended:
 
   ```bash
@@ -33,7 +33,7 @@ pnpx skills add howarewoo/woostack
 /woostack-init
 ```
 
-Run this **before any other woostack skill** — it sets up the `.woostack/` workspace, default
+Run this **before any other woostack skill**. It sets up the `.woostack/` workspace, default
 config, and gitignores.
 
 ## 3. Integrate

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: A model-agnostic collection of gated software-development skills.
 ---
 
 woostack packages opinionated, gated workflows into installable skills that any AI coding
-agent can follow — from greenfield bootstrapping to feature building, debugging, automated
+agent can follow, covering greenfield bootstrapping, feature building, debugging, automated
 code review, and feedback iteration. It ships a local, token-efficient memory system so later
 agent sessions don't repeat earlier mistakes.
 
@@ -12,11 +12,11 @@ agent sessions don't repeat earlier mistakes.
 pnpx skills add howarewoo/woostack
 ```
 
-- **Agent- & model-agnostic** — works across Claude Code, Cursor, Codex, Aider, and other
+- **Agent- & model-agnostic:** works across Claude Code, Cursor, Codex, Aider, and other
   agents that respect the `skills` convention.
-- **Local memory** — learnings retained and routed per clone.
-- **Team-ready** — built for small-to-medium collaborative codebases.
-- **Pairs with [impeccable](https://github.com/pbakaus/impeccable)** — woostack's recommended front-end design skill. Install alongside: `pnpx skills add pbakaus/impeccable`.
+- **Local memory:** learnings retained and routed per clone.
+- **Team-ready:** built for small-to-medium collaborative codebases.
+- **Pairs with [impeccable](https://github.com/pbakaus/impeccable):** woostack's recommended front-end design skill. Install alongside: `pnpx skills add pbakaus/impeccable`.
 
 ## Where to go next
 


### PR DESCRIPTION
## Goal

Remove the clearest AI-writing tell (em dashes) from the authored docs pages so the documentation reads as human-written. Output of a humanizer pass scoped to the committed prose only.

## Summary

- Replaced 16 prose em dashes across the four committed docs pages (`index`, `getting-started`, `concepts`, `configuration`) with periods, commas, colons, or parentheses.
- `index.mdx`: also rewrote a false-range "from X to Y" capability span as a plain list, and converted four feature bullets from `**Label** — desc` to `**Label:** desc`.
- `concepts.mdx`: folded one tailing negation into the same edit (`never answers` → `rather than answers`).
- Left the four standalone `—` cells in the `concepts.mdx` skill/store table untouched: they are "none" data placeholders, not prose punctuation.
- Did not touch the per-skill reference pages under `content/docs/skills/`: they are generated from each `SKILL.md` at build time and gitignored.

## Test plan

### Automated

- [ ] `pnpm -C site build` — ran locally, build succeeded; all docs routes (concepts, configuration, getting-started, index, + 21 generated skill pages) prerendered.

### Manual

**Before merge**

- [ ] Skim the four changed pages in the rendered preview; confirm no em or en dashes remain in prose and that meaning is unchanged.
