### PR TITLE
docs(fix): plan pre-generation least-code ladder

### DIFF
--- a/.woostack/fixes/2026-06-16-least-code-ladder.md
+++ b/.woostack/fixes/2026-06-16-least-code-ladder.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: hardened
+status: approved
 branch: fix/least-code-ladder
 ---
 

--- a/.woostack/fixes/2026-06-16-least-code-ladder.md
+++ b/.woostack/fixes/2026-06-16-least-code-ladder.md
@@ -1,0 +1,88 @@
+---
+type: fix
+status: hardened
+branch: fix/least-code-ladder
+---
+
+# Fix: No generation-time least-code guidance — over-build is caught only in review
+
+## 1. Root Cause
+
+woostack's minimalism doctrine is **entirely review-side**: the `architecture` review angle
+hunts missed deletions, thin abstractions, and copy-paste-over-extraction
+(`skills/woostack-review/prompts/angles/architecture.md`), and the execute-phase
+`quality-reviewer.md:22` checks "dead code; duplication (DRY); needless complexity (YAGNI)."
+All of that fires **after** the diff already exists.
+
+There is no guidance at **generation time** telling the implementer to reach for the least code
+that already exists *before* writing custom code. `implementer.md`'s `## How to work` step 2 says
+only "Implement exactly the task — no more, no less" — a scope guard, not a build-order ladder.
+`woostack-ideate` cuts unneeded *features* (`YAGNI ruthlessly`) but says nothing about preferring
+an existing solution (stdlib / native / installed dep) over a new abstraction.
+
+Net: over-build is **caught in review, never prevented**. This fix adds the missing
+prevention-time guidance. Inspired by the ponytail skill's "best code is the code you never
+wrote" philosophy; complements (does not duplicate) the diff-scoped `architecture` angle.
+
+## 2. Proposed Fix
+
+Two altitude-distinct prose additions. **No shared reference file** — the two statements sit at
+different altitudes (code-generation vs design) and parse no shared value, so a new canonical doc
+would itself be over-engineering (it would manufacture a `[[lockstep-edit-sites]]` multi-site
+contract to dedupe ~12 lines). The fix embodies its own ladder: smallest change that works.
+
+### Change A — `skills/woostack-execute/prompts/implementer.md` (canonical, generation-time)
+
+The ladder **must** land *inside* the fenced subagent-prompt blob (the ` ```` ` … ` ```` ` block)
+or it never reaches the implementer subagent. Anchor = the existing `## How to work` step 2.
+Expand that one step in place (no new section):
+
+> 2. Implement exactly the task — no more (no extra flags, files, or features), no less. Reach for
+>    the **least code that already exists** before writing your own — in order: **skip it** (YAGNI —
+>    if the task doesn't require it, don't build it) → **language standard library** → a **native
+>    platform/framework feature** → an **already-installed dependency** → a **one-liner** → and only
+>    then **minimal custom code**. Never trade away **security, accessibility, data-loss, or
+>    trust-boundary** handling to shrink code — those are never on the chopping block.
+
+### Change B — `skills/woostack-ideate/SKILL.md` `## Key principles` (design-time nudge)
+
+Add one bullet immediately after the existing `**YAGNI ruthlessly.**` line:
+
+> - **Least code wins.** Prefer the smallest solution that already exists — stdlib, a native
+>   feature, an installed dependency — before proposing a new abstraction or dependency.
+
+### Out of scope (explicit scope guard)
+
+- **No** whole-repo over-engineering audit (conflicts with woostack's diff-scoped doctrine).
+- **No** ad-hoc shortcut / debt-ledger marker (conflicts with the `woostack-defer(<ref>)`
+  increment-scoped contract).
+- **No** new reference file and no structural/lockstep test: the two additions parse no shared
+  value, so there is no multi-site joint for a test to pin (`[[lockstep-edit-sites]]`).
+- **No** `site/` change (verified at harden): the per-skill `site/content/docs/skills/woostack-ideate.mdx`
+  is **generated from `SKILL.md` and gitignored**, so Change B regenerates automatically; the authored
+  `concepts.mdx` describes the loop at a high level ("implementer writes each task") and enumerates
+  neither ideate's Key principles nor the implement-step ladder, so Changes A/B do not alter what it
+  states. The change touches neither the skill surface/count, the build-loop gates, the core concepts,
+  nor getting-started.
+
+## 3. Implementation Plan
+
+- [ ] **Step 1: Pin the assertion (red).** Confirm the target phrases are currently ABSENT, so the
+      edit has a verifiable before/after (docs edit → structural assertion in place of a failing
+      test, per `implementer.md` step 1):
+  - `grep -c "least code that already exists" skills/woostack-execute/prompts/implementer.md` → `0`
+  - `grep -c "Least code wins" skills/woostack-ideate/SKILL.md` → `0`
+- [ ] **Step 2: Apply Change A.** Edit `skills/woostack-execute/prompts/implementer.md` — expand
+      `## How to work` step 2 to the ladder text in §2 above, **inside** the fenced blob. Preserve
+      the `tier: standard` frontmatter and the surrounding numbered list.
+- [ ] **Step 3: Apply Change B.** Edit `skills/woostack-ideate/SKILL.md` — add the `Least code wins.`
+      bullet under `## Key principles`, directly after `**YAGNI ruthlessly.**`.
+- [ ] **Step 4: Verify (green).** Assert the additions landed correctly and stayed in scope:
+  - `grep -c "least code that already exists" skills/woostack-execute/prompts/implementer.md` → `1`
+  - `grep -c "Least code wins" skills/woostack-ideate/SKILL.md` → `1`
+  - Ladder is inside the fenced blob: the `least code that already exists` line falls between the
+    opening ` ```` ` and closing ` ```` ` of `implementer.md`'s prompt block (e.g. confirm via
+    `awk` range or visual read — it sits within `## How to work`, which is inside the blob).
+  - Protected zones present: `grep -c "trust-boundary" skills/woostack-execute/prompts/implementer.md` → `1`.
+  - No stray files / scope creep: `git status --porcelain` shows only the two edited skill files
+    (plus this fix doc); no new reference file, no `site/` change.


