### PR TITLE
docs(review): enrich seo/aeo rubrics with claude-seo learnings

### DIFF
--- a/.woostack/plans/2026-06-19-seo-angle-refine.md
+++ b/.woostack/plans/2026-06-19-seo-angle-refine.md
@@ -237,11 +237,11 @@ branch: feature/seo-angle-refine
 **Files:**
 - Modify: `skills/woostack-review/prompts/angles/seo.md`
 
-- [ ] **Step 1: Verify the new content is absent (red)**
+- [x] **Step 1: Verify the new content is absent (red)**
   Run: `grep -c "2.5s" skills/woostack-review/prompts/angles/seo.md || true`
   Expected: `0` (no CWV numeric target yet).
 
-- [ ] **Step 2: Add Core Web Vitals numeric targets**
+- [x] **Step 2: Add Core Web Vitals numeric targets**
   Replace:
   ```
   - **Core Web Vitals**: Detect potential LCP, INP, or CLS regressions in the diff (e.g., large unoptimized images, layout shifts).
@@ -251,7 +251,7 @@ branch: feature/seo-angle-refine
   - **Core Web Vitals**: Detect potential LCP (target < 2.5s), INP (< 200ms), or CLS (< 0.1) regressions in the diff (e.g., large unoptimized images, layout shifts, render-blocking resources).
   ```
 
-- [ ] **Step 3: Extend the canonical check to chains / self-ref / noindex conflict**
+- [x] **Step 3: Extend the canonical check to chains / self-ref / noindex conflict**
   Replace:
   ```
   - **Canonical & Hreflang**: Missing or wrong `<link rel="canonical">` or `hreflang` mismatches on i18n/new pages.
@@ -261,7 +261,7 @@ branch: feature/seo-angle-refine
   - **Canonical & Hreflang**: Missing, wrong, or broken canonical chains (`<link rel="canonical">` pointing through a redirect or to a non-200), non-self-referencing canonicals, a canonical that conflicts with a `noindex` on the same page, or `hreflang` mismatches on i18n/new pages.
   ```
 
-- [ ] **Step 4: Add SPA suppressor + falsifiability to the Skip list**
+- [x] **Step 4: Add SPA suppressor + falsifiability to the Skip list**
   Replace:
   ```
   ## Skip
@@ -279,7 +279,7 @@ branch: feature/seo-angle-refine
   - Speculative "could rank better?" suggestions without a concrete regression in the diff — every finding must cite the observable diff fact it is grounded in.
   ```
 
-- [ ] **Step 5: Verify present + output contract intact (green)**
+- [x] **Step 5: Verify present + output contract intact (green)**
   Run:
   ```bash
   grep -q "target < 2.5s" skills/woostack-review/prompts/angles/seo.md \
@@ -291,7 +291,7 @@ branch: feature/seo-angle-refine
   ```
   Expected: `OK` (all four additions present; the `findings.seo.json` output contract line is untouched).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
   ```bash
   gt modify -c -m "docs(review): sharpen seo rubric (CWV targets, canonical chains, SPA + falsifiability)"
   ```
@@ -301,7 +301,7 @@ branch: feature/seo-angle-refine
 **Files:**
 - Modify: `skills/woostack-review/prompts/angles/aeo.md`
 
-- [ ] **Step 1: Verify the reframe is absent (red), falsifiability already present**
+- [x] **Step 1: Verify the reframe is absent (red), falsifiability already present**
   Run:
   ```bash
   grep -c "AI/entity signals" skills/woostack-review/prompts/angles/aeo.md || true
@@ -309,7 +309,7 @@ branch: feature/seo-angle-refine
   ```
   Expected: first prints `0` (reframe not yet added); second prints `falsifiability-present` — AC4's falsifiability line already exists (Skip list), so this task only reframes schema.
 
-- [ ] **Step 2: Reframe `### 4. Structured data for AI`**
+- [x] **Step 2: Reframe `### 4. Structured data for AI`**
   Replace:
   ```
   ### 4. Structured data for AI (P2)
@@ -327,7 +327,7 @@ branch: feature/seo-angle-refine
   - Schema introduced that mis-describes the page (would mislead AI extraction).
   ```
 
-- [ ] **Step 3: Align the severity rubric with the reframe (lockstep)**
+- [x] **Step 3: Align the severity rubric with the reframe (lockstep)**
   The MEDIUM severity line still treats schema *removal* as a finding, contradicting the §4 reframe. Replace:
   ```
   - `MEDIUM` + `blocking: false` — Lost citations / statistics / author attribution; FAQ or HowTo schema removed or malformed; answer passages buried below filler; comparison tables converted to prose; missing `/pricing.md` companion for new pricing page.
@@ -337,7 +337,7 @@ branch: feature/seo-angle-refine
   - `MEDIUM` + `blocking: false` — Lost citations / statistics / author attribution; FAQ or HowTo schema malformed or mis-describing content (not its mere absence — see §4); answer passages buried below filler; comparison tables converted to prose; missing `/pricing.md` companion for new pricing page.
   ```
 
