### PR TITLE
docs(site): add worktrees parallelism concept page

### DIFF
--- a/.woostack/plans/2026-06-16-concepts-page-split.md
+++ b/.woostack/plans/2026-06-16-concepts-page-split.md
@@ -340,7 +340,7 @@ dependencies (spec §3).
 - Modify: `site/content/docs/concepts/meta.json` (add `"worktrees"`)
 - Modify: `site/content/docs/concepts/index.mdx` (add a worktrees Card)
 
-- [ ] **Step 1: Write `worktrees.mdx`** (every claim traces to
+- [x] **Step 1: Write `worktrees.mdx`** (every claim traces to
   `skills/woostack-init/references/worktrees.md` — spec §4 grounding)
   ```mdx
   ---
@@ -404,7 +404,7 @@ dependencies (spec §3).
   isolation, not intra-plan concurrency.
   ```
 
-- [ ] **Step 2: Add `"worktrees"` to `concepts/meta.json`** (append after `"context-management"`)
+- [x] **Step 2: Add `"worktrees"` to `concepts/meta.json`** (append after `"context-management"`)
   ```json
   {
     "title": "Core concepts",
@@ -418,18 +418,18 @@ dependencies (spec §3).
   }
   ```
 
-- [ ] **Step 3: Add the worktrees Card to the hub** (`concepts/index.mdx`, inside `<Cards>`)
+- [x] **Step 3: Add the worktrees Card to the hub** (`concepts/index.mdx`, inside `<Cards>`)
   ```mdx
     <Card title="Parallelism with worktrees" href="/docs/concepts/worktrees" description="Run many builds and fixes at once, each isolated in its own git worktree." />
   ```
 
-- [ ] **Step 4: Build green and links resolve**
+- [x] **Step 4: Build green and links resolve**
   Run: `pnpm -C site build`
   Expected: exits 0; route list includes `/docs/concepts/worktrees`.
   Run: `grep -F "resolve-base.sh" site/content/docs/concepts/worktrees.mdx && grep -F ".woostack/worktrees/" site/content/docs/concepts/worktrees.mdx`
   Expected: both print (the key contract facts are present).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt create -m "docs(site): add worktrees parallelism concept page"
   ```

--- a/site/content/docs/concepts/index.mdx
+++ b/site/content/docs/concepts/index.mdx
@@ -23,4 +23,5 @@ surfaces, worktrees and the status board, keep parallel work and collaboration c
   <Card title="Building rules" href="/docs/concepts/building-rules" description="The gated build loop, its three hard gates, and the one-spec-one-plan-N-PRs invariant." />
   <Card title="Memory" href="/docs/concepts/memory" description="The memory and wisdom stores, and how each is recalled." />
   <Card title="Context management" href="/docs/concepts/context-management" description="Scripts compute, subagents isolate, and model tiers route work." />
+  <Card title="Parallelism with worktrees" href="/docs/concepts/worktrees" description="How woostack isolates each run in its own git worktree so multiple builds never collide." />
 </Cards>

--- a/site/content/docs/concepts/meta.json
+++ b/site/content/docs/concepts/meta.json
@@ -4,6 +4,7 @@
     "index",
     "building-rules",
     "memory",
-    "context-management"
+    "context-management",
+    "worktrees"
   ]
 }

--- a/site/content/docs/concepts/worktrees.mdx
+++ b/site/content/docs/concepts/worktrees.mdx
@@ -32,28 +32,28 @@ This is the invariant that makes parallel runs safe:
 
 <Callout type="info">
   A run does all its writes in its own worktree. The primary checkout stays on the base branch,
-  clean — the stable point every run branches from. Two runs never touch the primary tree, so
+  clean. It is the stable point every run branches from. Two runs never touch the primary tree, so
   runs with disjoint branch sets never collide.
 </Callout>
 
 Stacked increments build on each other rather than on the primary tree: increment _k_ branches
-off increment _k–1_'s tip (increment 1 off the spec+plan branch). The shared `.git` and Graphite
-metadata serialize through git's index and ref locks — brief contention, never corruption.
+off increment _k-1_'s tip (increment 1 off the spec+plan branch). The shared `.git` and Graphite
+metadata serialize through git's index and ref locks: brief contention, never corruption.
 
 ## Teardown, and what survives
 
-- **Success** — once the commit, push, and PR exist, the run removes the worktree directory
+- **Success:** once the commit, push, and PR exist, the run removes the worktree directory
   (`git worktree remove`). The branch, commits, and PR persist; only the working directory is
   deleted.
-- **Failure** — on a commit/push error or an unresolved review blocker, the run **leaves the
+- **Failure:** on a commit/push error or an unresolved review blocker, the run **leaves the
   worktree in place** and reports its path, so you can inspect it.
-- **Abandon** — a run dropped before any PR exists force-removes the worktree and deletes its
+- **Abandon:** a run dropped before any PR exists force-removes the worktree and deletes its
   dangling branch.
 
 A stale directory left by a crashed run is inert (the `worktrees/` path is gitignored).
 [woostack-doctor](/docs/skills/woostack-doctor) detects an orphaned worktree and prunes it; you
 can also reclaim one by hand with `git worktree prune` / `git worktree remove`.
 
-Parallelism here is **across independent runs** — several `woostack-build` or `woostack-fix`
+Parallelism here is **across independent runs**, several `woostack-build` or `woostack-fix`
 plans in flight at once. Increments within a single plan run sequentially; the worktree's job is
 isolation, not intra-plan concurrency.

--- a/site/content/docs/concepts/worktrees.mdx
+++ b/site/content/docs/concepts/worktrees.mdx
@@ -1,0 +1,59 @@
+---
+title: Parallelism with worktrees
+description: How woostack runs many builds, fixes, and executions at once by isolating each in its own git worktree.
+---
+
+woostack runs several plans at the same time on one machine without collision. The mechanism is
+the **git worktree**: every build, fix, and execution does all of its writes in a private working
+tree, while the primary checkout stays clean on the base branch. Two runs never touch the same
+files, so they never collide.
+
+## A worktree per run
+
+When a run starts, it creates a worktree under `.woostack/worktrees/<slug>`, where `<slug>` is the
+branch name with `/` replaced by `-` (branch `feature/foo` → directory `feature-foo`). The branch
+it creates follows the run:
+
+| Run | Branch | Worktree directory |
+| --- | --- | --- |
+| [woostack-build](/docs/skills/woostack-build) spec+plan | `feature/<slug>` | `.woostack/worktrees/feature-<slug>` |
+| [woostack-fix](/docs/skills/woostack-fix) | `fix/<slug>` | `.woostack/worktrees/fix-<slug>` |
+| [woostack-execute](/docs/skills/woostack-execute) increment | the plan's increment branch | one per increment |
+
+The base branch is never hard-coded. A small script, `resolve-base.sh`, resolves it in order: an
+explicit `WOOSTACK_BASE_BRANCH` override, then `base_branch` in
+[`.woostack/config.json`](/docs/configuration), then the remote's default branch, then `main`.
+After the worktree is added, the run registers the Graphite parent from inside it with
+`gt track --parent <base>`, so `gt submit` opens the PR against the right base.
+
+## The primary tree stays clean
+
+This is the invariant that makes parallel runs safe:
+
+<Callout type="info">
+  A run does all its writes in its own worktree. The primary checkout stays on the base branch,
+  clean — the stable point every run branches from. Two runs never touch the primary tree, so
+  runs with disjoint branch sets never collide.
+</Callout>
+
+Stacked increments build on each other rather than on the primary tree: increment _k_ branches
+off increment _k–1_'s tip (increment 1 off the spec+plan branch). The shared `.git` and Graphite
+metadata serialize through git's index and ref locks — brief contention, never corruption.
+
+## Teardown, and what survives
+
+- **Success** — once the commit, push, and PR exist, the run removes the worktree directory
+  (`git worktree remove`). The branch, commits, and PR persist; only the working directory is
+  deleted.
+- **Failure** — on a commit/push error or an unresolved review blocker, the run **leaves the
+  worktree in place** and reports its path, so you can inspect it.
+- **Abandon** — a run dropped before any PR exists force-removes the worktree and deletes its
+  dangling branch.
+
+A stale directory left by a crashed run is inert (the `worktrees/` path is gitignored).
+[woostack-doctor](/docs/skills/woostack-doctor) detects an orphaned worktree and prunes it; you
+can also reclaim one by hand with `git worktree prune` / `git worktree remove`.
+
+Parallelism here is **across independent runs** — several `woostack-build` or `woostack-fix`
+plans in flight at once. Increments within a single plan run sequentially; the worktree's job is
+isolation, not intra-plan concurrency.


### PR DESCRIPTION
## Goal

Add the "Parallelism with worktrees" concept page — a topic the old monolithic page never covered
despite it being a headline woostack capability.

## Summary

- Adds `site/content/docs/concepts/worktrees.mdx`: how woostack isolates each build/fix/execute in
  its own git worktree under `.woostack/worktrees/<slug>`, branch naming, base via
  `resolve-base.sh`, `gt track`, the primary-tree-stays-clean invariant, and teardown /
  leave-on-failure rules. Every claim traces to `skills/woostack-init/references/worktrees.md`.
- Registers it in `concepts/meta.json` and adds its hub `<Card>`.
- Ticks Increment 2 of the plan.

## Test plan

### Automated

- [x] `pnpm -C site build` → exit 0; `/docs/concepts/worktrees` route emitted.
- [x] `resolve-base.sh` and `.woostack/worktrees/` contract facts present on the page; hub Cards = 4;
      `meta.json` pages = [index, building-rules, memory, context-management, worktrees].

### Manual

**Before merge**

- [ ] Open `/docs/concepts/worktrees`; confirm the run→branch→worktree table, the primary-tree
      Callout, and the teardown list read cleanly and match the worktree contract.

Spec: .woostack/specs/2026-06-16-concepts-page-split.md
