### PR TITLE
feat(review): wire simplify + production-readiness angles into the catalog

### DIFF
--- a/.woostack/plans/2026-06-25-woostack-audit.md
+++ b/.woostack/plans/2026-06-25-woostack-audit.md
@@ -217,13 +217,13 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 **Files:**
 - Modify: `skills/woostack-review/scripts/load-config.sh:92`
 
-- [ ] **Step 1: Add both angles to the set**
+- [x] **Step 1: Add both angles to the set**
   Edit line 92 — append `, "simplify", "production-readiness"` inside the `VALID_ANGLES` set so it reads:
   ```python
   VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture", "skills", "comments", "simplify", "production-readiness"}
   ```
 
-- [ ] **Step 2: Verify both angles are in the validated set (structural)**
+- [x] **Step 2: Verify both angles are in the validated set (structural)**
   Run:
   ```bash
   python3 -c "import re; s=open('skills/woostack-review/scripts/load-config.sh').read(); \
@@ -237,7 +237,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 **Files:**
 - Modify: `skills/woostack-review/scripts/detect-angles.sh` (general-source block near `:326`, doc catalog near `:68`)
 
-- [ ] **Step 1: Push both angles where `architecture`/`comments` are pushed**
+- [x] **Step 1: Push both angles where `architecture`/`comments` are pushed**
   After the existing `ANGLES+=("architecture")` / `ANGLES+=("comments")` lines (inside the
   general-purpose-source `if`), add:
   ```bash
@@ -245,7 +245,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   ANGLES+=("production-readiness")
   ```
 
-- [ ] **Step 2: Extend the top-of-file doc catalog**
+- [x] **Step 2: Extend the top-of-file doc catalog**
   In the angle-gating comment block, add two lines mirroring the `architecture`/`comments` entries:
   ```bash
   #   simplify  — general-purpose source files in the diff (same signal as architecture).
@@ -255,7 +255,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   #               posture (timeouts, retries, idempotency, degradation, resource limits).
   ```
 
-- [ ] **Step 3: Write the gating test (red→green)**
+- [x] **Step 3: Write the gating test (red→green)**
   Create `skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh`:
   ```bash
   #!/usr/bin/env bash
@@ -281,7 +281,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   finish
   ```
 
-- [ ] **Step 4: Run the gating test, confirm pass**
+- [x] **Step 4: Run the gating test, confirm pass**
   Run: `bash skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh`
   Expected: `4 passed, 0 failed`
 
@@ -290,21 +290,21 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 **Files:**
 - Modify: `skills/woostack-review/prompts/_header.md` (count `:100`, table `:120`, footer whitelist `:295`, schema list `:429`)
 
-- [ ] **Step 1: Bump the angle count word**
+- [x] **Step 1: Bump the angle count word**
   Line ~100: change "runs up to **nineteen** distinct review angles" → "**twenty-one**".
 
-- [ ] **Step 2: Add two catalog table rows**
+- [x] **Step 2: Add two catalog table rows**
   After the `comments` row (~`:122`), add:
   ```markdown
   | `simplify` | no | LLM only — gated on general-purpose source files in diff (same signal as `architecture`); YAGNI / dead-code / duplication delete-list; defers structural-shape to `architecture` when both run |
   | `production-readiness` | no | LLM only — gated on general-purpose source files in diff; resilience/operability posture (timeouts, retries, idempotency, degradation, resource limits) |
   ```
 
-- [ ] **Step 3: Add both to the two angle whitelists**
+- [x] **Step 3: Add both to the two angle whitelists**
   Line ~295 (python footer whitelist set) and line ~429 (the `angle is one of …` schema list):
   append `"simplify","production-readiness"` to the set on 295, and ` | simplify | production-readiness` to the pipe list on 429.
 
-- [ ] **Step 4: Verify all whitelist sites carry both names**
+- [x] **Step 4: Verify all whitelist sites carry both names**
   Run:
   ```bash
   grep -c 'simplify' skills/woostack-review/prompts/_header.md; \
