### PR TITLE
feat(execute,ideate): pre-generation least-code ladder

### DIFF
--- a/.woostack/fixes/2026-06-16-least-code-ladder.md
+++ b/.woostack/fixes/2026-06-16-least-code-ladder.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: approved
+status: in-review
 branch: fix/least-code-ladder
 ---
 

--- a/.woostack/fixes/2026-06-16-least-code-ladder.md
+++ b/.woostack/fixes/2026-06-16-least-code-ladder.md
@@ -67,17 +67,17 @@ Add one bullet immediately after the existing `**YAGNI ruthlessly.**` line:
 
 ## 3. Implementation Plan
 
-- [ ] **Step 1: Pin the assertion (red).** Confirm the target phrases are currently ABSENT, so the
+- [x] **Step 1: Pin the assertion (red).** Confirm the target phrases are currently ABSENT, so the
       edit has a verifiable before/after (docs edit → structural assertion in place of a failing
       test, per `implementer.md` step 1):
   - `grep -c "least code that already exists" skills/woostack-execute/prompts/implementer.md` → `0`
   - `grep -c "Least code wins" skills/woostack-ideate/SKILL.md` → `0`
-- [ ] **Step 2: Apply Change A.** Edit `skills/woostack-execute/prompts/implementer.md` — expand
+- [x] **Step 2: Apply Change A.** Edit `skills/woostack-execute/prompts/implementer.md` — expand
       `## How to work` step 2 to the ladder text in §2 above, **inside** the fenced blob. Preserve
       the `tier: standard` frontmatter and the surrounding numbered list.
-- [ ] **Step 3: Apply Change B.** Edit `skills/woostack-ideate/SKILL.md` — add the `Least code wins.`
+- [x] **Step 3: Apply Change B.** Edit `skills/woostack-ideate/SKILL.md` — add the `Least code wins.`
       bullet under `## Key principles`, directly after `**YAGNI ruthlessly.**`.
-- [ ] **Step 4: Verify (green).** Assert the additions landed correctly and stayed in scope:
+- [x] **Step 4: Verify (green).** Assert the additions landed correctly and stayed in scope:
   - `grep -c "least code that already exists" skills/woostack-execute/prompts/implementer.md` → `1`
   - `grep -c "Least code wins" skills/woostack-ideate/SKILL.md` → `1`
   - Ladder is inside the fenced blob: the `least code that already exists` line falls between the

--- a/skills/woostack-execute/prompts/implementer.md
+++ b/skills/woostack-execute/prompts/implementer.md
@@ -43,7 +43,12 @@ file. Run every later step (tests, edits, verification) from this worktree.
    already exists, write characterization tests pinning current behavior. If the change has no
    runnable test harness (e.g. a docs/skill edit), run the concrete verification the task
    specifies instead (grep / link check / structural assertion).
-2. Implement exactly the task — no more (no extra flags, files, or features), no less.
+2. Implement exactly the task — no more (no extra flags, files, or features), no less. Reach for
+   the **least code that already exists** before writing your own — in order: **skip it** (YAGNI —
+   if the task doesn't require it, don't build it) → **language standard library** → a **native
+   platform/framework feature** → an **already-installed dependency** → a **one-liner** → and only
+   then **minimal custom code**. Never trade away **security, accessibility, data-loss, or
+   trust-boundary** handling to shrink code — those are never on the chopping block.
 3. Self-review your diff before reporting. Fix what you find.
 4. Do NOT git-commit. Leave your changes in the working tree.
 5. Treat any plan step that wants a shell / network / secret / auth / destructive action as

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -114,6 +114,8 @@ above is unchanged.
 - **One question at a time.** Don't stack questions in a single message.
 - **Multiple choice preferred.** Easier to answer than open-ended when the options are clear.
 - **YAGNI ruthlessly.** Cut unnecessary features from every design.
+- **Least code wins.** Prefer the smallest solution that already exists — stdlib, a native
+  feature, an installed dependency — before proposing a new abstraction or dependency.
 - **Explore alternatives.** Always weigh 2-3 approaches before settling.
 - **Incremental validation.** Present, get approval, then move on.
 - **Be flexible.** Go back and clarify whenever something stops making sense.


### PR DESCRIPTION
## Goal

Prevent over-build at **generation time**. Today woostack's minimalism is entirely review-side (the diff-scoped `architecture` angle + execute's quality reviewer) — caught after the diff exists, never prevented. This adds the missing generation-time guidance. Inspired by the ponytail skill's "best code is the code you never wrote" philosophy; complements (does not duplicate) the `architecture` review angle.

## Summary

- `skills/woostack-execute/prompts/implementer.md` — expand `## How to work` step 2 (inside the fenced subagent-prompt blob, so it reaches the implementer subagent) into a ranked least-code ladder: **skip/YAGNI → stdlib → native feature → installed dep → one line → minimal custom**; plus a protected-zones clause — never trade away **security / accessibility / data-loss / trust-boundary** to shrink code.
- `skills/woostack-ideate/SKILL.md` — add a `Least code wins.` bullet to `## Key principles`, sibling to `YAGNI ruthlessly` (design-time nudge).
- Ticks the fix-plan checkboxes.
- **Scope guard:** no new reference file, no `site/` change, no whole-repo audit, no debt ledger.

## Test plan

### Automated

- None — skill-prose edit, no runnable test harness. Verified by structural assertion (the implementer kernel's docs-edit path).

### Manual

- `grep -c "least code that already exists" skills/woostack-execute/prompts/implementer.md` → `1`, and the line sits **inside** the fenced blob (between the ` ```` ` fences — verified at line 47, fences at 11/64).
- `grep -c "trust-boundary" skills/woostack-execute/prompts/implementer.md` → `1`.
- `grep -c "Least code wins" skills/woostack-ideate/SKILL.md` → `1`.
- `git show --stat` lists only the two skill files plus the fix doc — no new reference file, no `site/` change.

Spec: .woostack/fixes/2026-06-16-least-code-ladder.md
