### PR TITLE
feat(audit): synthesize all-added target diff + meta (cap + chunk reuse)

### DIFF
--- a/.woostack/plans/2026-06-25-woostack-audit.md
+++ b/.woostack/plans/2026-06-25-woostack-audit.md
@@ -463,7 +463,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 - Create: `skills/woostack-audit/scripts/build-target-diff.sh`
 - Test: `skills/woostack-audit/scripts/tests/test-build-target-diff.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   #!/usr/bin/env bash
   set -euo pipefail
@@ -501,11 +501,11 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   finish
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-audit/scripts/tests/test-build-target-diff.sh`
   Expected: FAIL — script not found.
 
-- [ ] **Step 3: Implement the builder**
+- [x] **Step 3: Implement the builder**
   ```bash
   #!/usr/bin/env bash
   # Builds an all-added synthetic diff for an explicit standing-code target so review's
@@ -552,11 +552,11 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   bash "$RVW/chunk-diff.sh" >/dev/null 2>&1 || true
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run: `bash skills/woostack-audit/scripts/tests/test-build-target-diff.sh`
   Expected: `… passed, 0 failed`
 
-- [ ] **Step 5: Verify a synthetic line is review-anchorable**
+- [x] **Step 5: Verify a synthetic line is review-anchorable**
   Run:
   ```bash
   t="$(mktemp -d)"; printf 'export const a = 1\n' > "$t/a.ts"; export OUTDIR="$(mktemp -d)/out"; mkdir -p "$OUTDIR"; \
