### PR TITLE
fix: update openai review model defaults

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -1,12 +1,4 @@
 {
-	"models": {
-		"openai": {
-			"standard": {
-				"model": "gpt-5.4-mini",
-				"effort": "xhigh"
-			}
-		}
-	},
 	"review": {
 		"metrics": true
 	},

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: false
     default: ''
   openai_effort:
-    description: 'Optional OpenAI Codex reasoning_effort override (minimal | low | medium | high | xhigh). Empty uses the tier default: xhigh for fast/standard, medium for deep.'
+    description: 'Optional OpenAI Codex reasoning_effort override (minimal | low | medium | high | xhigh). Empty uses the tier default: low for fast, medium for standard, high for deep.'
     required: false
     default: ''
   mode:

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -45,7 +45,9 @@ the sections below.
   },
   "models": {
     "openai": {
-      "standard": { "model": "gpt-5.4-mini", "effort": "xhigh" }
+      "fast": { "model": "gpt-5.5", "effort": "low" },
+      "standard": { "model": "gpt-5.5", "effort": "medium" },
+      "deep": { "model": "gpt-5.5", "effort": "high" }
     }
   },
   "review_sweep": { "max_rounds": 3 },
@@ -130,7 +132,7 @@ The default model per provider and tier:
 | Provider | `fast` | `standard` | `deep` |
 | --- | --- | --- | --- |
 | anthropic | `claude-haiku-4-5` | `claude-sonnet-4-6` | `claude-opus-4-8` |
-| openai | `gpt-5.3-codex-spark` | `gpt-5.4-mini` | `gpt-5.5` |
+| openai | `gpt-5.5` | `gpt-5.5` | `gpt-5.5` |
 | google | `gemini-3-5-flash` | `gemini-3-5-flash` | `gemini-3-5-flash` |
 | openrouter | `openrouter/deepseek/deepseek-v4-flash` | `openrouter/deepseek/deepseek-v4-pro` | `openrouter/deepseek/deepseek-v4-pro` |
 

--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -11,13 +11,13 @@ implicitly `fast`.
 
 | Tier | Use for | Anthropic | OpenAI (Codex) | Google (Gemini) | OpenRouter |
 |---|---|---|---|---|---|
-| `fast` | rubric checklists, mechanical fully-specified 1–2-file tasks, context summaries | `claude-haiku-4-5` | `gpt-5.3-codex-spark` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
-| `standard` | reasoning workers, multi-file integration | `claude-sonnet-4-6` | `gpt-5.4-mini` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
-| `deep` | skeptical validation, design/architecture judgment, code-quality review | `claude-opus-4-8` | `gpt-5.5` + `reasoning_effort: medium` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
+| `fast` | rubric checklists, mechanical fully-specified 1–2-file tasks, context summaries | `claude-haiku-4-5` | `gpt-5.5` + `reasoning_effort: low` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
+| `standard` | reasoning workers, multi-file integration | `claude-sonnet-4-6` | `gpt-5.5` + `reasoning_effort: medium` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
+| `deep` | skeptical validation, design/architecture judgment, code-quality review | `claude-opus-4-8` | `gpt-5.5` + `reasoning_effort: high` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
 
 > **Provider notes:**
 > - **Google** currently ships only `gemini-3-5-flash` in the 3.5 line; no Pro/Ultra/Thinking variant exists yet, so all tiers collapse onto flash (tier routing is effectively a no-op until Google releases a larger model).
