### PR TITLE
fix: require woostack-fix closeout

### DIFF
--- a/.woostack/fixes/2026-06-27-fix-closeout-invariant.md
+++ b/.woostack/fixes/2026-06-27-fix-closeout-invariant.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: executing
+status: in-review
 branch: fix/fix-closeout-invariant
 ---
 

--- a/.woostack/fixes/2026-06-27-fix-closeout-invariant.md
+++ b/.woostack/fixes/2026-06-27-fix-closeout-invariant.md
@@ -1,0 +1,55 @@
+---
+type: fix
+status: hardened
+branch: fix/fix-closeout-invariant
+---
+
+# Fix: Make woostack-fix closeout mandatory
+
+## 1. Root Cause
+
+`woostack-fix` already says a successful fix should update the single PR, set the
+fix lifecycle to `in-review`, and tear down the worktree. However, those duties are
+buried in step 6 as lifecycle tracking after step 5 delegates execution to
+`woostack-execute`. The skill does not state a clear completion invariant that
+forbids final handback immediately after implementation/tests.
+
+Evidence:
+
+- Step 5 emphasizes that `woostack-execute` commits the code and opens or updates
+  the one PR, which can make the flow appear finished once tests pass.
+- Step 6 contains the required lifecycle and teardown behavior, but its heading is
+  “Track the PR and lifecycle,” not a mandatory closeout gate.
+- The hard constraints say to delegate execution and never merge, but they do not
+  explicitly define “done” as PR submitted, fix status committed as `in-review`,
+  and the worktree removed.
+
+## 2. Proposed Fix
+
+Update `skills/woostack-fix/SKILL.md` so a successful run has an explicit closeout
+invariant: after approved execution succeeds, the agent must not final-answer until
+the PR is submitted or updated, the fix file is marked `in-review`, that lifecycle
+update is committed/submitted, and the fix worktree is torn down. Keep failure
+behavior unchanged: leave the worktree in place and report its path when commit,
+submit, review, or teardown cannot complete.
+
+If the authored docs page mirrors this wording, update
+`site/content/docs/skills/woostack-fix.mdx` in the same change.
+
+## 3. Implementation Plan
+
+- [ ] **Step 1: Reproduce with a failing documentation check**
+  - Add a lightweight shell test that asserts `skills/woostack-fix/SKILL.md`
+    contains a “Completion invariant” section and the mandatory closeout terms:
+    submit/update PR, `in-review`, commit/submit lifecycle update, and remove the
+    worktree.
+- [ ] **Step 2: Apply the minimal fix**
+  - Add the completion invariant near the top of `skills/woostack-fix/SKILL.md`
+    so it is visible before the detailed procedure.
+  - Rename or strengthen step 6 so closeout cannot be read as optional tracking.
+  - State the failure exception explicitly: if closeout cannot commit, submit, or
+    tear down, leave the worktree and report the blocker/path.
+  - Mirror the authored docs page only where it is manually maintained and affected.
+- [ ] **Step 3: Verification**
+  - Run the new documentation check.
+  - Run `pnpm -C site build` if the authored docs page changes.

--- a/.woostack/fixes/2026-06-27-fix-closeout-invariant.md
+++ b/.woostack/fixes/2026-06-27-fix-closeout-invariant.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: hardened
+status: executing
 branch: fix/fix-closeout-invariant
 ---
 
@@ -38,18 +38,18 @@ If the authored docs page mirrors this wording, update
 
 ## 3. Implementation Plan
 
-- [ ] **Step 1: Reproduce with a failing documentation check**
+- [x] **Step 1: Reproduce with a failing documentation check**
   - Add a lightweight shell test that asserts `skills/woostack-fix/SKILL.md`
     contains a “Completion invariant” section and the mandatory closeout terms:
     submit/update PR, `in-review`, commit/submit lifecycle update, and remove the
     worktree.
