### PR TITLE
docs(site): humanize landing-page hero copy

### DIFF
--- a/site/app/(home)/page.tsx
+++ b/site/app/(home)/page.tsx
@@ -5,9 +5,9 @@ export default function HomePage() {
     <main className="flex flex-1 flex-col items-center justify-center gap-6 px-4 py-24 text-center">
       <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">woostack</h1>
       <p className="max-w-2xl text-lg text-fd-muted-foreground">
-        A model-agnostic collection of software-development skills covering every phase of the
-        engineering process — bootstrap, build, plan, debug, review, and iterate — with a local,
-        token-efficient memory system.
+        A model-agnostic collection of software-development skills for every phase of the
+        engineering process: bootstrap, build, plan, debug, review, and iterate. It runs on a
+        local, token-efficient memory system.
       </p>
       <code className="rounded-lg bg-fd-muted px-4 py-2 text-sm font-medium">
         pnpx skills add howarewoo/woostack


### PR DESCRIPTION
## Goal

The site landing-page hero used two em dashes and an "-ing" significance phrase, the exact AI tells AGENTS.md bans in authored site copy. This rewrites the hero so it reads as human-authored.

## Summary

- Rewrote the hero `<p>` in `site/app/(home)/page.tsx`: replaced both em dashes (colon + sentence split) and dropped the "covering every phase" -ing padding.
- Meaning preserved: model-agnostic skill collection, full engineering lifecycle, local token-efficient memory.

## Test plan

### Automated

- [ ] `pnpm -C site build` — Not run (text-only change inside a JSX string literal, no logic touched).

### Manual

**Before merge**

- [ ] Read the diff and confirm the hero copy contains no em or en dashes and reads naturally.