-> - **OpenAI** GPT-5-family reasoning is a parameter on the same slug, not a slug suffix. Use `gpt-5.5` with `reasoning_effort: medium` for complex review and the skeptical validator, `gpt-5.4-mini` with `reasoning_effort: xhigh` for everyday coding review, and `gpt-5.3-codex-spark` with `reasoning_effort: xhigh` for simple/cost-sensitive rubric workers and latency-first real-time coding checks. There is no `gpt-5-pro`.
+> - **OpenAI** GPT-5-family reasoning is a parameter on the same slug, not a slug suffix. Use `gpt-5.5` for every tier, with `reasoning_effort: low` for fast, `medium` for standard, and `high` for deep. There is no `gpt-5-pro`.
 > - **OpenRouter** DeepSeek exposes exactly two slugs — `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-pro`. Reasoning is a `reasoning_effort` parameter (`high` / `xhigh`, where `xhigh` maps to max). Use plain `v4-pro` for standard and `v4-pro` with `reasoning_effort: xhigh` for deep. Do not route to `deepseek-r1` — V4 supersedes it.
 
 ## Routing by host capability (generic)

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -149,12 +149,12 @@ Full schema (every key shown; all optional):
 {
   "models": {
     "fast": "anthropic/claude-haiku-4-5",
-    "standard": { "model": "openai/gpt-5.4-mini", "effort": "xhigh" },
+    "standard": { "model": "openai/gpt-5.5", "effort": "medium" },
     "deep": "anthropic/claude-opus-4-8",
     "openai": {
-      "fast": { "model": "gpt-5.3-codex-spark", "effort": "xhigh" },
-      "standard": { "model": "gpt-5.4-mini", "effort": "low" },
-      "deep": { "model": "gpt-5.5", "effort": "medium" }
+      "fast": { "model": "gpt-5.5", "effort": "low" },
+      "standard": { "model": "gpt-5.5", "effort": "medium" },
+      "deep": { "model": "gpt-5.5", "effort": "high" }
     },
     "anthropic": {
       "fast": "claude-haiku-4-5",
@@ -389,12 +389,12 @@ Per-provider resolution (full table in `_header.md`):
 
 | Tier | Anthropic | OpenAI | Google | OpenRouter |
 |---|---|---|---|---|
-| `fast` | `claude-haiku-4-5` | `gpt-5.3-codex-spark` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
-| `standard` | `claude-sonnet-4-6` | `gpt-5.4-mini` + `reasoning_effort: xhigh` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
-| `deep` | `claude-opus-4-8` | `gpt-5.5` + `reasoning_effort: medium` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
+| `fast` | `claude-haiku-4-5` | `gpt-5.5` + `reasoning_effort: low` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-flash` |
+| `standard` | `claude-sonnet-4-6` | `gpt-5.5` + `reasoning_effort: medium` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` |
+| `deep` | `claude-opus-4-8` | `gpt-5.5` + `reasoning_effort: high` | `gemini-3-5-flash` | `openrouter/deepseek/deepseek-v4-pro` + `reasoning_effort: xhigh` |
 
 - **Google** currently exposes only `gemini-3-5-flash` — tier routing is a no-op on Gemini until a larger 3.5 model ships.
-- **OpenAI** GPT-5-family reasoning is a `reasoning_effort` parameter, not a slug suffix. Use `gpt-5.5` with `reasoning_effort: medium` for the skeptical validator and complex review passes, `gpt-5.4-mini` with `reasoning_effort: xhigh` for everyday review work, and `gpt-5.3-codex-spark` with `reasoning_effort: xhigh` for fast rubric workers and ultra-fast real-time coding checks. There is no `gpt-5-pro`.
+- **OpenAI** GPT-5-family reasoning is a `reasoning_effort` parameter, not a slug suffix. Use `gpt-5.5` for every tier, with `reasoning_effort: low` for fast, `medium` for standard, and `high` for deep. There is no `gpt-5-pro`.
 - **OpenRouter** exposes only `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-pro`; reasoning is the `reasoning_effort` parameter (`high`/`xhigh`). Do not route to `deepseek-r1` — V4 supersedes it.
 
 **Host capability:**
@@ -577,7 +577,7 @@ The `if:` gate restricts comment-triggered runs to the repo owner / members / co
 
 - Always parallelize Stage 3 when the host supports it; the validator pass is calibrated for ~5 angles' worth of input.
 - Trust the Skeptical Validator. Disabling it produces noisy reviews.
-- Honor angle-prompt tiers (`fast`/`standard`/`deep`) when the host supports per-call model routing. Hosts that run one model per session should pin `gpt-5.5` for maximum validator quality, or `gpt-5.4-mini` when cost matters more than deep validation.
+- Honor angle-prompt tiers (`fast`/`standard`/`deep`) when the host supports per-call model routing. Hosts that run one model per session should pin `gpt-5.5`; use tier-specific reasoning effort when the host supports it.
 - Pass `disable_angles` to skip optional angles when scope is narrow (e.g. backend-only PR → `disable_angles: "seo,aeo,design,react,i18n"`).
 - For a confirmed bug (not a style nit) that the author wants to fix, suggest investigating it with [`woostack-debug`](../woostack-debug/SKILL.md): `/woostack-debug <target>` (it runs an autonomous root-cause analysis and hands back the root cause and a proposed fix). Review never dispatches `woostack-debug` itself: it owns no fix behavior and never auto-addresses findings, so it only points the author at the command.
 

--- a/skills/woostack-review/prompts/_header.md
+++ b/skills/woostack-review/prompts/_header.md
@@ -403,7 +403,7 @@ Field-by-field:
 
 - **`<host>`** — canonical slug for the host agent invoking this skill. Use one of: `claude-code`, `cursor`, `antigravity-cli`, `codex`, `opencode`, or another stable identifier the host advertises. When a sub-agent profile or persona is identifiable (e.g. opencode running the `mimo-v2.5` agent), append it in parentheses: `opencode (mimo-v2.5)`. Detection hints: `CLAUDECODE=1` → `claude-code`; `OPENCODE*` env vars → `opencode`; `AGY_*` / `ANTIGRAVITY_*` → `antigravity-cli`; `CODEX_HOME` → `codex`; `CURSOR*` → `cursor`. Each orchestrator prompt declares a default host identifier near the top — prefer that only after the precedence above is exhausted.
 - **`<provider>`** — `anthropic` / `openai` / `google` / `openrouter` / `bedrock` / `vertex` / etc. Whatever the host is *actually* routing through. `opencode.md` is loaded for any OpenRouter-style orchestration shape, but OpenCode can route to any provider — do NOT assume `openrouter` just because this file was selected.
-- **`<model>`** — the actual validator model slug as the host sees it (e.g. `claude-opus-4-8`, `claude-sonnet-4-6`, `gpt-5.5`, `gpt-5.3-codex-spark`, `gemini-3-pro`, `openrouter/deepseek/deepseek-v4-pro`). When `inputs.model`, `models.<provider>.<tier>`, or flat `models.<tier>` in `config.json` overrode the default, report the override value, not the table default.
+- **`<model>`** — the actual validator model slug as the host sees it (e.g. `claude-opus-4-8`, `claude-sonnet-4-6`, `gpt-5.5`, `gemini-3-pro`, `openrouter/deepseek/deepseek-v4-pro`). When `inputs.model`, `models.<provider>.<tier>`, or flat `models.<tier>` in `config.json` overrode the default, report the override value, not the table default.
 
 ## Findings Schema (`/tmp/pr-review/findings.json`)
 

--- a/skills/woostack-review/prompts/openai.md
+++ b/skills/woostack-review/prompts/openai.md
@@ -14,25 +14,25 @@ Codex has two execution shapes:
 - **Codex Action / no per-spawn model override:** one model runs the full job. The `tier:` frontmatter is informational only, and the action resolves one session model in `load-prompt.sh`.
 
 The single-session action path resolves one session model in `load-prompt.sh` using this precedence:
-1. `FORCE_TIER` from Review Context (from `/woostack-review --fast` or `--deep`, or `review.force_tier` in config): fast→`gpt-5.3-codex-spark`, deep→`gpt-5.5`. Only `fast` and `deep` are valid `FORCE_TIER` values; the `standard` tier (`gpt-5.4-mini`) is the implicit default when `FORCE_TIER` is unset — see step 3.
+1. `FORCE_TIER` from Review Context (from `/woostack-review --fast` or `--deep`, or `review.force_tier` in config): fast→`gpt-5.5`, deep→`gpt-5.5`. Only `fast` and `deep` are valid `FORCE_TIER` values; the `standard` tier (`gpt-5.5`) is the implicit default when `FORCE_TIER` is unset — see step 3.
 2. `inputs.model` when explicitly set.
-3. Provider defaults (`gpt-5.4-mini` standard).
+3. Provider defaults (`gpt-5.5` standard).
 
 Per-repo override remains in effect during run-model resolution: if `$OUTDIR/config.json` has `models.openai.<run_tier>` set (or flat `models.<run_tier>`), use that value before falling back to the default.
 
-For quality/cost splits, GPT-5-family reasoning is a `reasoning_effort` parameter, not a slug suffix (`high`, `xhigh` etc.); there is no `gpt-5-pro`. Pass effort via `inputs.openai_effort` (wired through to codex-action `effort`). Defaults are `medium` for deep, `xhigh` for standard, and `xhigh` for fast. A per-tier `effort` may also be set on the config leaf (`models.openai.<tier>.effort`); `load-prompt.sh` resolves it **config-first** (`inputs.openai_effort` → config `effort` → tier/model default).
+For quality/cost splits, GPT-5-family reasoning is a `reasoning_effort` parameter, not a slug suffix; there is no `gpt-5-pro`. Pass effort via `inputs.openai_effort` (wired through to codex-action `effort`). Defaults are `high` for deep, `medium` for standard, and `low` for fast. A per-tier `effort` may also be set on the config leaf (`models.openai.<tier>.effort`); `load-prompt.sh` resolves it **config-first** (`inputs.openai_effort` → config `effort` → tier/model default).
 
-**Per-repo override:** resolve using the active run tier: if `$OUTDIR/config.json` has `models.openai.<run_tier>` set, use it; otherwise fall back to flat `models.<run_tier>` (precedence: `FORCE_TIER` > `inputs.model` > `models.openai.<run_tier>` > `models.<run_tier>` > default `gpt-5.4-mini`). The loader normalizes each leaf to an object `{model, effort?}`, so read `.model` with a run-tier-aware lookup, e.g. when `run_tier=deep`: `jq -r '((.models.openai.deep // .models.deep) | if type=="object" then .model else . end) // empty' $OUTDIR/config.json`.
+**Per-repo override:** resolve using the active run tier: if `$OUTDIR/config.json` has `models.openai.<run_tier>` set, use it; otherwise fall back to flat `models.<run_tier>` (precedence: `FORCE_TIER` > `inputs.model` > `models.openai.<run_tier>` > `models.<run_tier>` > default `gpt-5.5`). The loader normalizes each leaf to an object `{model, effort?}`, so read `.model` with a run-tier-aware lookup, e.g. when `run_tier=deep`: `jq -r '((.models.openai.deep // .models.deep) | if type=="object" then .model else . end) // empty' $OUTDIR/config.json`.
 
 For per-call local subagents, resolve each spawn with the same precedence, but use the target prompt's tier unless a forced tier is set:
 
 | Target | Effective tier when no `FORCE_TIER` | Default OpenAI model |
 |---|---|---|
-| `seo`, `aeo`, `i18n`, `docs`, `deps`, `comments`, context summary | `fast` | `gpt-5.3-codex-spark` |
-| all other angle workers | `standard` | `gpt-5.4-mini` |
+| `seo`, `aeo`, `i18n`, `docs`, `deps`, `comments`, context summary | `fast` | `gpt-5.5` |
+| all other angle workers | `standard` | `gpt-5.5` |
 | prosecutor and defender validators | `deep` | `gpt-5.5` |
 
-If the spawn API accepts a reasoning-effort override, pass the mapped effort too (`xhigh` for fast/standard, `medium` for deep). If it only accepts `model`, still pass `model`; do not fall back to parent-model inheritance.
+If the spawn API accepts a reasoning-effort override, pass the mapped effort too (`low` for fast, `medium` for standard, `high` for deep). If it only accepts `model`, still pass `model`; do not fall back to parent-model inheritance.
 
 ---
 

--- a/skills/woostack-review/scripts/load-config.sh
+++ b/skills/woostack-review/scripts/load-config.sh
@@ -163,7 +163,7 @@ if "review" in raw:
         loud("`review.models` has moved to a top-level `models` field; "
              "move it out of `review`, e.g. "
              "{\"models\": {\"openai\": {\"standard\": "
-             "{\"model\": \"gpt-5.4-mini\", \"effort\": \"xhigh\"}}}}")
+             "{\"model\": \"gpt-5.5\", \"effort\": \"medium\"}}}}")
     unknown = sorted(set(rc.keys()) - REVIEW_KEYS)
     if unknown:
         loud("unknown `review` key(s): {}".format(", ".join(unknown)))

--- a/skills/woostack-review/scripts/load-prompt.sh
+++ b/skills/woostack-review/scripts/load-prompt.sh
@@ -79,8 +79,9 @@ config_effort_for() {
 default_openai_effort_for() {
   local tier="$1"
   case "$tier" in
-    fast|standard) echo "xhigh" ;;
-    deep) echo "medium" ;;
+    fast) echo "low" ;;
+    standard) echo "medium" ;;
+    deep) echo "high" ;;
     *)
       echo "::error::Unknown OpenAI effort tier '$tier'"
       exit 1
