### PR TITLE
feat(review): root models config field + per-tier effort (clean break)

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -1,11 +1,14 @@
 {
-	"review": {
-		"metrics": true,
-		"models": {
-			"openai": {
-				"standard": "gpt-5.4-mini"
+	"models": {
+		"openai": {
+			"standard": {
+				"model": "gpt-5.4-mini",
+				"effort": "xhigh"
 			}
 		}
+	},
+	"review": {
+		"metrics": true
 	},
 	"status": {
 		"staleDays": 14

--- a/.woostack/plans/2026-06-26-models-root-effort.md
+++ b/.woostack/plans/2026-06-26-models-root-effort.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-26-models-root-effort.md
-status: ready
+status: executing
 branch: feature/models-root-effort
 ---
 
@@ -41,7 +41,7 @@ harness. No new dependencies.
   the loader so no intermediate commit leaves this repo's config invalid under the clean break)
 - Test: `skills/woostack-review/scripts/tests/test-load-config-models-root.sh` (new)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   cat > skills/woostack-review/scripts/tests/test-load-config-models-root.sh <<'EOF'
   #!/usr/bin/env bash
@@ -119,13 +119,13 @@ harness. No new dependencies.
   chmod +x skills/woostack-review/scripts/tests/test-load-config-models-root.sh
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-review/scripts/tests/test-load-config-models-root.sh`
   Expected: FAIL — case 3 fails (`review.models` is currently accepted, loader exits 0), and the
   object-leaf cases fail (current loader requires string leaves: `models.openai.standard must be a
   non-empty string`).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   Edit `skills/woostack-review/scripts/load-config.sh`.
 
   (a) Key sets — remove `"models"` from `REVIEW_KEYS`, add `EFFORT_LEVELS` (lines 96-103):
@@ -241,15 +241,15 @@ harness. No new dependencies.
       out["models"] = cleaned_models
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run: `bash skills/woostack-review/scripts/tests/test-load-config-models-root.sh`
   Expected: PASS
 
-- [ ] **Step 5: Confirm the existing loader test still passes (no regression on the review path)**
+- [x] **Step 5: Confirm the existing loader test still passes (no regression on the review path)**
   Run: `bash skills/woostack-review/scripts/tests/test-load-config-root.sh`
   Expected: PASS (the `{"review":{"severity_floor":"low"}}` path is untouched)
 
-- [ ] **Step 6: Migrate this repo's dogfood config in the same change**
+- [x] **Step 6: Migrate this repo's dogfood config in the same change**
   The clean break now rejects this repo's own pre-migration `.woostack/config.json` (it still has
   `review.models`). Confirm the rejection, then migrate. First confirm the failure:
   ```bash
@@ -261,14 +261,14 @@ harness. No new dependencies.
   {"models":{"openai":{"standard":{"model":"gpt-5.4-mini","effort":"xhigh"}}},"review":{"metrics":true},"status":{"staleDays":14}}
   ```
 
-- [ ] **Step 7: Confirm the migrated repo config parses**
+- [x] **Step 7: Confirm the migrated repo config parses**
   ```bash
   OUT="$(mktemp -d)"; OUTDIR="$OUT" bash skills/woostack-review/scripts/load-config.sh && \
     jq -c '.models.openai.standard' "$OUT/config.json"
   ```
   Expected: PASS — exit 0, prints `{"effort":"xhigh","model":"gpt-5.4-mini"}`.
 
-- [ ] **Step 8: Commit (loader + dogfood config together)**
+- [x] **Step 8: Commit (loader + dogfood config together)**
   ```bash
   gt create -m "feat(review): root models config field + per-tier effort (clean break)"
   ```
@@ -279,7 +279,7 @@ harness. No new dependencies.
 - Modify: `skills/woostack-review/scripts/resolve-model.sh:67,72`
 - Test: `skills/woostack-review/scripts/tests/test-resolve-model.sh` (extend)
 
-- [ ] **Step 1: Write the failing test** — append object-leaf cases before `finish` (line 103):
+- [x] **Step 1: Write the failing test** — append object-leaf cases before `finish` (line 103):
   ```bash
   # --- object leaf {model,effort}: resolver returns .model ---
   outdir="$(mktemp -d)"
@@ -296,12 +296,12 @@ harness. No new dependencies.
   rm -rf "$outdir"
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-review/scripts/tests/test-resolve-model.sh`
   Expected: FAIL — object leaf returns the JSON object string (e.g. `{"effort":"low","model":...}`),
   not `obj-standard-x`.
 
-- [ ] **Step 3: Minimal implementation** — make both jq lookups object-safe.
+- [x] **Step 3: Minimal implementation** — make both jq lookups object-safe.
   `resolve-model.sh:67`:
   ```bash
       override="$(jq -r --arg p "$provider" --arg t "$tier" '(.models[$p][$t] | if type=="object" then .model else . end) // empty' "$config" 2>/dev/null || true)"
@@ -311,11 +311,11 @@ harness. No new dependencies.
       override="$(jq -r --arg t "$tier" '(.models[$t] | if type=="object" then .model else . end) // empty' "$config" 2>/dev/null || true)"
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run: `bash skills/woostack-review/scripts/tests/test-resolve-model.sh`
   Expected: PASS (string-leaf cases unchanged: `else .` returns the bare slug)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "feat(review): resolve-model reads object {model} tier leaves"
   ```
@@ -326,7 +326,7 @@ harness. No new dependencies.
 - Modify: `skills/woostack-review/scripts/verify-receipts.sh:67,72`
 - Test: `skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh` (extend)
 
-- [ ] **Step 1: Write the failing test** — insert an object-leaf case after line 33 (before the
+- [x] **Step 1: Write the failing test** — insert an object-leaf case after line 33 (before the
   `unset WOO_REVIEW_PROVIDER` at line 35, while provider is still openai):
   ```bash
   printf '{"models":{"openai":{"standard":{"model":"gpt-obj-standard","effort":"low"}}}}\n' > "$OUTDIR/config.json"
@@ -335,12 +335,12 @@ harness. No new dependencies.
   assert_exit 0 "$rc" "OpenAI object-leaf {model,effort} config override resolves to .model"
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh`
   Expected: FAIL — expected model resolves to the object JSON string, so the matching receipt is
   judged a mismatch and the script exits 1.
 
-- [ ] **Step 3: Minimal implementation** — make both jq lookups object-safe.
+- [x] **Step 3: Minimal implementation** — make both jq lookups object-safe.
   `verify-receipts.sh:67`:
   ```bash
       override="$(jq -r --arg p "$provider" --arg t "$tier" '(.models[$p][$t] | if type=="object" then .model else . end) // empty' "$config" 2>/dev/null || true)"
@@ -350,11 +350,11 @@ harness. No new dependencies.
       override="$(jq -r --arg t "$tier" '(.models[$t] | if type=="object" then .model else . end) // empty' "$config" 2>/dev/null || true)"
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run: `bash skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh`
   Expected: PASS (string-leaf override cases at lines 25/30 unchanged)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "feat(review): verify-receipts reads object {model} tier leaves"
   ```
@@ -366,7 +366,7 @@ harness. No new dependencies.
   openai effort block at lines 115-120)
 - Test: `skills/woostack-review/scripts/tests/test-load-prompt-models.sh` (extend)
 
-- [ ] **Step 1: Write the failing test** — append before `finish` (line 155):
+- [x] **Step 1: Write the failing test** — append before `finish` (line 155):
   ```bash
   # Config object-leaf effort wins over the model/tier default.
   outdir="$(mktemp -d)"; github_output="$outdir/github_output"; touch "$github_output"
@@ -395,12 +395,12 @@ harness. No new dependencies.
   rm -rf "$outdir"
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-review/scripts/tests/test-load-prompt-models.sh`
   Expected: FAIL — the first new case expects `run_effort=low` but, with `model=gpt-5.4-mini`,
   the current code derives `xhigh` from the model default (config `.effort` is never read).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   Add the helper after the `resolve-model.sh` source (after line 65), e.g. just below it:
   ```bash
   # config_effort_for <provider> <tier> → per-tier effort from $CONFIG_PATH, else empty.
@@ -431,12 +431,12 @@ harness. No new dependencies.
   existing `minimal|low|medium|high|xhigh` validation at lines 121-127 still runs, so a config
   effort is re-validated host-side too.)
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run: `bash skills/woostack-review/scripts/tests/test-load-prompt-models.sh`
   Expected: PASS (existing string-leaf case at line 135 still yields `medium` — string leaf has no
   `.effort`, so it falls through to the gpt-5.5 model default)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "feat(review): load-prompt resolves OpenAI effort config-first"
   ```

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -9,11 +9,12 @@ key is absent, the skill that reads it falls back to a built-in default. The ini
 only two top-level namespaces (an empty `review` and a `status` block), and
 [woostack-doctor](/docs/skills/woostack-doctor) checks that those two are present.
 
-There are five top-level namespaces:
+There are six top-level namespaces:
 
 | Namespace | Read by | Tunes |
 | --- | --- | --- |
-| `review` | [woostack-review](/docs/skills/woostack-review) | the PR review engine: angles, noise, models, validation |
+| `review` | [woostack-review](/docs/skills/woostack-review) | the PR review engine: angles, noise, validation |
+| `models` | [woostack-review](/docs/skills/woostack-review) | model selection and tier parameters (e.g. reasoning effort) |
 | `review_sweep` | [woostack-sweep](/docs/skills/woostack-sweep) | how many review rounds a stack sweep runs |
 | `commit` | [woostack-commit](/docs/skills/woostack-commit) | a pre-commit hook command |
 | `status` | [woostack-status](/docs/skills/woostack-status) | when the board flags a spec as stale |
@@ -36,14 +37,16 @@ the sections below.
     "ignore": ["**/*.generated.ts", "pnpm-lock.yaml"],
     "project_rules": ["docs/engineering/rules.md"],
     "authors_skip": ["dependabot[bot]", "renovate[bot]"],
-    "models": {
-      "anthropic": { "deep": "claude-opus-4-8" }
-    },
     "force_tier": "",
     "chunking": { "max_loc": 4000 },
     "disable_adversarial": false,
     "defer_markers": true,
     "metrics": false
+  },
+  "models": {
+    "openai": {
+      "standard": { "model": "gpt-5.4-mini", "effort": "xhigh" }
+    }
   },
   "review_sweep": { "max_rounds": 3 },
   "commit": { "pre_commit": "pnpm format && pnpm test" },
@@ -105,14 +108,15 @@ to opt out: an empty array for `authors_skip`, or an empty string for the patter
 
 Each review subagent runs at a tier (`fast`, `standard`, or `deep`), and each tier maps to a
 concrete model per provider. Override a single tier for one provider with
-`review.models.<provider>.<tier>`, or set a provider-agnostic fallback with the flat
-`review.models.<tier>`. `review.force_tier` pins every subagent to one tier, the config-file
-equivalent of running the review with `--fast` or `--deep`.
+`models.<provider>.<tier>`, or set a provider-agnostic fallback with the flat
+`models.<tier>`. A model leaf can be a string (the model slug) or an object specifying `{ model, effort }`.
+Note that `review.models` is deprecated and causes a hard validation error. `review.force_tier`
+pins every subagent to one tier, the config-file equivalent of running the review with `--fast` or `--deep`.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `review.models.<tier>` | string | provider table | Provider-agnostic model slug for `fast` / `standard` / `deep`. |
-| `review.models.<provider>.<tier>` | string | provider table | Per-provider override; provider is `anthropic`, `openai`, `google`, or `openrouter`. |
+| `models.<tier>` | string \| object | provider table | Provider-agnostic model fallback for `fast` / `standard` / `deep`. Object format supports `{ model, effort }`. |
+| `models.<provider>.<tier>` | string \| object | provider table | Per-provider override; provider is `anthropic`, `openai`, `google`, or `openrouter`. Object format supports `{ model, effort }`. |
 | `review.force_tier` | string | absent (= standard) | Pin every subagent to `fast` or `deep`. Empty string = absent. |
 
 The default model per provider and tier:
@@ -126,7 +130,7 @@ The default model per provider and tier:
 
 The tier resolves by precedence, highest to lowest: an inline `--fast` / `--deep` comment on the
 PR → the action's `force_tier` input → `review.force_tier` → the action's `model` input →
-`review.models.<provider>.<tier>` → the flat `review.models.<tier>` → the provider table default.
+`models.<provider>.<tier>` → the flat `models.<tier>` → the provider table default.
 
 ### Chunking, validation, and metrics
 

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -109,7 +109,8 @@ to opt out: an empty array for `authors_skip`, or an empty string for the patter
 Each review subagent runs at a tier (`fast`, `standard`, or `deep`), and each tier maps to a
 concrete model per provider. Override a single tier for one provider with
 `models.<provider>.<tier>`, or set a provider-agnostic fallback with the flat
-`models.<tier>`. A model leaf can be a string (the model slug) or an object specifying `{ model, effort }`.
+`models.<tier>`. A model leaf can be a string (the model slug) or an object specifying `{ model, effort }`,
+where `effort` is one of `minimal`, `low`, `medium`, `high`, or `xhigh`.
 Note that `review.models` is deprecated and causes a hard validation error. `review.force_tier`
 pins every subagent to one tier, the config-file equivalent of running the review with `--fast` or `--deep`.
 

--- a/skills/woostack-review/scripts/load-config.sh
+++ b/skills/woostack-review/scripts/load-config.sh
@@ -6,9 +6,11 @@
 #
 # Config nesting: review settings live under a top-level `review` object so the
 # file can hold sibling namespaces for other woostack tools (build, bootstrap)
-# without collision. Sibling top-level keys are ignored by this loader. The
-# emitted canonical JSON is still FLAT (review keys hoisted to top level) so
-# downstream stages read `.severity_floor`, `.angles`, etc. unchanged.
+# without collision. Most sibling top-level keys are ignored by this loader; the
+# exception is the root `models` field (model tiers, parsed below — relocated out
+# of `review.models`, which is now a hard error). The emitted canonical JSON is
+# still FLAT (review keys hoisted to top level) so downstream stages read
+# `.severity_floor`, `.angles`, `.models`, etc. unchanged.
 #
 #   { "review": { "severity_floor": "medium", "angles": { "skip": ["seo"] } } }
 #
@@ -18,6 +20,15 @@
 #
 # Noise control: severity_floor defaults to "high" so only high-priority
 # findings surface unless the consumer widens it (low | medium) in config.json.
+#
+# Root-level schema (parsed independently of `review`; all keys optional):
+#   models.<tier>            str | {model: str, effort?: str}  (host-agnostic
+#                            fallback; tier is fast | standard | deep)
+#   models.<provider>.<tier> str | {model: str, effort?: str}  (provider is one
+#                            of anthropic/openai/google/openrouter)
+#                            effort in minimal|low|medium|high|xhigh (empty = unset);
+#                            the loader normalizes every leaf to {model,[effort]}.
+#                            A nested `review.models` is a hard error (relocated).
 #
 # Schema under `review` (all keys optional):
 #   angles.force        list[str] subset of angle enum
@@ -36,12 +47,6 @@
 #                                  `^(staging|release|chore\(release\))`
 #                                  applied at use-site. Empty string opts
 #                                  out entirely.)
-#   models.fast         str (provider-agnostic fallback)
-#   models.standard     str (provider-agnostic fallback)
-#   models.deep         str (provider-agnostic fallback)
-#   models.<provider>.<tier>
-#                       str (provider-specific override; provider is one of
-#                            anthropic/openai/google/openrouter)
 #   force_tier          str (provider-agnostic "fast" | "deep" override for this
 #                            run; empty/absent means standard-tier model)
 #   fix_commands        list[str]  (consumed by issue #15 --loop mode)

--- a/skills/woostack-review/scripts/load-config.sh
+++ b/skills/woostack-review/scripts/load-config.sh
@@ -95,12 +95,13 @@ FORCE_TIERS = {"fast", "deep"}
 # Keys recognized inside the `review` block (and the legacy top-level form).
 REVIEW_KEYS = {
     "angles", "severity_floor", "ignore", "project_rules",
-    "authors_skip", "release_rollup_pattern", "models", "fix_commands",
+    "authors_skip", "release_rollup_pattern", "fix_commands",
     "disable_adversarial", "metrics", "chunking", "force_tier", "nits",
     "defer_markers",
 }
 MODEL_TIERS = {"fast", "standard", "deep"}
 MODEL_PROVIDERS = {"anthropic", "openai", "google", "openrouter"}
+EFFORT_LEVELS = {"minimal", "low", "medium", "high", "xhigh"}
 
 
 def loud(msg, line=None, col=None):
@@ -140,21 +141,31 @@ except json.JSONDecodeError as exc:
 if not isinstance(raw, dict):
     loud("top-level JSON must be an object, got {}".format(type(raw).__name__))
 
+# Capture the true top-level object before the review-block reassignment below.
+# Root-level `models` is read from `top`, independent of the `review` block, so a
+# root `models` sibling next to a `review` block is parsed (not silently ignored).
+top = raw
+
 # Resolve the review config block. Canonical form nests it under `review`;
-# sibling top-level namespaces (e.g. build/bootstrap config) are left alone.
-# Legacy form puts review keys at the top level — accepted with a deprecation
-# notice during the transition.
+# sibling top-level namespaces (e.g. build/bootstrap config, and `models`) are
+# left alone. Legacy form puts review keys at the top level — accepted with a
+# deprecation notice during the transition.
 if "review" in raw:
     rc = raw["review"]
     if not isinstance(rc, dict):
         loud("`review` must be an object, got {}".format(type(rc).__name__))
+    if "models" in rc:
+        loud("`review.models` has moved to a top-level `models` field; "
+             "move it out of `review`, e.g. "
+             "{\"models\": {\"openai\": {\"standard\": "
+             "{\"model\": \"gpt-5.4-mini\", \"effort\": \"xhigh\"}}}}")
     unknown = sorted(set(rc.keys()) - REVIEW_KEYS)
     if unknown:
         loud("unknown `review` key(s): {}".format(", ".join(unknown)))
 else:
     rc = raw
     legacy_review = sorted(set(rc.keys()) & REVIEW_KEYS)
-    unknown = sorted(set(rc.keys()) - REVIEW_KEYS)
+    unknown = sorted(set(rc.keys()) - REVIEW_KEYS - {"models"})
     if unknown:
         loud("unknown top-level key(s): {} (review settings now nest under `review`)".format(", ".join(unknown)))
     if legacy_review:
@@ -261,8 +272,36 @@ if "chunking" in raw:
             loud("`chunking.max_loc` must be >= 0 (got {})".format(v))
         out["chunking"] = {"max_loc": v}
 
-if "models" in raw:
-    models = raw["models"]
+def parse_model_leaf(label, val):
+    # A tier leaf is a model-slug string OR an object {model, effort?}; normalize
+    # both to {model, [effort]}. Empty effort string = unset (mirrors force_tier).
+    if isinstance(val, str):
+        if not val.strip():
+            loud("{} must be a non-empty string".format(label))
+        return {"model": val.strip()}
+    if isinstance(val, dict):
+        bad_leaf = sorted(set(val.keys()) - {"model", "effort"})
+        if bad_leaf:
+            loud("{} has unknown key(s): {} (valid: model, effort)".format(label, ", ".join(bad_leaf)))
+        model = val.get("model")
+        if not isinstance(model, str) or not model.strip():
+            loud("{}.model must be a non-empty string".format(label))
+        leaf = {"model": model.strip()}
+        if "effort" in val:
+            eff = val["effort"]
+            if not isinstance(eff, str):
+                loud("{}.effort must be a string".format(label))
+            eff_lc = eff.strip().lower()
+            if eff_lc:
+                if eff_lc not in EFFORT_LEVELS:
+                    loud("{}.effort must be one of: {} (got '{}')".format(
+                        label, ", ".join(sorted(EFFORT_LEVELS)), eff))
+                leaf["effort"] = eff_lc
+        return leaf
+    loud("{} must be a string or an object with a `model` key".format(label))
+
+if "models" in top:
+    models = top["models"]
     if not isinstance(models, dict):
         loud("`models` must be an object with fast/standard/deep keys and/or provider objects")
     valid_model_keys = MODEL_TIERS | MODEL_PROVIDERS
@@ -277,9 +316,7 @@ if "models" in raw:
     cleaned_models = {}
     for key, val in models.items():
         if key in MODEL_TIERS:
-            if not isinstance(val, str) or not val.strip():
-                loud("models.{} must be a non-empty string".format(key))
-            cleaned_models[key] = val.strip()
+            cleaned_models[key] = parse_model_leaf("models.{}".format(key), val)
             continue
 
         if not isinstance(val, dict):
@@ -292,10 +329,8 @@ if "models" in raw:
                 ", ".join(sorted(MODEL_TIERS)),
             ))
         cleaned_provider = {}
-        for tier, slug in val.items():
-            if not isinstance(slug, str) or not slug.strip():
-                loud("models.{}.{} must be a non-empty string".format(key, tier))
-            cleaned_provider[tier] = slug.strip()
+        for tier, leaf in val.items():
+            cleaned_provider[tier] = parse_model_leaf("models.{}.{}".format(key, tier), leaf)
         cleaned_models[key] = cleaned_provider
 
     out["models"] = cleaned_models

--- a/skills/woostack-review/scripts/load-prompt.sh
+++ b/skills/woostack-review/scripts/load-prompt.sh
@@ -64,6 +64,18 @@ safe_comment_body=$(sanitize_untrusted "${COMMENT_BODY:-}" 2000)
 # shellcheck source=skills/woostack-review/scripts/resolve-model.sh
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/resolve-model.sh"
 
+# config_effort_for <provider> <tier> → per-tier effort from $CONFIG_PATH, else empty.
+# The loader normalizes every tier leaf to an object {model,[effort]}; read .effort
+# provider-scoped first, then flat. Empty when unset → caller falls back to defaults.
+config_effort_for() {
+  local provider="$1" tier="$2" eff=""
+  if [ -n "${CONFIG_PATH:-}" ] && [ -f "$CONFIG_PATH" ]; then
+    eff="$(jq -r --arg p "$provider" --arg t "$tier" \
+      '(.models[$p][$t].effort? // .models[$t].effort?) // empty' "$CONFIG_PATH" 2>/dev/null || true)"
+  fi
+  printf '%s' "$eff"
+}
+
 default_openai_effort_for() {
   local tier="$1"
   case "$tier" in
@@ -112,6 +124,9 @@ fi
 RUN_EFFORT=""
 if [ "$PROVIDER" = "openai" ]; then
   RUN_EFFORT="$(printf '%s' "$INPUT_OPENAI_EFFORT" | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$RUN_EFFORT" ]; then
+    RUN_EFFORT="$(config_effort_for "$PROVIDER" "$RUN_TIER")"
+  fi
   if [ -z "$RUN_EFFORT" ]; then
     RUN_EFFORT="$(default_openai_effort_for_model "$RUN_MODEL")"
     if [ -z "$RUN_EFFORT" ]; then

--- a/skills/woostack-review/scripts/load-prompt.sh
+++ b/skills/woostack-review/scripts/load-prompt.sh
@@ -136,7 +136,7 @@ if [ "$PROVIDER" = "openai" ]; then
   case "$RUN_EFFORT" in
     minimal|low|medium|high|xhigh) ;;
     *)
-      echo "::error::INPUT_OPENAI_EFFORT must be one of: minimal, low, medium, high, xhigh (got '$RUN_EFFORT')"
+      echo "::error::run_effort must be one of: minimal, low, medium, high, xhigh (got '$RUN_EFFORT'; from openai_effort input, models.*.effort config, or tier default)"
       exit 1
       ;;
   esac

--- a/skills/woostack-review/scripts/resolve-model.sh
+++ b/skills/woostack-review/scripts/resolve-model.sh
@@ -64,12 +64,12 @@ provider_tier_model() {
   local config="${CONFIG_PATH:-${OUTDIR:-}/config.json}"
   local override
   if [ -n "$config" ] && [ -f "$config" ]; then
-    override="$(jq -r --arg p "$provider" --arg t "$tier" '.models[$p][$t] // empty' "$config" 2>/dev/null || true)"
+    override="$(jq -r --arg p "$provider" --arg t "$tier" '(.models[$p][$t] | if type=="object" then .model else . end) // empty' "$config" 2>/dev/null || true)"
     if [ -n "$override" ] && [ "$override" != "null" ]; then
       echo "$override"
       return 0
     fi
-    override="$(jq -r --arg t "$tier" '.models[$t] // empty' "$config" 2>/dev/null || true)"
+    override="$(jq -r --arg t "$tier" '(.models[$t] | if type=="object" then .model else . end) // empty' "$config" 2>/dev/null || true)"
     if [ -n "$override" ] && [ "$override" != "null" ]; then
       echo "$override"
       return 0

--- a/skills/woostack-review/scripts/tests/test-load-config-models-root.sh
+++ b/skills/woostack-review/scripts/tests/test-load-config-models-root.sh
@@ -7,14 +7,25 @@ ROOT="$(cd "$DIR/../../.." && pwd)"
 source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
 SCRIPT="$DIR/load-config.sh"
 
+CLEANUP_DIRS=()
+cleanup() {
+  for d in "${CLEANUP_DIRS[@]+"${CLEANUP_DIRS[@]}"}"; do
+    rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
 # run_loader <config-json> : sets OUT (flat config dir), ERRLOG, RC.
 run_loader() {
   local cfg="$1"
-  REPO="$(mktemp -d)"; ( cd "$REPO" && git init -q )
+  REPO="$(mktemp -d)"; CLEANUP_DIRS+=("$REPO")
+  ( cd "$REPO" && git init -q )
   local top; top="$(cd "$REPO" && git rev-parse --show-toplevel)"
   mkdir -p "$top/.woostack"
   printf '%s\n' "$cfg" > "$top/.woostack/config.json"
-  OUT="$(mktemp -d)/out"; mkdir -p "$OUT"; ERRLOG="$OUT/err"
+  local out_parent; out_parent="$(mktemp -d)"
+  CLEANUP_DIRS+=("$out_parent")
+  OUT="$out_parent/out"; mkdir -p "$OUT"; ERRLOG="$OUT/err"
   ( cd "$top" && env -u GITHUB_WORKSPACE OUTDIR="$OUT" bash "$SCRIPT" ) \
     >"$OUT/out.log" 2>"$ERRLOG" && RC=0 || RC=$?
 }

--- a/skills/woostack-review/scripts/tests/test-load-config-models-root.sh
+++ b/skills/woostack-review/scripts/tests/test-load-config-models-root.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Root `models` field: relocation (clean break from review.models), string|object
+# leaf normalization, effort enum, empty-effort-unset, host-agnostic flat leaves.
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/load-config.sh"
+
+# run_loader <config-json> : sets OUT (flat config dir), ERRLOG, RC.
+run_loader() {
+  local cfg="$1"
+  REPO="$(mktemp -d)"; ( cd "$REPO" && git init -q )
+  local top; top="$(cd "$REPO" && git rev-parse --show-toplevel)"
+  mkdir -p "$top/.woostack"
+  printf '%s\n' "$cfg" > "$top/.woostack/config.json"
+  OUT="$(mktemp -d)/out"; mkdir -p "$OUT"; ERRLOG="$OUT/err"
+  ( cd "$top" && env -u GITHUB_WORKSPACE OUTDIR="$OUT" bash "$SCRIPT" ) \
+    >"$OUT/out.log" 2>"$ERRLOG" && RC=0 || RC=$?
+}
+
+# 1. object leaf normalized + preserved
+run_loader '{"models":{"openai":{"standard":{"model":"gpt-5.4-mini","effort":"low"}}}}'
+assert_exit 0 "$RC" "root models object leaf accepted"
+assert_eq "$(jq -c '.models.openai.standard' "$OUT/config.json")" \
+  '{"effort":"low","model":"gpt-5.4-mini"}' "object leaf preserved (sorted keys)"
+
+# 2. string leaf normalized to object
+run_loader '{"models":{"openai":{"standard":"gpt-5.4-mini"}}}'
+assert_eq "$(jq -c '.models.openai.standard' "$OUT/config.json")" \
+  '{"model":"gpt-5.4-mini"}' "string leaf normalized to {model}"
+
+# 3. review.models rejected (clean break, tailored message)
+run_loader '{"review":{"models":{"openai":{"standard":"x"}}}}'
+assert_exit 1 "$RC" "review.models rejected"
+assert_contains "$(cat "$ERRLOG")" "has moved to a top-level" "tailored relocation message"
+
+# 4. object leaf missing model
+run_loader '{"models":{"openai":{"standard":{"effort":"low"}}}}'
+assert_exit 1 "$RC" "object leaf without model rejected"
+assert_contains "$(cat "$ERRLOG")" "model must be a non-empty string" "names missing model"
+
+# 5. unknown leaf key
+run_loader '{"models":{"openai":{"standard":{"model":"x","bogus":1}}}}'
+assert_exit 1 "$RC" "unknown leaf key rejected"
+assert_contains "$(cat "$ERRLOG")" "unknown key(s): bogus" "names unknown leaf key"
+
+# 6. invalid effort
+run_loader '{"models":{"openai":{"standard":{"model":"x","effort":"turbo"}}}}'
+assert_exit 1 "$RC" "invalid effort rejected"
+assert_contains "$(cat "$ERRLOG")" "effort must be one of" "names effort enum"
+
+# 7. empty effort = unset (no error, no effort key emitted)
+run_loader '{"models":{"openai":{"standard":{"model":"x","effort":""}}}}'
+assert_exit 0 "$RC" "empty effort accepted as unset"
+assert_eq "$(jq -c '.models.openai.standard' "$OUT/config.json")" '{"model":"x"}' \
+  "empty effort dropped from normalized leaf"
+
+# 8. host-agnostic flat tier leaf normalized
+run_loader '{"models":{"standard":"flat-x"}}'
+assert_eq "$(jq -c '.models.standard' "$OUT/config.json")" '{"model":"flat-x"}' \
+  "flat tier leaf normalized to {model}"
+
+# 9. root models alongside a (models-free) review block: both parsed
+run_loader '{"review":{"metrics":true},"models":{"openai":{"standard":"x"}}}'
+assert_exit 0 "$RC" "root models next to review block accepted"
+assert_eq "$(jq -r '.metrics' "$OUT/config.json")" "true" "review.metrics still parsed"
+assert_eq "$(jq -c '.models.openai.standard' "$OUT/config.json")" '{"model":"x"}' \
+  "sibling root models parsed (not silently ignored)"
+
+finish

--- a/skills/woostack-review/scripts/tests/test-load-prompt-models.sh
+++ b/skills/woostack-review/scripts/tests/test-load-prompt-models.sh
@@ -148,7 +148,7 @@ touch "$github_output"
 
 run_load_prompt_expect_failure "$outdir" "$github_output" INPUT_OPENAI_EFFORT="bogus"
 
-assert_contains "$(cat "$outdir/stdout" "$outdir/stderr")" "INPUT_OPENAI_EFFORT must be one of" "Invalid effort emits validation error"
+assert_contains "$(cat "$outdir/stdout" "$outdir/stderr")" "run_effort must be one of" "Invalid effort emits validation error"
 assert_eq "$(grep -c '^run_effort=bogus$' "$github_output" || true)" "0" "Invalid effort is not emitted"
 rm -rf "$outdir"
 

--- a/skills/woostack-review/scripts/tests/test-load-prompt-models.sh
+++ b/skills/woostack-review/scripts/tests/test-load-prompt-models.sh
@@ -152,4 +152,30 @@ assert_contains "$(cat "$outdir/stdout" "$outdir/stderr")" "INPUT_OPENAI_EFFORT 
 assert_eq "$(grep -c '^run_effort=bogus$' "$github_output" || true)" "0" "Invalid effort is not emitted"
 rm -rf "$outdir"
 
+# Config object-leaf effort wins over the model/tier default.
+outdir="$(mktemp -d)"; github_output="$outdir/github_output"; touch "$github_output"
+printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.4-mini","effort":"low"}}}}' > "$outdir/config.json"
+run_load_prompt "$outdir" "$github_output"
+run_model="$(grep '^run_model=' "$github_output" | cut -d= -f2 || echo "")"
+run_effort="$(grep '^run_effort=' "$github_output" | cut -d= -f2 || echo "")"
+assert_eq "$run_model" "gpt-5.4-mini" "config object leaf model resolves"
+assert_eq "$run_effort" "low" "config .effort wins over tier/model default"
+rm -rf "$outdir"
+
+# INPUT_OPENAI_EFFORT still beats config .effort.
+outdir="$(mktemp -d)"; github_output="$outdir/github_output"; touch "$github_output"
+printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.4-mini","effort":"low"}}}}' > "$outdir/config.json"
+run_load_prompt "$outdir" "$github_output" INPUT_OPENAI_EFFORT="high"
+run_effort="$(grep '^run_effort=' "$github_output" | cut -d= -f2 || echo "")"
+assert_eq "$run_effort" "high" "explicit INPUT_OPENAI_EFFORT beats config .effort"
+rm -rf "$outdir"
+
+# Object leaf without effort falls through to the model default (xhigh for gpt-5.4-mini).
+outdir="$(mktemp -d)"; github_output="$outdir/github_output"; touch "$github_output"
+printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.4-mini"}}}}' > "$outdir/config.json"
+run_load_prompt "$outdir" "$github_output"
+run_effort="$(grep '^run_effort=' "$github_output" | cut -d= -f2 || echo "")"
+assert_eq "$run_effort" "xhigh" "object leaf without effort uses model/tier default"
+rm -rf "$outdir"
+
 finish

--- a/skills/woostack-review/scripts/tests/test-resolve-model.sh
+++ b/skills/woostack-review/scripts/tests/test-resolve-model.sh
@@ -100,4 +100,18 @@ set -e
 assert_exit 1 "$code" "missing --provider exits non-zero"
 rm -rf "$outdir"
 
+# --- object leaf {model,effort}: resolver returns .model ---
+outdir="$(mktemp -d)"
+printf '%s\n' '{"models":{"openai":{"standard":{"model":"obj-standard-x","effort":"low"}}}}' > "$outdir/config.json"
+assert_eq "$(run_resolve "$outdir" --provider openai --tier standard)" "obj-standard-x" \
+  "object leaf {model,effort}: resolver returns .model"
+rm -rf "$outdir"
+
+# --- flat object leaf: resolver returns .model ---
+outdir="$(mktemp -d)"
+printf '%s\n' '{"models":{"standard":{"model":"flat-obj-y"}}}' > "$outdir/config.json"
+assert_eq "$(run_resolve "$outdir" --provider openai --tier standard)" "flat-obj-y" \
+  "flat object leaf: resolver returns .model"
+rm -rf "$outdir"
+
 finish

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh
@@ -32,6 +32,11 @@ printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-flat
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
 assert_exit 0 "$rc" "OpenAI flat config override is honored"
 
+printf '{"models":{"openai":{"standard":{"model":"gpt-obj-standard","effort":"low"}}}}\n' > "$OUTDIR/config.json"
+printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-obj-standard","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "OpenAI object-leaf {model,effort} config override resolves to .model"
+
 unset WOO_REVIEW_PROVIDER
 export WOO_REVIEW_HOST=codex
 rm -f "$OUTDIR/config.json"

--- a/skills/woostack-review/scripts/verify-receipts.sh
+++ b/skills/woostack-review/scripts/verify-receipts.sh
@@ -64,12 +64,12 @@ default_openai_model_for_tier() {
 config_model_for_tier() {
   local provider="$1" tier="$2" config="$OUTDIR/config.json" override=""
   if [ -s "$config" ]; then
-    override="$(jq -r --arg p "$provider" --arg t "$tier" '.models[$p][$t] // empty' "$config" 2>/dev/null || true)"
+    override="$(jq -r --arg p "$provider" --arg t "$tier" '(.models[$p][$t] | if type=="object" then .model else . end) // empty' "$config" 2>/dev/null || true)"
     if [ -n "$override" ]; then
       echo "$override"
       return 0
     fi
-    override="$(jq -r --arg t "$tier" '.models[$t] // empty' "$config" 2>/dev/null || true)"
+    override="$(jq -r --arg t "$tier" '(.models[$t] | if type=="object" then .model else . end) // empty' "$config" 2>/dev/null || true)"
     if [ -n "$override" ]; then
       echo "$override"
       return 0


### PR DESCRIPTION
## Goal

Relocate model tiers from `review.models` to a root `models` field (clean break) and make per-tier reasoning effort configurable, so tiers are shared infra (review now, execute later) and a tier can pin `{model, effort}`.

## Summary

- **Loader** (`load-config.sh`): parse `models` at the **root** (read from the true top-level, independent of the `review` block — closes the silent-sibling trap); a nested `review.models` is now a tailored hard error (clean break). Each tier leaf is a string **or** `{model, effort}`, normalized to an object in the flat output; `effort` validated against `minimal|low|medium|high|xhigh` (empty = unset).
- **Readers** move in lockstep so only one leaf shape is ever seen downstream: `resolve-model.sh` and `verify-receipts.sh` read `.model` object-safely (`if type=="object" then .model else . end`); `load-prompt.sh` resolves OpenAI effort **config-first** (`INPUT_OPENAI_EFFORT → config .effort → model/tier default`).
- Migrated this repo's own `.woostack/config.json` to the root object-leaf form (dogfood).

## Test plan

### Automated

- [x] `test-load-config-models-root.sh` (new) — 17 passed (root accept, review.models reject, string/object normalize, effort enum, empty-effort-unset, flat leaf, sibling-trap)
- [x] `test-resolve-model.sh` — 16 passed (added object-leaf cases)
- [x] `test-verify-receipts-openai-models.sh` — 9 passed (added object-leaf case)
- [x] `test-load-prompt-models.sh` — 20 passed (added config-first effort, input-beats-config, default-fallback)
- [x] Full `skills/woostack-review/scripts/tests/` suite — all 41 files exit 0

### Manual

**Before merge**

- [ ] Confirm `review.models` rejection message is actionable and the dogfood config migration is correct.

Spec: .woostack/specs/2026-06-26-models-root-effort.md
