### PR TITLE
docs: document and specify status tracking and execution updates

### DIFF
--- a/site/content/docs/concepts/status-tracking.mdx
+++ b/site/content/docs/concepts/status-tracking.mdx
@@ -21,6 +21,58 @@ The build loop authors each transition as it advances, and the board reads it. T
 its join rules are defined once in the
 [status conventions](https://github.com/howarewoo/woostack/blob/main/skills/woostack-status/references/conventions.md).
 
+## Status definitions
+
+### Spec statuses
+
+| Status | Meaning |
+| --- | --- |
+| `draft` | The spec exists but has not completed hardening. |
+| `hardened` | The spec has been grilled and refined, but still needs user approval. |
+| `approved` | The spec approval gate is cleared and planning can begin. |
+| `abandoned` | Work intentionally stopped. |
+
+### Plan statuses
+
+| Status | Meaning |
+| --- | --- |
+| `planning` | The implementation plan exists but has not completed hardening. |
+| `ready` | The plan is hardened, no implementation boxes are checked, and the spec+plan PR should exist before execution. |
+| `executing` | `woostack-execute` has started plan execution and authored this status for a non-final increment. |
+| `in-review` | The board derives this from an open increment PR; it is not the durable plan frontmatter state. |
+| `done` | `woostack-execute` authored the final plan status after every box is checked; the board confirms completion from merged PR artifacts. |
+| `abandoned` | Work intentionally stopped. |
+
+### Fix statuses
+
+| Status | Meaning |
+| --- | --- |
+| `draft` | The fix plan exists but has not completed hardening. |
+| `hardened` | The fix plan has been refined but still needs user approval. |
+| `approved` | The fix approval gate is cleared. |
+| `executing` | `woostack-fix` has delegated execution to `woostack-execute` on the fix worktree. |
+| `in-review` | The fix PR is open for review. |
+| `done` | The fix lifecycle is complete. |
+| `abandoned` | Work intentionally stopped. |
+
+## Who updates status
+
+Each workflow writes status only to the artifact it owns:
+
+| Flow | Status location | Updates |
+| --- | --- | --- |
+| [woostack-build](/docs/skills/woostack-build) | `.woostack/specs/<slug>.md` frontmatter | creates the spec with `status: draft`, marks it `hardened` after spec hardening, then `approved` after the spec approval gate |
+| [woostack-plan](/docs/skills/woostack-plan) inside the build loop | `.woostack/plans/<spec-basename>.md` frontmatter | creates the one matching plan with `status: planning` and the `**Source:** [[specs/<basename>]]` join |
+| [woostack-build](/docs/skills/woostack-build), after plan hardening | `.woostack/plans/<spec-basename>.md` frontmatter | marks the plan `ready` after the plan is hardened and the spec+plan PR is opened |
+| [woostack-status](/docs/skills/woostack-status) during feature execution | no writes; it reads specs, plans, branches, commits, and PRs | computes the visible `executing` and `in-review` band from artifacts instead of trusting stale frontmatter |
+| [woostack-execute](/docs/skills/woostack-execute) on a feature plan | `.woostack/plans/<spec-basename>.md` checkboxes and frontmatter | ticks implementation tasks as increments land, writes `status: executing` for non-final increments, and writes terminal `status: done` after the final increment; the board still derives `in-review` from open PR artifacts |
+| [woostack-fix](/docs/skills/woostack-fix) | `.woostack/fixes/YYYY-MM-DD-<slug>.md` frontmatter | creates the fix file with `status: draft`, marks it `hardened`, waits at the approval gate, then sets `approved`, `executing`, `in-review`, and eventually `done` |
+| [woostack-execute](/docs/skills/woostack-execute) on a fix file | `.woostack/fixes/YYYY-MM-DD-<slug>.md` checkboxes only | reuses the fix worktree, runs TDD tasks, ticks the fix plan, and commits the fix markdown plus code into one PR; it does not change the fix file's frontmatter lifecycle |
+
+That split is deliberate. Features are tracked by the spec/plan pair and shown on the
+`woostack-status` board. Fixes are tracked by their `.woostack/fixes/` file because a fix
+combines the spec and plan into one artifact and ships as one PR.
+
 ## One spec, one plan, N PRs, joined by artifacts
 
 The board relies on the `spec : plan : PRs = 1 : 1 : N` invariant. It walks two joins:

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-execute
-description: Use to execute an approved woostack plan as a sequence of PR-sized, stacked increments via an inline or subagent-driven driver (--inline/--subagent, smart default) — implement each increment with TDD, tick the plan's checkboxes in place, commit via woostack-commit on its own Graphite branch, review each task with spec+quality checks (inline by the controller, or via subagents with tier routing), distill durable learnings, then continue; at the final increment, author the plan's terminal status: done. This is the execute phase of the woostack build loop (woostack-build step 8); also usable standalone via /woostack-execute <plan-path> [--inline|--subagent]. One plan per spec, multiple PRs per plan. Never merges.
+description: Use to execute an approved woostack plan as PR-sized stacked increments, updating plan progress and status, committing each increment, reviewing the work, and continuing until done. Never merges.
 ---
 
 # woostack-execute
@@ -134,20 +134,20 @@ For each increment:
    `woostack-commit`. Metrics, telemetry, and watermark sidecars remain primary-root local state
    per the [worktree contract](../woostack-init/references/worktrees.md) §5.
 
-8. **Author the plan's terminal `status: done` — final increment, plan files only.** If this
-   increment was the last (every checkbox in the plan file is now `[x]`) **and** the artifact is a
-   plan (`type: plan`, under `.woostack/plans/`), author `status: done` on the plan's frontmatter
-   inside this increment's worktree and commit that one-line bump via
-   [`woostack-commit`](../woostack-commit/SKILL.md) `--no-pr-update`, so the terminal authored
-   state persists to the branch tip rather than dying with the worktree. This is the plan
-   lifecycle's terminal authored transition — symmetric with `planning`
+8. **Author the plan's execution status — plan files only.** If the artifact is a plan
+   (`type: plan`, under `.woostack/plans/`), author the plan's frontmatter status inside this
+   increment's worktree and commit that one-line bump via
+   [`woostack-commit`](../woostack-commit/SKILL.md) `--no-pr-update`, so the authored
+   state persists to the branch tip rather than dying with the worktree. Use `status: executing`
+   for every non-final increment, and use terminal `status: done` for the final increment. These
+   are execute's authored lifecycle transitions after `planning`
    ([`woostack-plan`](../woostack-plan/SKILL.md)) and `ready`
-   ([`woostack-build`](../woostack-build/SKILL.md) step 6) — and is execute's **only** frontmatter
-   write. **Skip it for a `.woostack/fixes/` file:** a fix file's frontmatter lifecycle stays owned
-   by [`woostack-fix`](../woostack-fix/SKILL.md). The board still derives the `executing` →
-   `in-review` → `done` band from artifacts and shows `in-review` while the final PR is open,
-   reconciling to `done` at merge — so authoring `done` here only stops the plan file from rotting,
-   it does not assert the stack is merged.
+   ([`woostack-build`](../woostack-build/SKILL.md) step 6). **Skip it for a `.woostack/fixes/`
+   file:** a fix file's frontmatter lifecycle stays owned by
+   [`woostack-fix`](../woostack-fix/SKILL.md). The board still derives the `in-review` band from
+   artifacts and shows `in-review` while an increment PR is open, reconciling to `done` at merge
+   after the final PR — authoring `done` only stops the plan file from rotting, it does not assert
+   the stack is merged.
 9. **Teardown the worktree.** After the increment is committed, reviewed, distilled, and (on the
    final increment) marked `done`, remove its
    worktree (`git worktree remove "$WOOSTACK_ROOT/.woostack/worktrees/<inc-slug>"`); the
@@ -179,9 +179,10 @@ Stop when every increment is implemented, checked off, committed, reviewed, and 
 leaving a Graphite stack of reviewed PRs. "Reviewed" means each task passed the shared
 spec-compliance and code-quality checks, either inline in the controller session or through the
 subagent reviewer loop, plus the human's post-execution review of each PR. Report the branches/PRs
-and their review mode. **Never merge.** For a **plan** file, the final increment also advanced the
-plan's frontmatter to `status: done` (step 8) — execute's only frontmatter write; a
-`.woostack/fixes/` file's lifecycle stays with [`woostack-fix`](../woostack-fix/SKILL.md).
+and their review mode. **Never merge.** For a **plan** file, non-final increments also advanced the plan's frontmatter to
+`status: executing`, and the final increment advanced it to `status: done` (step 8); these
+are execute's only frontmatter writes. A `.woostack/fixes/` file's lifecycle stays with
+[`woostack-fix`](../woostack-fix/SKILL.md).
 
 ## Memory Is Shared
 
@@ -227,10 +228,11 @@ not an approval gate. The skill never merges and never auto-addresses review fin
   implementation files.
 - **Tick checkboxes in place.** The plan file is the live progress record.
 - **Author the plan's terminal `status: done` — and only that.** At the final increment of a
-  plan file (every box `[x]`), author `status: done` and commit the bump via
-  `woostack-commit --no-pr-update` (step 8). That terminal transition is execute's **only**
-  frontmatter write — never author any other `status:`, and never touch a `.woostack/fixes/`
-  file's frontmatter (owned by [`woostack-fix`](../woostack-fix/SKILL.md)).
+  plan file (every box `[x]`), author `status: done`; otherwise author
+  `status: executing` for plan increments that are not final. Commit the bump via
+  `woostack-commit --no-pr-update` (step 8). These are execute's only frontmatter writes; never
+  touch a `.woostack/fixes/` file's frontmatter (owned by
+  [`woostack-fix`](../woostack-fix/SKILL.md)).
 - **Commit + review every increment.** `woostack-commit` always; each task must already have
   passed the shared spec-compliance plus code-quality checks before the increment is committed.
   Inline mode performs them in the controller session; subagent mode dispatches reviewer