### PR DESCRIPTION
## Goal

woostack's minimalism is entirely **review-side** — over-build is caught by the diff-scoped `architecture` review angle and execute's quality reviewer, never **prevented** at generation time. This fix plan adds the missing generation-time guidance so the implementer reaches for the least code that already exists before writing custom code. Inspired by the ponytail skill's "best code is the code you never wrote" philosophy.

## Summary

- Adds `.woostack/fixes/2026-06-16-least-code-ladder.md` — a hardened, one-increment fix plan. **Docs-only; no skill edits in this PR.**
- Planned edits (executed in the stacked code PR on top of this one):
  - `skills/woostack-execute/prompts/implementer.md` — expand `## How to work` step 2 into a ranked least-code ladder (skip/YAGNI → stdlib → native feature → installed dep → one line → minimal custom), inside the fenced subagent-prompt blob, with a protected-zones clause (security / accessibility / data-loss / trust-boundary never on the chopping block).
  - `skills/woostack-ideate/SKILL.md` — add a `Least code wins.` bullet to `## Key principles`, sibling to `YAGNI ruthlessly`.
- **Scope guard:** no whole-repo audit, no debt ledger, no new reference file, no `site/` change. Complements the `architecture` review angle (prevention vs detection); does not duplicate it.

## Test plan

### Automated

- None — docs-only PR (adds a planning artifact). The stacked code PR has no runnable test harness for skill prose, so it verifies with grep/structural assertions (phrases present, ladder inside the fenced blob, only the two skill files changed).

### Manual

**Before merge**
- Read `.woostack/fixes/2026-06-16-least-code-ladder.md`; confirm the root cause, the two planned edits, and the scope guards read correctly.
- Confirm this PR carries only the fix-plan markdown (no skill edits yet): `git show --stat` lists exactly one file under `.woostack/fixes/`.

Spec: .woostack/fixes/2026-06-16-least-code-ladder.md
