### PR TITLE
feat(audit): render report-only severity-grouped findings doc

### DIFF
--- a/.woostack/plans/2026-06-25-woostack-audit.md
+++ b/.woostack/plans/2026-06-25-woostack-audit.md
@@ -583,7 +583,7 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
 - Create: `skills/woostack-audit/scripts/render-report.sh`
 - Test: `skills/woostack-audit/scripts/tests/test-render-report.sh`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   #!/usr/bin/env bash
   set -euo pipefail
@@ -614,11 +614,11 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   finish
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-audit/scripts/tests/test-render-report.sh`
   Expected: FAIL — script not found.
 
-- [ ] **Step 3: Implement the renderer**
+- [x] **Step 3: Implement the renderer**
   ```bash
   #!/usr/bin/env bash
   # Renders $OUTDIR/findings.json into a severity-grouped markdown report (report-only; no
@@ -653,15 +653,15 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   PY
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run: `bash skills/woostack-audit/scripts/tests/test-render-report.sh`
   Expected: `… passed, 0 failed`
 
-- [ ] **Step 5: Verify no network call in the renderer**
+- [x] **Step 5: Verify no network call in the renderer**
   Run: `! grep -Eq 'gh |curl |wget |api\.github' skills/woostack-audit/scripts/render-report.sh && echo report-only`
   Expected: `report-only`
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
   ```bash
   gt modify -c -m "feat(audit): render report-only severity-grouped findings doc"
   ```

--- a/skills/woostack-audit/scripts/render-report.sh
+++ b/skills/woostack-audit/scripts/render-report.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Renders $OUTDIR/findings.json into a severity-grouped markdown report (report-only; no network).
-# Writes AUDIT_REPORT_PATH (default .woostack/audits/<date>-<slug>.md) and prints a terminal summary.
+# Writes AUDIT_REPORT_PATH (required; the caller sets it, e.g. .woostack/audits/<date>-<slug>.md)
+# and prints a terminal summary.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../../woostack-review/scripts/resolve-outdir.sh"
 FINDINGS="$OUTDIR/findings.json"
@@ -18,19 +19,23 @@ if not findings:
     lines += ["**Result: clean.** No findings.", ""]
 else:
     order = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
-    findings.sort(key=lambda f: (order.get(f.get("severity", "LOW"), 3), f.get("angle", "")))
+    # Use `(f.get(k) or default)`, not `f.get(k, default)`: a finding can carry an explicit null
+    # (jq `has()` passes null through merge-findings' schema gate), and dict.get only substitutes
+    # the default for *missing* keys — not null values. A null would otherwise reach the renderer
+    # and crash the sort/join or print a literal "None".
+    findings.sort(key=lambda f: (order.get((f.get("severity") or "LOW"), 3), (f.get("angle") or "")))
     cur = None
     for f in findings:
-        sev = f.get("severity", "LOW")
+        sev = f.get("severity") or "LOW"
         if sev != cur:
             lines += ["", "## %s" % sev, ""]
             cur = sev