--- a/skills/woostack-status/references/conventions.md
+++ b/skills/woostack-status/references/conventions.md
@@ -37,7 +37,8 @@ These definitions are the source of truth for the `/woostack-status` board and t
   - `approved` — spec gate cleared, no plan yet
   - `planning` — plan written, not yet hardened, 0 boxes done
   - `ready` — plan hardened, 0 boxes done, spec+plan PR should be opened before execution
-  - `executing` — branch + commits, plan partial
+  - `executing` — authored by `woostack-execute` for non-final increments; branch + commits,
+    plan partial
   - `in-review` — increment PR open
   - `done` — authored by `woostack-execute` at the final increment (all boxes `[x]`, plan files);
     the board also derives/confirms it from artifacts (100% + all PRs merged) and shows `in-review`


### PR DESCRIPTION
## Goal

Clarify and document which woostack workflows are responsible for writing and updating the status fields of specs, plans, and fixes.

## Summary

- Add a new "Status definitions" section to `site/content/docs/concepts/status-tracking.mdx` with markdown tables explaining spec, plan, and fix statuses.
- Update the "Who updates status" mapping table to specify that `woostack-execute` writes `status: executing` for non-final plan increments.
- Update `skills/woostack-execute/SKILL.md` to specify that `woostack-execute` writes `status: executing` on non-final increments.
- Update `skills/woostack-status/references/conventions.md` to show `executing` is authored by `woostack-execute` for non-final increments.

## Test plan

### Automated

- [x] `pnpm -C site build` passed

### Manual

**Before merge**

- [ ] Verify the content clarity and accuracy of the "Status definitions" and "Who updates status" sections in `site/content/docs/concepts/status-tracking.mdx`.
- [ ] Verify that skill instructions in `skills/woostack-execute/SKILL.md` and conventions in `skills/woostack-status/references/conventions.md` are correctly updated and consistent.
