### PR TITLE
docs(site): require humanized authored copy via AGENTS.md

### DIFF
--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md (docs site)
+
+Scope: the `site/` subtree. Extends the root [`AGENTS.md`](../AGENTS.md); the root file wins on
+conflict.
+
+## Copy must be humanized
+
+All prose you author or edit in this site should read as human-written, not machine-generated.
+Run the `humanizer` skill (or apply its rules by hand) on any copy you add or change, and drop
+the common AI tells:
+
+- No em dashes or en dashes in prose. Use periods, commas, colons, or parentheses instead. (The
+  one carve-out is `—` used as a "none" data placeholder inside a table cell.)
+- No `**Label** — desc` bullet shape. Write `**Label:** desc`.
+- No false "from X to Y" range when you mean a plain list.
+- No tailing negations, hollow superlatives, or rule-of-three filler. Say the thing plainly.
+
+This rule covers the **authored** pages only: `content/docs/index.mdx`, `getting-started.mdx`,
+`concepts.mdx`, `configuration.mdx`, and the landing page. The per-skill reference pages under
+`content/docs/skills/` are generated from each `../skills/*/SKILL.md` at build time and are
+gitignored, so humanize the source `SKILL.md`, never the generated MDX.
+
+## Before you finish
+
+- Keep authored pages in sync with the skills they describe (see the root `AGENTS.md` hard
+  constraints).
+- Run `pnpm build` to confirm the site still builds.


### PR DESCRIPTION
## Goal

Make "authored docs copy must read as human-written" an enforced house rule for the docs site, so agents editing `site/` humanize prose instead of leaving AI tells.

## Summary

- Add `site/AGENTS.md`, a subtree-scoped instruction file that extends the root `AGENTS.md` (root wins on conflict).
- Require the `humanizer` pass (or its rules by hand) on any authored copy, with concrete tells to drop: em/en dashes in prose, `**Label** — desc` bullets, false "from X to Y" ranges, tailing negations / rule-of-three filler.
- Scope the rule to the authored pages only (`index`, `getting-started`, `concepts`, `configuration`, landing); the generated per-skill pages under `content/docs/skills/` regenerate from `SKILL.md`, so the rule points back at humanizing the source.
- Restate the existing close-out checks (keep authored pages in sync with skills, run `pnpm build`).

## Test plan

### Manual

**Before merge**

- [ ] Read `site/AGENTS.md`: confirm it scopes to `site/`, defers to root `AGENTS.md` on conflict, and excludes generated `content/docs/skills/` pages.
- [ ] Confirm the file itself contains no em dashes in prose (follows its own rule).
