### PR TITLE
feat(review): add simplify + production-readiness angle prompts (unwired)

### DIFF
--- a/.woostack/plans/2026-06-25-woostack-audit.md
+++ b/.woostack/plans/2026-06-25-woostack-audit.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-25-woostack-audit.md
-status: ready
+status: executing
 branch: feature/woostack-audit
 ---
 

--- a/.woostack/plans/2026-06-25-woostack-audit.md
+++ b/.woostack/plans/2026-06-25-woostack-audit.md
@@ -48,7 +48,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 **Files:**
 - Create: `skills/woostack-review/prompts/angles/simplify.md`
 
-- [ ] **Step 1: Write the prompt file**
+- [x] **Step 1: Write the prompt file**
   ```markdown
   ---
   tier: standard
@@ -116,11 +116,11 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   deletion/replacement at `line`; otherwise `fix_type: "prose"` with `suggestion: null`.
   ```
 
-- [ ] **Step 2: Confirm structural shape (verification)**
+- [x] **Step 2: Confirm structural shape (verification)**
   Run: `bash -n /dev/stdin < /dev/null; grep -c '^tier: standard' skills/woostack-review/prompts/angles/simplify.md && grep -c 'findings.simplify.json' skills/woostack-review/prompts/angles/simplify.md`
   Expected: prints `1` then `1` (frontmatter tier present; output path correct).
 
-- [ ] **Step 3: Confirm deferral marker present**
+- [x] **Step 3: Confirm deferral marker present**
   Run: `grep -c 'woostack-defer(increment 2)' skills/woostack-review/prompts/angles/simplify.md`
   Expected: `1`
 
@@ -129,7 +129,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 **Files:**
 - Create: `skills/woostack-review/prompts/angles/production-readiness.md`
 
-- [ ] **Step 1: Write the prompt file**
+- [x] **Step 1: Write the prompt file**
   ```markdown
   ---
   tier: standard
@@ -195,11 +195,11 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   drop-in at `line`; otherwise `fix_type: "prose"` with `suggestion: null`.
   ```
 
-- [ ] **Step 2: Confirm structural shape (verification)**
+- [x] **Step 2: Confirm structural shape (verification)**
   Run: `grep -c '^tier: standard' skills/woostack-review/prompts/angles/production-readiness.md && grep -c 'findings.production-readiness.json' skills/woostack-review/prompts/angles/production-readiness.md`
   Expected: prints `1` then `1`.
 
-- [ ] **Step 3: Commit the increment**
+- [x] **Step 3: Commit the increment**
   ```bash
   gt create -m "feat(review): add simplify + production-readiness angle prompts (unwired)"
   ```

--- a/skills/woostack-review/prompts/angles/production-readiness.md
+++ b/skills/woostack-review/prompts/angles/production-readiness.md
@@ -1,0 +1,62 @@
+---
+tier: standard
+---
+
+<!-- woostack-defer(increment 2): registered in VALID_ANGLES + detect-angles + _header in increment 2 -->
+
+# Angle: Production readiness
+
+**Scope.** Audit the **resilience and operability** of the code in `$OUTDIR/diff.txt` (files in
+`$OUTDIR/meta.json`): will it survive partial failure, load, and operation in production? You
+own the failure-under-stress posture that no other angle covers.
+
+**Find:**
+
+- **No timeout / no deadline** on an outbound call (HTTP, DB, queue, RPC) that can hang.
+- **No retry / no backoff** on a transient-failure-prone call, OR retry without a cap / jitter
+  (retry storm risk).
+- **Non-idempotent mutation** on a retried or at-least-once path (double-charge, double-write)
+  with no idempotency key / dedup.
+- **No graceful degradation** — a non-critical dependency failure takes down the whole request
+  instead of degrading; no fallback / circuit-breaker where one is warranted.
+- **Unbounded resource / concurrency** — unbounded queue, unbounded `Promise.all` fan-out over
+  user-sized input, no connection-pool cap, no pagination on a list that grows.
+- **Config & secret hygiene** — required config read with no presence check / no fail-fast at
+  boot; a secret read from source instead of env/secret-store (defer the *hardcoded-secret
+  finding itself* to `security`; you own the **missing fail-fast / missing validation** around
+  config).
+- **Missing health / readiness** — a new long-lived service/worker with no health or readiness
+  signal, or shutdown that drops in-flight work (no graceful drain).
+- **Failure isolation** — one tenant/request able to exhaust a shared resource for all.
+
+**Scope-split (no double-report):**
+
+- **Signal quality** — whether a failure is *logged*, log levels, PII in logs, swallowed
+  errors → `observability` owns it. You own whether the code *recovers*, not whether it *logs*.
+- **Threats** — injection, authz, secret exposure → `security` owns it.
+- **Correctness** — wrong result for valid input → `bugs` owns it.
+
+**Skip:**
+
+- Code with no I/O, no external calls, no shared resource, no long-lived process — it has no
+  production-readiness surface; write `[]`.
+- Speculative "might not scale" with no concrete failure mode in the code as written.
+- Style / naming.
+
+**Severity rubric:**
+
+- `HIGH` + `blocking: true` — a concrete production-down failure mode: a retried non-idempotent
+  payment, an unbounded fan-out over user input, a hang with no timeout on a request path.
+- `MEDIUM` + `blocking: false` — a real resilience gap that bites under failure/load but not on
+  the happy path (missing backoff, no degradation).
+- `LOW` + `blocking: false` — a hardening nicety (add a deadline to a fast internal call).
+
+**Grounding requirement.** Every `description` MUST name the concrete failure mode (what
+happens when the call hangs / the retry fires / the input is large) — not a generic "add a
+timeout". A finding without a named failure mode is dropped by the validator.
+
+**Output.** Write findings as a JSON array to `$OUTDIR/findings.production-readiness.json` per
+the schema in `_header.md`. Each finding gets `"angle": "production-readiness"` and MUST
+populate `title` (≤60 chars), `description` (the failure mode, no fix), `fix` (the resilience
+change in prose), and `fix_type`. `fix_type: "suggestion"` only for a ≤10-line single-file
+drop-in at `line`; otherwise `fix_type: "prose"` with `suggestion: null`.

