### PR TITLE
docs: plan visualize quality rubric

### DIFF
--- a/.woostack/plans/2026-06-17-visualize-quality-rubric.md
+++ b/.woostack/plans/2026-06-17-visualize-quality-rubric.md
@@ -1,0 +1,160 @@
+---
+type: plan
+source: .woostack/specs/2026-06-17-visualize-quality-rubric.md
+status: ready
+branch: feature/visualize-quality-rubric
+---
+
+**Source:** [[specs/2026-06-17-visualize-quality-rubric]]
+
+# woostack-visualize Quality Rubric Implementation Plan
+
+**Goal:** Teach `woostack-visualize` to produce better source-grounded offline HTML renders by adding when-to-visualize guidance, a local primitives palette, and high-stakes self-review while preserving the disposable render contract.
+
+**Architecture:** This is one docs-only skill update. `SKILL.md` owns the command procedure, including the decision gate, source research bar, primitive-selection step, and inline self-review. `references/primitives.md` owns the reusable offline section palette; `references/audiences.md` remains unchanged so audience policy does not duplicate primitive definitions.
+
+**Tech Stack:** Markdown skill files, `rg` structural checks, Git/Graphite.
+
+## Increment 1: Add visualize quality rubric and primitives reference
+
+> One independently shippable PR (<=500 LOC soft target) -- its own Graphite-stacked branch.
+
+### Task 1: Strengthen `woostack-visualize` procedure
+
+**Files:**
+- Modify: `skills/woostack-visualize/SKILL.md`
+
+**Step 1: Write the failing structural checks**
+
+Run:
+
+```bash
+for p in "When to visualize" "Research before composing" "Choose visual primitives" "High-stakes self-review"; do
+  rg -n "$p" skills/woostack-visualize/SKILL.md >/dev/null || exit 1
+done
+```
+
+Expected: FAIL - `rg` exits 1 because the current skill does not contain those procedure anchors.
+
+**Step 2: Minimal implementation**
+
+Edit `skills/woostack-visualize/SKILL.md` to:
+
+- add a "When to visualize" section before the existing procedure, recommending visual output for comparison, approval, relationship mapping, architecture/state review, and multi-file/code/data inspection, while telling agents to skip trivial or clearer-as-text cases;
+- expand "Resolve input" into "Research before composing" guidance that requires real files, directories, symbols, source sections, data shapes, and existing helpers where relevant;
+- add a step that chooses primitives from `references/primitives.md` after resolving the audience;
+- add an inline "High-stakes self-review" checklist for architecture, backend, data-model, migration, security, multi-file, or public-contract renders;
+- preserve the existing command shape, write path, no-browser-without-consent rule, self-contained offline rule, and disposable source-of-truth rule.
+
+**Step 3: Run the structural checks, confirm they pass**
+
+Run:
+
+```bash
+for p in "When to visualize" "Research before composing" "Choose visual primitives" "High-stakes self-review"; do
+  rg -n "$p" skills/woostack-visualize/SKILL.md >/dev/null || exit 1
+done
+```
+
+Expected: PASS - each anchor appears in `SKILL.md`.
+
+### Task 2: Add offline visual primitives reference
+
+**Files:**
+- Create: `skills/woostack-visualize/references/primitives.md`
+- Modify: `skills/woostack-visualize/SKILL.md`
+
+**Step 1: Write the failing structural checks**
+
+Run:
+
+```bash
+test -f skills/woostack-visualize/references/primitives.md &&
+for p in "source summary" "file map" "annotated code" "before/after" "API/data contract" "state matrix" "flow diagram" "decision table" "risk register" "open questions"; do
+  rg -n "$p" skills/woostack-visualize/references/primitives.md >/dev/null || exit 1
+done
+```
+
+Expected: FAIL - the file does not exist yet.
+
+**Step 2: Minimal implementation**
+
+Create `skills/woostack-visualize/references/primitives.md` with a concise palette. For each primitive, document:
+
+- when to use it;
+- what source evidence is required;
+- what to omit or mark unknown when unsupported.
+
+Include at least: source summary, file map, annotated code, diff/before-after panel, API/data contract, state matrix, flow diagram, decision table, risk register, and open questions.
+
+Update `SKILL.md` to link `references/primitives.md` from the primitive-selection step. Keep `audiences.md` unchanged.
+
+**Step 3: Run the structural checks, confirm they pass**
+
+Run:
+
+```bash
+test -f skills/woostack-visualize/references/primitives.md &&
+for p in "source summary" "file map" "annotated code" "before/after" "API/data contract" "state matrix" "flow diagram" "decision table" "risk register" "open questions"; do
+  rg -n "$p" skills/woostack-visualize/references/primitives.md >/dev/null || exit 1
+done
+```
+
+Expected: PASS - the file exists and every required primitive phrase is present.
+
+### Task 3: Verify offline/disposable boundaries and unchanged audience file
+
+**Files:**
+- Modify: `skills/woostack-visualize/SKILL.md`
+- Create: `skills/woostack-visualize/references/primitives.md`
+
+**Step 1: Write the boundary checks before finalizing**
+
+Run:
+
+```bash
+for p in "self-contained" "offline" "disposable render" "source of truth" "No browser without consent"; do
+  rg -n "$p" skills/woostack-visualize/SKILL.md >/dev/null || exit 1
+done &&
+! rg -n "Agent-Native|Plan MCP|MCP connector|auth/reconnect|feedback API|publish flow|export receipt|lockfile|build step|CI workflow" skills/woostack-visualize &&
+git diff --exit-code -- skills/woostack-visualize/references/audiences.md
+```
+
+Expected: PASS - the original offline/disposable constraints remain, conflicting BuilderIO workflow terms are absent, and `audiences.md` has no diff.
+
+**Step 2: If the check fails, make the minimal correction**
+
+- Restore or reword the original offline/disposable constraints in `SKILL.md`.
+- Remove any hosted Plan/MCP/auth/publish/export workflow language.
+- Revert any accidental `audiences.md` change.
+
+**Step 3: Run the boundary checks again**
+
+Run:
+
+```bash
+for p in "self-contained" "offline" "disposable render" "source of truth" "No browser without consent"; do
+  rg -n "$p" skills/woostack-visualize/SKILL.md >/dev/null || exit 1
+done &&
+! rg -n "Agent-Native|Plan MCP|MCP connector|auth/reconnect|feedback API|publish flow|export receipt|lockfile|build step|CI workflow" skills/woostack-visualize &&
+git diff --exit-code -- skills/woostack-visualize/references/audiences.md
+```
+
+Expected: PASS.
+
+**Step 4: Commit the implementation increment**
+
+Run:
+
+```bash
+gt create -m "docs: strengthen visualize quality rubric"
+```
+
+Expected: PASS - Graphite creates the implementation branch stacked on the spec+plan PR when execution runs.
+
+## Self-review checklist
+
+- **Spec coverage:** AC1 maps to Task 1; AC2 maps to Task 1; AC3 maps to Task 2; AC4 maps to Task 1; AC5 maps to Task 3.
+- **AC coverage:** Each acceptance criterion has an explicit structural check or no-diff boundary check.
+- **No placeholders:** All commands and expected outcomes are concrete.
+- **Type consistency:** This is a Markdown-only skill collection change; no code types or runtime APIs are involved.