-        loc = "%s:%s" % (f.get("file", "?"), f.get("line", "?"))
+        loc = "%s:%s" % (f.get("file") or "?", f.get("line") or "?")
         lines += [
-            "### %s — `%s` · `%s`" % (f.get("title", "(untitled)"), loc, f.get("angle", "?")),
-            f.get("description", ""),
+            "### %s — `%s` · `%s`" % (f.get("title") or "(untitled)", loc, f.get("angle") or "?"),
+            f.get("description") or "",
             "",
-            "**Fix:** %s" % f.get("fix", ""),
+            "**Fix:** %s" % (f.get("fix") or ""),
             "",
             "_Next: `/woostack-fix` for a small change, `/woostack-build` for a larger one._",
             "",

--- a/skills/woostack-audit/scripts/render-report.sh
+++ b/skills/woostack-audit/scripts/render-report.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Renders $OUTDIR/findings.json into a severity-grouped markdown report (report-only; no network).
+# Writes AUDIT_REPORT_PATH (default .woostack/audits/<date>-<slug>.md) and prints a terminal summary.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]:-$0}")/../../woostack-review/scripts/resolve-outdir.sh"
+FINDINGS="$OUTDIR/findings.json"
+[ -f "$FINDINGS" ] || echo '[]' > "$FINDINGS"
+REPORT="${AUDIT_REPORT_PATH:?AUDIT_REPORT_PATH required}"
+TARGET="${AUDIT_TARGET:-(unspecified)}"
+mkdir -p "$(dirname "$REPORT")"
+
+python3 - "$FINDINGS" "$REPORT" "$TARGET" <<'PY'
+import json, sys
+findings = json.load(open(sys.argv[1]))
+report, target = sys.argv[2], sys.argv[3]
+lines = ["# Audit report — `%s`" % target, ""]
+if not findings:
+    lines += ["**Result: clean.** No findings.", ""]
+else:
+    order = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+    findings.sort(key=lambda f: (order.get(f.get("severity", "LOW"), 3), f.get("angle", "")))
+    cur = None
+    for f in findings:
+        sev = f.get("severity", "LOW")
+        if sev != cur:
+            lines += ["", "## %s" % sev, ""]
+            cur = sev
+        loc = "%s:%s" % (f.get("file", "?"), f.get("line", "?"))
+        lines += [
+            "### %s — `%s` · `%s`" % (f.get("title", "(untitled)"), loc, f.get("angle", "?")),
+            f.get("description", ""),
+            "",
+            "**Fix:** %s" % f.get("fix", ""),
+            "",
+            "_Next: `/woostack-fix` for a small change, `/woostack-build` for a larger one._",
+            "",
+        ]
+open(report, "w").write("\n".join(lines) + "\n")
+print("audit: %d finding(s) -> %s" % (len(findings), report))
+PY

--- a/skills/woostack-audit/scripts/tests/test-render-report.sh
+++ b/skills/woostack-audit/scripts/tests/test-render-report.sh
@@ -24,4 +24,32 @@ echo '[]' > "$OUTDIR/findings.json"
 AUDIT_REPORT_PATH="$out" AUDIT_TARGET="src" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
 assert_eq "$ec" "0" "clean exits 0"
 assert_contains "$(cat "$out")" "clean" "clean report states clean"
+
+# All three severities -> every section renders, in HIGH > MEDIUM > LOW order (input is shuffled).
+cat > "$OUTDIR/findings.json" <<'JSON'
+[{"angle":"bugs","severity":"LOW","file":"src/c.ts","line":3,"title":"Lo","description":"d","fix":"f"},
+{"angle":"bugs","severity":"HIGH","file":"src/a.ts","line":1,"title":"Hi","description":"d","fix":"f"},
+{"angle":"bugs","severity":"MEDIUM","file":"src/b.ts","line":2,"title":"Mid","description":"d","fix":"f"}]
+JSON
+AUDIT_REPORT_PATH="$out" AUDIT_TARGET="src" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "0" "multi-severity exits 0"
+body="$(cat "$out")"
+assert_contains "$body" "## MEDIUM" "renders the MEDIUM section"
+assert_contains "$body" "## LOW" "renders the LOW section"
+hi="$(grep -n '^## HIGH' "$out" | head -1 | cut -d: -f1)"
+md="$(grep -n '^## MEDIUM' "$out" | head -1 | cut -d: -f1)"
+lo="$(grep -n '^## LOW' "$out" | head -1 | cut -d: -f1)"
+assert_eq "$([ "$hi" -lt "$md" ] && [ "$md" -lt "$lo" ] && echo y || echo n)" "y" "sections sorted HIGH<MEDIUM<LOW"
+
+# Explicit null optional fields are reachable (jq `has()` passes null through the merge schema
+# gate). The renderer must not crash on the null `description` join and must not emit literal
+# "None" for a null `fix`; a null `angle` falls back to "?".
+cat > "$OUTDIR/findings.json" <<'JSON'
+[{"angle":null,"severity":"MEDIUM","file":"src/x.ts","line":9,"title":"Null fields","description":null,"fix":null}]
+JSON
+AUDIT_REPORT_PATH="$out" AUDIT_TARGET="src" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "0" "null optional fields do not crash the renderer"
+body="$(cat "$out")"
+assert_contains "$body" "Null fields" "renders the finding title with null fields"
+assert_not_contains "$body" "**Fix:** None" "null fix is not rendered as the literal string None"
 finish

--- a/skills/woostack-audit/scripts/tests/test-render-report.sh
+++ b/skills/woostack-audit/scripts/tests/test-render-report.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/render-report.sh"
+
+export OUTDIR="$(mktemp -d)/out"; mkdir -p "$OUTDIR"
+cat > "$OUTDIR/findings.json" <<'JSON'
+[{"angle":"simplify","severity":"HIGH","file":"src/a.ts","line":1,"title":"Unused export `a`","description":"nothing references a","fix":"delete it"},
+{"angle":"production-readiness","severity":"LOW","file":"src/b.py","line":2,"title":"No timeout on fetch","description":"call can hang","fix":"add a deadline"}]
+JSON
+out="$(mktemp -d)/report.md"
+AUDIT_REPORT_PATH="$out" AUDIT_TARGET="src" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "0" "renderer exits 0"
+body="$(cat "$out")"
+assert_contains "$body" "## HIGH" "groups by severity"
+assert_contains "$body" "src/a.ts:1" "anchors finding"
+assert_contains "$body" "/woostack-fix" "suggests a next step"
+assert_not_contains "$body" "REQUEST_CHANGES" "no PR-event language (report-only)"
+
+# Zero findings -> clean report, exit 0.
+echo '[]' > "$OUTDIR/findings.json"
+AUDIT_REPORT_PATH="$out" AUDIT_TARGET="src" bash "$SCRIPT" >/dev/null 2>&1 && ec=0 || ec=$?
+assert_eq "$ec" "0" "clean exits 0"
+assert_contains "$(cat "$out")" "clean" "clean report states clean"
+finish


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
