### PR TITLE
fix(review): gate seo angle behind hard-file or metadata token

### DIFF
--- a/.woostack/plans/2026-06-19-seo-angle-refine.md
+++ b/.woostack/plans/2026-06-19-seo-angle-refine.md
@@ -29,7 +29,7 @@ branch: feature/seo-angle-refine
 - Create: `skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`
 - Modify: `skills/woostack-review/scripts/detect-angles.sh` (`has_seo_file`, `has_seo_diff_token`, doc-comment block)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   Create `skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`:
   ```bash
   #!/usr/bin/env bash
@@ -126,7 +126,7 @@ branch: feature/seo-angle-refine
   finish
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`
   Expected: FAIL — the current gate fires `seo` on every soft file, so cases 4, 7, 9, 10, 11, 12 fail, e.g.:
   ```
@@ -139,7 +139,7 @@ branch: feature/seo-angle-refine
   ```
   (exit 1 from `finish`)
 
-- [ ] **Step 3: Narrow `has_seo_file` to hard files only**
+- [x] **Step 3: Narrow `has_seo_file` to hard files only**
   In `skills/woostack-review/scripts/detect-angles.sh`, replace the `has_seo_file` function:
   ```bash
   has_seo_file() {
@@ -162,7 +162,7 @@ branch: feature/seo-angle-refine
   }
   ```
 
-- [ ] **Step 4: Add the changed-line-anchored metadata co-signal to `has_seo_diff_token`**
+- [x] **Step 4: Add the changed-line-anchored metadata co-signal to `has_seo_diff_token`**
   Replace the `has_seo_diff_token` function:
   ```bash
   has_seo_diff_token() {
@@ -188,7 +188,7 @@ branch: feature/seo-angle-refine
   }
   ```
 
-- [ ] **Step 5: Update the lockstep doc-comment catalog**
+- [x] **Step 5: Update the lockstep doc-comment catalog**
   In the same file, replace the `seo` lines in the top-of-file "Angle gating:" comment block:
   ```
   #   seo       — *.html, head.{ts,tsx}, layout.{ts,tsx}, robots.txt, sitemap.{xml,ts},
@@ -206,11 +206,11 @@ branch: feature/seo-angle-refine
   #               <link rel= are excluded (SVG <title> / stylesheet-link collisions).
   ```
 
-- [ ] **Step 6: Run the test, confirm it passes**
+- [x] **Step 6: Run the test, confirm it passes**
   Run: `bash skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`
-  Expected: PASS — `  13 passed, 0 failed` (exit 0).
+  Expected: PASS — `  13 passed, 0 failed` (exit 0). ✓ Observed `13 passed, 0 failed`.
 
-- [ ] **Step 7: Regression — run the sibling detect-angles tests**
+- [x] **Step 7: Regression — run the sibling detect-angles tests**
   Run:
   ```bash
   for t in skills/woostack-review/scripts/tests/test-detect-angles-*.sh; do
@@ -219,7 +219,7 @@ branch: feature/seo-angle-refine
   ```
   Expected: every file ends `… 0 failed`; loop exits 0. Confirms the SEO narrowing did not regress `comments`, `skills`, or `observability` gates.
 