@@ -91,7 +92,6 @@ default_openai_effort_for() {
 default_openai_effort_for_model() {
   local model="$1"
   case "$model" in
-    gpt-5.3-codex-spark|gpt-5.4-mini) echo "xhigh" ;;
     gpt-5.5) echo "medium" ;;
     *) echo "" ;;
   esac
@@ -128,10 +128,7 @@ if [ "$PROVIDER" = "openai" ]; then
     RUN_EFFORT="$(config_effort_for "$PROVIDER" "$RUN_TIER")"
   fi
   if [ -z "$RUN_EFFORT" ]; then
-    RUN_EFFORT="$(default_openai_effort_for_model "$RUN_MODEL")"
-    if [ -z "$RUN_EFFORT" ]; then
-      RUN_EFFORT="$(default_openai_effort_for "$RUN_TIER")"
-    fi
+    RUN_EFFORT="$(default_openai_effort_for "$RUN_TIER")"
   fi
   case "$RUN_EFFORT" in
     minimal|low|medium|high|xhigh) ;;

--- a/skills/woostack-review/scripts/resolve-model.sh
+++ b/skills/woostack-review/scripts/resolve-model.sh
@@ -35,8 +35,8 @@ default_model_for() {
       ;;
     openai)
       case "$tier" in
-        fast) echo "gpt-5.3-codex-spark" ;;
-        standard) echo "gpt-5.4-mini" ;;
+        fast) echo "gpt-5.5" ;;
+        standard) echo "gpt-5.5" ;;
         deep) echo "gpt-5.5" ;;
       esac
       ;;

