### PR TITLE
docs: strengthen visualize quality rubric

### DIFF
--- a/.woostack/plans/2026-06-17-visualize-quality-rubric.md
+++ b/.woostack/plans/2026-06-17-visualize-quality-rubric.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-17-visualize-quality-rubric.md
-status: ready
+status: done
 branch: feature/visualize-quality-rubric
 ---
 

--- a/skills/woostack-visualize/SKILL.md
+++ b/skills/woostack-visualize/SKILL.md
@@ -19,24 +19,50 @@ The Markdown/code source stays the source of truth; the HTML is a disposable ren
     - `/woostack-visualize packages/api for a non-technical PM`
     - `/woostack-visualize the review swarm architecture`
 
+## When to visualize
+
+Use this skill when the task benefits from spatial layout, comparison, or at-a-glance
+pattern recognition: side-by-side comparisons, approval reviews, relationship mapping,
+architecture or state-machine walkthroughs, multi-file or multi-symbol inspections, and
+data-shape or schema exploration. Free-form subjects are supported when the source is
+groundable in real repo content.
+
+Skip visualization when the output would be trivial (a single value, a short list) or when
+plain prose or a code block is clearly clearer — do not render for rendering's sake.
+
 ## Procedure
 
-1. **Resolve input.** Read the actual source. For a file/glob, read the files. For a
-   directory, read enough structure (entry points, key modules, READMEs) to characterize it
-   honestly; state in the visual what you sampled versus read in full. For a free-form
-   subject with no path, build only from what the repo and conversation actually contain.
+1. **Research before composing.** Read the actual source before writing a single line of
+   HTML. For a file or glob, read the files. For a directory, read enough structure —
+   entry points, key modules, READMEs — to characterize it honestly; if the directory is
+   large, state your selection criteria and what you skipped, rather than pretending full
+   coverage. For a free-form subject, ground every claim in files, directories, symbols,
+   source sections, data shapes, or existing helpers that exist in the repo or conversation.
    Never invent content. If the source cannot be read, stop and say so — do not render guesses.
 2. **Resolve audience.** A preset loads its profile from
    [references/audiences.md](references/audiences.md). A free-form audience is interpreted
    against the same dimension rubric in that file. Default `engineer`.
