### PR TITLE
docs: document root models field + per-tier effort (SKILL, _header, model-tiers, prompts, site, init)

### DIFF
--- a/.woostack/plans/2026-06-26-models-root-effort.md
+++ b/.woostack/plans/2026-06-26-models-root-effort.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-06-26-models-root-effort.md
-status: executing
+status: done
 branch: feature/models-root-effort
 ---
 
@@ -581,15 +581,15 @@ harness. No new dependencies.
 - Modify: `skills/woostack-review/SKILL.md:171-185` (schema example), `:206` (key reference),
   `:212` (precedence line)
 
-- [ ] **Step 1: Write the failing check** — confirm `models` is still nested under `review` in the
+- [x] **Step 1: Write the failing check** — confirm `models` is still nested under `review` in the
   schema example:
   Run: `awk 'NR>=149 && NR<=194' skills/woostack-review/SKILL.md | grep -n '"models"'`
   Expected: FAIL-state evidence — `"models"` appears indented inside the `"review": { ... }` block
   (line ~171).
 
-- [ ] **Step 2: Confirm the failure** (same command) — Expected: shows the nested `"models"` line.
+- [x] **Step 2: Confirm the failure** (same command) — Expected: shows the nested `"models"` line.
 
-- [ ] **Step 3: Edit the doc.**
+- [x] **Step 3: Edit the doc.**
   (a) In the JSON example, **remove** the `models` block (lines 171-185) from inside `"review"`,
   and add a sibling root `"models"` block before `"review"` (so the example shows the new home).
   The root block:
@@ -626,12 +626,12 @@ harness. No new dependencies.
   `… → action input `inputs.model` → root `models.<provider>.<tier>` → flat root `models.<tier>` →
   table default …`.
 
-- [ ] **Step 4: Run the check, confirm it passes**
+- [x] **Step 4: Run the check, confirm it passes**
   Run: `awk 'NR>=148 && NR<=200' skills/woostack-review/SKILL.md | grep -nE '"models"|effort'`
   Expected: PASS — `"models"` now appears as a top-level sibling (not inside `review`) and `effort`
   appears in the leaf objects.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt create -m "docs(review): document root models field + per-tier effort"
   ```
@@ -642,14 +642,14 @@ harness. No new dependencies.
 - Modify: `skills/woostack-review/prompts/_header.md:73-78` (binding paragraph), `:94` (config
   table row)
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
   Run: `grep -n 'models.<provider>.<tier>` / `models.<tier>` in `/tmp/pr-review/config.json' skills/woostack-review/prompts/_header.md`
   Expected: FAIL-state evidence — line 75 still describes the override keys without noting they are
   root-level or that leaves may carry effort.
 
-- [ ] **Step 2: Confirm the failure** (same command) — Expected: shows line 75.
+- [x] **Step 2: Confirm the failure** (same command) — Expected: shows line 75.
 
-- [ ] **Step 3: Edit the doc.**
+- [x] **Step 3: Edit the doc.**
   (a) In the binding paragraph (line 75), change the override-key description to make clear the keys
   are **root** `models.<provider>.<tier>` / `models.<tier>` (no longer under `review`), and that a
   leaf is `"<slug>"` or `{ "model", "effort" }`.
@@ -658,12 +658,12 @@ harness. No new dependencies.
   | root `models.fast` / `.standard` / `.deep`; `models.<provider>.<tier>` (leaf: `"<slug>"` or `{model, effort}`) | orchestrator prompts (tier resolution) + `load-prompt.sh` (OpenAI effort) | Stage 2 |
   ```
 