@@ -318,15 +318,15 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 - Modify: `skills/woostack-review/prompts/anthropic.md`, `openai.md`, `google.md`, `opencode.md` (tier tables)
 - Modify: `skills/woostack-review/prompts/angles/simplify.md`, `production-readiness.md` (drop markers)
 
-- [ ] **Step 1: Add `standard`-tier rows for both angles in each provider table**
+- [x] **Step 1: Add `standard`-tier rows for both angles in each provider table**
   In each provider prompt's per-angle tier table, add `simplify` and `production-readiness` at
   `standard` (mirroring the existing `architecture` row's placement).
 
-- [ ] **Step 2: Remove the increment-1 deferral markers**
+- [x] **Step 2: Remove the increment-1 deferral markers**
   Delete the `<!-- woostack-defer(increment 2): … -->` line from both new angle prompts (the
   wiring they pointed at now exists in this increment).
 
-- [ ] **Step 3: Verify markers are gone and tiers are present**
+- [x] **Step 3: Verify markers are gone and tiers are present**
   Run:
   ```bash
   ! grep -rq 'woostack-defer(increment 2)' skills/woostack-review/prompts/angles/ && echo "markers-cleared"; \
@@ -334,7 +334,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   ```
   Expected: prints `markers-cleared` then `4`.
 
-- [ ] **Step 4: Commit the increment**
+- [x] **Step 4: Commit the increment**
   ```bash
   gt modify -c -m "feat(review): wire simplify + production-readiness angles into the catalog"
   ```

--- a/site/content/docs/concepts/index.mdx
+++ b/site/content/docs/concepts/index.mdx
@@ -15,6 +15,6 @@ concept on its own.
   <Card title="Context management" href="/docs/concepts/context-management" description="Scripts compute, subagents isolate, and model tiers route work." />
   <Card title="Parallelism with worktrees" href="/docs/concepts/worktrees" description="How woostack isolates each run in its own git worktree so multiple builds never collide." />
   <Card title="Collaboration with status tracking" href="/docs/concepts/status-tracking" description="How woostack computes a shared feature board from git artifacts so teams stay aligned without a hand-maintained status file." />
-  <Card title="Review angles" href="/docs/concepts/review-angles" description="All 19 review angles: what each one audits, when it auto-fires, and which model tier it runs at." />
+  <Card title="Review angles" href="/docs/concepts/review-angles" description="All 21 review angles: what each one audits, when it auto-fires, and which model tier it runs at." />
   <Card title="Utilities" href="/docs/concepts/utilities" description="On-demand skills (ask, visualize, status, debug, doctor, dream) that complement the loops without being a step in one." />
 </Cards>

--- a/site/content/docs/concepts/review-angles.mdx
+++ b/site/content/docs/concepts/review-angles.mdx
@@ -36,7 +36,7 @@ Every angle, what it reviews, a plain-language summary of when it auto-fires, an
 | `react` | React correctness: Rules of Hooks and render behavior | a `.tsx` or `.jsx` file changes | standard |
 | `security` | Threat model: injection, auth, secrets, unsafe patterns | always (cannot be skipped) | standard |
 | `seo` | Search-engine optimization: meta tags, sitemaps, canonical URLs | HTML, head / layout files, `robots.txt`, `sitemap`, `next.config`, or SEO tokens in the diff | fast |
-| `simplify` | Simplification: code that should be smaller or not exist — YAGNI, dead code, duplication, thin abstractions | any general-purpose source file changes (same signal as `architecture`) | standard |
+| `simplify` | Simplification: code that should be smaller or not exist (YAGNI, dead code, duplication, thin abstractions) | any general-purpose source file changes (same signal as `architecture`) | standard |
 | `skills` | Agent Skill authoring: a changed SKILL.md against the best-practices guide | a `SKILL.md` file changes anywhere in the diff | standard |
 | `tests` | Test coverage and quality | a test file changes (`.test.*`, `.spec.*`, `_test.*`, or `tests/` / `__tests__/` / `spec/` trees) | standard |
 | `types` | Type design: TypeScript invariants and signatures | a `.ts` / `.tsx` / `.cts` / `.mts` file changes | standard |

--- a/site/content/docs/concepts/review-angles.mdx
+++ b/site/content/docs/concepts/review-angles.mdx
@@ -32,9 +32,11 @@ Every angle, what it reviews, a plain-language summary of when it auto-fires, an
 | `i18n` | Internationalization: translation catalogs and message usage | `locales/`, `messages/`, `i18n/`, `.po` files, or translation tokens in the diff | fast |
 | `infra` | Infrastructure: CI, containers, IaC, Kubernetes | workflow files, Dockerfiles, Terraform / Pulumi / CDK, k8s or helm trees, or IaC tokens in the diff | standard |
 | `observability` | Logging and error handling: silent failures and swallowed errors | logging or error-handling tokens in the diff (console / logger / Sentry / OpenTelemetry, swallowed catches, production mock fallbacks) | standard |
+| `production-readiness` | Resilience and operability: failure handling, retries, timeouts, resource limits, operational readiness | any general-purpose source file changes (same signal as `architecture`) | standard |
 | `react` | React correctness: Rules of Hooks and render behavior | a `.tsx` or `.jsx` file changes | standard |
 | `security` | Threat model: injection, auth, secrets, unsafe patterns | always (cannot be skipped) | standard |
 | `seo` | Search-engine optimization: meta tags, sitemaps, canonical URLs | HTML, head / layout files, `robots.txt`, `sitemap`, `next.config`, or SEO tokens in the diff | fast |
+| `simplify` | Simplification: code that should be smaller or not exist — YAGNI, dead code, duplication, thin abstractions | any general-purpose source file changes (same signal as `architecture`) | standard |
 | `skills` | Agent Skill authoring: a changed SKILL.md against the best-practices guide | a `SKILL.md` file changes anywhere in the diff | standard |
 | `tests` | Test coverage and quality | a test file changes (`.test.*`, `.spec.*`, `_test.*`, or `tests/` / `__tests__/` / `spec/` trees) | standard |
 | `types` | Type design: TypeScript invariants and signatures | a `.ts` / `.tsx` / `.cts` / `.mts` file changes | standard |

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -79,7 +79,7 @@ never be skipped. They are silently kept even if listed.
 | `review.angles.force` | array of string | `[]` | Angles always enabled. |
 | `review.angles.skip` | array of string | `[]` | Angles never enabled (except `bugs` / `security`). |
 
-See [Review angles](/docs/concepts/review-angles) for the full catalog of all 19 angles: what each one
+See [Review angles](/docs/concepts/review-angles) for the full catalog of all 21 angles: what each one
 audits, when it auto-fires, and its model tier.
 
 ### Filtering the diff

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -295,7 +295,7 @@ bash "$WOO_REVIEW_ACTION_PATH/scripts/load-config.sh"   # parses .woostack/confi
 bash "$WOO_REVIEW_ACTION_PATH/scripts/detect-angles.sh"
 ```
 
-Read the result from `$OUTDIR/angles.txt` (one angle per line). Always-on angles: `bugs`, `security`. Conditional (auto-detected from changed paths + diff body): `conventions` (when `rules.md` is present), `seo`, `aeo`, `design`, `react`, `database`, `tests`, `api`, `infra`, `observability`, `types`, `i18n`, `docs`, `deps`, `skills` (when a `SKILL.md` is in the diff), `architecture` and `comments` (when the diff touches general-purpose source files). See `scripts/detect-angles.sh` for per-angle gating heuristics.
+Read the result from `$OUTDIR/angles.txt` (one angle per line). Always-on angles: `bugs`, `security`. Conditional (auto-detected from changed paths + diff body): `conventions` (when `rules.md` is present), `seo`, `aeo`, `design`, `react`, `database`, `tests`, `api`, `infra`, `observability`, `types`, `i18n`, `docs`, `deps`, `skills` (when a `SKILL.md` is in the diff), `architecture`, `comments`, `simplify`, and `production-readiness` (when the diff touches general-purpose source files). See `scripts/detect-angles.sh` for per-angle gating heuristics.
 
 Prefetch also produces optional chunking artifacts when the post-ignore diff exceeds `chunking.max_loc` (default 4000 LOC). When present, the host MUST fan out one sub-agent per `(angle, chunk)` pair in Stage 3:
 
@@ -375,6 +375,7 @@ Sub-agents MUST NOT post comments, edit the PR, touch other angles' files, run `
 | Context+summary subagent | `fast` | Mechanical summarization. |
 | `bugs`, `security` workers | `standard` | Reasoning-heavy: correctness + threat model. |
 | `architecture` worker | `standard` | Structural-quality / code-judo judgment; high-subjectivity, needs reasoning depth. |
+| `simplify`, `production-readiness` workers | `standard` | Deletion/YAGNI judgment + resilience-under-stress reasoning. |
 | `design`, `react` workers | `standard` | Heuristic + Rules-of-Hooks judgment after deterministic tools. |
 | `database` worker | `standard` | Postgres correctness, RLS reasoning, plan/index judgment. |
 | `tests`, `api`, `infra` workers | `standard` | Coverage/contract/IaC reasoning. |

--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -97,7 +97,7 @@ The prefetch step parses an optional `.woostack/config.json` in the consumer rep
 
 ## Review Angles
 
-This action runs up to nineteen distinct review angles, auto-selected from the changed files. The set of enabled angles is listed in `/tmp/pr-review/angles.txt`. The per-angle prompt bodies live at `${ACTION_PATH}/prompts/angles/<angle>.md` and are loaded by the orchestrator.
+This action runs up to twenty-one distinct review angles, auto-selected from the changed files. The set of enabled angles is listed in `/tmp/pr-review/angles.txt`. The per-angle prompt bodies live at `${ACTION_PATH}/prompts/angles/<angle>.md` and are loaded by the orchestrator.
 
 | Angle | Always-on | Tooling |
 |---|---|---|
@@ -120,6 +120,8 @@ This action runs up to nineteen distinct review angles, auto-selected from the c
 | `architecture` | no | LLM only — gated on general-purpose source files in diff (`*.ts`/`*.js`/`*.py`/`*.go`/`*.rs`/`*.java`/`*.rb`/`*.php`/`*.cs`/…); structural-quality / code-judo pass; skips doc-only and config-only PRs |
 | `skills` | no | LLM only — gated on a `SKILL.md` in diff; audits the changed Agent Skill against Anthropic's skill best-practices guide (`SKILL.md` is excluded from the `docs` gate so a SKILL.md-only PR routes here) |
 | `comments` | no | LLM only — gated on general-purpose source files in diff (same signal as `architecture`); audits whether code comments still match the code the PR changed. Always non-blocking. |
+| `simplify` | no | LLM only — gated on general-purpose source files in diff (same signal as `architecture`); YAGNI / dead-code / duplication delete-list; defers structural-shape to `architecture` when both run |
+| `production-readiness` | no | LLM only — gated on general-purpose source files in diff; resilience/operability posture (timeouts, retries, idempotency, degradation, resource limits) |
 
 Each angle writes its findings to `/tmp/pr-review/findings.<angle>.json`. The orchestrator merges them into `/tmp/pr-review/findings.json` after the validator pass, then posts inline comments via a single batched GitHub Review. PR labels MUST NOT be mutated — blocking is signalled exclusively through the native `REQUEST_CHANGES` review event.
 
@@ -292,7 +294,7 @@ for f in findings:
         else:
             sev_tag = severity
         footer_parts.append(f"<strong>{sev_tag}</strong>")
-    if angle in {"bugs","security","conventions","seo","aeo","design","react","database","tests","api","infra","observability","types","i18n","docs","deps","architecture","skills","comments"}:
+    if angle in {"bugs","security","conventions","seo","aeo","design","react","database","tests","api","infra","observability","types","i18n","docs","deps","architecture","skills","comments","simplify","production-readiness"}:
         footer_parts.append(f"flagged by the <code>{angle}</code> agent")
     if footer_parts:
         body += "\n\n<sub>— " + " · ".join(footer_parts) + "</sub>"
@@ -426,7 +428,7 @@ Every runner MUST write a final `findings.json` (for debugging + potential post-
 ]
 ```
 
-`angle` is one of `bugs | security | conventions | seo | aeo | design | react | database | tests | api | infra | observability | types | i18n | docs | deps | architecture | comments`.
+`angle` is one of `bugs | security | conventions | seo | aeo | design | react | database | tests | api | infra | observability | types | i18n | docs | deps | architecture | comments | simplify | production-readiness`.
 
 `line` MUST be the post-patch absolute file line — i.e. a line that exists on the RIGHT side of the diff (a `+` added line or a ` ` context line within a hunk for `file`). Lines that fall in a deletion-only region, or outside any hunk for the file, will be rejected by the GitHub API. Validate every line via `scripts/resolve-diff-line.sh` before writing the finding (see *Output Discipline* above); drop the finding when the helper returns `null`.
 

--- a/skills/woostack-review/prompts/angles/production-readiness.md
+++ b/skills/woostack-review/prompts/angles/production-readiness.md
@@ -2,8 +2,6 @@
 tier: standard
 ---
 
-<!-- woostack-defer(increment 2): registered in VALID_ANGLES + detect-angles + _header in increment 2 -->
-
 # Angle: Production readiness
 
 **Scope.** Audit the **resilience and operability** of the code in `$OUTDIR/diff.txt` (files in

--- a/skills/woostack-review/prompts/angles/simplify.md
+++ b/skills/woostack-review/prompts/angles/simplify.md
@@ -2,8 +2,6 @@
 tier: standard
 ---
 
-<!-- woostack-defer(increment 2): registered in VALID_ANGLES + detect-angles + _header in increment 2 -->
-
 # Angle: Simplify
 
 **Scope.** Find code that should be **smaller or not exist at all**. Read `$OUTDIR/diff.txt`

--- a/skills/woostack-review/prompts/anthropic.md
+++ b/skills/woostack-review/prompts/anthropic.md
@@ -92,7 +92,7 @@ Read `$OUTDIR/angles.txt`. Check `$OUTDIR/chunks.txt`:
 Each subagent:
 
 - Loads its angle prompt: `$WOO_REVIEW_ACTION_PATH/prompts/angles/<angle>.md`.
-- Runs on the Anthropic model resolved from that prompt's `tier:` frontmatter via the table above (Sonnet for `bugs`/`security`/`architecture`/`design`/`react`/`database`/`tests`/`api`/`infra`/`observability`/`types`, Haiku for `seo`/`aeo`/`i18n`/`docs`/`deps`/`comments`). The spawning Task call MUST pass `model:` explicitly — see Model Routing section above.
+- Runs on the Anthropic model resolved from that prompt's `tier:` frontmatter via the table above (Sonnet for `bugs`/`security`/`architecture`/`design`/`react`/`database`/`tests`/`api`/`infra`/`observability`/`types`/`simplify`/`production-readiness`, Haiku for `seo`/`aeo`/`i18n`/`docs`/`deps`/`comments`). The spawning Task call MUST pass `model:` explicitly — see Model Routing section above.
 - Reads its assigned diff (`$OUTDIR/diff.txt` for the unchunked case, `$OUTDIR/diff.chunk-<id>.txt` for chunked).
 - For `react`: runs `npx -y react-doctor@$REACT_DOCTOR_VERSION --diff $BASE_REF --offline`, parses output, then performs LLM review per the react prompt.
 - Returns its findings list AND writes them to `$OUTDIR/findings.<angle>.json` (unchunked) or `$OUTDIR/findings.<angle>.<chunk_id>.json` (chunked).

--- a/skills/woostack-review/scripts/detect-angles.sh
+++ b/skills/woostack-review/scripts/detect-angles.sh
@@ -76,6 +76,11 @@
 #   comments  — reuses the general-purpose source-file signal (any *.{ts,js,py,go,…}
 #               in the diff, same as architecture). Audits whether code comments still
 #               match the code the PR changed (comment rot). Always non-blocking.
+#   simplify  — general-purpose source files in the diff (same signal as architecture).
+#               YAGNI / dead-code / duplication delete-list. Defers structural-shape to
+#               architecture when both are enabled.
+#   production-readiness — general-purpose source files in the diff. Resilience/operability
+#               posture (timeouts, retries, idempotency, degradation, resource limits).
 
 set -euo pipefail
 
@@ -328,6 +333,14 @@ fi
 
 if has_code_file; then
   ANGLES+=("comments")
+fi
+
+if has_code_file; then
+  ANGLES+=("simplify")
+fi
+
+if has_code_file; then
+  ANGLES+=("production-readiness")
 fi
 
 # Merge config.angles.skip into the disable CSV. Config-driven and input-driven

--- a/skills/woostack-review/scripts/load-config.sh
+++ b/skills/woostack-review/scripts/load-config.sh
@@ -89,7 +89,7 @@ import sys
 
 src, dst = sys.argv[1], sys.argv[2]
 
-VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture", "skills", "comments"}
+VALID_ANGLES = {"bugs", "security", "conventions", "seo", "aeo", "design", "react", "database", "tests", "api", "infra", "observability", "types", "i18n", "docs", "deps", "architecture", "skills", "comments", "simplify", "production-readiness"}
 VALID_FLOORS = {"low", "medium", "high"}
 FORCE_TIERS = {"fast", "deep"}
 # Keys recognized inside the `review` block (and the legacy top-level form).

--- a/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
@@ -26,4 +26,11 @@ VA_LINE="$(grep 'VALID_ANGLES' "$DIR/load-config.sh")"
 assert_contains "$VA_LINE" "simplify" "VALID_ANGLES includes simplify"
 assert_contains "$VA_LINE" "production-readiness" "VALID_ANGLES includes production-readiness"
 
+# Site 10 (anthropic.md Sonnet-tier list): both angles must appear so the
+# per-provider tier table doesn't silently drop them (memory: review-add-angle-sites,
+# the site historically missed for the comments angle).
+ANTHRO_LINE="$(grep 'Sonnet for' "$DIR/../prompts/anthropic.md")"
+assert_contains "$ANTHRO_LINE" "simplify" "anthropic Sonnet tier lists simplify"
+assert_contains "$ANTHRO_LINE" "production-readiness" "anthropic Sonnet tier lists production-readiness"
+
 finish

--- a/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
@@ -18,4 +18,12 @@ setup "README.md"; bash "$SCRIPT" >/dev/null 2>&1
 assert_eq "$(grep -cx 'simplify' "$OUTDIR/angles.txt" || true)" "0" "docs-only: no simplify"
 assert_eq "$(grep -cx 'production-readiness' "$OUTDIR/angles.txt" || true)" "0" "docs-only: no production-readiness"
 rm -rf "$work"
+
+# Site 3 (load-config.sh VALID_ANGLES): both new angles must be registered, else
+# review.angles.force / .skip silently reject them. This is the historically
+# missed site when adding an angle (memory: review-add-angle-sites).
+VA_LINE="$(grep 'VALID_ANGLES' "$DIR/load-config.sh")"
+assert_contains "$VA_LINE" "simplify" "VALID_ANGLES includes simplify"
+assert_contains "$VA_LINE" "production-readiness" "VALID_ANGLES includes production-readiness"
+
 finish

--- a/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/detect-angles.sh"
+setup() { work="$(mktemp -d)"; export OUTDIR="$work/out"; mkdir -p "$OUTDIR"; \
+  printf '%s\n' "$1" | jq -R . | jq -s '{files: [.[] | {path: .}]}' > "$OUTDIR/meta.json"; : > "$OUTDIR/diff.txt"; }
+
+# Source file enables both new angles (same gate as architecture).
+setup "src/index.ts"; bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "simplify" "source enables simplify"
+assert_contains "$(cat "$OUTDIR/angles.txt")" "production-readiness" "source enables production-readiness"
+rm -rf "$work"
+
+# Docs-only PR enables neither.
+setup "README.md"; bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(grep -cx 'simplify' "$OUTDIR/angles.txt" || true)" "0" "docs-only: no simplify"
+assert_eq "$(grep -cx 'production-readiness' "$OUTDIR/angles.txt" || true)" "0" "docs-only: no production-readiness"
+rm -rf "$work"
+finish


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