--- a/skills/woostack-review/scripts/tests/test-load-config-models-root.sh
+++ b/skills/woostack-review/scripts/tests/test-load-config-models-root.sh
@@ -31,15 +31,15 @@ run_loader() {
 }
 
 # 1. object leaf normalized + preserved
-run_loader '{"models":{"openai":{"standard":{"model":"gpt-5.4-mini","effort":"low"}}}}'
+run_loader '{"models":{"openai":{"standard":{"model":"gpt-5.5","effort":"medium"}}}}'
 assert_exit 0 "$RC" "root models object leaf accepted"
 assert_eq "$(jq -c '.models.openai.standard' "$OUT/config.json")" \
-  '{"effort":"low","model":"gpt-5.4-mini"}' "object leaf preserved (sorted keys)"
+  '{"effort":"medium","model":"gpt-5.5"}' "object leaf preserved (sorted keys)"
 
 # 2. string leaf normalized to object
-run_loader '{"models":{"openai":{"standard":"gpt-5.4-mini"}}}'
+run_loader '{"models":{"openai":{"standard":"gpt-5.5"}}}'
 assert_eq "$(jq -c '.models.openai.standard' "$OUT/config.json")" \
-  '{"model":"gpt-5.4-mini"}' "string leaf normalized to {model}"
+  '{"model":"gpt-5.5"}' "string leaf normalized to {model}"
 
 # 3. review.models rejected (clean break, tailored message)
 run_loader '{"review":{"models":{"openai":{"standard":"x"}}}}'