--- a/.woostack/specs/2026-06-17-visualize-quality-rubric.md
+++ b/.woostack/specs/2026-06-17-visualize-quality-rubric.md
@@ -1,0 +1,140 @@
+---
+name: visualize-quality-rubric
+type: spec
+status: approved
+date: 2026-06-17
+branch: feature/visualize-quality-rubric
+---
+
+# woostack-visualize Quality Rubric - Design Spec
+
+> **Plan:** [[plans/2026-06-17-visualize-quality-rubric]]
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; HTML is a presentation target only.
+> `status:` is build-loop phase enum. The enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+`woostack-visualize` already defines the core contract: read real source, choose an audience, and write one self-contained offline HTML render that is never the source of truth. That boundary is correct and should not change.
+
+The current skill is thin on judgment, though. It tells the agent to compose bespoke HTML, but it does not give much guidance on when a visualization is worth producing, what source-grounding bar to meet before composing, which visual section patterns are useful for different source shapes, or how to self-check high-stakes renders before handoff.
+
+BuilderIO's `visual-plan` skill has useful planning discipline in those areas: gate visual work thoughtfully, research real files first, use richer blocks such as file maps and annotated code, surface open questions, and self-review risky plans. Its hosted Agent-Native Plans model, MCP tools, feedback APIs, auth flow, and publish/export workflow do not fit woostack's offline/disposable render model.
+
+## 2. Goal
+
+Improve `woostack-visualize` so agents produce more useful offline HTML renders without changing the command shape or ownership model.
+
+The skill should:
+
+- explain when to visualize and when to skip it;
+- require source-grounded research before composing a render;
+- offer concrete offline visual primitives agents can combine in bespoke HTML;
+- surface hard-to-reverse decisions and open questions when present in the source;
+- add a lightweight self-review checklist for high-stakes architecture, data, migration, or multi-file renders;
+- keep every output self-contained, offline-viewable, disposable, and grounded in the source.
+
+## 3. Non-goals
+
+- No hosted Plan MCP, Agent-Native Plans dependency, auth/reconnect workflow, hosted comments, feedback API, publish flow, or export receipt.
+- No new slash command and no change to `/woostack-visualize <source> [for <audience>]`.
+- No application code, package manager lockfile, build step, runtime dependency, browser server, or CI workflow.
+- No MDX plan artifact model. Markdown/code remains the source of truth; HTML remains the disposable render.
+- No fixed template that every visualization must follow.
+- No fabricated metrics, timelines, traction, benchmark numbers, code facts, or architecture claims.
+
+## 4. Approach
+
+Update `skills/woostack-visualize/SKILL.md` with a stronger procedure:
+
+1. **Decide whether visualization adds value.** Recommend visualization when a reader needs to see relationships, compare options, review architecture or state, approve direction, or inspect a multi-file/code/data shape. Recommend skipping trivial one-line changes or cases where a plain answer is clearer.
+2. **Research before composing.** Keep the existing "read actual source" rule, but make the bar explicit: name real files, directories, symbols, data shapes, source sections, and existing helpers when they are relevant. For directories, summarize selection criteria instead of pretending every file was read.
+3. **Select visual primitives.** Link a new `references/primitives.md` file that lists reusable offline patterns: source summary, file map, annotated code, diff/before-after panel, API/data contract, state matrix, flow diagram, decision table, risk register, and open questions.
+4. **Compose bespoke HTML.** Keep the current self-contained HTML rule. The primitives are a palette, not a template. Use only what the source and audience justify.
+5. **Self-review high-stakes renders.** For architecture, backend, data-model, migration, security, multi-file, or public-contract renders, check that the output is source-grounded, offline, audience-framed, and clear about unknowns before reporting the path.
+
+Add `skills/woostack-visualize/references/primitives.md` as a short reference. It should describe each primitive, when to use it, what source evidence it needs, and what not to invent.
+
+Keep `skills/woostack-visualize/references/audiences.md` stable. Audience-specific primitive selection belongs in `SKILL.md`: resolve the audience first, then choose from `primitives.md` based on that audience. This avoids duplicating the primitive palette across two reference files.
+
+Keep the high-stakes self-review checklist inline in `SKILL.md`, not in `primitives.md`. The checklist is part of the command procedure and should be hard to miss. `primitives.md` stays a palette of section patterns, not a second workflow.
+
+No authored docs page is expected to change because this does not alter the command surface or skill count. Still verify the command routing mentions remain accurate.
+
+## 5. Components & data flow
+
+Updated skill behavior:
+
+1. User runs `/woostack-visualize <source> [for <audience>]`.
+2. Agent resolves and reads the source as today.
+3. Agent decides whether a visualization is useful for the request. If not, it should say so and avoid padded output.
+4. Agent resolves the audience using `references/audiences.md`.
+5. Agent chooses a small set of primitives from `references/primitives.md` based on the source shape and audience.
+6. Agent writes one self-contained HTML file to `.woostack/visuals/YYYY-MM-DD-<slug>-<audience>.html` or the user path.
+7. Agent reports the path and does not open a browser without consent.
+
+Files:
+
+- Modify `skills/woostack-visualize/SKILL.md`.
+- Add `skills/woostack-visualize/references/primitives.md`.
+No `audiences.md` change is expected.
+
+## 6. Error handling
+
+- **Source cannot be read.** Stop and report the missing or unreadable source. Do not compose from memory.
+- **Directory is too large.** Read a representative set, state the selection basis in the render, and mark uninspected areas as unknown rather than implying total coverage.
+- **Visualization would be filler.** Say the source is better handled as a concise answer or code review; do not create a padded single-step visual.
+- **Primitive lacks evidence.** Omit it or mark the field unknown. Do not infer missing metrics, call graphs, API contracts, or timelines.
+- **High-stakes render self-review fails.** Fix the render before handoff, or report the specific gap if it cannot be fixed from available source.
+
+## 7. Acceptance criteria
+
+**AC1 - The skill explains when to visualize**
+
+- happy: `SKILL.md` includes guidance to use visualization for comparison, approval, relationship mapping, architecture/state review, and multi-file/code/data inspection.
+- error: `SKILL.md` tells agents to skip trivial or clearer-as-text cases instead of padding a visual.
+- edge: free-form subjects remain supported when there is enough source/context to ground the render.
+
+**AC2 - The skill requires source-grounded composition**
+
+- happy: `SKILL.md` explicitly requires real source research before composing and names concrete evidence types such as files, symbols, data shapes, source sections, and existing helpers.
+- error: unreadable sources remain a stop condition.
+- edge: large directories require stated selection criteria and unknowns rather than pretending complete coverage.
+
+**AC3 - Offline primitives are documented**
+
+- happy: `references/primitives.md` documents a reusable palette including file maps, annotated code, diffs/before-after panels, API/data contracts, state matrices, flows, decisions, risks, and open questions.
+- error: the reference says primitives are optional and must be omitted when unsupported by source.
+- edge: the reference preserves bespoke composition and does not become a mandatory template.
+
+**AC4 - High-stakes renders get self-review**
+
+- happy: `SKILL.md` defines high-stakes render categories and a pre-handoff self-review checklist.
+- error: failed self-review leads to fixing the render or reporting the gap.
+- edge: small or low-risk renders are not burdened with a heavy review process.
+- edge: the self-review checklist is inline in `SKILL.md`, while `primitives.md` remains a palette rather than a workflow.
+
+**AC5 - Offline/disposable contract is preserved**
+
+- happy: `SKILL.md` still says HTML is disposable, source remains source of truth, outputs are self-contained and offline, and browser opening requires consent.
+- error: no hosted Plan MCP, auth, feedback API, publish/export flow, dependency, build step, app code, lockfile, or CI workflow is introduced.
+- edge: BuilderIO is credited only as source inspiration; its external workflow is not imported.
+
+## 8. Testing
+
+Automated verification is text-structure oriented because this repo is a skill collection, not an app:
+
+- `test -f skills/woostack-visualize/SKILL.md`
+- `test -f skills/woostack-visualize/references/primitives.md`
+- `rg -n "When to visualize|Research before|primitives|self-review|offline|disposable" skills/woostack-visualize`
+- `rg -n "Agent-Native|MCP|auth|publish|feedback API|lockfile|build step|CI workflow" skills/woostack-visualize`
+- `git diff --exit-code -- skills/woostack-visualize/references/audiences.md`
+
+Manual checks:
+
+- Read `SKILL.md` and confirm the procedure is still concise enough for a skill description.
+- Read `primitives.md` and confirm it is a palette, not a fixed template.
+- Confirm command routing in `AGENTS.md` and `skills/using-woostack/SKILL.md` remains accurate without a command-surface edit.
+
+## 9. Open questions
+
+None.


### PR DESCRIPTION
## Goal

Plan the `woostack-visualize` update that incorporates the useful BuilderIO visual-plan discipline while preserving woostack's offline, disposable HTML render contract.

## Summary

- Added the approved spec for the visualize quality rubric.
- Added the ready implementation plan with one docs-only increment.
- The plan keeps `audiences.md` stable, adds a new offline primitives reference, and strengthens `SKILL.md` with when-to-visualize, source-grounding, primitive-selection, and high-stakes self-review guidance.

## Test plan

### Automated

- PASS: checked the new spec status/branch and plan status/`**Source:**` wikilink with `rg`.
- PASS: `skills/woostack-doctor/scripts/doctor.sh . --check` exited 0.
- NOTE: doctor still reports pre-existing warnings for memory overlap and `.woostack/plans/2026-06-14-impeccable-integration.md` legacy Source line; this PR no longer adds a spec-plan warning after adding the spec backlink.

### Manual

**Before merge**

- Review the spec and plan for scope: docs-only skill changes, no hosted Plan/MCP workflow, no app code, and no command-surface change.
- Confirm the plan remains one reviewable increment and maps all spec acceptance criteria.

**After merge**

- None.

Spec: .woostack/specs/2026-06-17-visualize-quality-rubric.md