-- [ ] **Step 4: Verify present + double-report boundary intact (green)**
+- [x] **Step 4: Verify present + double-report boundary intact (green)**
   Run:
   ```bash
   grep -q "AI/entity signals" skills/woostack-review/prompts/angles/aeo.md \
@@ -348,7 +348,7 @@ branch: feature/seo-angle-refine
   ```
   Expected: `OK` (reframe + severity-line alignment present; the `seo`-boundary "do not double-report" Skip line is untouched).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "docs(review): reframe aeo structured-data as AI/entity signals"
   ```

--- a/.woostack/plans/2026-06-19-seo-angle-refine.md
+++ b/.woostack/plans/2026-06-19-seo-angle-refine.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-19-seo-angle-refine.md
-status: ready
+status: done
 branch: feature/seo-angle-refine
 ---
 

--- a/skills/woostack-review/prompts/angles/aeo.md
+++ b/skills/woostack-review/prompts/angles/aeo.md
@@ -41,7 +41,7 @@ gh api repos/coreyhaines31/marketingskills/contents/skills/ai-seo/references/con
 - Prefer **JSON-LD** (the format AI extractors and Google both favor) over inline microdata / RDFa.
 - Removed or broken `Article`/`BlogPosting`, `Product`, `ItemList`, `Review`/`AggregateRating`, `Organization` schema on content where it applied.
 - `HowTo` and `FAQPage` no longer produce Google rich results for most sites — treat them as **AI/entity signals**, not rich-result regressions: flag mis-describing or invalid markup, not the mere absence of a rich result.
-- New FAQ / comparison / how-to content shipped without matching schema.
+- New FAQ / comparison / how-to content shipped with no structured data at all, where JSON-LD would materially aid AI extraction — prefer `Article` / `ItemList` markup over none (a design signal, not a rich-result regression).
 - Schema introduced that mis-describes the page (would mislead AI extraction).
 
 ### 5. Machine-readable & agent surfaces (P2)

--- a/skills/woostack-review/prompts/angles/aeo.md
+++ b/skills/woostack-review/prompts/angles/aeo.md
@@ -38,7 +38,9 @@ gh api repos/coreyhaines31/marketingskills/contents/skills/ai-seo/references/con
 - Author / E-E-A-T signals removed (credentials, byline, organisation).
 
 ### 4. Structured data for AI (P2)
-- Removed or broken `FAQPage`, `HowTo`, `Article`/`BlogPosting`, `Product`, `ItemList`, `Review`/`AggregateRating`, `Organization` schema on content where it applied.
+- Prefer **JSON-LD** (the format AI extractors and Google both favor) over inline microdata / RDFa.
+- Removed or broken `Article`/`BlogPosting`, `Product`, `ItemList`, `Review`/`AggregateRating`, `Organization` schema on content where it applied.
+- `HowTo` and `FAQPage` no longer produce Google rich results for most sites — treat them as **AI/entity signals**, not rich-result regressions: flag mis-describing or invalid markup, not the mere absence of a rich result.
 - New FAQ / comparison / how-to content shipped without matching schema.
 - Schema introduced that mis-describes the page (would mislead AI extraction).
 
@@ -62,7 +64,7 @@ gh api repos/coreyhaines31/marketingskills/contents/skills/ai-seo/references/con
 
 ## Severity rubric
 - `HIGH` + `blocking: true` — `robots.txt` newly blocks a major AEO crawler (GPTBot / PerplexityBot / ClaudeBot / Google-Extended); critical structured data removed from a high-traffic content type; pricing/product data moved off public, parseable surface; key answer content rendered only via client-side JS with no SSR fallback.
-- `MEDIUM` + `blocking: false` — Lost citations / statistics / author attribution; FAQ or HowTo schema removed or malformed; answer passages buried below filler; comparison tables converted to prose; missing `/pricing.md` companion for new pricing page.
+- `MEDIUM` + `blocking: false` — Lost citations / statistics / author attribution; FAQ or HowTo schema malformed or mis-describing content (not its mere absence — see §4); answer passages buried below filler; comparison tables converted to prose; missing `/pricing.md` companion for new pricing page.
 - `LOW` + `blocking: false` — Heading wording drifted from query patterns; missing "Last updated" date; minor accessibility-tree regressions that hurt agentic experiences; opportunities to add machine-readable files.
 
 **Output.** Write findings as a JSON array to `/tmp/pr-review/findings.aeo.json` using the schema in `_header.md`. Each finding gets `"angle": "aeo"` and MUST populate `title` (bold headline ≤60 chars), `description` (the issue only — no fix), `fix` (recommended change in prose), and `fix_type`. Set `fix_type: "suggestion"` only when a ≤10-line single-file drop-in replacement at `line` is safe — and populate `suggestion` accordingly. Otherwise set `fix_type: "prose"` with `suggestion: null`. See `_header.md` for the full rule.

--- a/skills/woostack-review/prompts/angles/seo.md
+++ b/skills/woostack-review/prompts/angles/seo.md
@@ -16,7 +16,7 @@ tier: fast
 - **Architecture**: Ensure new important pages are logically structured and reachable.
 
 ### 2. Technical Foundations (P1)
-- **Core Web Vitals**: Detect potential LCP, INP, or CLS regressions in the diff (e.g., large unoptimized images, layout shifts).
+- **Core Web Vitals**: Detect potential LCP (target < 2.5s), INP (< 200ms), or CLS (< 0.1) regressions in the diff (e.g., large unoptimized images, layout shifts, render-blocking resources).
 - **Security**: Mixed content on new pages, HTTPS/SSL violations.
 - **Mobile-Friendliness**: Responsive design regressions, tap target size issues (< 44px), mobile-first indexing readiness.
 
@@ -25,7 +25,7 @@ tier: fast
 - **Heading Structure**: Proper H1 usage (exactly one per page) and logical hierarchy (H1 → H2 → H3).
 - **Image Optimization**: Missing Alt text, poor filenames, or non-modern formats (prefer WebP/AVIF).
 - **Social Metadata**: Missing or malformed Open Graph (`og:`) and Twitter card tags on shareable pages.
-- **Canonical & Hreflang**: Missing or wrong `<link rel="canonical">` or `hreflang` mismatches on i18n/new pages.
+- **Canonical & Hreflang**: Missing, wrong, or broken canonical chains (`<link rel="canonical">` pointing through a redirect or to a non-200), non-self-referencing canonicals, a canonical that conflicts with a `noindex` on the same page, or `hreflang` mismatches on i18n/new pages.
 
 ### 4. Content Quality & E-E-A-T (P3)
 - **Experience & Expertise**: Ensure content demonstrating first-hand knowledge includes author credentials or experience indicators.
@@ -36,6 +36,8 @@ tier: fast
 - Internal admin / authenticated pages (should not be indexable).
 - Style-only changes to existing SEO-correct pages.
 - Pre-existing missing metadata not touched by this PR.
+- Client-rendered routes with no SSR/metadata surface in the diff — a static diff cannot observe the rendered output, so do not flag content-depth or Core Web Vitals there (heavy client-side hydration produces noisy, unverifiable findings).
+- Speculative "could rank better?" suggestions without a concrete regression in the diff — every finding must cite the observable diff fact it is grounded in.
 
 ## Severity Rubric
 - `HIGH` + `blocking: true` — Robots disallow production; Broken sitemap; Production `noindex`; Broken canonicals; Severe WCAG/Accessibility fails affecting SEO.


### PR DESCRIPTION
## Goal

Modernize the `seo` and `aeo` review rubrics with current, falsifiable guidance ported from AgriciDaniel/claude-seo, so findings cite concrete diff facts instead of speculation.

## Summary

- `seo.md`: Core Web Vitals numeric targets (LCP < 2.5s / INP < 200ms / CLS < 0.1); canonical check extended to broken chains / non-self-referencing / `noindex` conflicts; Skip rules add an SPA/hydration suppressor and a falsifiability requirement (cite the observable diff fact).
- `aeo.md`: structured-data section reframed — `HowTo`/`FAQPage` are AI/entity signals, not rich-result regressions; JSON-LD noted as preferred; MEDIUM severity line aligned so mere schema absence is no longer flagged.
- Plan checkboxes completed (plan now 100%).

## Test plan

### Automated

- [x] Content `grep` assertions for every new `seo.md` line + the `findings.seo.json` output contract → present
- [x] Content `grep` assertions for `aeo.md` reframe + severity alignment + intact `do not double-report` boundary → present

### Manual

**Before merge**

- [ ] Read `seo.md`/`aeo.md` diffs: confirm framing reads correctly and no exact-date claims were fabricated

Spec: .woostack/specs/2026-06-19-seo-angle-refine.md