-- [ ] **Step 2: Apply the minimal fix**
+- [x] **Step 2: Apply the minimal fix**
   - Add the completion invariant near the top of `skills/woostack-fix/SKILL.md`
     so it is visible before the detailed procedure.
   - Rename or strengthen step 6 so closeout cannot be read as optional tracking.
   - State the failure exception explicitly: if closeout cannot commit, submit, or
     tear down, leave the worktree and report the blocker/path.
   - Mirror the authored docs page only where it is manually maintained and affected.
-- [ ] **Step 3: Verification**
+- [x] **Step 3: Verification**
   - Run the new documentation check.
   - Run `pnpm -C site build` if the authored docs page changes.

--- a/site/content/docs/concepts/status-tracking.mdx
+++ b/site/content/docs/concepts/status-tracking.mdx
@@ -73,6 +73,10 @@ That split is deliberate. Features are tracked by the spec/plan pair and shown o
 `woostack-status` board. Fixes are tracked by their `.woostack/fixes/` file because a fix
 combines the spec and plan into one artifact and ships as one PR.
 
+During closeout, `woostack-execute` owns the code/checklist commit and `woostack-fix`
+owns the final `status: in-review` lifecycle commit, PR URL handback, verification
+summary, and worktree teardown on that same fix PR.
+
 ## One spec, one plan, N PRs, joined by artifacts
 
 The board relies on the `spec : plan : PRs = 1 : 1 : N` invariant. It walks two joins:

--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -166,6 +166,10 @@ investigation.
    (step 4) stays upstream.
 
 6. **Submit PR, Mark In Review, And Tear Down Worktree.**
+   This closeout commit is separate from the execution commit: `woostack-execute`
+   commits code, checklist, and execution lifecycle updates through
+   `woostack-commit`; after that succeeds, `woostack-fix` commits only the final
+   `status: in-review` lifecycle update to the same PR before teardown.
    Do not stop after implementation, tests, or the code commit. This closeout is part of the
    successful fix loop, not optional cleanup for a later user request.
    There is **no separate post-execution commit step** — step 3 already committed the hardened plan
@@ -202,5 +206,6 @@ investigation.
 - **One worktree across the whole run.** A single `fix/<slug>` worktree spans the run: created in step 2, kept alive across the approve-to-execute gate (so revise/abandon stay cheap — during the gate it is torn down only on **Abandon**, via `git worktree remove --force`), then **reused** by `woostack-execute` for the code increment — execute does not cut a fresh worktree or a child branch, and tears the worktree down on **Go** after the one PR is open.
 - **Delegate execution.** Step 5 hands the fix file to [`woostack-execute`](../woostack-execute/SKILL.md); never re-inline a TDD/commit/review/distill loop. Execute runs inside the step-2 fix worktree on `fix/<slug>` and owns the branch, TDD per task, checkbox ticking, commit via `woostack-commit` (code + plan updates into the one PR), task review, and distill. This skill retains only diagnosis, the fix plan, hardening, the pre-approval plan commit, the approval gate, and the frontmatter lifecycle.
 - **Closeout is mandatory.** After approved execution succeeds, do not final-answer until the single PR is submitted or updated, the fix frontmatter is `status: in-review`, the lifecycle update is committed and submitted, and the fix worktree is removed. If any closeout step fails, leave the worktree in place and report the blocker plus path.
+- **Closeout handback.** The final response must include the PR URL and verification summary. A failed closeout must report both the blocker and the fix worktree path.
 - **TDD Kernel.** Every fix is driven by a failing test first — enforced by `woostack-execute`'s per-task TDD loop.
 - **Never merge.** Execution (via `woostack-execute`) commits and opens or updates the single fix PR; this skill never merges.

--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -19,6 +19,21 @@ diagnose root cause (woostack-debug) → write fix plan (fixes/ markdown) → ha
 
 The skill has exactly **one** hard gate: **approve-to-execute**. The hardened fix plan is committed before the gate so the user can inspect the committed diff, branch, or PR without opening the worktree; no code is written until approval clears. Because a fix is small enough that this is appropriate, the plan and the code still ship as a **single PR** on the one `fix/<slug>` branch — there is no separate docs-only base PR and no stacked code increment. Delegation adds no gate: `woostack-execute` owns no approval gate and never merges, so the fix's one gate stays upstream of execution.
 
