### PR TITLE
feat: root models template key + doctor review.models migration warn

### DIFF
--- a/.woostack/plans/2026-06-26-models-root-effort.md
+++ b/.woostack/plans/2026-06-26-models-root-effort.md
@@ -455,13 +455,13 @@ harness. No new dependencies.
 - Test: `skills/woostack-doctor/scripts/tests/test-health-checks.sh` (or `test-doctor.sh`) — verify
   config-keys requires the new key (see Step 1)
 
-- [ ] **Step 1: Write the failing check** — confirm the template lacks a root `models` key today:
+- [x] **Step 1: Write the failing check** — confirm the template lacks a root `models` key today:
   Run: `jq -e 'has("models")' skills/woostack-init/templates/config.json; echo "exit=$?"`
   Expected: FAIL — `exit=1` (key absent; `jq -e` false → exit 1).
 
-- [ ] **Step 2: Confirm the failure** (same command) — Expected: `false` / exit 1.
+- [x] **Step 2: Confirm the failure** (same command) — Expected: `false` / exit 1.
 
-- [ ] **Step 3: Add the key** — write `skills/woostack-init/templates/config.json`:
+- [x] **Step 3: Add the key** — write `skills/woostack-init/templates/config.json`:
   ```json
   {
     "models": {},
@@ -472,18 +472,18 @@ harness. No new dependencies.
   }
   ```
 
-- [ ] **Step 4: Run the check, confirm it passes**
+- [x] **Step 4: Run the check, confirm it passes**
   Run: `jq -e 'has("models")' skills/woostack-init/templates/config.json; echo "exit=$?"`
   Expected: PASS — `true` / `exit=0`. (The doctor `config-keys.sh` check reads template top-level
   keys and will now require root `models` in consumer configs; this repo's config already has it
   after Increment 1.)
 
-- [ ] **Step 5: Verify the doctor still passes on this repo**
+- [x] **Step 5: Verify the doctor still passes on this repo**
   Run: `bash skills/woostack-doctor/scripts/doctor.sh --check . ; echo "exit=$?"`
   Expected: PASS — `exit=0` (this repo's config has root `models` from Increment 1, so config-keys
   finds the now-required key).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
   ```bash
   gt create -m "feat(init): add root models key to config template"
   ```
@@ -494,7 +494,7 @@ harness. No new dependencies.
 - Create: `skills/woostack-doctor/scripts/checks/review-models-moved.sh`
 - Test: `skills/woostack-doctor/scripts/tests/test-review-models-moved.sh` (new)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   cat > skills/woostack-doctor/scripts/tests/test-review-models-moved.sh <<'EOF'
   #!/usr/bin/env bash