--- a/skills/woostack-review/scripts/tests/test-load-prompt-models.sh
+++ b/skills/woostack-review/scripts/tests/test-load-prompt-models.sh
@@ -77,9 +77,9 @@ run_test() {
 }
 
 # Run tests for each tier
-run_test "fast" "gpt-5.3-codex-spark" "xhigh"
-run_test "" "gpt-5.4-mini" "xhigh"
-run_test "deep" "gpt-5.5" "medium"
+run_test "fast" "gpt-5.5" "low"
+run_test "" "gpt-5.5" "medium"
+run_test "deep" "gpt-5.5" "high"
 
 # If FORCE_TIER is unset, standard should be the default
 outdir="$(mktemp -d)"
@@ -90,8 +90,8 @@ run_load_prompt "$outdir" "$github_output"
 
 run_model="$(grep '^run_model=' "$github_output" | cut -d= -f2 || echo "")"
 run_effort="$(grep '^run_effort=' "$github_output" | cut -d= -f2 || echo "")"
-assert_eq "$run_model" "gpt-5.4-mini" "Default OpenAI/Codex routing (no FORCE_TIER) resolves to 'gpt-5.4-mini'"
-assert_eq "$run_effort" "xhigh" "Default OpenAI/Codex effort (no FORCE_TIER) resolves to 'xhigh'"
+assert_eq "$run_model" "gpt-5.5" "Default OpenAI/Codex routing (no FORCE_TIER) resolves to 'gpt-5.5'"
+assert_eq "$run_effort" "medium" "Default OpenAI/Codex effort (no FORCE_TIER) resolves to 'medium'"
 rm -rf "$outdir"
 
 # Explicit effort override should win over the tier default.