-- [ ] **Step 8: Syntax check + commit**
+- [x] **Step 8: Syntax check + commit**
   Run: `bash -n skills/woostack-review/scripts/detect-angles.sh && echo OK`
   Expected: `OK`
   ```bash

--- a/skills/woostack-review/scripts/detect-angles.sh
+++ b/skills/woostack-review/scripts/detect-angles.sh
@@ -7,9 +7,13 @@
 # Angle gating:
 #   bugs      — always on
 #   security  — always on
-#   seo       — *.html, head.{ts,tsx}, layout.{ts,tsx}, robots.txt, sitemap.{xml,ts},
-#               next.config.{js,ts,mjs}, app/manifest.{ts,json}, OR diff body
-#               contains <meta / og: / twitter: / canonical / robots / sitemap
+#   seo       — HARD files (fire on path alone): robots.txt, sitemap.{xml,ts},
+#               app/manifest.{ts,json}. SOFT surfaces (*.html, head/layout.{ts,tsx,js,jsx},
+#               next.config.*) no longer gate on path — they fire only via a diff token:
+#               legacy <meta / og: / twitter: / rel=canonical / name=robots / <loc> /
+#               Sitemap:, OR a changed-line (^[+-]) metadata co-signal generateMetadata /
+#               export const metadata / hreflang (additions and removals). <title and
+#               <link rel= are excluded (SVG <title> / stylesheet-link collisions).
 #   aeo       — robots.txt, llms.txt, pricing.{md,txt}, *.{md,mdx,html}, OR diff
 #               body contains AI-crawler tokens (GPTBot / PerplexityBot /
 #               ClaudeBot / Google-Extended / anthropic-ai) or JSON-LD schema
@@ -98,18 +102,25 @@ else
 fi
 
 has_seo_file() {
-  echo "$CHANGED_PATHS" | grep -qE '(^|/)(robots\.txt|sitemap\.(xml|ts)|next\.config\.(js|ts|mjs))$' && return 0
-  echo "$CHANGED_PATHS" | grep -qE '\.html$' && return 0
-  echo "$CHANGED_PATHS" | grep -qE '(^|/)(head|layout)\.(ts|tsx|js|jsx)$' && return 0
+  # Hard SEO surfaces only — unambiguous, fire on path alone. Soft surfaces
+  # (*.html, head/layout.*, next.config.*) now gate on a diff token co-signal
+  # in has_seo_diff_token() to cut over-firing on non-SEO edits.
+  echo "$CHANGED_PATHS" | grep -qE '(^|/)(robots\.txt|sitemap\.(xml|ts))$' && return 0
   echo "$CHANGED_PATHS" | grep -qE '(^|/)app/manifest\.(ts|json)$' && return 0
   return 1
 }
 
 has_seo_diff_token() {
-  # Anchored to reduce false positives in docs/comments/JSON keys.
-  # Matches: meta tags, og:/twitter: prefixed props, rel=canonical, name=robots,
-  # <loc> sitemap entries, Sitemap: directive.
-  grep -qE "</?meta\b|\bog:[a-z_-]+|\btwitter:[a-z_-]+|rel=[\"']canonical|name=[\"']robots|<loc>|(^|[[:space:]])Sitemap:" "$DIFF"
+  # Legacy unanchored tokens: meta tags, og:/twitter: prefixed props, rel=canonical,
+  # name=robots, <loc> sitemap entries, Sitemap: directive.
+  grep -qE "</?meta\b|\bog:[a-z_-]+|\btwitter:[a-z_-]+|rel=[\"']canonical|name=[\"']robots|<loc>|(^|[[:space:]])Sitemap:" "$DIFF" && return 0
+  # Soft-surface co-signal: Next.js metadata edits in head/layout/*.html files.
+  # Anchored to CHANGED lines (^[+-]) so a styling-only edit near an unchanged
+  # metadata export does not fire, and a REMOVED export (an SEO regression) does.
+  # <title and <link rel= are intentionally excluded (SVG <title> / stylesheet-link
+  # collisions; rel=canonical + hreflang already cover SEO links).
+  grep -qE "^[+-].*(\bgenerateMetadata\b|export[[:space:]]+const[[:space:]]+metadata\b|\bhreflang\b)" "$DIFF" && return 0
+  return 1
 }
 
 has_aeo_file() {

--- a/skills/woostack-review/scripts/tests/test-detect-angles-seo.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-seo.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/detect-angles.sh"
+
+# setup $1 = changed file path, $2 = diff body (may be multi-line; literal +/- prefixes)
+setup_diff() {
+  work="$(mktemp -d)"
+  export OUTDIR="$work/out"
+  mkdir -p "$OUTDIR"
+  printf '{"files":[{"path":"%s"}]}\n' "$1" > "$OUTDIR/meta.json"
+  printf '%s\n' "$2" > "$OUTDIR/diff.txt"
+}
+absent() { grep -cx 'seo' "$OUTDIR/angles.txt" || true; }  # "0" when seo not enabled
+
+# 1. HARD file: robots.txt fires on path alone (no token needed).
+setup_diff "public/robots.txt" "+Disallow: /tmp"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "robots.txt enables seo on path alone"
+assert_contains "$(cat "$OUTDIR/angles.txt")" "bugs" "bugs always on"
+rm -rf "$work"
+
+# 2. HARD file: sitemap.xml fires on path alone.
+setup_diff "app/sitemap.xml" "+  <loc>https://x.com/</loc>"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "sitemap.xml enables seo"
+rm -rf "$work"
+
+# 3. HARD file: app/manifest.ts fires on path alone.
+setup_diff "app/manifest.ts" "+  name: 'X',"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "app/manifest.ts enables seo"
+rm -rf "$work"
+
+# 4. SOFT file, no token: layout.tsx restyle does NOT enable seo.
+setup_diff "app/layout.tsx" '+  <div className="wrap">'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "layout.tsx restyle does not enable seo"
+rm -rf "$work"
+
+# 5. SOFT file + metadata co-signal (added): generateMetadata enables seo.
+setup_diff "app/layout.tsx" '+export async function generateMetadata() {'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "added generateMetadata enables seo"
+rm -rf "$work"
+
+# 6. SOFT file + metadata co-signal (REMOVED): a removed export is an SEO regression.
+setup_diff "app/page.tsx" '-export const metadata = { title: "Old" }'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "removed metadata export enables seo"
+rm -rf "$work"
+
+# 7. SOFT file, no token: *.html with no SEO tag does NOT enable seo.
+setup_diff "emails/welcome.html" '+  <div>Hello</div>'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "html with no SEO tag does not enable seo"
+rm -rf "$work"
+
+# 8. SOFT file + token: *.html with <meta> enables seo.
+setup_diff "public/index.html" '+  <meta name="description" content="x">'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "html with <meta> enables seo"
+rm -rf "$work"
+
+# 9. SOFT file, no token: next.config.ts alone does NOT enable seo.
+setup_diff "next.config.ts" '+  images: { remotePatterns: [] },'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "next.config.ts alone does not enable seo"
+rm -rf "$work"
+
+# 10. Excluded token: SVG <title> does NOT enable seo (collision guard).
+setup_diff "components/Icon.tsx" '+    <title>Close</title>'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "SVG <title> does not enable seo"
+rm -rf "$work"
+
+# 11. Excluded token: <link rel="stylesheet"> does NOT enable seo.
+setup_diff "app/layout.tsx" '+  <link rel="stylesheet" href="/x.css">'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "link rel=stylesheet does not enable seo"
+rm -rf "$work"
+
+# 12. Anchoring: an UNCHANGED (context) metadata line does NOT enable seo.
+setup_diff "app/layout.tsx" "$(printf '+  <div className="x">\n   export const metadata = { title: "keep" }')"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "unchanged-context metadata does not enable seo"
+rm -rf "$work"
+
+finish

--- a/skills/woostack-review/scripts/tests/test-detect-angles-seo.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-seo.sh
@@ -53,37 +53,43 @@ bash "$SCRIPT" >/dev/null 2>&1
 assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "removed metadata export enables seo"
 rm -rf "$work"
 
-# 7. SOFT file, no token: *.html with no SEO tag does NOT enable seo.
+# 7. SOFT file + metadata co-signal (hreflang): an alternate-language link enables seo.
+setup_diff "app/layout.tsx" '+<link rel="alternate" hreflang="fr" href="/fr/">'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "hreflang enables seo"
+rm -rf "$work"
+
+# 8. SOFT file, no token: *.html with no SEO tag does NOT enable seo.
 setup_diff "emails/welcome.html" '+  <div>Hello</div>'
 bash "$SCRIPT" >/dev/null 2>&1
 assert_eq "$(absent)" "0" "html with no SEO tag does not enable seo"
 rm -rf "$work"
 
-# 8. SOFT file + token: *.html with <meta> enables seo.
+# 9. SOFT file + token: *.html with <meta> enables seo.
 setup_diff "public/index.html" '+  <meta name="description" content="x">'
 bash "$SCRIPT" >/dev/null 2>&1
 assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "html with <meta> enables seo"
 rm -rf "$work"
 
-# 9. SOFT file, no token: next.config.ts alone does NOT enable seo.
+# 10. SOFT file, no token: next.config.ts alone does NOT enable seo.
 setup_diff "next.config.ts" '+  images: { remotePatterns: [] },'
 bash "$SCRIPT" >/dev/null 2>&1
 assert_eq "$(absent)" "0" "next.config.ts alone does not enable seo"
 rm -rf "$work"
 
-# 10. Excluded token: SVG <title> does NOT enable seo (collision guard).
+# 11. Excluded token: SVG <title> does NOT enable seo (collision guard).
 setup_diff "components/Icon.tsx" '+    <title>Close</title>'
 bash "$SCRIPT" >/dev/null 2>&1
 assert_eq "$(absent)" "0" "SVG <title> does not enable seo"
 rm -rf "$work"
 
-# 11. Excluded token: <link rel="stylesheet"> does NOT enable seo.
+# 12. Excluded token: <link rel="stylesheet"> does NOT enable seo.
 setup_diff "app/layout.tsx" '+  <link rel="stylesheet" href="/x.css">'
 bash "$SCRIPT" >/dev/null 2>&1
 assert_eq "$(absent)" "0" "link rel=stylesheet does not enable seo"
 rm -rf "$work"
 
-# 12. Anchoring: an UNCHANGED (context) metadata line does NOT enable seo.
+# 13. Anchoring: an UNCHANGED (context) metadata line does NOT enable seo.
 setup_diff "app/layout.tsx" "$(printf '+  <div className="x">\n   export const metadata = { title: "keep" }')"
 bash "$SCRIPT" >/dev/null 2>&1
 assert_eq "$(absent)" "0" "unchanged-context metadata does not enable seo"


### PR DESCRIPTION
## Goal

Stop the `seo` review angle from firing on PRs with no SEO relevance — today any `*.html`, `head`/`layout`, or `next.config` change enables it.

## Summary

- `detect-angles.sh`: `has_seo_file()` now matches only hard SEO surfaces (`robots.txt`, `sitemap.*`, `app/manifest.*`); soft surfaces dropped from the path check.
- `has_seo_diff_token()`: legacy tokens unchanged, plus a changed-line-anchored (`^[+-]`) metadata co-signal (`generateMetadata` / `export const metadata` / `hreflang`) so soft-file SEO edits — additions and removals — still fire, while styling-only edits do not. `<title` / `<link rel=` deliberately excluded (SVG / stylesheet collisions).
- Top-of-file gating doc-comment updated in lockstep.
- New `test-detect-angles-seo.sh` pins all 12 cases (hard files, soft+token, soft-no-token skips, anchoring, excluded-token guards).

## Test plan

### Automated

- [x] `bash test-detect-angles-seo.sh` → `13 passed, 0 failed`
- [x] Regression: all `test-detect-angles-*.sh` → no FAIL lines
- [x] `bash -n detect-angles.sh` → syntax OK

### Manual

**Before merge**

- [ ] Skim the gate diff: confirm `next.config` / bare `*.html` / `layout` restyles no longer enable `seo`

Spec: .woostack/specs/2026-06-19-seo-angle-refine.md