-- [ ] **Step 4: Run the check, confirm it passes**
+- [x] **Step 4: Run the check, confirm it passes**
   Run: `grep -nE 'root `models|\{model, effort\}' skills/woostack-review/prompts/_header.md`
   Expected: PASS — the binding paragraph and table row now reference root `models` and the
   `{model, effort}` leaf.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "docs(review): _header reflects root models + effort leaf"
   ```
@@ -674,15 +674,15 @@ harness. No new dependencies.
 - Modify: `skills/using-woostack/references/model-tiers.md` (Override precedence section + a note
   formalizing `effort` as a config field)
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
   Run: `grep -n 'review' skills/using-woostack/references/model-tiers.md`
   Expected: FAIL-state evidence — the precedence section binds review to
   `models.<provider>.<tier>` in `/tmp/pr-review/config.json` but does not mention that the source
   consumer key is now **root** `models` nor that a leaf may carry `effort`.
 
-- [ ] **Step 2: Confirm the failure** (same command) — Expected: shows the binding paragraph.
+- [x] **Step 2: Confirm the failure** (same command) — Expected: shows the binding paragraph.
 
-- [ ] **Step 3: Edit the doc.** In the "Override precedence (generic)" section, update the
+- [x] **Step 3: Edit the doc.** In the "Override precedence (generic)" section, update the
   `woostack-review` binding sentence so the per-provider/per-tier and flat keys are described as
   **root** `models.*` keys in the consumer `.woostack/config.json` (canonicalized into
   `/tmp/pr-review/config.json`), and add one sentence: each tier leaf is a model-slug string or an
@@ -690,12 +690,12 @@ harness. No new dependencies.
   field — replacing the table's informational `reasoning_effort:` annotations as the source of
   truth for effort; the table annotations remain illustrative defaults.
 
-- [ ] **Step 4: Run the check, confirm it passes**
+- [x] **Step 4: Run the check, confirm it passes**
   Run: `grep -nE 'root `models|\{ model, effort \}|effort' skills/using-woostack/references/model-tiers.md`
   Expected: PASS — the precedence section now references root `models` and the `{model, effort}`
   leaf / config effort field.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "docs(model-tiers): formalize effort as a config field"
   ```
@@ -706,15 +706,15 @@ harness. No new dependencies.
 - Modify: `skills/woostack-review/prompts/anthropic.md:67`, `skills/woostack-review/prompts/openai.md:21,25`,
   `skills/woostack-review/prompts/opencode.md:27`
 
-- [ ] **Step 1: Write the failing check**
+- [x] **Step 1: Write the failing check**
   Run: `grep -nE '\.models\.[a-z]+\.(deep|standard|fast) // \.models\.(deep|standard|fast) // empty' skills/woostack-review/prompts/anthropic.md skills/woostack-review/prompts/openai.md skills/woostack-review/prompts/opencode.md`
   Expected: FAIL-state evidence — the three prompts document the **string-leaf** jq
   (`.models.<p>.<tier> // .models.<tier> // empty`), which returns the whole object for an object
   leaf.
 
-- [ ] **Step 2: Confirm the failure** (same command) — Expected: lists the three jq lines.
+- [x] **Step 2: Confirm the failure** (same command) — Expected: lists the three jq lines.
 
-- [ ] **Step 3: Edit the prompts.** Update each documented override lookup to read the normalized
+- [x] **Step 3: Edit the prompts.** Update each documented override lookup to read the normalized
   object leaf's `.model`, e.g. `anthropic.md:67`:
   ```text
   3. **Per-repo override**: check `$OUTDIR/config.json` for `models.anthropic.<effective_tier>`,
@@ -728,11 +728,11 @@ harness. No new dependencies.
   the per-tier `effort` may now also come from the config leaf (`models.openai.<tier>.effort`),
   resolved config-first by `load-prompt.sh` before the built-in default.
 
-- [ ] **Step 4: Run the check, confirm it passes**
+- [x] **Step 4: Run the check, confirm it passes**
   Run: `grep -nE 'if type=="object" then .model else . end' skills/woostack-review/prompts/anthropic.md skills/woostack-review/prompts/openai.md skills/woostack-review/prompts/opencode.md`
   Expected: PASS — all three prompts now document the object-safe lookup.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "docs(review): provider prompts read object {model} tier leaves"
   ```

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -117,7 +117,7 @@ over the built-in default). `review.force_tier` pins every subagent to one tier,
 equivalent of running the review with `--fast` or `--deep`.
 
 **Clean break:** `models` moved out of `review`. A `review.models` block is now a hard config
