### PR TITLE
docs(site): add status-tracking collaboration concept page

### DIFF
--- a/.woostack/plans/2026-06-16-concepts-page-split.md
+++ b/.woostack/plans/2026-06-16-concepts-page-split.md
@@ -447,7 +447,7 @@ dependencies (spec §3).
 - Modify: `site/content/docs/concepts/meta.json` (add `"status-tracking"`)
 - Modify: `site/content/docs/concepts/index.mdx` (add a status Card)
 
-- [ ] **Step 1: Write `status-tracking.mdx`** (every claim traces to
+- [x] **Step 1: Write `status-tracking.mdx`** (every claim traces to
   `skills/woostack-status/SKILL.md` + `references/conventions.md` — spec §4 grounding)
   ```mdx
   ---
@@ -503,7 +503,7 @@ dependencies (spec §3).
   to run anywhere, including CI, without mutating anything.
   ```
 
-- [ ] **Step 2: Add `"status-tracking"` to `concepts/meta.json`** (append after `"worktrees"`)
+- [x] **Step 2: Add `"status-tracking"` to `concepts/meta.json`** (append after `"worktrees"`)
   ```json
   {
     "title": "Core concepts",
@@ -518,18 +518,18 @@ dependencies (spec §3).
   }
   ```
 
-- [ ] **Step 3: Add the status Card to the hub** (`concepts/index.mdx`, inside `<Cards>`)
+- [x] **Step 3: Add the status Card to the hub** (`concepts/index.mdx`, inside `<Cards>`)
   ```mdx
     <Card title="Collaboration with status tracking" href="/docs/concepts/status-tracking" description="A shared feature board computed from artifacts in git, never a hand-maintained file." />
   ```
 
-- [ ] **Step 4: Build green and facts present**
+- [x] **Step 4: Build green and facts present**
   Run: `pnpm -C site build`
   Expected: exits 0; route list includes `/docs/concepts/status-tracking`.
   Run: `grep -F "1 : 1 : N" site/content/docs/concepts/status-tracking.mdx && grep -F "staleDays" site/content/docs/concepts/status-tracking.mdx`
   Expected: both print.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt create -m "docs(site): add status-tracking collaboration concept page"
   ```

--- a/site/content/docs/concepts/index.mdx
+++ b/site/content/docs/concepts/index.mdx
@@ -24,4 +24,5 @@ surfaces, worktrees and the status board, keep parallel work and collaboration c
   <Card title="Memory" href="/docs/concepts/memory" description="The memory and wisdom stores, and how each is recalled." />
   <Card title="Context management" href="/docs/concepts/context-management" description="Scripts compute, subagents isolate, and model tiers route work." />
   <Card title="Parallelism with worktrees" href="/docs/concepts/worktrees" description="How woostack isolates each run in its own git worktree so multiple builds never collide." />
+  <Card title="Collaboration with status tracking" href="/docs/concepts/status-tracking" description="How woostack computes a shared feature board from git artifacts so teams stay aligned without a hand-maintained status file." />
 </Cards>

--- a/site/content/docs/concepts/meta.json
+++ b/site/content/docs/concepts/meta.json
@@ -5,6 +5,7 @@
     "building-rules",
     "memory",
     "context-management",
-    "worktrees"
+    "worktrees",
+    "status-tracking"
   ]
 }

--- a/site/content/docs/concepts/status-tracking.mdx
+++ b/site/content/docs/concepts/status-tracking.mdx
@@ -1,0 +1,51 @@
+---
+title: Collaboration with status tracking
+description: "How woostack gives a team a shared feature board that is computed from artifacts in git, never a hand-maintained file."
+---
+
+woostack never commits a `STATUS.md`. Instead [woostack-status](/docs/skills/woostack-status)
+**computes** a feature board on demand from artifacts that already live in git — the specs, the
+plans, and the open PRs — and prints it to the terminal. Because the board is derived, it can
+never drift from reality the way a hand-edited status file does, and any teammate gets the same
+board from the same clone.
+
+## The phase enum
+
+Every feature moves through a fixed set of phases. The spec frontmatter owns the design-approval
+phases; once the spec is approved, the plan frontmatter owns the implementation lifecycle:
+
+> **spec:** `draft → hardened → approved`  ·  **plan:** `planning → ready → executing → in-review → done`
+> (plus the terminal `abandoned`)
+
+The build loop authors each transition as it advances, and the board reads it. The full enum and
+its join rules are defined once in the
+[status conventions](https://github.com/howarewoo/woostack/blob/main/skills/woostack-status/references/conventions.md).
+
+## One spec, one plan, N PRs — joined by artifacts
+
+The board relies on the `spec : plan : PRs = 1 : 1 : N` invariant. It walks two joins:
+
+- **spec → plan**: the plan carries a `**Source:** [[specs/<basename>]]` line back to its spec.
+- **plan → PR**: every PR body carries a `Spec: .woostack/specs/<file>.md` trailer.
+
+Following those joins, the board pairs each spec with its one plan and that plan's N increment
+PRs.
+
+## Computed, not authored
+
+<Callout type="info">
+  The board is computed fresh each run and printed to the terminal. It never fetches, commits, or
+  pushes, and there is no committed status file. A lagging authored `status:` is reconciled
+  against the artifacts, not trusted blindly.
+</Callout>
+
+For phases before a plan exists, the board shows the spec's authored `status:`. Once execution
+starts, it shows the **computed** phase derived from branches, commits, and PR state — and a
+disagreement between the authored value and the computed one is surfaced as a flag, not displayed
+as truth. The board also flags drift it can prove from the artifacts: an unknown `status:`, a
+missing or duplicate plan, a missing branch for an executing feature, head-state phases while PRs
+already exist, two in-flight rows on one branch, and executing rows older than
+`status.staleDays` (a [config](/docs/configuration) key, default 14).
+
+Because `status.sh` only reads — it exits 0 even when it prints drift flags — the board is safe
+to run anywhere, including CI, without mutating anything.

--- a/site/content/docs/concepts/status-tracking.mdx
+++ b/site/content/docs/concepts/status-tracking.mdx
@@ -4,8 +4,8 @@ description: "How woostack gives a team a shared feature board that is computed 
 ---
 
 woostack never commits a `STATUS.md`. Instead [woostack-status](/docs/skills/woostack-status)
-**computes** a feature board on demand from artifacts that already live in git — the specs, the
-plans, and the open PRs — and prints it to the terminal. Because the board is derived, it can
+**computes** a feature board on demand from artifacts that already live in git (the specs, the
+plans, and the open PRs) and prints it to the terminal. Because the board is derived, it can
 never drift from reality the way a hand-edited status file does, and any teammate gets the same
 board from the same clone.
 
@@ -21,7 +21,7 @@ The build loop authors each transition as it advances, and the board reads it. T
 its join rules are defined once in the
 [status conventions](https://github.com/howarewoo/woostack/blob/main/skills/woostack-status/references/conventions.md).
 
-## One spec, one plan, N PRs — joined by artifacts
+## One spec, one plan, N PRs, joined by artifacts
 
 The board relies on the `spec : plan : PRs = 1 : 1 : N` invariant. It walks two joins:
 
@@ -40,12 +40,12 @@ PRs.
 </Callout>
 
 For phases before a plan exists, the board shows the spec's authored `status:`. Once execution
-starts, it shows the **computed** phase derived from branches, commits, and PR state — and a
+starts, it shows the **computed** phase derived from branches, commits, and PR state, and a
 disagreement between the authored value and the computed one is surfaced as a flag, not displayed
 as truth. The board also flags drift it can prove from the artifacts: an unknown `status:`, a
 missing or duplicate plan, a missing branch for an executing feature, head-state phases while PRs
 already exist, two in-flight rows on one branch, and executing rows older than
 `status.staleDays` (a [config](/docs/configuration) key, default 14).
 
-Because `status.sh` only reads — it exits 0 even when it prints drift flags — the board is safe
+Because `status.sh` only reads (it exits 0 even when it prints drift flags), the board is safe
 to run anywhere, including CI, without mutating anything.

--- a/site/content/docs/concepts/status-tracking.mdx
+++ b/site/content/docs/concepts/status-tracking.mdx
@@ -43,8 +43,9 @@ For phases before a plan exists, the board shows the spec's authored `status:`. 
 starts, it shows the **computed** phase derived from branches, commits, and PR state, and a
 disagreement between the authored value and the computed one is surfaced as a flag, not displayed
 as truth. The board also flags drift it can prove from the artifacts: an unknown `status:`, a
-missing or duplicate plan, a missing branch for an executing feature, head-state phases while PRs
-already exist, two in-flight rows on one branch, and executing rows older than
+missing or duplicate plan, a missing branch for an executing feature, head-state phases (other
+than `ready`, whose spec+plan PR is expected) while PRs already exist, two in-flight rows on one
+branch, and executing rows older than
 `status.staleDays` (a [config](/docs/configuration) key, default 14).
 
 Because `status.sh` only reads (it exits 0 even when it prints drift flags), the board is safe


### PR DESCRIPTION
## Goal

Add the "Collaboration with status tracking" concept page — explaining the derived feature board,
which the old page only hinted at via the 1:1:N invariant.

## Summary

- Adds `site/content/docs/concepts/status-tracking.mdx`: the phase enum, the `spec : plan : PRs =
  1 : 1 : N` join (Source line + PR trailer), the board being computed from artifacts rather than
  authored, drift + `staleDays` staleness flags, and "no committed STATUS.md". Every claim traces
  to `woostack-status/SKILL.md` + `references/conventions.md`.
- Registers it in `concepts/meta.json` and adds its hub `<Card>`.
- Ticks Increment 3 of the plan.

## Test plan

### Automated

- [x] `pnpm -C site build` → exit 0; `/docs/concepts/status-tracking` route emitted.
- [x] `1 : 1 : N` and `staleDays` facts present; hub Cards = 5; `meta.json` pages include
      `status-tracking`.

### Manual

**Before merge**

- [ ] Open `/docs/concepts/status-tracking`; confirm the enum blockquote, the computed-not-authored
      Callout, and the drift/staleness list read cleanly and match the status conventions.

Spec: .woostack/specs/2026-06-16-concepts-page-split.md