-3. **Compose bespoke HTML.** Design the layout, section set, and diagrams to fit *this*
-   content and *this* audience, guided by the audience profile — not a fixed template. Emit a
+3. **Choose visual primitives.** After resolving the audience, select layout and diagram
+   primitives from [references/primitives.md](references/primitives.md) that fit this content
+   and this audience — not a fixed template.
+4. **Compose bespoke HTML.** Design the layout, section set, and diagrams to fit *this*
+   content and *this* audience, guided by the audience profile and chosen primitives. Emit a
    single self-contained `.html` file: inline `<style>` always; diagrams as inline SVG or
    pure CSS; JavaScript only when it adds real value and can be inlined. The file MUST render
    its core content offline, with no network fetch (no CDN-loaded library). For the
    engineer-audience spec case, [woostack-build's spec-template.html](../woostack-build/references/spec-template.html)
    is an available starting point.
-4. **Write and report.** Write to `.woostack/visuals/YYYY-MM-DD-<slug>-<audience>.html`
+5. **High-stakes self-review.** For renders that touch architecture, backend internals,
+   data models, migrations, security boundaries, multi-file scope, or public contracts,
+   run this checklist before handing off:
+   - Every claim traces to a real source line, symbol, or file — nothing inferred or invented.
+   - The HTML renders its core content offline (no CDN dependency).
+   - The framing matches the resolved audience profile.
+   - Unknowns and coverage gaps are explicitly labeled in the render, not silently omitted.
+   If any item fails, fix the render or report the gap — do not ship a render that hides
+   what you do not know. Low-risk or small renders (a single file, a short concept) do not
+   require this checklist.
+6. **Write and report.** Write to `.woostack/visuals/YYYY-MM-DD-<slug>-<audience>.html`
    (derive `<slug>` from the source name/subject; kebab-case a free-form audience to a short
    form). Honor an explicit user-supplied path instead. Print the path and offer to open it
    — do not open a browser unprompted. If `.woostack/` does not exist, write next to the

--- a/skills/woostack-visualize/references/primitives.md
+++ b/skills/woostack-visualize/references/primitives.md
@@ -1,0 +1,129 @@
+# Visual primitives palette
+
+These are optional building blocks to combine in bespoke HTML renders — not a fixed template.
+Pick only the primitives that the source evidence supports. Omit any primitive (or mark its
+fields unknown) when the source does not supply the needed evidence.
+
+---
+
+## source summary
+
+**When:** always — opens every render with a one-paragraph framing of what was visualized,
+who it is for, and what the key takeaway is.
+
+**Source evidence:** the request, the audience, and whatever documents or code were supplied.
+
+**Omit/unknown:** omit fields that cannot be inferred; do not fabricate scope, ownership, or
+status not present in the source.
+
+---
+
+## file map
+
+**When:** the change or feature spans multiple files and the reader needs spatial orientation
+before diving into detail.
+
+**Source evidence:** a file tree, diff stat, or explicit enumeration of affected paths.
+
+**Omit/unknown:** omit directories or files not mentioned in the source; do not guess at
+sibling files or infer a broader project layout.
+
+---
+
+## annotated code
+
+**When:** a specific code path, function, or snippet is central to understanding the change
+and the audience is technical.
+
+**Source evidence:** verbatim code supplied in the request or attached diff.
+
+**Omit/unknown:** omit code blocks when only a prose description is available; never
+reconstruct code from description alone.
+
+---
+
+## before/after
+
+**When:** a change replaces or modifies existing behavior and the contrast is the clearest
+way to communicate the delta.
+
+**Source evidence:** a diff, explicit old/new values, or a before state plus a described
+change.
+
+**Omit/unknown:** omit the "before" column when the prior state is unknown; do not infer old
+behavior from new code alone.
+
+---
+
+## API/data contract
+
+**When:** the visualization covers an interface boundary — REST endpoint, function signature,
+schema, or event shape — and the reader needs to know what flows across it.
+
+**Source evidence:** explicit schema, OpenAPI spec, type definitions, or interface
+declarations in the supplied source.
+
+**Omit/unknown:** mark fields as unknown when types or shapes are absent from the source; do
+not invent field names, types, or constraints.
+
+---
+
+## state matrix
+
+**When:** the subject has discrete states and transitions that are otherwise hard to reason
+about in prose.
+
+**Source evidence:** explicit state names and transitions in code, docs, or the request.
+
+**Omit/unknown:** omit transition rows when the trigger or target state is not evidenced;
+never guess at implied states.
+
+---
+
+## flow diagram
+
+**When:** a sequential or branching process (request lifecycle, user journey, data pipeline)
+is the primary subject and a linear description would lose the branching structure.
+
+**Source evidence:** step-by-step logic, conditional branches, or a described user or data
+path in the source.
+
+**Omit/unknown:** omit branches or steps not described in the source; mark entry and exit
+points unknown if not stated.
+
+---
+
+## decision table
+
+**When:** multiple conditions combine to produce distinct outcomes and a truth-table layout
+surfaces the logic more clearly than prose.
+
+**Source evidence:** explicit conditions and their outcomes stated in code, config, or docs.
+
+**Omit/unknown:** omit rows for condition combinations not evidenced; do not extrapolate
+outcomes from partial rules.
+
+---
+
+## risk register
+
+**When:** the visualization targets a decision-maker who needs to weigh known unknowns,
+failure modes, or open tradeoffs before acting.
+
+**Source evidence:** risks, caveats, or tradeoffs explicitly called out in the source or
+derivable from stated constraints.
+
+**Omit/unknown:** mark likelihood and impact unknown when not evidenced; do not fabricate
+risk severity or assign owners not named in the source.
+
+---
+
+## open questions
+
+**When:** the source leaves material gaps — unresolved decisions, missing specs, or
+unknowns that affect what the reader would do next.
+
+**Source evidence:** explicit "TBD", missing fields, or contradictions found in the source.
+
+**Omit/unknown:** omit this primitive entirely when the source is complete; never invent
+questions that are not implied by an actual gap in the evidence.


### PR DESCRIPTION
## Goal

Teach `woostack-visualize` to produce better source-grounded offline HTML renders by adding when-to-visualize guidance, a reusable offline primitives palette, and a high-stakes self-review checklist — without changing the command shape or the disposable-render ownership model.

## Summary

- `skills/woostack-visualize/SKILL.md`: added a `## When to visualize` section (use for comparison, approval, relationship mapping, architecture/state review, multi-file/code/data inspection; skip trivial or clearer-as-text cases); expanded "Resolve input" into a "Research before composing" step naming concrete source evidence (files, directories, symbols, source sections, data shapes, existing helpers; large-directory selection criteria + unknowns); added a "Choose visual primitives" step linking the new palette; added an inline "High-stakes self-review" checklist for architecture/backend/data-model/migration/security/multi-file/public-contract renders.
- `skills/woostack-visualize/references/primitives.md` (new): a concise palette of 10 offline primitives (source summary, file map, annotated code, before/after, API/data contract, state matrix, flow diagram, decision table, risk register, open questions), each with when-to-use / source-evidence-required / omit-or-mark-unknown. Framed as an optional palette, never a mandatory template.
- Preserved the offline, self-contained, disposable, source-of-truth, and no-browser-without-consent constraints; `references/audiences.md` unchanged.

## Test plan

### Automated

- [x] Task 1 anchors present — `rg "When to visualize|Research before composing|Choose visual primitives|High-stakes self-review" SKILL.md` → all 4 present (red→green confirmed)
- [x] Task 2 palette phrases present — `rg` for all 10 primitive phrases in `references/primitives.md` → all present (red→green confirmed)
- [x] Task 3 boundary check — offline/disposable phrases preserved, no hosted-workflow terms (`Agent-Native|Plan MCP|...|CI workflow`), and `git diff --exit-code -- references/audiences.md` → exit 0 (PASS)

### Manual

**Before merge**

- [ ] Read `skills/woostack-visualize/SKILL.md`; confirm the procedure is still concise enough for a skill and the new sections read well.
- [ ] Read `skills/woostack-visualize/references/primitives.md`; confirm it is a palette (optional, omit-when-unsupported), not a fixed template.
- [ ] Confirm command routing in `AGENTS.md` and `skills/using-woostack/SKILL.md` is still accurate (no command-surface change).

Spec: .woostack/specs/2026-06-17-visualize-quality-rubric.md