-error — move it to the top level. `woostack-doctor` warns on a lingering `review.models`.
+error. Move it to the top level. `woostack-doctor` warns on a lingering `review.models`.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -107,17 +107,22 @@ to opt out: an empty array for `authors_skip`, or an empty string for the patter
 ### Model selection
 
 Each review subagent runs at a tier (`fast`, `standard`, or `deep`), and each tier maps to a
-concrete model per provider. Override a single tier for one provider with
-`models.<provider>.<tier>`, or set a provider-agnostic fallback with the flat
-`models.<tier>`. A model leaf can be a string (the model slug) or an object specifying `{ model, effort }`,
-where `effort` is one of `minimal`, `low`, `medium`, `high`, or `xhigh`.
-Note that `review.models` is deprecated and causes a hard validation error. `review.force_tier`
-pins every subagent to one tier, the config-file equivalent of running the review with `--fast` or `--deep`.
+concrete model per provider. Model tiers live at the **root** of `.woostack/config.json` (a
+top-level `models` field, not under `review`) so they can also drive non-review consumers.
+Override a single tier for one provider with `models.<provider>.<tier>`, or set a
+provider-agnostic fallback with the flat `models.<tier>`. Each tier leaf is a model-slug string
+**or** an object `{ "model": "<slug>", "effort": "<level>" }`, where `effort` is one of
+`minimal`, `low`, `medium`, `high`, or `xhigh` (consumed by OpenAI/Codex, resolved config-first
+over the built-in default). `review.force_tier` pins every subagent to one tier, the config-file
+equivalent of running the review with `--fast` or `--deep`.
+
+**Clean break:** `models` moved out of `review`. A `review.models` block is now a hard config
+error — move it to the top level. `woostack-doctor` warns on a lingering `review.models`.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `models.<tier>` | string \| object | provider table | Provider-agnostic model fallback for `fast` / `standard` / `deep`. Object format supports `{ model, effort }`. |
-| `models.<provider>.<tier>` | string \| object | provider table | Per-provider override; provider is `anthropic`, `openai`, `google`, or `openrouter`. Object format supports `{ model, effort }`. |
+| `models.<tier>` | string or `{model, effort}` | provider table | Provider-agnostic model for `fast` / `standard` / `deep`. |
+| `models.<provider>.<tier>` | string or `{model, effort}` | provider table | Per-provider override; provider is `anthropic`, `openai`, `google`, or `openrouter`. |
 | `review.force_tier` | string | absent (= standard) | Pin every subagent to `fast` or `deep`. Empty string = absent. |
 
 The default model per provider and tier:

--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -41,7 +41,12 @@ When a host supports per-repo / per-run overrides, resolve highest-precedence fi
 5. **Table default** (above).
 
 Each consumer binds these to its own surface. For example `woostack-review` binds them to
-`FORCE_TIER` (Review Context) › `inputs.model` (action.yml) › `models.<provider>.<tier>` /
-`models.<tier>` in `/tmp/pr-review/config.json`, resolved by `scripts/load-prompt.sh`
-(`default_model_for()` is the Bash mirror of the Anthropic/OpenAI/Google/OpenRouter columns —
-keep it in sync with this table).
+`FORCE_TIER` (Review Context) › `inputs.model` (action.yml) › **root** `models.<provider>.<tier>` /
+`models.<tier>` in the consumer `.woostack/config.json` (canonicalized into
+`/tmp/pr-review/config.json`), resolved by `scripts/load-prompt.sh` (`default_model_for()` is the
+Bash mirror of the Anthropic/OpenAI/Google/OpenRouter columns — keep it in sync with this table).
+
+Each tier leaf is a model-slug string **or** an object `{ model, effort }`. `effort`
+(`minimal | low | medium | high | xhigh`) is a real config field: the `reasoning_effort:`
+annotations in the table above are illustrative defaults, and a config-set `effort` overrides them
+config-first in `load-prompt.sh` (precedence: action input → config `effort` → tier default).

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -42,11 +42,11 @@ Two callers:
    | `.woostack/fixes/.gitkeep` | `templates/fixes/.gitkeep` |
    | `.woostack/wisdom/` directory | (create empty) |
    | `.woostack/wisdom/.gitkeep` | `templates/wisdom/.gitkeep` |
