### PR TITLE
docs: SEO angle gate + rubric refinement (spec + plan)

### DIFF
--- a/.woostack/plans/2026-06-19-seo-angle-refine.md
+++ b/.woostack/plans/2026-06-19-seo-angle-refine.md
@@ -1,0 +1,364 @@
+---
+type: plan
+source: .woostack/specs/2026-06-19-seo-angle-refine.md
+status: ready
+branch: feature/seo-angle-refine
+---
+
+**Source:** [[specs/2026-06-19-seo-angle-refine]]
+
+# Refine SEO review angle — tiered gate + claude-seo rubric learnings — Implementation Plan
+
+**Goal:** Cut `seo` review-angle over-firing by gating soft files behind an SEO diff-token co-signal, and sharpen the `seo`/`aeo` rubrics with targeted current learnings.
+
+**Architecture:** Two independent, linearly-stacked increments. **Increment 1** rewrites the `seo` gate in `scripts/detect-angles.sh` (hard files fire on path; soft files need a changed-line-anchored metadata token) plus its lockstep doc-comment, pinned by a new committed gating test. **Increment 2** edits the two rubric prompts (`seo.md`, `aeo.md`) — markdown only, no runtime behavior. No change to `VALID_ANGLES`, `_header.md`, `load-config.sh`, the finding schema, SEO's `fast` tier, or `aeo` gating.
+
+**Tech Stack:** Bash (`set -euo pipefail`, `grep -qE` ERE), the `skills/woostack-init/scripts/tests/assert.sh` test helper, Markdown prompts.
+
+**Lockstep note (wisdom: [[lockstep-edit-sites]]):** a gate edit moves 3 sites together — the predicate functions, the top-of-file doc-comment catalog, and the committed gating test. No other angle-wiring site changes here: `seo` stays a valid angle (so `load-config.sh` VALID_ANGLES, `_header.md` catalog/footer/count, `anthropic.md` `fast` tier, and SKILL.md's defer-to-script line are all untouched). `aeo` gating is unchanged.
+
+---
+
+## Increment 1: Tiered SEO gate + committed gating test
+
+> One independently shippable PR — rewrites the `seo` gate and pins it with a structural test. Base of the increment stack (stacks on the spec+plan PR).
+
+### Task 1: Narrow the `seo` gate to hard-file OR token, behind a red→green test
+
+**Files:**
+- Create: `skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`
+- Modify: `skills/woostack-review/scripts/detect-angles.sh` (`has_seo_file`, `has_seo_diff_token`, doc-comment block)
+
+- [ ] **Step 1: Write the failing test**
+  Create `skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`:
+  ```bash
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  ROOT="$(cd "$DIR/../../.." && pwd)"
+  source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+  SCRIPT="$DIR/detect-angles.sh"
+
+  # setup $1 = changed file path, $2 = diff body (may be multi-line; literal +/- prefixes)
+  setup_diff() {
+    work="$(mktemp -d)"
+    export OUTDIR="$work/out"
+    mkdir -p "$OUTDIR"
+    printf '{"files":[{"path":"%s"}]}\n' "$1" > "$OUTDIR/meta.json"
+    printf '%s\n' "$2" > "$OUTDIR/diff.txt"
+  }
+  absent() { grep -cx 'seo' "$OUTDIR/angles.txt" || true; }  # "0" when seo not enabled
+
+  # 1. HARD file: robots.txt fires on path alone (no token needed).
+  setup_diff "public/robots.txt" "+Disallow: /tmp"
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "robots.txt enables seo on path alone"
+  assert_contains "$(cat "$OUTDIR/angles.txt")" "bugs" "bugs always on"
+  rm -rf "$work"
+
+  # 2. HARD file: sitemap.xml fires on path alone.
+  setup_diff "app/sitemap.xml" "+  <loc>https://x.com/</loc>"
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "sitemap.xml enables seo"
+  rm -rf "$work"
+
+  # 3. HARD file: app/manifest.ts fires on path alone.
+  setup_diff "app/manifest.ts" "+  name: 'X',"
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "app/manifest.ts enables seo"
+  rm -rf "$work"
+
+  # 4. SOFT file, no token: layout.tsx restyle does NOT enable seo.
+  setup_diff "app/layout.tsx" '+  <div className="wrap">'
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_eq "$(absent)" "0" "layout.tsx restyle does not enable seo"
+  rm -rf "$work"
+
+  # 5. SOFT file + metadata co-signal (added): generateMetadata enables seo.
+  setup_diff "app/layout.tsx" '+export async function generateMetadata() {'
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "added generateMetadata enables seo"
+  rm -rf "$work"
+
+  # 6. SOFT file + metadata co-signal (REMOVED): a removed export is an SEO regression.
+  setup_diff "app/page.tsx" '-export const metadata = { title: "Old" }'
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "removed metadata export enables seo"
+  rm -rf "$work"
+
+  # 7. SOFT file, no token: *.html with no SEO tag does NOT enable seo.
+  setup_diff "emails/welcome.html" '+  <div>Hello</div>'
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_eq "$(absent)" "0" "html with no SEO tag does not enable seo"
+  rm -rf "$work"
+
+  # 8. SOFT file + token: *.html with <meta> enables seo.
+  setup_diff "public/index.html" '+  <meta name="description" content="x">'
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "html with <meta> enables seo"
+  rm -rf "$work"
+
+  # 9. SOFT file, no token: next.config.ts alone does NOT enable seo.
+  setup_diff "next.config.ts" '+  images: { remotePatterns: [] },'
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_eq "$(absent)" "0" "next.config.ts alone does not enable seo"
+  rm -rf "$work"
+
+  # 10. Excluded token: SVG <title> does NOT enable seo (collision guard).
+  setup_diff "components/Icon.tsx" '+    <title>Close</title>'
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_eq "$(absent)" "0" "SVG <title> does not enable seo"
+  rm -rf "$work"
+
+  # 11. Excluded token: <link rel="stylesheet"> does NOT enable seo.
+  setup_diff "app/layout.tsx" '+  <link rel="stylesheet" href="/x.css">'
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_eq "$(absent)" "0" "link rel=stylesheet does not enable seo"
+  rm -rf "$work"
+
+  # 12. Anchoring: an UNCHANGED (context) metadata line does NOT enable seo.
+  setup_diff "app/layout.tsx" "$(printf '+  <div className="x">\n   export const metadata = { title: "keep" }')"
+  bash "$SCRIPT" >/dev/null 2>&1
+  assert_eq "$(absent)" "0" "unchanged-context metadata does not enable seo"
+  rm -rf "$work"
+
+  finish
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: `bash skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`
+  Expected: FAIL — the current gate fires `seo` on every soft file, so cases 4, 7, 9, 10, 11, 12 fail, e.g.:
+  ```
+    FAIL: layout.tsx restyle does not enable seo
+      expected: [0]
+      actual:   [1]
+    FAIL: next.config.ts alone does not enable seo
+    ...
+    N passed, 6 failed
+  ```
+  (exit 1 from `finish`)
+
+- [ ] **Step 3: Narrow `has_seo_file` to hard files only**
+  In `skills/woostack-review/scripts/detect-angles.sh`, replace the `has_seo_file` function:
+  ```bash
+  has_seo_file() {
+    echo "$CHANGED_PATHS" | grep -qE '(^|/)(robots\.txt|sitemap\.(xml|ts)|next\.config\.(js|ts|mjs))$' && return 0
+    echo "$CHANGED_PATHS" | grep -qE '\.html$' && return 0
+    echo "$CHANGED_PATHS" | grep -qE '(^|/)(head|layout)\.(ts|tsx|js|jsx)$' && return 0
+    echo "$CHANGED_PATHS" | grep -qE '(^|/)app/manifest\.(ts|json)$' && return 0
+    return 1
+  }
+  ```
+  with (hard SEO surfaces only):
+  ```bash
+  has_seo_file() {
+    # Hard SEO surfaces only — unambiguous, fire on path alone. Soft surfaces
+    # (*.html, head/layout.*, next.config.*) now gate on a diff token co-signal
+    # in has_seo_diff_token() to cut over-firing on non-SEO edits.
+    echo "$CHANGED_PATHS" | grep -qE '(^|/)(robots\.txt|sitemap\.(xml|ts))$' && return 0
+    echo "$CHANGED_PATHS" | grep -qE '(^|/)app/manifest\.(ts|json)$' && return 0
+    return 1
+  }
+  ```
+
+- [ ] **Step 4: Add the changed-line-anchored metadata co-signal to `has_seo_diff_token`**
+  Replace the `has_seo_diff_token` function:
+  ```bash
+  has_seo_diff_token() {
+    # Anchored to reduce false positives in docs/comments/JSON keys.
+    # Matches: meta tags, og:/twitter: prefixed props, rel=canonical, name=robots,
+    # <loc> sitemap entries, Sitemap: directive.
+    grep -qE "</?meta\b|\bog:[a-z_-]+|\btwitter:[a-z_-]+|rel=[\"']canonical|name=[\"']robots|<loc>|(^|[[:space:]])Sitemap:" "$DIFF"
+  }
+  ```
+  with (legacy tokens unchanged + a second, changed-line-anchored metadata check):
+  ```bash
+  has_seo_diff_token() {
+    # Legacy unanchored tokens: meta tags, og:/twitter: prefixed props, rel=canonical,
+    # name=robots, <loc> sitemap entries, Sitemap: directive.
+    grep -qE "</?meta\b|\bog:[a-z_-]+|\btwitter:[a-z_-]+|rel=[\"']canonical|name=[\"']robots|<loc>|(^|[[:space:]])Sitemap:" "$DIFF" && return 0
+    # Soft-surface co-signal: Next.js metadata edits in head/layout/*.html files.
+    # Anchored to CHANGED lines (^[+-]) so a styling-only edit near an unchanged
+    # metadata export does not fire, and a REMOVED export (an SEO regression) does.
+    # <title and <link rel= are intentionally excluded (SVG <title> / stylesheet-link
+    # collisions; rel=canonical + hreflang already cover SEO links).
+    grep -qE "^[+-].*(\bgenerateMetadata\b|export[[:space:]]+const[[:space:]]+metadata\b|\bhreflang\b)" "$DIFF" && return 0
+    return 1
+  }
+  ```
+
+- [ ] **Step 5: Update the lockstep doc-comment catalog**
+  In the same file, replace the `seo` lines in the top-of-file "Angle gating:" comment block:
+  ```
+  #   seo       — *.html, head.{ts,tsx}, layout.{ts,tsx}, robots.txt, sitemap.{xml,ts},
+  #               next.config.{js,ts,mjs}, app/manifest.{ts,json}, OR diff body
+  #               contains <meta / og: / twitter: / canonical / robots / sitemap
+  ```
+  with:
+  ```
+  #   seo       — HARD files (fire on path alone): robots.txt, sitemap.{xml,ts},
+  #               app/manifest.{ts,json}. SOFT surfaces (*.html, head/layout.{ts,tsx,js,jsx},
+  #               next.config.*) no longer gate on path — they fire only via a diff token:
+  #               legacy <meta / og: / twitter: / rel=canonical / name=robots / <loc> /
+  #               Sitemap:, OR a changed-line (^[+-]) metadata co-signal generateMetadata /
+  #               export const metadata / hreflang (additions and removals). <title and
+  #               <link rel= are excluded (SVG <title> / stylesheet-link collisions).
+  ```
+
+- [ ] **Step 6: Run the test, confirm it passes**
+  Run: `bash skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`
+  Expected: PASS — `  13 passed, 0 failed` (exit 0).
+
+- [ ] **Step 7: Regression — run the sibling detect-angles tests**
+  Run:
+  ```bash
+  for t in skills/woostack-review/scripts/tests/test-detect-angles-*.sh; do
+    echo "== $t =="; bash "$t" || exit 1
+  done
+  ```
+  Expected: every file ends `… 0 failed`; loop exits 0. Confirms the SEO narrowing did not regress `comments`, `skills`, or `observability` gates.
+
+- [ ] **Step 8: Syntax check + commit**
+  Run: `bash -n skills/woostack-review/scripts/detect-angles.sh && echo OK`
+  Expected: `OK`
+  ```bash
+  gt create -m "fix(review): gate seo angle behind hard-file or metadata token"
+  ```
+
+---
+
+## Increment 2: SEO + AEO rubric enrichment
+
+> One independently shippable PR — markdown rubric edits only, no runtime behavior. Stacks on Increment 1.
+
+### Task 1: Enrich `seo.md` (CWV targets, canonical chains, SPA suppressor, falsifiability)
+
+**Files:**
+- Modify: `skills/woostack-review/prompts/angles/seo.md`
+
+- [ ] **Step 1: Verify the new content is absent (red)**
+  Run: `grep -c "2.5s" skills/woostack-review/prompts/angles/seo.md || true`
+  Expected: `0` (no CWV numeric target yet).
+
+- [ ] **Step 2: Add Core Web Vitals numeric targets**
+  Replace:
+  ```
+  - **Core Web Vitals**: Detect potential LCP, INP, or CLS regressions in the diff (e.g., large unoptimized images, layout shifts).
+  ```
+  with:
+  ```
+  - **Core Web Vitals**: Detect potential LCP (target < 2.5s), INP (< 200ms), or CLS (< 0.1) regressions in the diff (e.g., large unoptimized images, layout shifts, render-blocking resources).
+  ```
+
+- [ ] **Step 3: Extend the canonical check to chains / self-ref / noindex conflict**
+  Replace:
+  ```
+  - **Canonical & Hreflang**: Missing or wrong `<link rel="canonical">` or `hreflang` mismatches on i18n/new pages.
+  ```
+  with:
+  ```
+  - **Canonical & Hreflang**: Missing, wrong, or broken canonical chains (`<link rel="canonical">` pointing through a redirect or to a non-200), non-self-referencing canonicals, a canonical that conflicts with a `noindex` on the same page, or `hreflang` mismatches on i18n/new pages.
+  ```
+
+- [ ] **Step 4: Add SPA suppressor + falsifiability to the Skip list**
+  Replace:
+  ```
+  ## Skip
+  - Internal admin / authenticated pages (should not be indexable).
+  - Style-only changes to existing SEO-correct pages.
+  - Pre-existing missing metadata not touched by this PR.
+  ```
+  with:
+  ```
+  ## Skip
+  - Internal admin / authenticated pages (should not be indexable).
+  - Style-only changes to existing SEO-correct pages.
+  - Pre-existing missing metadata not touched by this PR.
+  - Client-rendered routes with no SSR/metadata surface in the diff — a static diff cannot observe the rendered output, so do not flag content-depth or Core Web Vitals there (heavy client-side hydration produces noisy, unverifiable findings).
+  - Speculative "could rank better?" suggestions without a concrete regression in the diff — every finding must cite the observable diff fact it is grounded in.
+  ```
+
+- [ ] **Step 5: Verify present + output contract intact (green)**
+  Run:
+  ```bash
+  grep -q "target < 2.5s" skills/woostack-review/prompts/angles/seo.md \
+    && grep -q "broken canonical chains" skills/woostack-review/prompts/angles/seo.md \
+    && grep -q "cannot observe the rendered output" skills/woostack-review/prompts/angles/seo.md \
+    && grep -q "must cite the observable diff fact" skills/woostack-review/prompts/angles/seo.md \
+    && grep -q 'findings.seo.json' skills/woostack-review/prompts/angles/seo.md \
+    && echo OK
+  ```
+  Expected: `OK` (all four additions present; the `findings.seo.json` output contract line is untouched).
+
+- [ ] **Step 6: Commit**
+  ```bash
+  gt modify -c -m "docs(review): sharpen seo rubric (CWV targets, canonical chains, SPA + falsifiability)"
+  ```
+
+### Task 2: Refresh `aeo.md` structured-data framing
+
+**Files:**
+- Modify: `skills/woostack-review/prompts/angles/aeo.md`
+
+- [ ] **Step 1: Verify the reframe is absent (red), falsifiability already present**
+  Run:
+  ```bash
+  grep -c "AI/entity signals" skills/woostack-review/prompts/angles/aeo.md || true
+  grep -q "without a concrete regression in the diff" skills/woostack-review/prompts/angles/aeo.md && echo "falsifiability-present"
+  ```
+  Expected: first prints `0` (reframe not yet added); second prints `falsifiability-present` — AC4's falsifiability line already exists (Skip list), so this task only reframes schema.
+
+- [ ] **Step 2: Reframe `### 4. Structured data for AI`**
+  Replace:
+  ```
+  ### 4. Structured data for AI (P2)
+  - Removed or broken `FAQPage`, `HowTo`, `Article`/`BlogPosting`, `Product`, `ItemList`, `Review`/`AggregateRating`, `Organization` schema on content where it applied.
+  - New FAQ / comparison / how-to content shipped without matching schema.
+  - Schema introduced that mis-describes the page (would mislead AI extraction).
+  ```
+  with:
+  ```
+  ### 4. Structured data for AI (P2)
+  - Prefer **JSON-LD** (the format AI extractors and Google both favor) over inline microdata / RDFa.
+  - Removed or broken `Article`/`BlogPosting`, `Product`, `ItemList`, `Review`/`AggregateRating`, `Organization` schema on content where it applied.
+  - `HowTo` and `FAQPage` no longer produce Google rich results for most sites — treat them as **AI/entity signals**, not rich-result regressions: flag mis-describing or invalid markup, not the mere absence of a rich result.
+  - New FAQ / comparison / how-to content shipped without matching schema.
+  - Schema introduced that mis-describes the page (would mislead AI extraction).
+  ```
+
+- [ ] **Step 3: Align the severity rubric with the reframe (lockstep)**
+  The MEDIUM severity line still treats schema *removal* as a finding, contradicting the §4 reframe. Replace:
+  ```
+  - `MEDIUM` + `blocking: false` — Lost citations / statistics / author attribution; FAQ or HowTo schema removed or malformed; answer passages buried below filler; comparison tables converted to prose; missing `/pricing.md` companion for new pricing page.
+  ```
+  with:
+  ```
+  - `MEDIUM` + `blocking: false` — Lost citations / statistics / author attribution; FAQ or HowTo schema malformed or mis-describing content (not its mere absence — see §4); answer passages buried below filler; comparison tables converted to prose; missing `/pricing.md` companion for new pricing page.
+  ```
+
+- [ ] **Step 4: Verify present + double-report boundary intact (green)**
+  Run:
+  ```bash
+  grep -q "AI/entity signals" skills/woostack-review/prompts/angles/aeo.md \
+    && grep -q "Prefer \*\*JSON-LD\*\*" skills/woostack-review/prompts/angles/aeo.md \
+    && grep -q "malformed or mis-describing content" skills/woostack-review/prompts/angles/aeo.md \
+    && grep -q "do not double-report" skills/woostack-review/prompts/angles/aeo.md \
+    && echo OK
+  ```
+  Expected: `OK` (reframe + severity-line alignment present; the `seo`-boundary "do not double-report" Skip line is untouched).
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs(review): reframe aeo structured-data as AI/entity signals"
+  ```
+
+---
+
+## Plan Checks
+
+- **Spec coverage** — §4a gate → Increment 1; §4b `seo.md` → Inc 2 Task 1; §4c `aeo.md` → Inc 2 Task 2; §8 test strategy → Inc 1 Steps 1-2,6-7. All covered.
+- **AC coverage** — AC1 (gate fires on hard file/token; soft-no-token/SVG/stylesheet/next.config/unchanged-context skip; added+removed metadata fire) → Inc 1 test cases 1-12. AC2 (bugs/security on; aeo gate unchanged; sibling tests pass) → Inc 1 case 1 (`bugs`) + Step 7 regression. AC3 (`seo.md` learnings) → Inc 2 Task 1 Steps 2-5. AC4 (`aeo.md` reframe + JSON-LD; falsifiability present) → Inc 2 Task 2 (falsifiability pre-satisfied, verified Step 1). Every filled happy/error/edge maps to a step.
+- **No placeholders** — every step carries full file content / exact `grep`/`bash` commands with expected output. No TBD/TODO.
+- **Type consistency** — token names (`generateMetadata`, `export const metadata`, `hreflang`) identical across the gate function, the doc-comment, and the test; the excluded tokens (`<title`, `<link rel=`) named identically in all three.
+- **Angle coverage** (plan lens) — architecture: 2 single-responsibility increments (gate vs prose), no layer leak. tests: each AC maps to a committed gate-test case or a `grep` verification; the load-bearing gate is backed by a structural test (wisdom: [[autonomy-needs-structural-proof]]). security/observability: no new input/secret/network surface; gate still emits `angles.{txt,json}` unchanged. Lockstep (doc-comment + function + test) walked per [[lockstep-edit-sites]]. No deferral markers — increments share no open gap.

--- a/.woostack/specs/2026-06-19-seo-angle-refine.md
+++ b/.woostack/specs/2026-06-19-seo-angle-refine.md
@@ -1,0 +1,132 @@
+---
+name: 2026-06-19-seo-angle-refine
+type: spec
+status: approved
+date: 2026-06-19
+branch: feature/seo-angle-refine
+links:
+---
+
+# Refine SEO review angle — tiered gate + claude-seo rubric learnings — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../woostack-status/references/conventions.md).
+
+> **Plan:** [[plans/2026-06-19-seo-angle-refine]]
+
+## 1. Problem
+
+The `seo` review angle in `woostack-review` **fires too often** on PRs with no SEO relevance, and its rubric (`prompts/angles/seo.md`) has drifted behind current search guidance.
+
+Gating (`scripts/detect-angles.sh`) enables `seo` on broad file signals with **no SEO co-signal**:
+
+- `*.html` → fires on *any* HTML file: test fixtures, email templates, storybook stories, component fragments, generated `woostack-visualize` output.
+- `head.{ts,tsx,js,jsx}` / `layout.{ts,tsx,js,jsx}` → fires on *every* layout/head edit, the majority of which are structural or styling changes with no metadata impact.
+- `next.config.{js,ts,mjs}` → fires on *any* Next config edit (webpack, env, images, redirects), mostly non-SEO.
+
+Each false fire spawns a Haiku angle worker, adds noise to the review, and trains authors to ignore the gate.
+
+Separately, the rubric lacks concrete current thresholds (Core Web Vitals targets), treats canonical only as missing/wrong (not broken chains), has no falsifiability discipline (findings can be speculative), and has no suppressor for client-rendered routes a static diff cannot evaluate. The sibling `aeo` angle still frames `HowTo`/`FAQPage` schema removal as a rich-result regression, which is stale.
+
+## 2. Goal
+
+1. **Cut SEO over-firing** by moving the broad file signals behind an SEO diff-token co-signal, while keeping unambiguous SEO surfaces firing on path alone.
+2. **Sharpen the `seo` rubric** with targeted, current learnings ported from [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo): exact CWV targets, canonical-chain checks, a falsifiability rule, and an SPA/hydration noise suppressor.
+3. **Refresh the `aeo` rubric** so deprecated structured-data types are framed as AI/entity signals rather than rich-result regressions, plus the same falsifiability discipline.
+
+Gate change is **`seo`-only**; `aeo` gating is unchanged (the reported pain is SEO firing too much).
+
+## 3. Non-goals
+
+- No new review angle; no change to `VALID_ANGLES`, `_header.md`, `load-config.sh`, or the finding schema.
+- No wholesale port of claude-seo's 25-skill live-crawl auditor — its rendered-page + Google-API checks are out of scope for a static diff reviewer.
+- No change to the `aeo` **gate** (only its prompt content).
+- No change to SEO's tier (`fast`/Haiku) or model routing.
+- No re-scoping of which angle owns schema/JSON-LD: `aeo` keeps it; `seo` keeps OG/Twitter card mechanics, canonical, hreflang, CWV, crawl/index.
+
+## 4. Approach
+
+### 4a. Gate — tiered co-signal (`scripts/detect-angles.sh`)
+
+The token check `has_seo_diff_token()` already fires `seo` regardless of which file changed. So "soft files need a token" reduces mechanically to **drop the soft files from the path check and widen the token check** — no new gate condition or co-location slicing required.
+
+- `has_seo_file()` — keep **only** the unambiguous SEO surfaces: `robots.txt`, `sitemap.{xml,ts}`, `app/manifest.{ts,json}`. Remove `*.html`, `head/layout.*`, `next.config.*`.
+- `has_seo_diff_token()` — keep the existing alternation (`<meta`, `og:`, `twitter:`, `rel=canonical`, `name=robots`, `<loc>`, `Sitemap:`) unchanged, and add a **second, changed-line-anchored** check for the Next.js / metadata co-signals that real SEO edits to soft files carry: `generateMetadata`, `export const metadata`, `hreflang`, matched `^[+-]` so both **additions and removals** fire (removing `generateMetadata` is itself an SEO regression). Anchoring to changed lines means a styling-only `layout.tsx` with an *unchanged* `generateMetadata` elsewhere in the file does **not** fire.
+  - Deliberately **excluded** candidates: `<title` (collides with SVG `<title>`, ubiquitous in icon components) and `<link rel=` (collides with `<link rel="stylesheet|preload|icon">`; the SEO links — `rel=canonical` and `hreflang` — are already covered). Tradeoff: a plain-HTML page whose only SEO change is a `<title>` edit with no `<meta>`/metadata export won't fire — acceptable for the noise-cut goal.
+- The gate line `if has_seo_file || has_seo_diff_token; then ANGLES+=("seo"); fi` is **unchanged** (the new anchored check lives inside `has_seo_diff_token`, which `return 0`s on either sub-check).
+- The **doc-comment block** at the top of `detect-angles.sh` (the `seo —` lines) is the lockstep partner of these functions and is rewritten to describe the tiered behavior. (See [[wisdom/lockstep-edit-sites]].)
+
+Resulting behavior:
+
+| PR change | Before | After |
+|---|---|---|
+| `layout.tsx` restyle, no metadata | seo fires | **skips** |
+| `layout.tsx` editing `generateMetadata` | seo fires | seo fires |
+| `*.html` fixture/email, no SEO tags | seo fires | **skips** |
+| `*.html` page with `<meta>`/`<title>` | seo fires | seo fires |
+| `next.config.ts` alone (webpack/env) | seo fires | **skips** |
+| `robots.txt` / `sitemap.xml` / `app/manifest.ts` | seo fires | seo fires |
+| any diff carrying `og:`/canonical/etc. | seo fires | seo fires |
+
+### 4b. `seo` rubric enrichment (`prompts/angles/seo.md`)
+
+- **CWV targets** — add exact thresholds to §2: LCP < 2.5s, INP < 200ms, CLS < 0.1.
+- **Canonical chains** — extend the §3 canonical bullet beyond missing/wrong to: broken canonical chains, non-self-referencing canonical, and canonical conflicting with `noindex`.
+- **Falsifiability** — one rubric line: every finding must cite the observable diff fact it is grounded in; reject speculative "could be improved" with no concrete regression in the diff.
+- **SPA suppressor** — a Skip rule: do not flag content-depth or CWV on routes that are clearly client-rendered in the diff with no SSR/metadata surface, because a static diff cannot observe the rendered output (matches claude-seo's stated hydration-noise limitation).
+
+### 4c. `aeo` rubric refresh (`prompts/angles/aeo.md`)
+
+- **Schema deprecation** — reframe §4: `HowTo` (deprecated 2023) and `FAQPage` no longer yield Google rich results for most sites; treat their presence/absence as an AI/entity signal, not a rich-result regression. Note JSON-LD is the preferred serialization. Conservative phrasing — no fabricated exact dates.
+- **Falsifiability** — mirror the `seo` falsifiability line.
+
+## 5. Components & data flow
+
+- `scripts/detect-angles.sh` — `has_seo_file()`, `has_seo_diff_token()`, and the top-of-file doc comment. Consumes `$OUTDIR/{meta.json,diff.txt}` (and `*.filtered` variants); appends `seo` to `ANGLES`; writes `$OUTDIR/angles.{txt,json}`. No interface change — same inputs/outputs, narrower gate.
+- `prompts/angles/seo.md` — rubric markdown read by the `seo` angle worker; `tier: fast` frontmatter unchanged; output contract (`findings.seo.json`, schema in `_header.md`) unchanged.
+- `prompts/angles/aeo.md` — rubric markdown read by the `aeo` angle worker; unchanged contract.
+- **New** `scripts/tests/test-detect-angles-seo.sh` — follows the `test-detect-angles-observability.sh` harness (`setup_diff` writing `meta.json` + `diff.txt`, asserting on `angles.txt`).
+
+No downstream consumer changes: angle workers, `merge-findings.sh`, `intersect-findings.sh`, and the validator are agnostic to which angles fire.
+
+## 6. Error handling
+
+- Gate runs under `set -euo pipefail`; `grep -qE` returns non-zero on no-match, which the `||`/`return 1` structure already absorbs — narrowing the patterns does not introduce new failure modes.
+- Empty / sub-threshold diff: `has_seo_file` and `has_seo_diff_token` both return false → `seo` simply absent from `ANGLES` (existing behavior, no error).
+- Widened token alternation must stay valid ERE; a malformed pattern would make `grep` exit non-zero under `pipefail` and abort detection — covered by running the existing detect-angles test suite plus the new SEO test.
+- No untrusted input is parsed beyond the already-trusted prefetched diff; no new secrets, network, or filesystem surface.
+
+## 7. Acceptance criteria
+
+> **Angle pre-flight.** security: no new input/secret/network surface (grep over already-trusted prefetch artifacts) — N/A. observability: gate still emits `angles.{txt,json}`; no logging change — N/A. api/database: N/A. edge/error: covered by AC1 edge rows below.
+
+- **AC1 — SEO gate fires only on hard files or an SEO token**
+  - happy: a diff changing `robots.txt` (or `sitemap.xml`, or `app/manifest.ts`) enables `seo`; a diff whose body carries `og:`/`<meta`/`rel=canonical` enables `seo`.
+  - error: a `layout.tsx` whose only change is `generateMetadata`/`export const metadata`/`hreflang` (added **or removed**) enables `seo` (changed-line token co-signal present).
+  - edge: a `layout.tsx` restyle with no metadata token — even with an *unchanged* `generateMetadata` elsewhere in the file — does **not** enable `seo`; a `*.html` fixture with no SEO tags does **not** enable `seo`; `next.config.ts` alone does **not** enable `seo`; an added SVG `<title>`/`<link rel="stylesheet">` does **not** enable `seo` (excluded tokens).
+- **AC2 — Unrelated angles and `aeo` gating are unchanged**
+  - happy: `bugs` + `security` still always present; `aeo` still fires on its existing signals (`robots.txt`, `*.md`, AI-crawler tokens, JSON-LD types).
+  - error: a `*.html` with `<meta>` enables both `seo` and `aeo` (each per its own gate) without one suppressing the other.
+  - edge: the existing `detect-angles` test suite (`test-detect-angles-{comments,skills,observability}.sh`) still passes — the SEO narrowing does not regress other angle gates.
+- **AC3 — `seo.md` rubric carries the new learnings**
+  - happy: §2 states LCP/INP/CLS numeric targets; §3 canonical bullet covers chains/self-ref/noindex-conflict; a falsifiability line and an SPA-suppressor Skip rule are present.
+  - error: N/A — markdown rubric, no runtime error path.
+  - edge: existing output contract (`angle: "seo"`, `title/description/fix/fix_type`, `_header.md` schema) is untouched.
+- **AC4 — `aeo.md` rubric reframes deprecated schema + adds falsifiability**
+  - happy: §4 frames `HowTo`/`FAQPage` as AI/entity signals (not rich-result regressions), notes JSON-LD preference; a falsifiability line is present.
+  - error: N/A — markdown rubric.
+  - edge: `aeo`'s "do not double-report `seo`" boundary remains intact.
+
+## 8. Testing
+
+> Strategy only — harness, test levels, fixtures, CI. Per-behavior cases live in §7.
+
+- **Gate:** new `scripts/tests/test-detect-angles-seo.sh` modeled on `test-detect-angles-observability.sh` — `setup_diff <path> <added-line>`, run `detect-angles.sh`, assert presence/absence of `seo` in `$OUTDIR/angles.txt`. Cases: robots→yes, sitemap→yes, manifest→yes, layout-restyle→no, layout+`generateMetadata`(added)→yes, `generateMetadata`-removed (`^-`)→yes, html-no-token→no, html+`<meta>`→yes, next.config→no, SVG `<title>`→no, `<link rel="stylesheet">`→no. (`setup_diff` may need a removed-line variant or a raw-diff helper to exercise the `^-` case.)
+- **Regression:** run the full `scripts/tests/test-detect-angles-*.sh` set to confirm no other angle gate regressed.
+- **Prompts:** no runtime test (markdown). Verification is review-time: the `seo`/`aeo` workers still produce schema-valid `findings.*.json` (contract unchanged). Manual: spot-confirm the doc-comment block matches the function logic.
+
+## 9. Open questions
+
+- None blocking. Resolved during ideation: tiered co-signal over denylist; SEO-only gate change; `next.config` dropped from the gate entirely; conservative (no exact-date) phrasing for schema-deprecation claims.
+- Resolved during spec harden: **precise token matching** — new metadata tokens (`generateMetadata`, `export const metadata`, `hreflang`) matched changed-line-anchored (`^[+-]`, additions + removals); `<title` and `<link rel=` **excluded** (SVG `<title>` / stylesheet-link collisions; `rel=canonical` + `hreflang` already cover SEO links). Accepted tradeoff: a plain-HTML title-only edit with no `<meta>`/metadata export won't fire.


### PR DESCRIPTION
## Goal

Reduce `seo` review-angle over-firing and modernize the `seo`/`aeo` rubrics. The SEO angle currently fires on any `*.html`, `head`/`layout`, or `next.config` change regardless of SEO relevance, adding noise that trains authors to ignore the gate.

## Summary

- Spec + plan (docs-only, base of a 2-increment Graphite stack — no code yet).
- **Increment 1:** tiered gate in `detect-angles.sh` — hard files (`robots.txt`/`sitemap.*`/`app/manifest.*`) fire on path; soft files (`*.html`/`head`/`layout`/`next.config`) fire only via a changed-line-anchored metadata token (`generateMetadata`/`export const metadata`/`hreflang`); `<title`/`<link rel=` excluded. Pinned by a new committed gating test.
- **Increment 2:** `seo.md` (CWV numeric targets, canonical chains, SPA suppressor, falsifiability) + `aeo.md` (reframe `HowTo`/`FAQPage` as AI/entity signals, JSON-LD preference) — learnings ported from AgriciDaniel/claude-seo.

## Test plan

### Manual

**Before merge**

- [ ] Review spec `.woostack/specs/2026-06-19-seo-angle-refine.md` — gate tradeoffs + 4 acceptance criteria
- [ ] Review plan `.woostack/plans/2026-06-19-seo-angle-refine.md` — 2 increments, complete-code TDD steps

Spec: .woostack/specs/2026-06-19-seo-angle-refine.md
