### PR TITLE
feat(audit): add audit config loader (sibling audit block + lens flags)

### DIFF
--- a/.woostack/plans/2026-06-25-woostack-audit.md
+++ b/.woostack/plans/2026-06-25-woostack-audit.md
@@ -353,7 +353,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 - Create: `skills/woostack-audit/scripts/load-audit-config.sh`
 - Test: `skills/woostack-audit/scripts/tests/test-load-audit-config.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   #!/usr/bin/env bash
   set -euo pipefail
@@ -391,11 +391,11 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   finish
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-audit/scripts/tests/test-load-audit-config.sh`
   Expected: FAIL — `load-audit-config.sh: No such file or directory`.
 
-- [ ] **Step 3: Implement the loader**
+- [x] **Step 3: Implement the loader**
   ```bash
   #!/usr/bin/env bash
   # Reads the sibling `audit` block from .woostack/config.json (or $AUDIT_CONFIG_FILE) and emits
@@ -441,11 +441,11 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   PY
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run: `bash skills/woostack-audit/scripts/tests/test-load-audit-config.sh`
   Expected: `… passed, 0 failed`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "feat(audit): add audit config loader (sibling audit block + lens flags)"
   ```

--- a/skills/woostack-audit/scripts/load-audit-config.sh
+++ b/skills/woostack-audit/scripts/load-audit-config.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Reads the sibling `audit` block from .woostack/config.json (or $AUDIT_CONFIG_FILE) and emits
+# $OUTDIR/config.json in the shape detect-angles.sh / intersect-findings.sh consume. Forces the
+# two audit angles on, skips architecture, applies an optional lens flag with a bugs+security
+# safety floor (bugs/security are always-on in detect-angles.sh). Mirrors review load-config.sh
+# strictness: an unknown key inside the audit block hard-fails.
+set -euo pipefail
+RVW="$(dirname "${BASH_SOURCE[0]:-$0}")/../../woostack-review/scripts"
+source "$RVW/resolve-root.sh"     # exports WOOSTACK_ROOT
+source "$RVW/resolve-outdir.sh"   # exports OUTDIR
+CFG_FILE="${AUDIT_CONFIG_FILE:-$WOOSTACK_ROOT/.woostack/config.json}"
+LENS="${AUDIT_LENS:-}"
+VALID_KEYS='angles severity_floor ignore models chunking report_dir'
+
+python3 - "$CFG_FILE" "$LENS" "$OUTDIR/config.json" "$VALID_KEYS" <<'PY'
+import json, sys, os
+cfg_file, lens, out, valid_keys = sys.argv[1], sys.argv[2], sys.argv[3], set(sys.argv[4].split())
+audit = {}
+if os.path.exists(cfg_file):
+    with open(cfg_file) as f:
+        try:
+            audit = (json.load(f) or {}).get("audit", {}) or {}
+        except json.JSONDecodeError as e:
+            sys.stderr.write("::error file=%s::invalid JSON: %s\n" % (cfg_file, e)); sys.exit(1)
+bad = [k for k in audit if k not in valid_keys]
+if bad:
+    sys.stderr.write("::error file=%s::unknown audit key(s): %s\n" % (cfg_file, ", ".join(bad))); sys.exit(1)
+force = ["simplify", "production-readiness"]
+if lens == "simplify":
+    force = ["simplify"]
+elif lens == "prod":
+    force = ["production-readiness"]
+ang = audit.get("angles", {}) or {}
+out_cfg = {
+    "angles": {"force": force + (ang.get("force", []) or []),
+               "skip": ["architecture"] + (ang.get("skip", []) or [])},
+    "severity_floor": audit.get("severity_floor", "high"),
+    "ignore": audit.get("ignore", []),
+    "models": audit.get("models", {}),
+    "chunking": audit.get("chunking", {"max_loc": 4000}),
+    "report_dir": audit.get("report_dir", ".woostack/audits"),
+}
+with open(out, "w") as f:
+    json.dump(out_cfg, f)
+PY

--- a/skills/woostack-audit/scripts/tests/test-load-audit-config.sh
+++ b/skills/woostack-audit/scripts/tests/test-load-audit-config.sh
@@ -30,6 +30,15 @@ cfg="$(cat "$OUTDIR/config.json")"
 assert_contains "$cfg" "simplify" "lens simplify forces simplify"
 assert_not_contains "$cfg" "production-readiness" "lens simplify drops prod-readiness"
 