-   | `.woostack/config.json` | `templates/config.json` (`{ "review": {}, "status": { "staleDays": 14 } }`) |
+   | `.woostack/config.json` | `templates/config.json` (`{ "models": {}, "review": {}, "status": { "staleDays": 14 } }`) |
    | `.woostack/.gitignore` | `templates/gitignore` |
    | `.woostack/worktrees/` directory | (create empty — per-PR git worktrees, gitignored) |
 
-   `config.json` ships as `{ "review": {}, "status": { "staleDays": 14 } }`. Each tool owns
+   `config.json` ships as `{ "models": {}, "review": {}, "status": { "staleDays": 14 } }`. Each tool owns
    its own namespace inside that object: for the `review` namespace see
    [references/memory.md](references/memory.md); the `status` namespace holds `staleDays`
    (default 14 — the age in days past which an executing spec is flagged stale on the

--- a/skills/woostack-init/references/memory.md
+++ b/skills/woostack-init/references/memory.md
@@ -22,11 +22,11 @@ The `/woostack-init` scaffold verb creates this tree in a consumer repo:
 ├── specs/           woostack-build markdown specs (type: spec)
 ├── plans/           woostack-build markdown plans
 ├── wisdom/          generalized findings, wholesale-loaded — see wisdom.md (sibling store)
-├── config.json      { "review": {} } skeleton
+├── config.json      { "models": {}, "review": {} } skeleton
 └── .gitignore       ignores metrics.json, *.local.*, memory/.telemetry.tsv, and memory/.dream-watermark ; tracks specs/plans/fixes/config/memory notes
 ```
 
-The `config.json` file uses a top-level namespace-per-tool convention: `"review"` is the key for woostack-review settings (see [../../woostack-review/SKILL.md](../../woostack-review/SKILL.md) for the schema of that namespace). The memory store needs no config in increment A. Future tools add sibling keys (`"memory"`, etc.) as needed; init scaffolds only the `{ "review": {} }` skeleton and documents the convention — it does not own the per-tool schemas.
+The `config.json` file uses a top-level namespace-per-tool convention: `"review"` is the key for woostack-review settings (see [../../woostack-review/SKILL.md](../../woostack-review/SKILL.md) for the schema of that namespace). `"models"` is a root model-tier field shared across tools (relocated out of `review.models`). The memory store needs no config in increment A. Future tools add sibling keys (`"memory"`, etc.) as needed; init scaffolds only the `{ "models": {}, "review": {} }` skeleton and documents the convention — it does not own the per-tool schemas.
 
 The `.gitignore` ignores `metrics.json` (the review engine's per-clone rolling aggregate), `*.local.*` (reserved for per-developer overrides such as `config.local.json`), `.woostack/memory/.telemetry.tsv`, and `.woostack/memory/.dream-watermark`. Memory notes and `MEMORY.md` are tracked shared team knowledge, alongside `specs/`, `plans/`, `fixes/`, and `config.json`.
 

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -149,11 +149,11 @@ Full schema (every key shown; all optional):
 {
   "models": {
     "fast": "anthropic/claude-haiku-4-5",
-    "standard": "openai/gpt-5.4-mini",
+    "standard": { "model": "openai/gpt-5.4-mini", "effort": "xhigh" },
     "deep": "anthropic/claude-opus-4-8",
     "openai": {
-      "fast": "gpt-5.3-codex-spark",
-      "standard": "gpt-5.4-mini",
+      "fast": { "model": "gpt-5.3-codex-spark", "effort": "xhigh" },
+      "standard": { "model": "gpt-5.4-mini", "effort": "low" },
       "deep": { "model": "gpt-5.5", "effort": "medium" }
     },
     "anthropic": {
@@ -203,7 +203,7 @@ Key reference (JSON has no comments, so the per-key semantics live here):
 - **`authors_skip`** — PR author logins that short-circuit the entire review. Defaults: `dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`. Set to `[]` to opt out.
 - **`release_rollup_pattern`** — Python regex on the PR title (default shown above; note `\\(` to escape the paren in JSON). Empty string opts out.
 - **`force_tier`** — `fast` or `deep`. Single-run override from config. Valid values are the same as `/woostack-review --fast` / `--deep`.
-- **`models`** — per-tier slug overrides. **A root-level sibling of `review`, not nested inside it** — a nested `review.models` is a hard error (the migration moved it to root). Use flat `models.fast` / `.standard` / `.deep` as provider-agnostic fallbacks, or provider-scoped maps such as `models.openai.deep`, `models.anthropic.standard`, `models.google.standard`, and `models.openrouter.fast` when the same repo is reviewed by multiple coding agents. Each leaf is either a slug string or an object `{ "model": "<slug>", "effort": "<low|medium|high|xhigh>" }` to pin per-tier reasoning effort. The action input `inputs.model` still wins.
+- **`models`** — **root-level** per-tier model overrides (moved out of `review.models`; a lingering `review.models` is now a hard loader error — `woostack-doctor` warns on it too). Each tier leaf is a model-slug string **or** an object `{ "model": "<slug>", "effort": "<level>" }`, where `effort` is one of `minimal | low | medium | high | xhigh` (empty = unset). Use flat `models.fast` / `.standard` / `.deep` as provider-agnostic fallbacks, or provider-scoped maps such as `models.openai.deep`, `models.anthropic.standard`, `models.google.standard`, and `models.openrouter.fast` when the same repo is reviewed by multiple coding agents. The action input `inputs.model` still wins. Effort is consumed by OpenAI/Codex (`load-prompt.sh`), config-first over the built-in tier default.
 - **`fix_commands`** — reserved for `--loop` mode (issue #15).
 - **`disable_adversarial`** — cost-sensitive opt-out for the prosecutor+defender validator (issue #13). When `true`, only the defender pass runs and its output becomes `findings.json` directly.
 - **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). Each angle also carries `overlap_total` + `overlap_with` (how often another angle raised the same issue, on the raw pre-validation set — a redundancy signal). Aggregate schema is v2; an older v1 aggregate is reseeded on first fold. See Stage 6.5.

--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -72,7 +72,8 @@ single-prompt runners stay self-contained:
 
 **Review's tier-resolution binding.** Resolve the effective tier per the shared doc's precedence,
 bound to review's surface: `FORCE_TIER` (Review Context) → `inputs.model` (action.yml) →
-`models.<provider>.<tier>` / `models.<tier>` in `/tmp/pr-review/config.json` → table default.
+root `models.<provider>.<tier>` / `models.<tier>` (leaf: `"<slug>"` or `{model, effort}`) in
+`/tmp/pr-review/config.json` → table default.
 `run_model` (resolved in `load-prompt.sh`) pins single-session hosts; explicit `FORCE_TIER` and
 `run_model` win before per-repo/per-tier overrides. The context+summary subagent is implicitly
 `fast`.
@@ -91,7 +92,7 @@ The prefetch step parses an optional `.woostack/config.json` in the consumer rep
 | `severity_floor` | `intersect-findings.sh` (floor classifier) | Stage 4c — **defaults to `high`**; below-floor validated findings become non-blocking nits, not drops; set `low`/`medium` to treat more findings as normal |
 | `nits` | `intersect-findings.sh` (floor classifier) | Stage 4c — default `true`; `false` drops below-floor non-blocking findings (old behavior). Below-floor blocking findings always surface |
 | `defer_markers` | `intersect-findings.sh` (floor classifier) + `validator.md` (defender) | Stage 4c — default `true`; honors inline `woostack-defer(<ref>)` markers, demoting a covered finding to a `Deferred to <ref>` nit. `false` ignores markers |
-| `models.fast` / `.standard` / `.deep`; `models.<provider>.<tier>` | orchestrator prompts (tier resolution) | Stage 2 |
+| root `models.fast` / `.standard` / `.deep`; `models.<provider>.<tier>` (leaf: `"<slug>"` or `{model, effort}`) | orchestrator prompts (tier resolution) + `load-prompt.sh` (OpenAI effort) | Stage 2 |
 | `fix_commands` | persisted only; consumed by `--loop` mode (#15) | n/a |
 | `chunking.max_loc` | `chunk-diff.sh` (split oversized diff into chunks; default 4000) | Stage 1 |
 

--- a/skills/woostack-review/prompts/anthropic.md
+++ b/skills/woostack-review/prompts/anthropic.md
@@ -64,7 +64,7 @@ Task({
 Resolution rule per spawn:
 1. Determine effective tier.
 2. Look up the Anthropic column in the shared Model Tiers table (inlined in `_header.md` above).
-3. **Per-repo override**: check `$OUTDIR/config.json` for `models.anthropic.<effective_tier>`, then flat `models.<effective_tier>` (e.g. when `run_tier=deep`: `jq -r '.models.anthropic.deep // .models.deep // empty' $OUTDIR/config.json`). If non-empty, use that slug instead of the table value.
+3. **Per-repo override**: check `$OUTDIR/config.json` for `models.anthropic.<effective_tier>`, then flat `models.<effective_tier>`. The loader normalizes each tier leaf to an object `{model, effort?}`, so read `.model` (e.g. when `run_tier=deep`: `jq -r '((.models.anthropic.deep // .models.deep) | if type=="object" then .model else . end) // empty' $OUTDIR/config.json`). If non-empty, use that slug instead of the table value.
 4. Pass the resolved slug as `model:` on the Task call.
 
 Do not default the validator to Sonnet — pass `model: "claude-opus-4-8"` explicitly. Opus's stricter false-positive filter pays for itself in review quality.

--- a/skills/woostack-review/prompts/openai.md
+++ b/skills/woostack-review/prompts/openai.md
@@ -20,9 +20,9 @@ The single-session action path resolves one session model in `load-prompt.sh` us
 
 Per-repo override remains in effect during run-model resolution: if `$OUTDIR/config.json` has `models.openai.<run_tier>` set (or flat `models.<run_tier>`), use that value before falling back to the default.
 
-For quality/cost splits, GPT-5-family reasoning is a `reasoning_effort` parameter, not a slug suffix (`high`, `xhigh` etc.); there is no `gpt-5-pro`. Pass effort via `inputs.openai_effort` (wired through to codex-action `effort`). Defaults are `medium` for deep, `xhigh` for standard, and `xhigh` for fast.
+For quality/cost splits, GPT-5-family reasoning is a `reasoning_effort` parameter, not a slug suffix (`high`, `xhigh` etc.); there is no `gpt-5-pro`. Pass effort via `inputs.openai_effort` (wired through to codex-action `effort`). Defaults are `medium` for deep, `xhigh` for standard, and `xhigh` for fast. A per-tier `effort` may also be set on the config leaf (`models.openai.<tier>.effort`); `load-prompt.sh` resolves it **config-first** (`inputs.openai_effort` → config `effort` → tier/model default).
 
-**Per-repo override:** resolve using the active run tier: if `$OUTDIR/config.json` has `models.openai.<run_tier>` set, use it; otherwise fall back to flat `models.<run_tier>` (precedence: `FORCE_TIER` > `inputs.model` > `models.openai.<run_tier>` > `models.<run_tier>` > default `gpt-5.4-mini`). Read with run-tier-aware lookup, e.g. when `run_tier=deep`: `jq -r '.models.openai.deep // .models.deep // empty' $OUTDIR/config.json`.
+**Per-repo override:** resolve using the active run tier: if `$OUTDIR/config.json` has `models.openai.<run_tier>` set, use it; otherwise fall back to flat `models.<run_tier>` (precedence: `FORCE_TIER` > `inputs.model` > `models.openai.<run_tier>` > `models.<run_tier>` > default `gpt-5.4-mini`). The loader normalizes each leaf to an object `{model, effort?}`, so read `.model` with a run-tier-aware lookup, e.g. when `run_tier=deep`: `jq -r '((.models.openai.deep // .models.deep) | if type=="object" then .model else . end) // empty' $OUTDIR/config.json`.
 
 For per-call local subagents, resolve each spawn with the same precedence, but use the target prompt's tier unless a forced tier is set:
 

--- a/skills/woostack-review/prompts/opencode.md
+++ b/skills/woostack-review/prompts/opencode.md
@@ -24,7 +24,7 @@ inlined into `_header.md` above); the OpenRouter column is:
 
 OpenRouter exposes only two DeepSeek slugs — reasoning is a `reasoning_effort` parameter on the same `v4-pro` slug, not a separate model ID. DeepSeek V4 supersedes R1 — do not route to `deepseek-r1`. If the OpenCode build cannot route per-subagent or cannot pass `reasoning_effort`, fall back to a single model for the whole job and pin it to the resolved `run_model` from `load-prompt.sh`. `inputs.model` (action.yml) overrides the default tier but is itself overridden when `FORCE_TIER` is set.
 
-**Per-repo override:** before applying the final model slug above, check `$OUTDIR/config.json` for `models.openrouter.<effective_tier>` and then flat `models.<effective_tier>` (`jq -r '.models.openrouter.deep // .models.deep // empty' $OUTDIR/config.json`, etc.). Precedence: `FORCE_TIER` (if set) first, then `inputs.model`, then `models.openrouter.<effective_tier>` > `models.<effective_tier>` > table default.
+**Per-repo override:** before applying the final model slug above, check `$OUTDIR/config.json` for `models.openrouter.<effective_tier>` and then flat `models.<effective_tier>`. The loader normalizes each leaf to an object `{model, effort?}`, so read `.model` (`jq -r '((.models.openrouter.deep // .models.deep) | if type=="object" then .model else . end) // empty' $OUTDIR/config.json`, etc.). Precedence: `FORCE_TIER` (if set) first, then `inputs.model`, then `models.openrouter.<effective_tier>` > `models.<effective_tier>` > table default.
 
 ---
 


### PR DESCRIPTION
## Goal

Bring the authored docs and provider prompts in line with the new root `models` field + per-tier effort, so the documented contract matches the code.

## Summary

- `woostack-review/SKILL.md`: schema example moves `models` to the root; key-reference + tier table document the object leaf `{model, effort}`, the effort enum, and the clean break.
- `prompts/_header.md`, `prompts/{anthropic,openai,opencode}.md`: tier-resolution binding + override jq are object-safe (`if type=="object" then .model else . end`); OpenAI prompt notes config-first effort.
- `using-woostack/references/model-tiers.md`: formalizes `effort` as a real config field (table annotations are now illustrative defaults).
- `site/content/docs/configuration.mdx`: root `models`, object-leaf table, clean-break note (authored site page kept in sync per repo constraint).
- `woostack-init/SKILL.md` + `references/memory.md`: template skeleton updated to `{ "models": {}, "review": {}, ... }` (matches the Inc2 template change).
- Plan marked `status: done` (all increments implemented).

## Test plan

### Automated

- [x] SKILL schema example parses as valid JSON; no `models` nested under `review`
- [x] All 3 provider prompts carry the object-safe jq; `_header`/`model-tiers` reference `{model, effort}`
- [x] Full review + doctor test suites still GREEN (docs-only change on top of Inc1+Inc2)

### Manual

**Before merge**

- [ ] `pnpm -C site build` — not run in the unattended session (`site/node_modules` absent); edits are plain markdown (no new MDX components), so build-break risk is low. Verify locally.
- [ ] Skim the rendered docs for tone/accuracy.

Spec: .woostack/specs/2026-06-26-models-root-effort.md