@@ -123,10 +123,10 @@ outdir="$(mktemp -d)"
 github_output="$outdir/github_output"
 touch "$github_output"
 
-run_load_prompt "$outdir" "$github_output" INPUT_MODEL="gpt-5.4-mini"
+run_load_prompt "$outdir" "$github_output" INPUT_MODEL="gpt-5.5"
 
 run_effort="$(grep '^run_effort=' "$github_output" | cut -d= -f2 || echo "")"
-assert_eq "$run_effort" "xhigh" "Explicit gpt-5.4-mini override resolves to xhigh effort"
+assert_eq "$run_effort" "medium" "Explicit gpt-5.5 override resolves to medium effort"
 rm -rf "$outdir"
 
 outdir="$(mktemp -d)"
@@ -154,28 +154,28 @@ rm -rf "$outdir"
 
 # Config object-leaf effort wins over the model/tier default.
 outdir="$(mktemp -d)"; github_output="$outdir/github_output"; touch "$github_output"
-printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.4-mini","effort":"low"}}}}' > "$outdir/config.json"
+printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.5","effort":"low"}}}}' > "$outdir/config.json"
 run_load_prompt "$outdir" "$github_output"
 run_model="$(grep '^run_model=' "$github_output" | cut -d= -f2 || echo "")"
 run_effort="$(grep '^run_effort=' "$github_output" | cut -d= -f2 || echo "")"
-assert_eq "$run_model" "gpt-5.4-mini" "config object leaf model resolves"
+assert_eq "$run_model" "gpt-5.5" "config object leaf model resolves"
 assert_eq "$run_effort" "low" "config .effort wins over tier/model default"
 rm -rf "$outdir"
 
 # INPUT_OPENAI_EFFORT still beats config .effort.
 outdir="$(mktemp -d)"; github_output="$outdir/github_output"; touch "$github_output"
-printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.4-mini","effort":"low"}}}}' > "$outdir/config.json"
+printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.5","effort":"low"}}}}' > "$outdir/config.json"
 run_load_prompt "$outdir" "$github_output" INPUT_OPENAI_EFFORT="high"
 run_effort="$(grep '^run_effort=' "$github_output" | cut -d= -f2 || echo "")"
 assert_eq "$run_effort" "high" "explicit INPUT_OPENAI_EFFORT beats config .effort"
 rm -rf "$outdir"
 
-# Object leaf without effort falls through to the model default (xhigh for gpt-5.4-mini).
+# Object leaf without effort falls through to the tier default (medium for standard).
 outdir="$(mktemp -d)"; github_output="$outdir/github_output"; touch "$github_output"
-printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.4-mini"}}}}' > "$outdir/config.json"
+printf '%s\n' '{"models":{"openai":{"standard":{"model":"gpt-5.5"}}}}' > "$outdir/config.json"
 run_load_prompt "$outdir" "$github_output"
 run_effort="$(grep '^run_effort=' "$github_output" | cut -d= -f2 || echo "")"
-assert_eq "$run_effort" "xhigh" "object leaf without effort uses model/tier default"
+assert_eq "$run_effort" "medium" "object leaf without effort uses model/tier default"
 rm -rf "$outdir"
 
 finish

