### PR TITLE
docs: plan Utilities concept page for site

### DIFF
--- a/.woostack/plans/2026-06-17-site-utilities-page.md
+++ b/.woostack/plans/2026-06-17-site-utilities-page.md
@@ -1,0 +1,182 @@
+---
+type: plan
+source: .woostack/specs/2026-06-17-site-utilities-page.md
+status: ready
+branch: feature/site-utilities-page
+---
+
+**Source:** [[specs/2026-06-17-site-utilities-page]]
+
+# Utilities concept page Implementation Plan
+
+**Goal:** Add a `Utilities` concept page to the docs site's Core-concepts category covering the six on-demand skills (`ask`, `visualize`, `status`, `debug`, `doctor`, `dream`), wired into the category nav and landing card grid.
+
+**Architecture:** One new hand-authored MDX page under `site/content/docs/concepts/`, plus two one-line wiring edits (the folder `meta.json` `pages` array and the served landing `index.mdx` card grid) — the lockstep trio a new Fumadocs concept page requires. The pre-split orphan `concepts.mdx` is deliberately left untouched. Verification is `pnpm -C site build` — which runs the `prebuild` skill-page generator (regenerating the six `/docs/skills/woostack-*` reference pages the member links target) then `next build` (compiles `utilities.mdx`, generates the `/docs/concepts/utilities` route) — plus `grep`/`node` content assertions, since docs have no unit-test runner (woostack-tdd no-runner → concrete-verification substitution). Note: `next build` has **no internal-link checker** configured; member-link integrity is instead guaranteed structurally — the six target pages are generated from `SKILL.md` sources asserted present in Task 4 Step 2 — with a manual nav/link click as the human backstop.
+
+**Tech Stack:** Fumadocs (fumadocs-mdx) on Next.js, MDX with `<Cards>`/`<Card>`/`<Callout>` components, pnpm.
+
+## Increment 1: Utilities concept page + category wiring
+
+> One independently shippable PR (<=500 LOC soft target) -- its own Graphite-stacked branch, stacked on the spec+plan PR. ~55 LOC across 3 files (one new page + two one-line edits).
+
+### Task 1: Author the Utilities page
+
+**Files:**
+- Create: `site/content/docs/concepts/utilities.mdx`
+- Test: concrete verification via `grep` (no docs test runner)
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -c "title: Utilities" site/content/docs/concepts/utilities.mdx 2>/dev/null || echo "RED: file absent"`
+  Expected: FAIL — prints `RED: file absent` (the page does not exist yet).
+
+- [ ] **Step 2: Create the page**
+  Create `site/content/docs/concepts/utilities.mdx` with exactly this content:
+  ```mdx
+  ---
+  title: Utilities
+  description: "On-demand skills that complement the build and fix loops — investigate, render, and tend the workspace — without being a step in any flow."
+  ---
+
+  Most woostack skills are steps in a flow: the [build loop](/docs/concepts/building-rules) chains
+  ideate → plan → execute, and the fix loop runs its own gated sequence. A second group of skills
+  sits beside those flows. You reach for them on demand, whenever you need them, and each hands back
+  a small result rather than advancing a pipeline. None of them merge, and none change your code.
+
+  They split by one question: **does the skill change your `.woostack` workspace?**
+
+  ## Investigate & present
+
+  These point at the truth — your repo, the `.woostack/` artifacts, a spec — and either answer or
+  render it. They never mutate workspace or repo state, so they are safe to run anytime, including in
+  CI.
+
+  | Skill | What it does | Writes? | Invoke |
+  | --- | --- | --- | --- |
+  | [woostack-ask](/docs/skills/woostack-ask) | Answers a question grounded in the `.woostack/` knowledge surface and the code, citing its evidence. | no | `/woostack-ask <question>` |
+  | [woostack-visualize](/docs/skills/woostack-visualize) | Renders any source — a spec, plan, file, or concept — to one self-contained HTML view for a chosen audience. | view only (HTML) | `/woostack-visualize <source>` |
+  | [woostack-status](/docs/skills/woostack-status) | Computes the feature board from git artifacts and prints it. | no | `/woostack-status` |
+  | [woostack-debug](/docs/skills/woostack-debug) | Runs a four-phase root-cause analysis and hands the findings back — it never writes the fix. | no | `/woostack-debug <target>` |
+
+  <Callout type="info">
+    `woostack-debug` is **dual-natured**: the standalone `/woostack-debug` command is the pure
+    on-demand utility listed here, but the same engine is also an internal hook that
+    [woostack-execute](/docs/skills/woostack-execute) and
+    [woostack-review](/docs/skills/woostack-review) fire from inside their flows. It earns its place
+    here because, run on its own, it only investigates.
+  </Callout>
+
+  ## Tend the workspace
+
+  These maintain the `.woostack/` workspace itself. Both are **gated**: they propose a changeset and
+  nothing is written until you approve it.
+
+  | Skill | What it does | Writes? | Invoke |
+  | --- | --- | --- | --- |
+  | [woostack-doctor](/docs/skills/woostack-doctor) | Diagnoses `.woostack/` store integrity and conventions, then applies repairs you approve. | gated | `/woostack-doctor` |
+  | [woostack-dream](/docs/skills/woostack-dream) | Curates the [memory and wisdom](/docs/concepts/memory) stores and docs via a gated changeset. | gated | `/woostack-dream [instructions]` |
+
+  ## Where to go next
+
+  <Cards>
+    <Card title="Building rules" href="/docs/concepts/building-rules" description="The gated build loop these utilities complement." />
+    <Card title="Memory" href="/docs/concepts/memory" description="The stores woostack-dream curates and woostack-ask recalls." />
+    <Card title="All skills" href="/docs/skills/using-woostack" description="Per-skill reference, generated from each SKILL.md." />
+  </Cards>
+  ```
+
+- [ ] **Step 3: Confirm the page covers all six members in the right clusters**
+  Run (from the worktree root):
+  ```bash
+  F=site/content/docs/concepts/utilities.mdx
+  for s in ask visualize status debug doctor dream; do grep -q "/docs/skills/woostack-$s" "$F" && echo "ok $s" || echo "MISSING $s"; done
+  grep -q "## Investigate & present" "$F" && echo "ok cluster1" || echo "MISSING cluster1"
+  grep -q "## Tend the workspace" "$F" && echo "ok cluster2" || echo "MISSING cluster2"
+  grep -q "dual-natured" "$F" && echo "ok debug-note" || echo "MISSING debug-note"
+  # Excluded flow phases must NOT appear as members:
+  for s in tdd commit plan ideate harden; do grep -q "/docs/skills/woostack-$s" "$F" && echo "note: links woostack-$s"; done
+  ```
+  Expected: PASS — `ok` for all six skills, both clusters, and the debug note. No `note:` line appears (only `woostack-execute` and `woostack-review` are referenced, and only inside the debug Callout — neither is in the excluded-list checked here).
+
+### Task 2: Wire the page into the category nav
+
+**Files:**
+- Modify: `site/content/docs/concepts/meta.json`
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -q '"utilities"' site/content/docs/concepts/meta.json && echo PASS || echo "RED: not in pages"`
+  Expected: FAIL — prints `RED: not in pages`.
+
+- [ ] **Step 2: Add `"utilities"` last in the `pages` array**
+  Edit `site/content/docs/concepts/meta.json` — change:
+  ```json
+  {"title":"Core concepts","pages":["index","building-rules","memory","context-management","worktrees","status-tracking","review-angles"]}
+  ```
+  to:
+  ```json
+  {"title":"Core concepts","pages":["index","building-rules","memory","context-management","worktrees","status-tracking","review-angles","utilities"]}
+  ```
+
+- [ ] **Step 3: Confirm valid JSON with `utilities` present**
+  Run: `node -e "const p=require('./site/content/docs/concepts/meta.json'); if(!p.pages.includes('utilities')) throw new Error('missing'); console.log('PASS', p.pages.join(','))"`
+  Expected: PASS — prints `PASS index,building-rules,memory,context-management,worktrees,status-tracking,review-angles,utilities`.
+
+### Task 3: Add the landing card
+
+**Files:**
+- Modify: `site/content/docs/concepts/index.mdx` (the served `/docs/concepts` landing; `<Cards>` grid at lines 12-19)
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -q 'href="/docs/concepts/utilities"' site/content/docs/concepts/index.mdx && echo PASS || echo "RED: no card"`
+  Expected: FAIL — prints `RED: no card`.
+
+- [ ] **Step 2: Add a 7th `<Card>` after the review-angles card**
+  In `site/content/docs/concepts/index.mdx`, insert a new line immediately after the
+  `<Card title="Review angles" ... />` line (line 18) and before `</Cards>`:
+  ```mdx
+    <Card title="Utilities" href="/docs/concepts/utilities" description="On-demand skills — ask, visualize, status, debug, doctor, dream — that complement the loops without being a step in one." />
+  ```
+
+- [ ] **Step 3: Confirm the card is present**
+  Run: `grep -q 'title="Utilities" href="/docs/concepts/utilities"' site/content/docs/concepts/index.mdx && echo PASS || echo FAIL`
+  Expected: PASS.
+
+### Task 4: Build verification + orphan untouched
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm the pre-split orphan is untouched**
+  Run: `git status --porcelain site/content/docs/concepts.mdx`
+  Expected: empty output (no staged/unstaged change to `concepts.mdx`).
+
+- [ ] **Step 2: Confirm every linked skill page source exists**
+  Run:
+  ```bash
+  for s in ask visualize status debug doctor dream; do test -f skills/woostack-$s/SKILL.md && echo "ok $s" || echo "MISSING SKILL $s"; done
+  ```
+  Expected: PASS — `ok` for all six (their `/docs/skills/woostack-<s>` pages regenerate from these `SKILL.md` files at build).
+
+- [ ] **Step 3: Build the site (authoritative MDX + route gate)**
+  Run:
+  ```bash
+  pnpm -C site install
+  pnpm -C site build
+  ```
+  Expected: PASS — install resolves; `pnpm -C site build` runs `prebuild` (regenerates the `/docs/skills/woostack-*` pages) then `next build`, exiting 0 (compiles `utilities.mdx`, generates the `/docs/concepts/utilities` route). `next build` has no internal-link checker, so this gate proves MDX validity + route generation, not link integrity (that is covered structurally by Step 2). On failure, read the build error and fix the offending wiring site — do not restructure the category or delete the orphan.
+
+### Task 5: Commit the increment
+
+- [ ] **Step 1: Commit via Graphite (stacks on the spec+plan PR)**
+  Hand off to [woostack-commit](../../skills/woostack-commit/SKILL.md), which creates the branch, pushes with Graphite, and opens/updates the PR. Equivalent first commit:
+  ```bash
+  gt create -m "docs(site): add Utilities concept page"
+  ```
+  Expected: a new Graphite branch stacked on the spec+plan branch, PR opened, `concepts.mdx` not in the diff.
+
+## Plan Checks
+
+- **Spec coverage** — AC1 (page exists + renders in category) → Tasks 1-3; AC2 (six members, clustered, linked, debug dual-nature) → Task 1 Step 3 + the page content; AC3 (meta + landing card + green build) → Tasks 2, 3, 4. The "out-of-scope orphan untouched" edge → Task 4 Step 1.
+- **AC coverage** — every §7 AC and its happy/error/edge case maps to a verification step above; no §7 section is `N/A`.
+- **No placeholders** — full MDX content in Task 1; exact `grep`/`node`/`pnpm` commands with expected output throughout.
+- **Type consistency** — skill slugs (`woostack-ask|visualize|status|debug|doctor|dream`), the route `/docs/concepts/utilities`, and the `meta.json` `pages` entry `"utilities"` match across all tasks.
+
+> Filename mirrors spec basename: `.woostack/plans/2026-06-17-site-utilities-page.md`.

--- a/.woostack/specs/2026-06-17-site-utilities-page.md
+++ b/.woostack/specs/2026-06-17-site-utilities-page.md
@@ -1,0 +1,172 @@
+---
+name: site-utilities-page
+type: spec
+status: approved
+date: 2026-06-17
+branch: feature/site-utilities-page
+links:
+---
+
+# Utilities concept page for the docs site — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
+> **Plan:** [[plans/2026-06-17-site-utilities-page]]
+
+## 1. Problem
+
+The docs site's **Core concepts** category (`site/content/docs/concepts/`) documents the
+build loop and its supporting mechanics, but has no page for the class of skills you invoke
+**on demand, outside any flow**. A reader who runs `/woostack-ask` or `/woostack-visualize`
+finds only the generated per-skill reference under **Skills** — there is no conceptual page
+that names this class, says what unifies it, and explains when to reach for each one. The
+membership is currently implicit: nothing tells a reader that `ask`, `visualize`, `status`,
+`doctor`, `dream`, and `debug` form a coherent group distinct from the gated build/fix loop
+phases.
+
+## 2. Goal
+
+Add one authored concept page, **Utilities**, to the Core-concepts category that:
+
+- Names the class — on-demand skills that complement the build/fix loop but are **not**
+  sequential steps in it — and states the unifying trait (each returns a small result and
+  hands back; none merge).
+- Covers the six members in two natural clusters, each with a short table linking to the
+  generated per-skill reference page.
+- Is wired into the category exactly like the existing concept pages (nav order + landing
+  card grid), with no broken links and a green `pnpm -C site build`.
+
+## 3. Non-goals
+
+- **No new skills, no skill behavior changes.** Pure docs.
+- **No change to the public skill-surface count or routing** (AGENTS.md / README /
+  `using-woostack`). Utilities is a *concept* page, not a command-surface change.
+- **No generated per-skill page edits.** Those regenerate from each `SKILL.md` and are
+  gitignored.
+- **No inclusion of flow phases that merely have a standalone entry point** (e.g. `tdd`,
+  `commit`, `review`). They belong to the loop; out of scope.
+- **No restructuring of existing concept pages.** Only additive cross-links where an existing
+  page overlaps (status→status-tracking, dream→memory).
+
+## 4. Approach
+
+Add `site/content/docs/concepts/utilities.mdx` as a hand-authored MDX page in the same shape
+as sibling concept pages (`status-tracking.mdx`, `review-angles.mdx`): YAML frontmatter
+(`title`, `description`), a one-paragraph intro that defines the class, then the body.
+
+**Membership (6), clustered by workspace impact** — the axis is *does the skill mutate your
+`.woostack` workspace / repo state?* No → it's a lens you point at the truth; gated-yes → it
+proposes changes you approve. This axis is crisp and maps directly to the table's `Writes?`
+column.
+
+- **Investigate & present** — read or render the truth; never mutate workspace/repo state:
+  - `ask` — answer a question grounded in `.woostack/` + code; cites evidence; writes nothing.
+  - `visualize` — render any source to one self-contained HTML; view-only, never the source of
+    truth (its only output is a disposable HTML view artifact, not workspace state).
+  - `status` — derived feature board from git artifacts; read-only.
+  - `debug` — root-cause analysis; writes nothing, hands findings back. **Dual nature:**
+    standalone `/woostack-debug <target>` *and* an internal hook that execute/review fire. It
+    sits here because its standalone mode is a pure read-only lens; the page states the dual
+    nature so a reader isn't misled that it is purely standalone.
+- **Tend the workspace** — propose gated mutations to the `.woostack` workspace; nothing
+  changes before explicit approval:
+  - `doctor` — diagnose + gated repair of `.woostack/` health.
+  - `dream` — curate memory/wisdom + docs via a gated changeset.
+
+Each cluster renders as a short Markdown table: `Skill | What it does | Writes? | Invoke`,
+with the skill name linking to `/docs/skills/woostack-<name>`. The `Writes?` column carries
+the axis: ask/status/debug `no`, visualize `view only (HTML)`, doctor/dream `gated`. A closing
+`<Cards>`/"Where to go next" block links back to related concept pages.
+
+The page reuses the existing Fumadocs MDX conventions already used across `concepts/` (front
+matter, `<Cards>`/`<Card>`, `<Callout>`); no new components are introduced.
+
+## 5. Components & data flow
+
+Files touched (all under the sanctioned `site/` subtree — Mode A; the build also writes the
+`.woostack/` spec+plan):
+
+1. **`site/content/docs/concepts/utilities.mdx`** *(new)* — the page.
+2. **`site/content/docs/concepts/meta.json`** — append `"utilities"` to the `pages` array,
+   last (after `review-angles`).
+3. **`site/content/docs/concepts/index.mdx`** — add a 7th `<Card>` for Utilities to the
+   `<Cards>` grid. This folder index (frontmatter `title: Overview`) is the page Fumadocs
+   serves at `/docs/concepts` and lists in the Core-concepts nav, so this is the served
+   landing's card grid.
+
+**Routing fact (resolved during harden, not an open item):** a *second*, standalone
+`site/content/docs/concepts.mdx` (frontmatter `title: Core concepts`, the long-form pre-split
+content) also exists and also maps to `/docs/concepts`. The generated `.source/server.ts`
+registers both, but the `concepts/` folder — its `meta.json` (`title: Core concepts`, `pages`
+list) plus `concepts/index.mdx` — owns the nav node and the served landing; the standalone
+`concepts.mdx` is an **orphan** the `concepts-page-split` feature intended to remove and is not
+in any `pages` list. **This feature does not touch or delete `concepts.mdx`** — removing the
+pre-split orphan is separate cleanup, out of scope here (flagged to the user). The Utilities
+card therefore goes only in `concepts/index.mdx`.
+
+This mirrors the **lockstep-edit-sites** wisdom: a new concept page is a multi-site contract
+(page + `meta.json` + landing card grid). `pnpm -C site build` verifies the joint — it runs the
+`prebuild` skill-page generator then `next build`, proving MDX validity + route generation.
+`next build` has **no internal-link checker**, so member-link integrity is guaranteed
+structurally instead: the six linked `/docs/skills/woostack-<name>` pages are generated from the
+`SKILL.md` sources (all present), with a manual nav/link click as the human backstop.
+
+No runtime data flow: static MDX compiled at build time.
+
+## 6. Error handling
+
+- **Build break:** caught by `pnpm -C site build` (the authoritative gate). The pre-existing
+  `concepts.mdx`/`concepts/index.mdx` duplicate already builds today and is left untouched, so
+  this change introduces no new route conflict; if the build nonetheless rejects, the fix is
+  scoped to the three wiring sites above — never restructuring the category or deleting the
+  orphan.
+- **Broken skill links:** any `/docs/skills/woostack-<name>` target that doesn't resolve is a
+  build/link failure; every linked member must have a generated page (all six do — confirmed in
+  `.source/server.ts`).
+- **Stale nav:** if `meta.json` omits `utilities`, the page renders but is unreachable from the
+  category nav — the index-card + meta entry together are required, not optional.
+
+## 7. Acceptance criteria
+
+- **AC1 — Utilities page exists and renders in the Core-concepts category**
+  - happy: `site/content/docs/concepts/utilities.mdx` exists with valid frontmatter
+    (`title: Utilities`, a `description`) and appears in the Core-concepts left-nav.
+  - error: missing/invalid frontmatter → `pnpm -C site build` fails; not acceptable.
+  - edge: page title/slug do not collide with an existing concept page.
+- **AC2 — All six members are covered, clustered, and correctly linked**
+  - happy: page lists `ask`, `visualize`, `status`, `debug` (Investigate & present) and
+    `doctor`, `dream` (Tend the workspace); each links to its `/docs/skills/woostack-<name>`
+    reference; `debug`'s dual nature is stated.
+  - error: a missing member, a wrong/broken skill link, or an excluded flow phase
+    (tdd/commit/review) appearing on the page → not acceptable.
+  - edge: workspace-impact axis is visible — the `Writes?` column reads `no` for
+    ask/status/debug, `view only (HTML)` for visualize, `gated` for doctor/dream.
+- **AC3 — Category wiring is complete and the site builds**
+  - happy: `concepts/meta.json` `pages` includes `"utilities"`; `concepts/index.mdx` (the
+    served landing) card grid includes a Utilities card; `pnpm -C site build` exits 0.
+  - error: `meta.json` omission, missing landing card, or non-zero build → not acceptable.
+  - edge: the standalone pre-split `concepts.mdx` orphan is left untouched (not edited, not
+    deleted); the card lives only in `concepts/index.mdx`.
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+This is a docs-only change with no unit-test harness for content. Verification is:
+
+- **Build gate:** `pnpm -C site build` must pass — runs the `prebuild` skill-page generator
+  then `next build`; the authoritative check for MDX validity and route generation. (It does
+  not check internal links; member-link integrity is structural — see §5.)
+- **Manual review (recorded in the PR test plan):** Utilities appears in the Core-concepts
+  nav and in the landing card grid; all six skill links resolve to their reference pages;
+  the two-cluster structure and the `debug` dual-nature note read correctly.
+
+## 9. Open questions
+
+None. Settled during harden: membership (6 incl. `debug`); clustering by workspace impact
+(`debug` → Investigate & present); placement (last in `concepts/meta.json`); the served
+landing for the card grid is `concepts/index.mdx`; and the standalone `concepts.mdx` is a
+pre-split orphan left untouched here (its removal is separate, out-of-scope cleanup flagged to
+the user).


### PR DESCRIPTION
## Goal

Document the class of woostack skills you invoke on demand — outside any flow — by adding a
Utilities page to the docs site's Core-concepts category. This PR is the spec+plan base of the
stack; the page itself ships in the stacked increment.

## Summary

- Adds the design spec `.woostack/specs/2026-06-17-site-utilities-page.md` for a new
  `site/content/docs/concepts/utilities.mdx` page covering six on-demand skills.
- Adds the execution plan `.woostack/plans/2026-06-17-site-utilities-page.md` (one PR-sized
  increment) wiring the page into the category nav + landing card grid.
- Members cluster by workspace impact: **Investigate & present** (ask, visualize, status,
  debug) vs **Tend the workspace** (doctor, dream); `debug`'s dual nature is called out.
- Records that the standalone `concepts.mdx` is a pre-split orphan, left untouched here
  (separate cleanup, noted for follow-up).

## Test plan

### Manual

**Before merge**

- [ ] Read the spec and plan; confirm membership (6 skills), the two clusters, and the
      `concepts/index.mdx`-is-the-served-landing routing call are correct.
- [ ] Confirm this PR carries no `site/` code — implementation lands in the stacked increment.

Spec: .woostack/specs/2026-06-17-site-utilities-page.md