--- a/skills/woostack-review/prompts/angles/simplify.md
+++ b/skills/woostack-review/prompts/angles/simplify.md
@@ -1,0 +1,64 @@
+---
+tier: standard
+---
+
+<!-- woostack-defer(increment 2): registered in VALID_ANGLES + detect-angles + _header in increment 2 -->
+
+# Angle: Simplify
+
+**Scope.** Find code that should be **smaller or not exist at all**. Read `$OUTDIR/diff.txt`
+and the files in `$OUTDIR/meta.json`. Apply the ladder, stopping at the first rung that
+removes code: **(1)** does this need to exist (YAGNI)? **(2)** is it already in this codebase
+(reuse)? **(3)** does the stdlib do it? **(4)** does a native platform feature do it? **(5)**
+does an installed dependency do it? **(6)** can it be one line? **(7)** otherwise the minimum
+that works. Your output is a **delete-list**: each finding names code to remove or shrink and
+the smaller shape that replaces it.
+
+**Find:**
+
+- **Does-not-need-to-exist.** Speculative generality, unused options/flags, abstractions with
+  one caller, config no path reads — code added for a future that is not here.
+- **Dead code / unused exports.** A symbol, file, or branch nothing reaches. For a suspected
+  unused **export**, verify across the tree before flagging: run
+  `rg -n --no-heading "\b<symbol>\b" -g '!<defining-file>'` (fall back to
+  `git grep -n "\b<symbol>\b" -- ':!<defining-file>'`, else `grep -rn`). Flag **only** when the
+  scan returns zero non-definition references. Quote the scan in `description`.
+- **Whole-tree duplication.** The same logic copy-pasted across files where one shared helper
+  (or an existing canonical utility the repo already exports) would replace both.
+- **Thin / identity abstraction.** A wrapper, indirection, or generic that adds a hop without
+  buying clarity — the code is simpler with it inlined.
+- **One-liner opportunities.** A hand-rolled loop/reducer a single stdlib/native call replaces.
+
+**Scope-split with `architecture`** (precedent: `types.md` defers to `react`). When the
+`architecture` angle is ALSO enabled (a `woostack-review` diff includes it in
+`$OUTDIR/angles.txt`), **defer within-change structural-shape** findings (nesting, layering,
+spaghetti, naming) to it and own only **existence/YAGNI, cross-file dead code, and
+duplication**. When `architecture` is NOT enabled (an audit run), own the full simplification
+surface including structural-shape.
+
+**Skip — "lazy, not negligent":**
+
+- **Never** recommend removing validation, error handling, security checks, or accessibility
+  affordances. These are not over-engineering even when they look like extra code.
+- Anything a linter/formatter mechanically fixes.
+- Pure taste with no concrete smaller shape — if you cannot name what replaces it, do not flag.
+- A symbol whose reference scan you could not run to zero — do not assert "unused" from
+  reading one file.
+
+**Severity rubric:**
+
+- `HIGH` + `blocking: true` — a whole module/file/dependency that can be deleted (nothing
+  reaches it), or a large duplication a single shared helper removes. Rare.
+- `MEDIUM` + `blocking: false` — a real missed-deletion / duplication / thin-abstraction with a
+  named smaller shape; the existing form still works. Default.
+- `LOW` + `blocking: false` — a one-liner or minor inlining opportunity.
+
+**Grounding requirement.** Every `description` MUST name (a) the specific code to remove/shrink
+and (b) the concrete smaller shape (and, for an unused-export claim, the zero-result scan). A
+finding that only says "could be simpler" is dropped by the validator.
+
+**Output.** Write findings as a JSON array to `$OUTDIR/findings.simplify.json` per the schema in
+`_header.md`. Each finding gets `"angle": "simplify"` and MUST populate `title` (≤60 chars),
+`description` (what to delete + the smaller shape, no fix steps), `fix` (the deletion/replacement
+in prose), and `fix_type`. Set `fix_type: "suggestion"` only for a ≤10-line single-file drop-in
+deletion/replacement at `line`; otherwise `fix_type: "prose"` with `suggestion: null`.


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