--- a/skills/woostack-review/scripts/tests/test-resolve-model.sh
+++ b/skills/woostack-review/scripts/tests/test-resolve-model.sh
@@ -24,15 +24,15 @@ run_resolve() {
 
 # --- issue #295: provider-scoped config override wins over the default table ---
 outdir="$(mktemp -d)"
-printf '%s\n' '{"models":{"openai":{"standard":"gpt-5.3-codex-spark"}}}' > "$outdir/config.json"
+printf '%s\n' '{"models":{"openai":{"standard":"gpt-5.5"}}}' > "$outdir/config.json"
 model="$(run_resolve "$outdir" --provider openai --tier standard)"
-assert_eq "$model" "gpt-5.3-codex-spark" \
-  "config models.openai.standard wins over default gpt-5.4-mini (issue #295)"
+assert_eq "$model" "gpt-5.5" \
+  "config models.openai.standard wins over default gpt-5.5 (issue #295)"
 rm -rf "$outdir"
 
 # --- provider-scoped override leaves other tiers on the default table ---
 outdir="$(mktemp -d)"
-printf '%s\n' '{"models":{"openai":{"standard":"gpt-5.3-codex-spark"}}}' > "$outdir/config.json"
+printf '%s\n' '{"models":{"openai":{"standard":"gpt-5.5"}}}' > "$outdir/config.json"
 model="$(run_resolve "$outdir" --provider openai --tier deep)"
 assert_eq "$model" "gpt-5.5" "untouched tier (deep) falls through to default table"
 rm -rf "$outdir"
@@ -53,10 +53,10 @@ rm -rf "$outdir"
 
 # --- no config: default table per provider/tier ---
 outdir="$(mktemp -d)"
-assert_eq "$(run_resolve "$outdir" --provider openai --tier standard)" "gpt-5.4-mini" \
-  "default openai/standard is gpt-5.4-mini"
-assert_eq "$(run_resolve "$outdir" --provider openai --tier fast)" "gpt-5.3-codex-spark" \
-  "default openai/fast is gpt-5.3-codex-spark"
+assert_eq "$(run_resolve "$outdir" --provider openai --tier standard)" "gpt-5.5" \
+  "default openai/standard is gpt-5.5"
+assert_eq "$(run_resolve "$outdir" --provider openai --tier fast)" "gpt-5.5" \
+  "default openai/fast is gpt-5.5"
 assert_eq "$(run_resolve "$outdir" --provider openai --tier deep)" "gpt-5.5" \
   "default openai/deep is gpt-5.5"
 assert_eq "$(run_resolve "$outdir" --provider anthropic --tier standard)" "claude-sonnet-4-6" \

--- a/skills/woostack-review/scripts/tests/test-resolve-model.sh
+++ b/skills/woostack-review/scripts/tests/test-resolve-model.sh
@@ -24,15 +24,15 @@ run_resolve() {
 
 # --- issue #295: provider-scoped config override wins over the default table ---
 outdir="$(mktemp -d)"
-printf '%s\n' '{"models":{"openai":{"standard":"gpt-5.5"}}}' > "$outdir/config.json"
+printf '%s\n' '{"models":{"openai":{"standard":"override-standard-model"}}}' > "$outdir/config.json"
 model="$(run_resolve "$outdir" --provider openai --tier standard)"
-assert_eq "$model" "gpt-5.5" \
+assert_eq "$model" "override-standard-model" \
   "config models.openai.standard wins over default gpt-5.5 (issue #295)"
 rm -rf "$outdir"
 
 # --- provider-scoped override leaves other tiers on the default table ---
 outdir="$(mktemp -d)"
-printf '%s\n' '{"models":{"openai":{"standard":"gpt-5.5"}}}' > "$outdir/config.json"
+printf '%s\n' '{"models":{"openai":{"standard":"override-standard-model"}}}' > "$outdir/config.json"
 model="$(run_resolve "$outdir" --provider openai --tier deep)"
 assert_eq "$model" "gpt-5.5" "untouched tier (deep) falls through to default table"
 rm -rf "$outdir"

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh
@@ -10,16 +10,16 @@ work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
 export WOO_REVIEW_PROVIDER=openai
 printf '%s\n' aeo bugs validator > "$OUTDIR/angles.txt"
-printf '{"angle":"aeo","chunk":null,"runner":"codex-subagent","model":"gpt-5.3-codex-spark","tier":"fast","ts":"t"}\n' > "$OUTDIR/receipt.aeo.json"
-printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-5.4-mini","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+printf '{"angle":"aeo","chunk":null,"runner":"codex-subagent","model":"gpt-5.5","tier":"fast","ts":"t"}\n' > "$OUTDIR/receipt.aeo.json"
+printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-5.5","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
 printf '{"angle":"validator","chunk":null,"runner":"codex-subagent","model":"gpt-5.5","tier":"deep","ts":"t"}\n' > "$OUTDIR/receipt.validator.json"
 
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
 assert_exit 0 "$rc" "OpenAI receipts matching tier models pass"
 
-printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"gpt-5.5","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+printf '{"angle":"bugs","chunk":null,"runner":"codex-subagent","model":"claude-sonnet-4-6","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
 rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
-assert_exit 1 "$rc" "OpenAI standard worker inheriting deep model fails"
+assert_exit 1 "$rc" "OpenAI standard worker with mismatched provider model fails"
 assert_contains "$err" "bugs" "names the worker with mismatched model"
 
 printf '{"models":{"openai":{"standard":"gpt-custom-standard"}}}\n' > "$OUTDIR/config.json"
@@ -40,12 +40,12 @@ assert_exit 0 "$rc" "OpenAI object-leaf {model,effort} config override resolves 
 unset WOO_REVIEW_PROVIDER
 export WOO_REVIEW_HOST=codex
 rm -f "$OUTDIR/config.json"
-printf '{"angle":"bugs","chunk":null,"runner":"local-worker","model":"gpt-5.5","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+printf '{"angle":"bugs","chunk":null,"runner":"local-worker","model":"claude-sonnet-4-6","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
 rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
 assert_exit 1 "$rc" "Codex host triggers model validation without provider or codex runner"
 assert_contains "$err" "bugs" "names the host-triggered worker with mismatched model"
 
-printf '{"angle":"bugs","chunk":null,"runner":"local-worker","model":"gpt-5.4-mini","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
+printf '{"angle":"bugs","chunk":null,"runner":"local-worker","model":"gpt-5.5","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
 assert_exit 0 "$rc" "Codex host accepts matching model without provider or codex runner"
 

--- a/skills/woostack-review/scripts/verify-receipts.sh
+++ b/skills/woostack-review/scripts/verify-receipts.sh
@@ -54,8 +54,8 @@ label() { # angle chunk
 
 default_openai_model_for_tier() {
   case "$1" in
-    fast) echo "gpt-5.3-codex-spark" ;;
-    standard) echo "gpt-5.4-mini" ;;
+    fast) echo "gpt-5.5" ;;
+    standard) echo "gpt-5.5" ;;
     deep) echo "gpt-5.5" ;;
     *) return 1 ;;
   esac