+## Completion invariant
+
+A successful `woostack-fix` run is not complete when implementation or tests pass.
+**Do not final-answer after implementation or tests.** After approved execution succeeds, the
+orchestrator must complete closeout before handing back:
+
+- the single fix PR is submitted or updated;
+- the fix file frontmatter is `status: in-review`;
+- that lifecycle update is committed and submitted on the same `fix/<slug>` branch;
+- the fix worktree is removed; and
+- the final response includes the PR URL and verification summary.
+
+If commit, submit, review, or teardown cannot complete, leave the worktree in place and report the
+blocker plus the worktree path. Do not treat closeout as optional cleanup for the user to request.
+
 ## Debug investigation mode
 
 Step 1's root-cause investigation runs through one of two drivers — the same `--inline` /
@@ -150,7 +165,9 @@ investigation.
    takeaway. `woostack-execute` owns no approval gate and never merges; the fix's one gate
    (step 4) stays upstream.
 
-6. **Track the PR and lifecycle.**
+6. **Submit PR, Mark In Review, And Tear Down Worktree.**
+   Do not stop after implementation, tests, or the code commit. This closeout is part of the
+   successful fix loop, not optional cleanup for a later user request.
    There is **no separate post-execution commit step** — step 3 already committed the hardened plan
    for review, and step 5's `woostack-execute` committed the code plus fix-file lifecycle/checklist
    updates and opened or updated the **one PR** via
@@ -164,8 +181,9 @@ investigation.
    that trailer attaches the PR to the fix file rather than to a spec — the fix file's frontmatter
    remains the lifecycle source of truth.
 
-   The **single** fix worktree is torn down by `woostack-execute` after the one PR is open; the
-   branch/commits/PR persist. **Leave the worktree on failure** and report its path. The memory
+   Tear down the **single** fix worktree after the one PR is open/updated and the `status:
+   in-review` lifecycle update is committed and submitted; the branch/commits/PR persist. **Leave
+   the worktree in place on failure** and report its path. The memory
    distill (run by `woostack-execute` in step 5) targets the primary tree via the `WOOSTACK_ROOT`
    export of the [worktree contract](../woostack-init/references/worktrees.md) §5, so it survives
    teardown.
@@ -183,5 +201,6 @@ investigation.
 - **One PR.** The fix plan and the code ship in a **single PR** on the one `fix/<slug>` branch — first as a plan commit for review, then with code and fix-file lifecycle/checklist updates added by `woostack-execute`. There is no separate docs-only base PR; a fix is one PR, because a fix is small enough that this is appropriate.
 - **One worktree across the whole run.** A single `fix/<slug>` worktree spans the run: created in step 2, kept alive across the approve-to-execute gate (so revise/abandon stay cheap — during the gate it is torn down only on **Abandon**, via `git worktree remove --force`), then **reused** by `woostack-execute` for the code increment — execute does not cut a fresh worktree or a child branch, and tears the worktree down on **Go** after the one PR is open.
 - **Delegate execution.** Step 5 hands the fix file to [`woostack-execute`](../woostack-execute/SKILL.md); never re-inline a TDD/commit/review/distill loop. Execute runs inside the step-2 fix worktree on `fix/<slug>` and owns the branch, TDD per task, checkbox ticking, commit via `woostack-commit` (code + plan updates into the one PR), task review, and distill. This skill retains only diagnosis, the fix plan, hardening, the pre-approval plan commit, the approval gate, and the frontmatter lifecycle.
