### PR TITLE
docs: spec + plan for review-angles docs page

### DIFF
--- a/.woostack/plans/2026-06-16-review-angles-docs.md
+++ b/.woostack/plans/2026-06-16-review-angles-docs.md
@@ -1,0 +1,206 @@
+---
+type: plan
+source: .woostack/specs/2026-06-16-review-angles-docs.md
+status: ready
+branch: feature/review-angles-docs
+---
+
+**Source:** [[specs/2026-06-16-review-angles-docs]]
+
+# Review angles — Docs page Implementation Plan
+
+**Goal:** Add one authored docs page, `site/content/docs/review-angles.mdx`, that catalogs every review angle (what it audits, when it auto-fires, its tier), wire it into nav, and collapse configuration.mdx's inline angle-name list into a cross-link.
+
+**Architecture:** Pure authored MDX content for the Fumadocs docs site. The new page uses the globally-available `Callout` / `Cards` / `Card` primitives (no imports, matching sibling pages) and Markdown tables. Three lockstep edits keep the site consistent: `meta.json` nav order, `configuration.mdx` list-to-link, and the `site/AGENTS.md` authored-pages enumeration. No application logic, no generator, no review-script changes. The build (`pnpm -C site build`) is the gate. Because there is no test runner for site content, each task is verified with concrete shell checks (grep / python3 / build) that fail before the edit and pass after.
+
+**Tech Stack:** MDX, Fumadocs (Next.js), pnpm.
+
+## Increment 1: Review-angles catalog page + lockstep wiring
+
+> One independently shippable PR (<=500 LOC soft target) -- its own Graphite-stacked branch. The whole change is one cohesive docs addition, so it ships as a single increment.
+
+### Task 1: Author the review-angles page
+
+**Files:**
+- Create: `site/content/docs/review-angles.mdx`
+
+- [ ] **Step 1: Confirm the page does not yet exist (red)**
+  Run: `test -f site/content/docs/review-angles.mdx && echo EXISTS || echo MISSING`
+  Expected: `MISSING`
+
+- [ ] **Step 2: Write the page**
+  Create `site/content/docs/review-angles.mdx` with exactly this content:
+  ````mdx
+  ---
+  title: Review angles
+  description: The lenses woostack-review fans out across a diff: what each angle audits, when it auto-fires, and the model tier it runs at.
+  ---
+
+  woostack-review reviews a pull request through a set of **angles**. Each angle is one lens (correctness, security, SQL, accessibility, and so on), and the review fans out one subagent per active angle in parallel, then validates their findings. This page is the catalog of every angle. To turn angles on or off, see [Choosing angles](/docs/configuration#choosing-angles) in the configuration reference.
+
+  ## How angles get chosen
+
+  Three rules decide which angles run on a given pull request:
+
+  1. **`bugs` and `security` always run.** They are on for every review and can never be skipped.
+  2. **The other angles auto-detect from the diff.** Each one looks at the files the PR touches and the content of the diff, and turns itself on when it sees something relevant. A `.sql` file pulls in `database`; a `.tsx` file pulls in `react`.
+  3. **You can override detection.** `review.angles.force` runs an angle whatever the diff looks like, and `review.angles.skip` keeps one off. `force` wins a tie, and `bugs` / `security` ignore `skip`. See [Choosing angles](/docs/configuration#choosing-angles).
+
+  ## The catalog
+
+  Every angle, what it reviews, a plain-language summary of when it auto-fires, and its model tier.
+
+  | Angle | Audits | Fires when | Tier |
+  | --- | --- | --- | --- |
+  | `aeo` | Answer-engine optimization: AI-crawler access and structured data for answer engines | `robots.txt`, `llms.txt`, Markdown or HTML content, or AI-crawler / JSON-LD tokens in the diff | fast |
+  | `api` | API contracts: routes, OpenAPI / GraphQL / proto schemas, HTTP handlers | OpenAPI / GraphQL / proto files, route trees, or HTTP-verb route bindings in the diff | standard |
+  | `architecture` | Structural quality of source: boundaries, coupling, code health | any general-purpose source file changes (skips doc-only and config-only PRs) | standard |
+  | `bugs` | Correctness: logic errors and broken behavior | always (cannot be skipped) | standard |
+  | `comments` | Comment rot: whether code comments still match the code the PR changed | any general-purpose source file changes. Always non-blocking | fast |
+  | `conventions` | Project rules: adherence to the repo's own AGENTS.md / CLAUDE.md and similar | the repo carries a rule file (AGENTS.md, CLAUDE.md, .cursorrules, .windsurfrules, GEMINI.md) along the changed paths | standard |
+  | `database` | SQL correctness, row-level security, indexes, query plans | `.sql`, migration trees, ORM schema files, or SQL DDL / RLS / raw-SQL tokens in the diff | standard |
+  | `deps` | Dependency hygiene: manifests and lockfiles | a dependency manifest or lockfile changes (package.json, pnpm-lock.yaml, go.mod, Cargo.toml, and the like) | fast |
+  | `design` | Visual and UX heuristics for front-end changes | a styling or markup file changes (`.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, and similar) | standard |
+  | `docs` | Documentation hygiene: READMEs, changelogs, Markdown | README, CHANGELOG, `docs/`, or `.md` / `.mdx` files change (a SKILL.md routes to `skills`) | fast |
+  | `i18n` | Internationalization: translation catalogs and message usage | `locales/`, `messages/`, `i18n/`, `.po` files, or translation tokens in the diff | fast |
+  | `infra` | Infrastructure: CI, containers, IaC, Kubernetes | workflow files, Dockerfiles, Terraform / Pulumi / CDK, k8s or helm trees, or IaC tokens in the diff | standard |
+  | `observability` | Logging and error handling: silent failures and swallowed errors | logging or error-handling tokens in the diff (console / logger / Sentry / OpenTelemetry, swallowed catches, production mock fallbacks) | standard |
+  | `react` | React correctness: Rules of Hooks and render behavior | a `.tsx` or `.jsx` file changes | standard |
+  | `security` | Threat model: injection, auth, secrets, unsafe patterns | always (cannot be skipped) | standard |
+  | `seo` | Search-engine optimization: meta tags, sitemaps, canonical URLs | HTML, head / layout files, `robots.txt`, `sitemap`, `next.config`, or SEO tokens in the diff | fast |
+  | `skills` | Agent Skill authoring: a changed SKILL.md against the best-practices guide | a `SKILL.md` file changes anywhere in the diff | standard |
+  | `tests` | Test coverage and quality | a test file changes (`.test.*`, `.spec.*`, `_test.*`, or `tests/` / `__tests__/` / `spec/` trees) | standard |
+  | `types` | Type design: TypeScript invariants and signatures | a `.ts` / `.tsx` / `.cts` / `.mts` file changes | standard |
+
+  The exact gating heuristics (file globs and diff-token patterns) live in [`detect-angles.sh`](https://github.com/howarewoo/woostack/blob/main/skills/woostack-review/scripts/detect-angles.sh), the source of truth. This table summarizes them in plain language.
+
+  <Callout type="info">
+    `bugs` and `security` run on every review and can never be skipped. Listing either under `review.angles.skip` is silently ignored.
+  </Callout>
+
+  <Callout type="info">
+    Two angles behave specially. `comments` is always non-blocking: it posts nits, never a blocking finding. `conventions` only runs when the repo carries a rule file (AGENTS.md, CLAUDE.md, .cursorrules, .windsurfrules, or GEMINI.md) along the changed paths.
+  </Callout>
+
+  ## Tiers
+
+  Each angle runs at a model tier matched to its work: `fast` for rubric and pattern checks, `standard` for reasoning-heavy passes. The skeptical validator that filters every finding runs at `deep`. The tier-to-model mapping per provider lives in [Core concepts](/docs/concepts#subagents-isolate-work), and you can override any tier in [Configuration](/docs/configuration#model-selection).
+
+  ## Where to go next
+
+  <Cards>
+    <Card title="woostack-review" href="/docs/skills/woostack-review" description="The review engine that runs these angles." />
+    <Card title="Configuration" href="/docs/configuration#choosing-angles" description="Force, skip, and tune angles in .woostack/config.json." />
+    <Card title="Core concepts" href="/docs/concepts" description="The build loop, context economy, and model tiers." />
+  </Cards>
+  ````
+
+- [ ] **Step 3: Confirm the page exists and is humanized (green)**
+  Run: `test -f site/content/docs/review-angles.mdx && echo EXISTS`
+  Expected: `EXISTS`
+  Run: `grep -nP '[—–]' site/content/docs/review-angles.mdx && echo FOUND_DASH || echo NO_DASH`
+  Expected: `NO_DASH` (no em/en dashes in the prose)
+
+- [ ] **Step 4: Confirm the catalog covers exactly the 19 valid angles (green)**
+  Run (line-number-independent: greps the `VALID_ANGLES` set wherever it lives in load-config.sh):
+  ```bash
+  diff \
+    <(grep -oE '^\| `[a-z0-9]+`' site/content/docs/review-angles.mdx | tr -d '| `' | sort) \
+    <(grep -m1 -F 'VALID_ANGLES = {' skills/woostack-review/scripts/load-config.sh | grep -oE '"[a-z0-9]+"' | tr -d '"' | sort) \
+    && echo ANGLES_MATCH
+  ```
+  Expected: `ANGLES_MATCH` (empty diff: the table's angle column equals `VALID_ANGLES`, all 19)
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt create -m "docs(site): add review-angles catalog page"
+  ```
+
+### Task 2: Wire nav and collapse configuration's angle list
+
+**Files:**
+- Modify: `site/content/docs/meta.json`
+- Modify: `site/content/docs/configuration.mdx:82-84`
+
+- [ ] **Step 1: Confirm nav and config list are in their pre-edit state (red)**
+  Run: `python3 -c "import json; print(json.load(open('site/content/docs/meta.json'))['pages'])"`
+  Expected: `['index', 'getting-started', 'concepts', 'configuration', 'skills']` (no `review-angles` yet)
+  Run: `grep -q 'The valid angles are' site/content/docs/configuration.mdx && echo OLD_LIST_PRESENT`
+  Expected: `OLD_LIST_PRESENT`
+
+- [ ] **Step 2: Add the page to nav**
+  Edit `site/content/docs/meta.json` so `pages` reads exactly:
+  ```json
+  {"title":"Docs","pages":["index","getting-started","concepts","configuration","review-angles","skills"]}
+  ```
+
+- [ ] **Step 3: Replace configuration's inline angle list with a cross-link**
+  In `site/content/docs/configuration.mdx`, replace the three-line list under "### Choosing angles":
+  ```
+  The valid angles are: `aeo`, `api`, `architecture`, `bugs`, `comments`, `conventions`,
+  `database`, `deps`, `design`, `docs`, `i18n`, `infra`, `observability`, `react`, `security`,
+  `seo`, `skills`, `tests`, `types`.
+  ```
+  with:
+  ```
+  See [Review angles](/docs/review-angles) for the full catalog of all 19 angles: what each one
+  audits, when it auto-fires, and its model tier.
+  ```
+
+- [ ] **Step 4: Confirm nav and link are wired (green)**
+  Run:
+  ```bash
+  python3 -c "import json; d=json.load(open('site/content/docs/meta.json')); assert d['pages']==['index','getting-started','concepts','configuration','review-angles','skills'], d['pages']; print('NAV_OK')"
+  ```
+  Expected: `NAV_OK`
+  Run: `grep -q '/docs/review-angles' site/content/docs/configuration.mdx && echo LINK_OK`
+  Expected: `LINK_OK`
+  Run: `grep -q 'The valid angles are' site/content/docs/configuration.mdx && echo OLD_LIST_PRESENT || echo OLD_LIST_GONE`
+  Expected: `OLD_LIST_GONE`
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs(site): link configuration angle list to the new catalog page"
+  ```
+
+### Task 3: Sync the authored-pages list and pass the build gate
+
+**Files:**
+- Modify: `site/AGENTS.md:18-19`
+
+- [ ] **Step 1: Confirm the authored-pages list omits the new page (red)**
+  Run: `grep -q 'review-angles.mdx' site/AGENTS.md && echo AGENTS_OK || echo AGENTS_MISSING`
+  Expected: `AGENTS_MISSING`
+
+- [ ] **Step 2: Add review-angles.mdx to the authored-pages enumeration**
+  In `site/AGENTS.md`, the sentence currently reads:
+  ```
+  This rule covers the **authored** pages only: `content/docs/index.mdx`, `getting-started.mdx`,
+  `concepts.mdx`, `configuration.mdx`, and the landing page.
+  ```
+  Change it to include the new page:
+  ```
+  This rule covers the **authored** pages only: `content/docs/index.mdx`, `getting-started.mdx`,
+  `concepts.mdx`, `configuration.mdx`, `review-angles.mdx`, and the landing page.
+  ```
+
+- [ ] **Step 3: Confirm the list is synced (green)**
+  Run: `grep -q 'review-angles.mdx' site/AGENTS.md && echo AGENTS_OK`
+  Expected: `AGENTS_OK`
+
+- [ ] **Step 4: Build the docs site (the gate)**
+  Run: `pnpm -C site build`
+  Expected: PASS. The `prebuild` hook runs `node scripts/gen-skills.mjs` (regenerating the gitignored per-skill pages from each `SKILL.md`), then `next build` compiles the site including the new `review-angles` route, with all internal links resolving.
+  If the build fails on missing dependencies (`node_modules` absent in the working tree), run `pnpm -C site install` once and re-run the build.
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs(site): list review-angles.mdx as an authored page"
+  ```
+
+## Plan Checks
+
+- **Spec coverage** — AC1 (page exists and builds) → Task 1 Step 3 + Task 3 Step 4; AC2 (catalog = exact 19 angles) → Task 1 Step 4; AC3 (no net duplication, canonical homes linked) → Task 1 Step 2 (detect-angles.sh + concepts links, plain-language triggers) and Task 2 (configuration list → cross-link); AC4 (humanized + authored-list synced) → Task 1 Step 3 (NO_DASH) and Task 3.
+- **AC coverage** — every AC and each filled happy/error/edge case maps to a concrete check above; §7 has no whole-section N/A.
+- **No placeholders** — the full page MDX is inline in Task 1 Step 2; every check carries an exact command and expected output.
+- **Type consistency** — angle names in the catalog match `VALID_ANGLES` exactly (pinned by the Task 1 Step 4 diff); tiers match each angle prompt's `tier:` frontmatter; nav array and cross-link anchors (`#choosing-angles`, `#subagents-isolate-work`, `#model-selection`) match the current pages.

--- a/.woostack/specs/2026-06-16-review-angles-docs.md
+++ b/.woostack/specs/2026-06-16-review-angles-docs.md
@@ -1,0 +1,177 @@
+---
+name: review-angles-docs
+type: spec
+status: approved
+date: 2026-06-16
+branch: feature/review-angles-docs
+links:
+---
+
+# Review angles — Docs page Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
+> **Plan:** [[plans/2026-06-16-review-angles-docs]]
+
+## 1. Problem
+
+The docs site has no human-facing reference for woostack-review's angles. A reader who wants to
+know what an angle audits, when it auto-fires, or what model tier it runs at has nowhere to look:
+
+- `configuration.mdx` "Choosing angles" lists the 19 angle **names** and the `force`/`skip`
+  semantics only — no meanings, no gating, no tiers.
+- The exact gating heuristics live in `skills/woostack-review/scripts/detect-angles.sh` (a shell
+  comment header) and the tier assignments live in `skills/woostack-review/SKILL.md` (dense prose
+  that reaches the site only as the gitignored generated `skills/woostack-review.mdx`).
+
+Neither is a clean reference page. The angle catalog also already lives in ~11 code sites
+(`lockstep-edit-sites` wisdom), so any new copy must be authored to minimize net duplication and
+desync risk — not become a 12th verbatim mirror of the gating regexes.
+
+## 2. Goal
+
+Add one authored, tracked docs page — `site/content/docs/review-angles.mdx` — that is the single
+human-facing catalog of the review angles: for each angle, what it audits, a plain-language
+"fires when" trigger, and its tier. Reduce net site duplication by collapsing
+`configuration.mdx`'s inline 19-name list into a cross-link to the new page. The page defers exact
+gating and the tier→model mapping to their canonical homes by link, so a future gating tweak does
+not silently desync it.
+
+## 3. Non-goals
+
+- No changes to `detect-angles.sh`, `SKILL.md`, angle prompts, or any review script/logic.
+- No new angle, no change to which angles exist or how they gate.
+- No per-angle deep-dive pages and no new MDX components.
+- No restating the tier→model table (lives in `concepts.mdx`) or the exact glob/token heuristics
+  (live in `detect-angles.sh`) — cross-link both instead.
+- Not touching the generated per-skill `skills/woostack-review.mdx` (regenerated from SKILL.md,
+  gitignored).
+
+## 4. Approach
+
+Author `site/content/docs/review-angles.mdx` with this structure:
+
+1. **Frontmatter** — `title: Review angles`, one-line `description`.
+2. **Intro** — angles are the lenses woostack-review fans out, one subagent per angle in parallel.
+   Cross-link `woostack-review` and `configuration#choosing-angles`.
+3. **How angles get chosen** — three facts: `bugs` + `security` always on and never skippable; the
+   other 17 auto-detected from the diff (files touched + diff-body tokens); `force`/`skip` override
+   detection (`force` wins; bugs/security cannot be skipped) → cross-link configuration.
+4. **The catalog** — one Markdown table in canonical alphabetical order (matching `VALID_ANGLES`
+   and the current `configuration.mdx` list), columns: **Angle · Audits · Fires when · Tier**, one
+   row per angle (19 rows). Plain-language "Fires when" per the gating-depth decision. Immediately
+   after the table, a line stating the exact gating heuristics live in `detect-angles.sh` (GitHub
+   source link) — the source of truth.
+5. **Two callouts** for non-obvious specials: (a) `bugs`/`security` always-on + never-skippable;
+   (b) `comments` is always non-blocking (nit-only) and `conventions` only fires when the repo
+   carries rule files (AGENTS.md / CLAUDE.md / .cursorrules / .windsurfrules / GEMINI.md).
+6. **Tiers** — short paragraph: each angle runs at fast / standard / deep; cross-link
+   `concepts#subagents-isolate-work` for the tier→model table rather than restating it.
+7. **Where to go next** — `<Cards>`: woostack-review, configuration, concepts.
+
+Then the **lockstep edits**:
+
+- `site/content/docs/meta.json` — add `"review-angles"` to `pages`, between `configuration` and
+  `skills`.
+- `site/content/docs/configuration.mdx` "Choosing angles" — replace the inline 19-name list with a
+  one-line cross-link to `/docs/review-angles`. (Keep the force/skip key table; it is config, not
+  catalog.)
+- `site/AGENTS.md` — the authored-pages enumeration (the "This rule covers the authored pages only:
+  …" line) lists which pages the humanize rule covers. The new page is authored, so add
+  `review-angles.mdx` to that list. Missing this desyncs the house-rule scope from the actual
+  authored set (`lockstep-edit-sites`).
+
+**House-rule: humanized copy.** `site/AGENTS.md` requires all authored site prose to read as
+human-written. The new page must comply (apply the `humanizer` rules by hand or via the skill):
+no em/en dashes in prose (the one carve-out is `—` as a "none" placeholder inside a table cell —
+not used on this page), `**Label:** desc` not `**Label** — desc`, no false "from X to Y" ranges,
+no trailing negations / hollow superlatives / rule-of-three filler. This governs the new page's
+wording and the edited `configuration.mdx` line.
+
+Angle source data (confirmed present, 19 angles): `aeo`, `api`, `architecture`, `bugs`,
+`comments`, `conventions`, `database`, `deps`, `design`, `docs`, `i18n`, `infra`, `observability`,
+`react`, `security`, `seo`, `skills`, `tests`, `types`. "Audits" + "Fires when" summarized from the
+`detect-angles.sh` header; "Tier" read from the SKILL.md tier-assignment table.
+
+## 5. Components & data flow
+
+- **`site/content/docs/review-angles.mdx`** (new) — the page. Pure MDX content using the same
+  Fumadocs primitives already used on sibling pages (`<Callout>`, `<Cards>`, `<Card>`, Markdown
+  tables). Standalone; no data fetching, no generator.
+- **`site/content/docs/meta.json`** (edit) — nav ordering; one array insertion.
+- **`site/content/docs/configuration.mdx`** (edit) — the "Choosing angles" section loses its
+  inline name list, gains a cross-link.
+
+Data flow: none at runtime. The page is static authored content built by `pnpm -C site build`
+(Fumadocs / Next.js) into the docs site like every other authored page.
+
+## 6. Error handling
+
+Build-time only. The single failure mode is an MDX/build break (bad frontmatter, malformed JSX,
+broken internal link, or a `meta.json` page entry with no matching file). Guard: `pnpm -C site
+build` must pass, and the new `meta.json` entry must point at the real new file. No runtime error
+surface.
+
+## 7. Acceptance criteria
+
+- **AC1 — The review-angles page exists and builds**
+  - happy: `site/content/docs/review-angles.mdx` exists with valid frontmatter; `pnpm -C site
+    build` succeeds with the page included.
+  - error: a malformed-frontmatter or broken-JSX page fails the build (caught by `pnpm -C site
+    build`, the gate).
+  - edge: page is reachable in nav because `meta.json` lists `review-angles`; a `meta.json` entry
+    with no file (or a file absent from `meta.json`) is caught at build/lint time.
+- **AC2 — The catalog covers exactly the 19 valid angles**
+  - happy: the catalog table has one row per angle in `load-config.sh`'s `VALID_ANGLES`, same
+    names, canonical alphabetical order.
+  - error: a row naming a non-existent angle, or a missing angle, is a defect — verified by
+    cross-checking the table rows against `VALID_ANGLES` (19 names).
+  - edge: `bugs`/`security` appear in the table and are additionally called out as always-on;
+    `comments`/`conventions` specials are called out.
+- **AC3 — No net new verbatim duplication; canonical homes are linked, not restated**
+  - happy: "Fires when" is plain-language; the page links `detect-angles.sh` for exact gating and
+    `concepts#subagents-isolate-work` for the tier→model table instead of copying either.
+  - error: reproducing the full glob/token regexes or the tier→model table verbatim on the page is
+    a spec violation.
+  - edge: `configuration.mdx`'s inline 19-name list is replaced by a cross-link (net site
+    angle-name lists go from 2 → 1).
+  - N/A class: none.
+- **AC4 — Authored copy is humanized and the authored-pages list stays in sync**
+  - happy: the new page and the edited `configuration.mdx` line carry no em/en dashes in prose,
+    no `**Label** — desc` bullets, no rule-of-three filler (the `site/AGENTS.md` rules); the
+    carve-out `—` "none" table placeholder is not used here.
+  - error: an em/en dash in the page prose, or leaving `review-angles.mdx` out of the
+    `site/AGENTS.md` authored-pages enumeration, is a defect.
+  - edge: the table itself may use plain hyphens / commas; the no-dash rule is about em/en dashes
+    in prose, not hyphenated words.
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+This is an authored docs change; the repo has no app test runner for site content. Verification is
+concrete and manual/CI-style:
+
+1. `pnpm -C site build` passes with the new page (the build is the gate, per the CLAUDE.md hard
+   constraint to keep the docs site building).
+2. Cross-check the catalog rows against `VALID_ANGLES` in
+   `skills/woostack-review/scripts/load-config.sh` (19 names, exact set) — done by eye / `grep`
+   during execution, not an automated test.
+3. Visual smoke: page renders in nav between Configuration and Skills; internal links resolve.
+4. Humanize pass: scan the new page + edited `configuration.mdx` line for em/en dashes in prose
+   and the other `site/AGENTS.md` AI tells before committing; confirm `review-angles.mdx` is added
+   to the `site/AGENTS.md` authored-pages list.
+
+No unit tests are added — there is no code under test, only MDX content.
+
+## 9. Open questions
+
+None outstanding. Resolved during ideation: placement (new dedicated page, configuration's list
+shrinks to a cross-link) and gating depth (plain-language trigger, not verbatim heuristic copy).
+Resolved during hardening by exploring the repo (no user input needed): the `site/AGENTS.md`
+humanize house-rule applies to the new authored page (folded into §4 and AC4), and the
+`site/AGENTS.md` authored-pages enumeration is a lockstep site that must add `review-angles.mdx`
+(folded into §4 and AC4). Cross-link anchors `#choosing-angles` and `#subagents-isolate-work`
+confirmed present in the current pages.


### PR DESCRIPTION
## Goal

Give the docs site a single human-facing reference for woostack-review's angles. Today the angle catalog lives only in `detect-angles.sh` comments and dense `SKILL.md` prose, and `configuration.mdx` lists the angle names without saying what each one audits, when it auto-fires, or its model tier.

## Summary

- Spec: `.woostack/specs/2026-06-16-review-angles-docs.md` (approved) — one new authored page `site/content/docs/review-angles.mdx` cataloging all 19 angles, with configuration's inline name list collapsed to a cross-link so the site carries one catalog instead of two partial lists.
- Plan: `.woostack/plans/2026-06-16-review-angles-docs.md` (ready) — one PR-sized increment, three TDD-by-verification tasks (author the page, wire nav + configuration link, sync `site/AGENTS.md` authored-pages list + build gate).
- Honors the `site/AGENTS.md` humanize house-rule and the `lockstep-edit-sites` wisdom (the authored-pages list is treated as a contract and updated in lockstep).

## Test plan

### Manual

**Before merge**

- [ ] Read the spec and plan; confirm the angle catalog covers exactly the 19 `VALID_ANGLES` and defers exact gating + tier-to-model to their canonical homes by link.

This PR is the docs-only base of the stack; the implementation increment stacks on top.

Spec: .woostack/specs/2026-06-16-review-angles-docs.md
