### PR TITLE
docs: register woostack-audit across the command surface (19th skill)

### DIFF
--- a/.woostack/plans/2026-06-25-woostack-audit.md
+++ b/.woostack/plans/2026-06-25-woostack-audit.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-25-woostack-audit.md
-status: executing
+status: done
 branch: feature/woostack-audit
 ---
 
@@ -767,27 +767,27 @@ structural test (grep/`bash -n`/`jq`/`python3 -c`), never bare prose.
   `skills/woostack-bootstrap/references/development.md`
 - Modify: `site/content/docs/` authored pages naming the skill surface/count
 
-- [ ] **Step 1: Update AGENTS.md count + lists**
+- [x] **Step 1: Update AGENTS.md count + lists**
   Change the "eighteen skills" phrasing to "nineteen", add `woostack-audit` to the public
   command list, the Quick file map, and the Mode B command list.
 
-- [ ] **Step 2: Add the routing row + README/CONTRIBUTING/development entries**
+- [x] **Step 2: Add the routing row + README/CONTRIBUTING/development entries**
   Add a `woostack-audit` routing row to `skills/using-woostack/SKILL.md` and matching mentions in
   `README.md`, `CONTRIBUTING.md`, and `skills/woostack-bootstrap/references/development.md`.
 
-- [ ] **Step 3: Update authored docs-site pages + verify build**
+- [x] **Step 3: Update authored docs-site pages + verify build**
   Update any authored `site/content/docs/` page that states the skill surface or its count, then:
   Run: `pnpm -C site build`
   Expected: build succeeds.
 
-- [ ] **Step 4: Verify the count is consistent across the surface**
+- [x] **Step 4: Verify the count is consistent across the surface**
   Run:
   ```bash
   grep -rl 'woostack-audit' AGENTS.md README.md CONTRIBUTING.md skills/using-woostack/SKILL.md skills/woostack-bootstrap/references/development.md | wc -l
   ```
   Expected: `5` (every surface doc names the skill).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt create -m "docs: register woostack-audit across the command surface (19th skill)"
   ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This is a published collection of skills, not an application codebase. It packag
 decisions for building new web, mobile, and API projects so agents can install it with
 `pnpx skills add howarewoo/woostack`.
 
-The public command/adoption surface has eighteen skills:
+The public command/adoption surface has nineteen skills:
 
 - [`using-woostack`](skills/using-woostack/SKILL.md)
 - [`woostack-init`](skills/woostack-init/SKILL.md)
@@ -34,12 +34,13 @@ The public command/adoption surface has eighteen skills:
 - [`woostack-dream`](skills/woostack-dream/SKILL.md)
 - [`woostack-doctor`](skills/woostack-doctor/SKILL.md)
 - [`woostack-sweep`](skills/woostack-sweep/SKILL.md)
+- [`woostack-audit`](skills/woostack-audit/SKILL.md)
 
 The collection also installs two internal sub-skills:
 [`woostack-ideate`](skills/woostack-ideate/SKILL.md) and
 [`woostack-harden`](skills/woostack-harden/SKILL.md). `woostack-build` delegates its ideate
 phase to the former and its harden phase to the latter. Both are bundled building blocks, not
-`/woostack-*` commands: they have no routing row and are absent from the eighteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
+`/woostack-*` commands: they have no routing row and are absent from the nineteen-skill command surface above. Like [`action.yml`](action.yml), they are shipped assets — do not delete them as
 strays.
 
 There is no application source code, app lockfile, build, or CI for this repo's own
@@ -71,7 +72,7 @@ do not add application code, app build configs, or app lockfiles **outside the s
 **Mode B: run a woostack command.** Use this when the user asks for `/woostack-init`,
 `/woostack-bootstrap`, `/woostack-build`, `/woostack-fix`, `/woostack-plan`, `/woostack-execute`, `/woostack-execute-overnight`, `/woostack-commit`,
 `/woostack-review`, `/woostack-address-comments`, `/woostack-status`, `/woostack-visualize`, `/woostack-debug`, `/woostack-dream`,
-`/woostack-tdd`, `/woostack-doctor`, or `/woostack-sweep`, including intent-equivalent wording. Load the matching skill
+`/woostack-tdd`, `/woostack-doctor`, `/woostack-sweep`, or `/woostack-audit`, including intent-equivalent wording. Load the matching skill
 before acting. For bootstrap work, the output belongs in a fresh repo in a different
 directory, not in this repo.
 
@@ -100,7 +101,7 @@ directory, not in this repo.
   pages need no manual edit: they regenerate from each `SKILL.md` at build time (see the
   documentation-site exception above). When in doubt, run `pnpm -C site build` to confirm the
   site still builds.