@@ -527,11 +527,11 @@ harness. No new dependencies.
   chmod +x skills/woostack-doctor/scripts/tests/test-review-models-moved.sh
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: `bash skills/woostack-doctor/scripts/tests/test-review-models-moved.sh`
   Expected: FAIL — `review-models-moved.sh` does not exist yet.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   ```bash
   cat > skills/woostack-doctor/scripts/checks/review-models-moved.sh <<'EOF'
   #!/usr/bin/env bash
@@ -553,16 +553,16 @@ harness. No new dependencies.
   chmod +x skills/woostack-doctor/scripts/checks/review-models-moved.sh
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run: `bash skills/woostack-doctor/scripts/tests/test-review-models-moved.sh`
   Expected: PASS
 
-- [ ] **Step 5: Confirm the check is discovered by the orchestrator and this repo stays clean**
+- [x] **Step 5: Confirm the check is discovered by the orchestrator and this repo stays clean**
   Run: `bash skills/woostack-doctor/scripts/doctor.sh . >/dev/null; echo "exit=$?"`
   Expected: PASS — `exit=0`. This repo's config has root `models` (no `review.models`), so the new
   check is silent; `doctor.sh` auto-runs every `checks/*.sh`, so no registration step is needed.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
   ```bash
   gt modify -c -m "feat(doctor): warn on lingering review.models (migration aid)"
   ```

--- a/skills/woostack-doctor/scripts/checks/review-models-moved.sh
+++ b/skills/woostack-doctor/scripts/checks/review-models-moved.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# review-models-moved.sh — migration aid: model tiers moved from `review.models` to a
+# top-level `models` field (clean break in woostack-review/scripts/load-config.sh).
+# Diagnose-only: warns when a consumer config still nests models under `review`.
+set -uo pipefail
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+command -v jq >/dev/null 2>&1 || exit 0
+WOO_ROOT="${1:-.}"
+CFG="$WOO_ROOT/.woostack/config.json"
+[ -f "$CFG" ] || exit 0
+has="$(jq -r 'try (.review.models != null) catch false' "$CFG" 2>/dev/null || echo false)"
+if [ "$has" = "true" ]; then
+  emit warn review-models-moved report ".woostack/config.json" \
+    "review.models has moved to a top-level \`models\` field; move it out of \`review\` (see woostack-review SKILL.md)"
+fi

--- a/skills/woostack-doctor/scripts/tests/test-review-models-moved.sh
+++ b/skills/woostack-doctor/scripts/tests/test-review-models-moved.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# review-models-moved.sh — diagnose-only warn when a config still nests review.models.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+set +e
+C="$HERE/../checks"
+r="$(mktemp -d)"; mkdir -p "$r/.woostack"
+
+printf '%s\n' '{"review":{"models":{"openai":{"standard":"x"}}}}' > "$r/.woostack/config.json"
+out="$(bash "$C/review-models-moved.sh" "$r")"
+assert_contains "$out" "$(printf 'warn\treview-models-moved')" "review.models present → warn"
+assert_contains "$out" ".woostack/config.json" "names the config file"
+
+printf '%s\n' '{"models":{"openai":{"standard":{"model":"x"}}}}' > "$r/.woostack/config.json"
+assert_eq "$(bash "$C/review-models-moved.sh" "$r")" "" "root models only → silent"
+
+printf '%s\n' '{"review":{"metrics":true}}' > "$r/.woostack/config.json"
+assert_eq "$(bash "$C/review-models-moved.sh" "$r")" "" "review block without models → silent"
+
+rm -f "$r/.woostack/config.json"
+assert_eq "$(bash "$C/review-models-moved.sh" "$r")" "" "no config → silent"
+
+assert_eq "$(grep -nE '(^|[^[:alnum:]_])(git|gh)[[:space:]]' "$C/review-models-moved.sh")" "" \
+  "migration check calls no git/gh"
+rm -rf "$r"
+finish

--- a/skills/woostack-init/templates/config.json
+++ b/skills/woostack-init/templates/config.json
@@ -1,4 +1,5 @@
 {
+  "models": {},
   "review": {},
   "status": {
     "staleDays": 14

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -135,7 +135,7 @@ Prefetch auto-discovers project rule files (`AGENTS.md`, `CLAUDE.md`, `.cursorru
 
 Drop an optional `.woostack/config.json` in the consumer repo to tune the review without forking the skill. **Review settings nest under a top-level `review` object** so the file can hold sibling config namespaces for other woostack tools without collision; keys outside `review` are ignored by the review loader. Prefetch parses the `review` block into `$OUTDIR/config.json` (canonical copy, flattened); downstream stages read from there. Missing file = defaults (`severity_floor: high`). **All keys are optional — specify only the ones you want to override; the rest keep their built-in defaults.** Invalid JSON, a non-object `review`, or an unknown key *inside* `review` → loud `::error file=.woostack/config.json,line=N::<msg>` annotation and the workflow fails (no silent fallback). Sibling top-level keys outside `review` are ignored, not errors.
 
-> **Transition note:** review keys placed at the top level (the pre-nesting layout) are still accepted but emit a deprecation `::warning`. Migrate them under `review`.
+> **Transition note:** review keys placed at the top level (the pre-nesting layout) are still accepted but emit a deprecation `::warning`. Migrate them under `review`. The one exception is `models`, which is a deliberate root-level sibling of `review` (see below) — a nested `review.models` is a hard error, not a deprecation.
 
 Minimal example — override one knob, everything else stays default:
 
@@ -147,6 +147,21 @@ Full schema (every key shown; all optional):
 
 ```json
 {
+  "models": {
+    "fast": "anthropic/claude-haiku-4-5",
+    "standard": "openai/gpt-5.4-mini",
+    "deep": "anthropic/claude-opus-4-8",
+    "openai": {
+      "fast": "gpt-5.3-codex-spark",
+      "standard": "gpt-5.4-mini",
+      "deep": { "model": "gpt-5.5", "effort": "medium" }
+    },
+    "anthropic": {
+      "fast": "claude-haiku-4-5",
+      "standard": "claude-sonnet-4-6",
+      "deep": "claude-opus-4-8"
+    }
+  },
   "review": {
     "angles": {
       "force": ["database"],
@@ -168,21 +183,6 @@ Full schema (every key shown; all optional):
       "renovate[bot]"
     ],
     "release_rollup_pattern": "^(staging|release|chore\\(release\\))",
-    "models": {
-      "fast": "anthropic/claude-haiku-4-5",
-      "standard": "openai/gpt-5.4-mini",
-        "deep": "anthropic/claude-opus-4-8",
-      "openai": {
-        "fast": "gpt-5.3-codex-spark",
-        "standard": "gpt-5.4-mini",
-        "deep": "gpt-5.5"
-      },
-      "anthropic": {
-        "fast": "claude-haiku-4-5",
-        "standard": "claude-sonnet-4-6",
-        "deep": "claude-opus-4-8"
-      }
-    },
     "force_tier": "deep",
     "fix_commands": ["pnpm lint:fix", "pnpm format"],
     "disable_adversarial": false,
@@ -203,7 +203,7 @@ Key reference (JSON has no comments, so the per-key semantics live here):
 - **`authors_skip`** — PR author logins that short-circuit the entire review. Defaults: `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`. Set to `[]` to opt out.
 - **`release_rollup_pattern`** — Python regex on the PR title (default shown above; note `\\(` to escape the paren in JSON). Empty string opts out.
 - **`force_tier`** — `fast` or `deep`. Single-run override from config. Valid values are the same as `/woostack-review --fast` / `--deep`.
-- **`models`** — per-tier slug overrides. Use flat `models.fast` / `.standard` / `.deep` as provider-agnostic fallbacks, or provider-scoped maps such as `models.openai.deep`, `models.anthropic.standard`, `models.google.standard`, and `models.openrouter.fast` when the same repo is reviewed by multiple coding agents. The action input `inputs.model` still wins.
+- **`models`** — per-tier slug overrides. **A root-level sibling of `review`, not nested inside it** — a nested `review.models` is a hard error (the migration moved it to root). Use flat `models.fast` / `.standard` / `.deep` as provider-agnostic fallbacks, or provider-scoped maps such as `models.openai.deep`, `models.anthropic.standard`, `models.google.standard`, and `models.openrouter.fast` when the same repo is reviewed by multiple coding agents. Each leaf is either a slug string or an object `{ "model": "<slug>", "effort": "<low|medium|high|xhigh>" }` to pin per-tier reasoning effort. The action input `inputs.model` still wins.
 - **`fix_commands`** — reserved for `--loop` mode (issue #15).
 - **`disable_adversarial`** — cost-sensitive opt-out for the prosecutor+defender validator (issue #13). When `true`, only the defender pass runs and its output becomes `findings.json` directly.
 - **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). Each angle also carries `overlap_total` + `overlap_with` (how often another angle raised the same issue, on the raw pre-validation set — a redundancy signal). Aggregate schema is v2; an older v1 aggregate is reseeded on first fold. See Stage 6.5.


### PR DESCRIPTION
## Goal

Make the root `models` field discoverable to consumers and catch a stale `review.models` proactively (before a review run hits the loader's hard error).

## Summary

- **Init template** (`config.json`): add a root `"models": {}` alongside `review`/`status`. The doctor `config-keys` check reads template top-level keys, so root `models` is now an expected consumer-config key (empty object satisfies the presence check).
- **Doctor check** (`checks/review-models-moved.sh`, new): diagnose-only — warns when a config still nests `review.models`, pointing at the root relocation. No `--fix` (does not move values). Auto-discovered by `doctor.sh` (drop-in `checks/*.sh`).

## Test plan

### Automated

- [x] `test-review-models-moved.sh` (new) — 6 passed (warn on review.models; silent on root-only / review-without-models / no-config; calls no git/gh)
- [x] `doctor.sh --check .` on this repo — exit 0 (config-keys finds root `models` from Inc1; migration check silent)
- [x] Full `skills/woostack-doctor/scripts/tests/` suite — 11 files GREEN

### Manual

**Before merge**

- [ ] Confirm the warning copy points clearly at the root `models` relocation.

Spec: .woostack/specs/2026-06-26-models-root-effort.md
