### PR TITLE
docs: humanize superpowers reference in site

### DIFF
--- a/.woostack/fixes/2026-06-17-superpowers-reference-update.md
+++ b/.woostack/fixes/2026-06-17-superpowers-reference-update.md
@@ -1,0 +1,22 @@
+---
+type: fix
+status: in-review
+branch: fix/superpowers-reference-update
+---
+
+# Fix: Update superpowers reference in site docs
+
+## 1. Root Cause
+The current description of Superpowers (obra/superpowers) in `site/content/docs/index.mdx` does not mention the key reasons for migrating away from it: that it required an additional hardening step to create better plans, and it lacked a cross-agent memory layer.
+
+## 2. Proposed Fix
+Update `site/content/docs/index.mdx` at the superpowers list item to state that a reason we moved away from the framework was that it needed an additional hardening step to create better plans, and it lacked a cross-agent memory layer.
+
+## 3. Implementation Plan
+- [x] **Step 1: Reproduce with a failing test**
+  - Verify that the outdated text is present in the site index page, and write a verification command to grep for the new required reasons (e.g. "hardening step" and "cross-agent memory").
+- [x] **Step 2: Apply the minimal fix**
+  - Update `site/content/docs/index.mdx` with the updated superpowers description.
+- [x] **Step 3: Verification**
+  - Verify that the new text is present in the index page using grep.
+  - Run the site build script `pnpm -C site build` to confirm the site compiles successfully.

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -41,9 +41,7 @@ version that holds six goals at the same time:
 These are all strong projects, and woostack borrows ideas from several of them. They just were not
 the fit I wanted personally:
 
-- **Superpowers** ([obra/superpowers](https://github.com/obra/superpowers)) is the most complete of
-  the four, but it installs as a Claude Code plugin and works best wired deep into Claude Code. I
-  wanted skills that travel across agents through the plain `skills` convention.
+- **Superpowers** ([obra/superpowers](https://github.com/obra/superpowers)) is the most complete option here, but it works best inside Claude Code as a dedicated plugin. I moved away from it because it lacked a cross-agent memory layer, and it needed an extra hardening step to get reliable plans. I also wanted skills that work with any agent using the plain `skills` convention.
 - **grill-me** does one thing well: it interviews you about a plan until the gaps are gone. For me
   that is a single phase of the loop, the discipline `woostack-harden` is built on, rather than the
   whole lifecycle.


### PR DESCRIPTION
## Goal

Explain the reasons for moving away from the Superpowers framework in the documentation site.

## Summary

- Humanized the description of the Superpowers framework on the site index page.
- Detailed the two reasons for migrating away: the need for an additional hardening step for plans and the lack of a cross-agent memory layer.

## Test plan

### Automated

- Built the documentation site using `pnpm -C site build` (succeeded).
- Grepped `site/content/docs/index.mdx` for "hardening step" and "cross-agent memory" (succeeded).

Spec: .woostack/fixes/2026-06-17-superpowers-reference-update.md