-- Do not move or rename any of the twenty `SKILL.md` files (the eighteen public command/adoption
+- Do not move or rename any of the twenty-one `SKILL.md` files (the nineteen public command/adoption
   skills plus the internal `woostack-ideate` and `woostack-harden`).
 - Do not rename files under
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
@@ -126,6 +127,8 @@ directory, not in this repo.
   [`skills/woostack-execute-overnight/SKILL.md`](skills/woostack-execute-overnight/SKILL.md)
 - Stack review-sweep engine (public command + delegated-to by execute-overnight):
   [`skills/woostack-sweep/SKILL.md`](skills/woostack-sweep/SKILL.md)
+- Standing-code audit engine (public command; repoints the review swarm at an all-added diff of a
+  target, report-only): [`skills/woostack-audit/SKILL.md`](skills/woostack-audit/SKILL.md)
 - Ideate phase engine for the build loop (internal sub-skill):
   [`skills/woostack-ideate/SKILL.md`](skills/woostack-ideate/SKILL.md)
 - Harden phase engine for the build loop (internal sub-skill):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, `woostack-debug`, `woostack-tdd`, `woostack-dream`, `woostack-doctor`, and `woostack-sweep`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
+This repo is a **published collection of skills**, not a codebase. Contributions are edits to the skills — the Markdown under `skills/` plus the support files a skill ships (HTML templates, the review engine's shell scripts and prompts, JSON config). The public command/adoption surface is `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-plan`, `woostack-execute`, `woostack-execute-overnight`, `woostack-commit`, `woostack-review`, `woostack-address-comments`, `woostack-status`, `woostack-visualize`, `woostack-debug`, `woostack-tdd`, `woostack-dream`, `woostack-doctor`, `woostack-sweep`, and `woostack-audit`. The collection also ships `woostack-ideate` and `woostack-harden` as internal sub-skills used by `woostack-build`.
 
 See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short contributor's version.
 
@@ -28,6 +28,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | Change the stack review-sweep engine (`/woostack-sweep`) | `skills/woostack-sweep/SKILL.md` |
 | Change the commit / PR update workflow | `skills/woostack-commit/SKILL.md` |
 | Change the review engine | `skills/woostack-review/SKILL.md`, `skills/woostack-review/scripts/`, `skills/woostack-review/prompts/` |
+| Change the standing-code audit engine (`/woostack-audit`) | `skills/woostack-audit/SKILL.md`, `skills/woostack-audit/scripts/` |
 | Change the systematic-debugging behavior (`/woostack-debug`) | `skills/woostack-debug/SKILL.md` |
 | Change the test-adder / TDD doctrine home (`/woostack-tdd`) | `skills/woostack-tdd/SKILL.md` |
 | Change the memory/docs curation engine (`/woostack-dream`) | `skills/woostack-dream/SKILL.md` |

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ After writing code, use the verification and iteration loop:
   Fans out sub-agents in parallel to check distinct angles (bugs, security, observability, database, etc.), then runs an adversarial **Skeptical Validator** (prosecutor and defender checks) to eliminate false positives before posting reviews.
 - **Addressing Reviews** → [/woostack-address-comments](skills/woostack-address-comments/SKILL.md)
   Iteratively guides you through resolving, clarifying, or pushing back on PR review comments, applying changes, and pushing commits.
+- **Auditing Standing Code** → [/woostack-audit](skills/woostack-audit/SKILL.md)
+  Audits an explicit target (a file, directory, or whole repo at rest — not a diff) for code simplification and production readiness, repointing the review swarm at an all-added diff and writing a report-only findings doc under `.woostack/audits/`. Never gates, posts, or merges.
 
 ---
 

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -189,5 +189,6 @@ worktrees are cut from.
   <Card title="woostack-review" href="/docs/skills/woostack-review" description="The review engine that reads every review.* key." />
   <Card title="woostack-init" href="/docs/skills/woostack-init" description="Creates .woostack/config.json and the workspace." />
   <Card title="woostack-doctor" href="/docs/skills/woostack-doctor" description="Checks workspace and config health." />
+  <Card title="woostack-audit" href="/docs/skills/woostack-audit" description="Audits standing code for simplification + production readiness (report-only)." />
   <Card title="All skills" href="/docs/skills/using-woostack" description="Per-skill reference, generated from each SKILL.md." />
 </Cards>

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -82,6 +82,7 @@ link it, never restate it.
 | `/woostack-sweep [PR#] [--base R] [--interactive]`, drive a stack of PRs to a clean review | `woostack-sweep` |
 | `/woostack-commit`, commit session-relevant changes and update PR fields | `woostack-commit` |
 | `/woostack-review [PR#]`, review a PR or local diff | `woostack-review` |
+| `/woostack-audit <target> [--all] [--simplify\|--prod-only]`, audit standing code (a file/dir/repo at rest) for simplification + production-readiness, report-only | `woostack-audit` |
 | `/woostack-address-comments [PR#]`, address unresolved review threads | `woostack-address-comments` |
 | `/woostack-status [--all] [--fetch]`, show the derived feature board (what's in flight, what to do next) | `woostack-status` |
 | `/woostack-visualize <source> [for <audience>]`, render a source as audience-tailored HTML | `woostack-visualize` |

--- a/skills/woostack-bootstrap/references/development.md
+++ b/skills/woostack-bootstrap/references/development.md
@@ -12,6 +12,7 @@ for each phase:
 | Build a feature, idea → implementation (gated chain — the skill owns the steps) | `woostack-build` |
 | Fix a small issue, diagnosis → implementation (gated fix loop) | `woostack-fix` |
 | Review | `woostack-review` |
+| Audit standing code (simplify + production-readiness) | `woostack-audit` |
 | Address review feedback | `woostack-address-comments` |
 
 Each command is discrete and ends by offering the next step. Merge stays with the human.


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