### PR DESCRIPTION
## Goal

Make woostack's OpenAI review tiers default to `gpt-5.5` across fast, standard, and deep while preserving tier-specific reasoning effort.

## Summary

- Updates OpenAI tier resolution so fast, standard, and deep all resolve to `gpt-5.5` with low, medium, and high effort respectively.
- Keeps review prompt loading and receipt validation aligned with the shared OpenAI slug and tier-specific effort defaults.
- Refreshes review docs, action metadata, configuration docs, and focused tests for the new OpenAI defaults.

## Test plan

### Automated

- [ ] `bash skills/woostack-review/scripts/tests/test-resolve-model.sh` passed: 16 passed, 0 failed.
- [ ] `bash skills/woostack-review/scripts/tests/test-load-prompt-models.sh` passed: 20 passed, 0 failed.
- [ ] `bash skills/woostack-review/scripts/tests/test-load-config-models-root.sh` passed: 17 passed, 0 failed.
- [ ] `bash skills/woostack-review/scripts/tests/test-verify-receipts-openai-models.sh` passed: 9 passed, 0 failed.
- [ ] `pnpm -C site build` passed.
- [ ] `git diff --check` passed.

### Manual

**Before merge**

- [ ] Review the OpenAI model tables and examples to confirm fast, standard, and deep all show `gpt-5.5` with low, medium, and high effort.
- [ ] Inspect the review scripts to confirm shared `gpt-5.5` routing still keeps effort tier-specific.