+- **Closeout is mandatory.** After approved execution succeeds, do not final-answer until the single PR is submitted or updated, the fix frontmatter is `status: in-review`, the lifecycle update is committed and submitted, and the fix worktree is removed. If any closeout step fails, leave the worktree in place and report the blocker plus path.
 - **TDD Kernel.** Every fix is driven by a failing test first — enforced by `woostack-execute`'s per-task TDD loop.
 - **Never merge.** Execution (via `woostack-execute`) commits and opens or updates the single fix PR; this skill never merges.

--- a/skills/woostack-fix/scripts/tests/test-closeout-invariant.sh
+++ b/skills/woostack-fix/scripts/tests/test-closeout-invariant.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+
+skill="$ROOT/skills/woostack-fix/SKILL.md"
+body="$(cat "$skill")"
+
+assert_contains "$body" "## Completion invariant" "fix skill declares completion invariant"
+assert_contains "$body" "Do not final-answer after implementation or tests" "invariant blocks early final handback"
+assert_contains "$body" "PR is submitted or updated" "invariant requires submitted or updated PR"
+assert_contains "$body" 'frontmatter is `status: in-review`' "invariant requires in-review lifecycle"
+assert_contains "$body" "lifecycle update is committed and submitted" "invariant requires lifecycle commit/submit"
+assert_contains "$body" "fix worktree is removed" "invariant requires worktree teardown"
+assert_contains "$body" "leave the worktree in place" "invariant preserves failure recovery"
+assert_contains "$body" "Submit PR, Mark In Review, And Tear Down Worktree" "step 6 heading is operational"
+
+finish

--- a/skills/woostack-fix/scripts/tests/test-closeout-invariant.sh
+++ b/skills/woostack-fix/scripts/tests/test-closeout-invariant.sh
@@ -13,8 +13,14 @@ assert_contains "$body" "Do not final-answer after implementation or tests" "inv
 assert_contains "$body" "PR is submitted or updated" "invariant requires submitted or updated PR"
 assert_contains "$body" 'frontmatter is `status: in-review`' "invariant requires in-review lifecycle"
 assert_contains "$body" "lifecycle update is committed and submitted" "invariant requires lifecycle commit/submit"
+assert_contains "$body" "commits code, checklist, and execution lifecycle updates" "invariant pins execute commit ownership"
+assert_contains "$body" '`woostack-fix` commits only the final' "invariant pins fix closeout commit ownership"
+assert_contains "$body" "to the same PR before teardown" "invariant requires same-PR lifecycle update"
+assert_contains "$body" "PR URL" "invariant requires PR URL handback"
+assert_contains "$body" "verification summary" "invariant requires verification summary handback"
 assert_contains "$body" "fix worktree is removed" "invariant requires worktree teardown"
 assert_contains "$body" "leave the worktree in place" "invariant preserves failure recovery"
+assert_contains "$body" "blocker and the fix worktree path" "invariant reports blocker and worktree path on failure"
 assert_contains "$body" "Submit PR, Mark In Review, And Tear Down Worktree" "step 6 heading is operational"
 
 finish


### PR DESCRIPTION
## Goal
Prevent `woostack-fix` runs from stopping after implementation/tests and leaving submit, lifecycle, and worktree teardown as manual follow-up.

## Summary
- Added a prominent `Completion invariant` to `woostack-fix` that defines done as PR submitted/updated, fix status committed as `in-review`, and worktree removed.
- Strengthened step 6 into an operational closeout step: submit PR, mark in review, and tear down the worktree.
- Added a lightweight regression check that asserts the closeout invariant remains present in the skill text.

## Test plan
### Automated
- `bash skills/woostack-fix/scripts/tests/test-closeout-invariant.sh` — 8 passed, 0 failed
- `bash -n skills/woostack-fix/scripts/tests/test-closeout-invariant.sh`

### Manual
- Confirmed `site/content/docs/skills/woostack-fix.mdx` is generated and gitignored, so no authored docs page required a manual edit.

**Before merge**
- Review that the closeout invariant matches the intended `woostack-fix` lifecycle.

**After merge**
- None.

Spec: .woostack/fixes/2026-06-27-fix-closeout-invariant.md