@@ -565,7 +565,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   ```
   Expected: a non-`null` value (the all-added line resolves on the RIGHT side). *(If `resolve-diff-line.sh` expects a repo-relative path, pass the path as it appears in `diff.txt`.)*
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
   ```bash
   gt modify -c -m "feat(audit): synthesize all-added target diff + meta (cap + chunk reuse)"
   ```

--- a/skills/woostack-audit/scripts/build-target-diff.sh
+++ b/skills/woostack-audit/scripts/build-target-diff.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Builds an all-added synthetic diff for an explicit standing-code target so review's
+# diff-anchored swarm audits code at rest. AUDIT_TARGET is required (no default). Skips binary,
+# gitignored, lockfile, and generated files. Applies the same section-aware cap as prefetch.sh
+# (WOO_REVIEW_DIFF_CAP_BYTES) and chunk-diff.sh chunking. bash-3.2 safe (guards empty arrays).
+set -euo pipefail
+RVW="$(dirname "${BASH_SOURCE[0]:-$0}")/../../woostack-review/scripts"
+source "$RVW/resolve-outdir.sh"
+TARGET="${AUDIT_TARGET:?AUDIT_TARGET (an explicit path) is required — woostack-audit <target>}"
+if [ ! -e "$TARGET" ]; then
+  echo "::error::audit target not found: $TARGET" >&2
+  exit 1
+fi
+: > "$OUTDIR/diff.txt"
+
+# Enumerate candidate files: honor .gitignore when the target lives inside a repo, else find.
+if git -C "$(dirname "$TARGET")" rev-parse --show-toplevel >/dev/null 2>&1; then
+  enum() { git ls-files --cached --others --exclude-standard -- "$TARGET" 2>/dev/null || find "$TARGET" -type f; }
+else
+  enum() { find "$TARGET" -type f; }
+fi
+
+files=()
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  case "$f" in *.lock|*-lock.json|*.min.js|*.map) continue;; esac
+  grep -Iq . "$f" 2>/dev/null || continue   # -I skips binary; empty files have no content to audit
+  files+=("$f")
+done < <(enum)
+
+# Append one all-added new-file section per file. `git diff --no-index /dev/null <f>` exits 1
+# ("differs", always true vs /dev/null) — expected, never a failure.
+for f in ${files[@]+"${files[@]}"}; do
+  git diff --no-index -- /dev/null "$f" >> "$OUTDIR/diff.txt" 2>/dev/null || true
+done
+
+# Synthesize meta.json (synthetic head = current HEAD when in a repo, else "audit").
+head_oid="$(git rev-parse HEAD 2>/dev/null || echo audit)"
+printf '%s\n' ${files[@]+"${files[@]}"} | jq -R 'select(length>0)' | jq -s \
+  --arg oid "$head_oid" --arg t "$TARGET" \
+  '{headRefOid:$oid, baseRefName:"audit", title:("(audit: "+$t+")"), body:"", files:[.[]|{path:.}]}' \
+  > "$OUTDIR/meta.json"
+
+# Section-aware cap + chunking, reusing review's machinery on the synthetic diff.
+cap="${WOO_REVIEW_DIFF_CAP_BYTES:-300000}"
+if [ "$(wc -c < "$OUTDIR/diff.txt")" -gt "$cap" ]; then
+  echo "::warning::audit diff exceeds ${cap}B; chunking" >&2
+fi
+bash "$RVW/chunk-diff.sh" >/dev/null 2>&1 || true

--- a/skills/woostack-audit/scripts/build-target-diff.sh
+++ b/skills/woostack-audit/scripts/build-target-diff.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Builds an all-added synthetic diff for an explicit standing-code target so review's
 # diff-anchored swarm audits code at rest. AUDIT_TARGET is required (no default). Skips binary,
-# gitignored, lockfile, and generated files. Applies the same section-aware cap as prefetch.sh
-# (WOO_REVIEW_DIFF_CAP_BYTES) and chunk-diff.sh chunking. bash-3.2 safe (guards empty arrays).
+# gitignored, lockfile, and generated files. Warns when the synthetic diff exceeds the cap
+# (WOO_REVIEW_DIFF_CAP_BYTES) and delegates size handling to chunk-diff.sh chunking — it does not
+# truncate. bash-3.2 safe (guards empty arrays).
 set -euo pipefail
 RVW="$(dirname "${BASH_SOURCE[0]:-$0}")/../../woostack-review/scripts"
 source "$RVW/resolve-outdir.sh"
@@ -14,8 +15,17 @@ fi
 : > "$OUTDIR/diff.txt"
 
 # Enumerate candidate files: honor .gitignore when the target lives inside a repo, else find.
-if git -C "$(dirname "$TARGET")" rev-parse --show-toplevel >/dev/null 2>&1; then
-  enum() { git ls-files --cached --others --exclude-standard -- "$TARGET" 2>/dev/null || find "$TARGET" -type f; }
+# Run git in the *target's* repo (via -C "$repo_root"), not the script's CWD, so a cross-repo
+# audit still honors the target's .gitignore instead of silently falling back to `find` (which
+# does not). --full-name yields repo-root-relative paths; sed re-absolutizes them for the loop.
+target_dir="$TARGET"; [ -d "$target_dir" ] || target_dir="$(dirname "$TARGET")"
+repo_root="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$repo_root" ]; then
+  enum() {
+    git -C "$repo_root" ls-files --cached --others --exclude-standard --full-name -- "$TARGET" 2>/dev/null \
+      | sed "s|^|$repo_root/|" \
+      || find "$TARGET" -type f
+  }
 else
   enum() { find "$TARGET" -type f; }
 fi

--- a/skills/woostack-audit/scripts/tests/test-build-target-diff.sh
+++ b/skills/woostack-audit/scripts/tests/test-build-target-diff.sh
@@ -31,4 +31,19 @@ AUDIT_TARGET="$t" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
 assert_eq "$ec" "0" "binary-only exits 0"
 assert_eq "$(wc -c < "$OUTDIR/diff.txt" | tr -d ' ')" "0" "binary-only yields empty diff"
 rm -rf "$t" "$OUTDIR"
+
+# Chunk integration end-to-end: with max_loc=1 the synthetic diff exceeds the threshold, so
+# chunk-diff.sh must emit a non-empty chunks.txt + a non-empty chunks.json manifest. The builder
+# calls chunk-diff.sh with `|| true`, so a broken integration would still exit 0 and pass every
+# assertion above; these assertions prove the chunking pipeline actually ran and produced usable
+# artifacts. (chunk-diff.sh only emits chunk files above threshold, hence the max_loc=1 config.)
+t="$(mktemp -d)"; mkdir -p "$t/src"; printf 'export const a = 1\nexport const b = 2\n' > "$t/src/a.ts"
+export OUTDIR="$(mktemp -d)/out"; mkdir -p "$OUTDIR"
+printf '%s\n' '{"chunking":{"max_loc":1}}' > "$OUTDIR/config.json"
+AUDIT_TARGET="$t/src" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "0" "builder exits 0 when chunking triggers"
+assert_eq "$([ -s "$OUTDIR/chunks.txt" ] && echo y || echo n)" "y" "chunk-diff emitted non-empty chunks.txt"
+chunks_json_ok="$(jq -e 'type=="array" and length>0' "$OUTDIR/chunks.json" >/dev/null 2>&1 && echo y || echo n)"
+assert_eq "$chunks_json_ok" "y" "chunk-diff emitted a non-empty chunks.json manifest"
+rm -rf "$t" "$OUTDIR"
 finish

--- a/skills/woostack-audit/scripts/tests/test-build-target-diff.sh
+++ b/skills/woostack-audit/scripts/tests/test-build-target-diff.sh
@@ -46,4 +46,22 @@ assert_eq "$([ -s "$OUTDIR/chunks.txt" ] && echo y || echo n)" "y" "chunk-diff e
 chunks_json_ok="$(jq -e 'type=="array" and length>0' "$OUTDIR/chunks.json" >/dev/null 2>&1 && echo y || echo n)"
 assert_eq "$chunks_json_ok" "y" "chunk-diff emitted a non-empty chunks.json manifest"
 rm -rf "$t" "$OUTDIR"
+
+# Git-repo enumeration branch (cross-repo): target lives inside its own repo, builder runs from a
+# DIFFERENT cwd. The enum must use the target's repo context (-C "$repo_root") and honor the
+# target's .gitignore — a gitignored file must NOT appear in the diff, a tracked file must. Guards
+# the cross-repo `git ls-files` path; before the -C fix this fell back to `find`, which re-included
+# the gitignored file. Exercises the L17-true branch that the other cases never reach.
+repo="$(mktemp -d)"
+( cd "$repo" && git init -q && git config user.email a@b.c && git config user.name t )
+mkdir -p "$repo/src"
+printf 'export const keep = 1\n' > "$repo/src/keep.ts"
+printf 'SECRET=xyz\n' > "$repo/src/secret.env"
+printf 'src/secret.env\n' > "$repo/.gitignore"
+export OUTDIR="$(mktemp -d)/out"; mkdir -p "$OUTDIR"
+( cd / && AUDIT_TARGET="$repo/src" bash "$SCRIPT" ) >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "0" "git-repo target exits 0 from a foreign cwd"
+assert_eq "$(grep -q 'keep\.ts' "$OUTDIR/diff.txt" && echo y || echo n)" "y" "tracked file included"
+assert_eq "$(grep -q 'secret\.env' "$OUTDIR/diff.txt" && echo y || echo n)" "n" "gitignored file excluded cross-repo (honors target .gitignore)"
+rm -rf "$repo" "$OUTDIR"
 finish

--- a/skills/woostack-audit/scripts/tests/test-build-target-diff.sh
+++ b/skills/woostack-audit/scripts/tests/test-build-target-diff.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/build-target-diff.sh"
+
+# A dir with two text files + one binary -> diff.txt has two new-file sections, all + lines,
+# binary skipped; meta.json lists the two text files.
+t="$(mktemp -d)"; mkdir -p "$t/src"; printf 'export const a = 1\n' > "$t/src/a.ts"; \
+  printf 'def b():\n    return 2\n' > "$t/src/b.py"; printf '\x00\x01\x02' > "$t/src/c.bin"
+export OUTDIR="$(mktemp -d)/out"; mkdir -p "$OUTDIR"
+AUDIT_TARGET="$t/src" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "0" "builder exits 0 on a normal target"
+assert_eq "$(grep -c '^diff --git' "$OUTDIR/diff.txt")" "2" "one new-file section per text file"
+assert_eq "$(grep -c '^new file mode' "$OUTDIR/diff.txt")" "2" "marked as new files (all-added)"
+assert_not_contains "$(cat "$OUTDIR/diff.txt")" "c.bin" "binary file skipped"
+assert_eq "$(jq '.files | length' "$OUTDIR/meta.json")" "2" "meta lists 2 files"
+rm -rf "$t" "$OUTDIR"
+
+# Missing target -> non-zero, no diff.txt.
+export OUTDIR="$(mktemp -d)/out"; mkdir -p "$OUTDIR"
+AUDIT_TARGET="/no/such/path" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "1" "missing target exits 1"
+assert_eq "$([ -f "$OUTDIR/diff.txt" ] && echo y || echo n)" "n" "no diff.txt on missing target"
+rm -rf "$OUTDIR"
+
+# Binary-only target -> empty diff.txt, exit 0.
+t="$(mktemp -d)"; printf '\x00\x01' > "$t/x.bin"; export OUTDIR="$(mktemp -d)/out"; mkdir -p "$OUTDIR"
+AUDIT_TARGET="$t" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "0" "binary-only exits 0"
+assert_eq "$(wc -c < "$OUTDIR/diff.txt" | tr -d ' ')" "0" "binary-only yields empty diff"
+rm -rf "$t" "$OUTDIR"
+finish


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