+# Lens flag prod forces production-readiness only, drops simplify.
+run '{}' 'prod'; assert_eq "$EC" "0" "lens prod ok"
+cfg="$(cat "$OUTDIR/config.json")"
+assert_contains "$cfg" "production-readiness" "lens prod forces production-readiness"
+assert_not_contains "$cfg" "simplify" "lens prod drops simplify"
+
+# angles:null is coerced to {} by the `or {}` guard, not treated as an error.
+run '{"audit":{"angles":null}}'; assert_eq "$EC" "0" "angles:null coerced, not an error"
+
 # Unknown audit key -> loud non-zero.
 run '{"audit":{"bogus":1}}'; assert_eq "$EC" "1" "unknown audit key rejected"
 finish

--- a/skills/woostack-audit/scripts/tests/test-load-audit-config.sh
+++ b/skills/woostack-audit/scripts/tests/test-load-audit-config.sh
@@ -39,6 +39,21 @@ assert_not_contains "$cfg" "simplify" "lens prod drops simplify"
 # angles:null is coerced to {} by the `or {}` guard, not treated as an error.
 run '{"audit":{"angles":null}}'; assert_eq "$EC" "0" "angles:null coerced, not an error"
 
+# User-supplied angles.force/skip merge onto the audit defaults (append, not replace).
+run '{"audit":{"angles":{"force":["bugs"],"skip":["docs"]}}}'; assert_eq "$EC" "0" "user angles merge ok"
+cfg="$(cat "$OUTDIR/config.json")"
+assert_contains "$cfg" "bugs" "user angles.force merged onto defaults"
+assert_contains "$cfg" "docs" "user angles.skip merged onto architecture"
+
+# Unknown lens flag falls back to running both audit angles, not an error.
+run '{}' 'bogus'; assert_eq "$EC" "0" "unknown lens falls back, no error"
+cfg="$(cat "$OUTDIR/config.json")"
+assert_contains "$cfg" "simplify" "unknown lens keeps simplify"
+assert_contains "$cfg" "production-readiness" "unknown lens keeps production-readiness"
+
+# Invalid JSON in the config file -> loud non-zero exit (JSONDecodeError path).
+run '{invalid'; assert_eq "$EC" "1" "invalid JSON rejected"
+
 # Unknown audit key -> loud non-zero.
 run '{"audit":{"bogus":1}}'; assert_eq "$EC" "1" "unknown audit key rejected"
 finish

--- a/skills/woostack-audit/scripts/tests/test-load-audit-config.sh
+++ b/skills/woostack-audit/scripts/tests/test-load-audit-config.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/load-audit-config.sh"
+
+EC=0
+run() { # $1=config json, $2=lens (optional). Sets OUTDIR (parent-visible) + EC.
+  work="$(mktemp -d)"; export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+  printf '%s' "$1" > "$work/config.json"
+  AUDIT_CONFIG_FILE="$work/config.json" AUDIT_LENS="${2:-}" bash "$SCRIPT" >/dev/null 2>&1 && EC=0 || EC=$?
+}
+
+# No audit block -> defaults: force simplify+production-readiness, skip architecture.
+run '{}'; assert_eq "$EC" "0" "empty config ok"
+cfg="$(cat "$OUTDIR/config.json")"
+assert_contains "$cfg" "simplify" "force includes simplify"
+assert_contains "$cfg" "production-readiness" "force includes production-readiness"
+assert_contains "$cfg" "architecture" "skip includes architecture"
+
+# Sibling review block is ignored, not an error.
+run '{"review":{"severity_floor":"low"},"audit":{"severity_floor":"medium"}}'
+assert_eq "$EC" "0" "sibling review block ignored"
+assert_contains "$(cat "$OUTDIR/config.json")" "medium" "audit severity_floor applied"
+
+# Lens flag simplify keeps the floor, drops production-readiness from force.
+run '{}' 'simplify'; assert_eq "$EC" "0" "lens ok"
+cfg="$(cat "$OUTDIR/config.json")"
+assert_contains "$cfg" "simplify" "lens simplify forces simplify"
+assert_not_contains "$cfg" "production-readiness" "lens simplify drops prod-readiness"
+
+# Unknown audit key -> loud non-zero.
+run '{"audit":{"bogus":1}}'; assert_eq "$EC" "1" "unknown audit key rejected"
+finish


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
