### PR TITLE
fix: always run simplify angle

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -91,7 +91,7 @@ inputs:
     required: false
     default: ''
   disable_angles:
-    description: 'Comma-separated list of review angles to skip (seo, aeo, design, react, database, tests, api, infra, observability, types, i18n, docs, deps). `bugs` and `security` are always on and cannot be disabled.'
+    description: 'Comma-separated list of review angles to skip (seo, aeo, design, react, database, tests, api, infra, observability, types, i18n, docs, deps). `bugs`, `security`, and `simplify` are always on and cannot be disabled.'
     required: false
     default: ''
   react_doctor_version:

--- a/site/content/docs/concepts/review-angles.mdx
+++ b/site/content/docs/concepts/review-angles.mdx
@@ -9,9 +9,9 @@ woostack-review reviews a pull request through a set of **angles**. Each angle i
 
 Three rules decide which angles run on a given pull request:
 
-1. **`bugs` and `security` always run.** They are on for every review and can never be skipped.
+1. **`bugs`, `security`, and `simplify` always run.** They are on for every review and can never be skipped.
 2. **The other angles auto-detect from the diff.** Each one looks at the files the PR touches and the content of the diff, and turns itself on when it sees something relevant. A `.sql` file pulls in `database`; a `.tsx` file pulls in `react`.
-3. **You can override detection.** `review.angles.force` runs an angle whatever the diff looks like, and `review.angles.skip` keeps one off. `force` wins a tie, and `bugs` / `security` ignore `skip`. See [Choosing angles](/docs/configuration#choosing-angles).
+3. **You can override detection.** `review.angles.force` runs an angle whatever the diff looks like, and `review.angles.skip` keeps one off. `force` wins a tie, and `bugs` / `security` / `simplify` ignore `skip`. See [Choosing angles](/docs/configuration#choosing-angles).
 
 ## The catalog
 
@@ -36,7 +36,7 @@ Every angle, what it reviews, a plain-language summary of when it auto-fires, an
 | `react` | React correctness: Rules of Hooks and render behavior | a `.tsx` or `.jsx` file changes | standard |
 | `security` | Threat model: injection, auth, secrets, unsafe patterns | always (cannot be skipped) | standard |
 | `seo` | Search-engine optimization: meta tags, sitemaps, canonical URLs | HTML, head / layout files, `robots.txt`, `sitemap`, `next.config`, or SEO tokens in the diff | fast |
-| `simplify` | Simplification: code that should be smaller or not exist (YAGNI, dead code, duplication, thin abstractions) | any general-purpose source file changes (same signal as `architecture`) | standard |
+| `simplify` | Simplification: code that should be smaller or not exist (YAGNI, dead code, duplication, thin abstractions) | every review | standard |
 | `skills` | Agent Skill authoring: a changed SKILL.md against the best-practices guide | a `SKILL.md` file changes anywhere in the diff | standard |
 | `tests` | Test coverage and quality | a test file changes (`.test.*`, `.spec.*`, `_test.*`, or `tests/` / `__tests__/` / `spec/` trees) | standard |
 | `types` | Type design: TypeScript invariants and signatures | a `.ts` / `.tsx` / `.cts` / `.mts` file changes | standard |
@@ -44,7 +44,7 @@ Every angle, what it reviews, a plain-language summary of when it auto-fires, an
 The exact gating heuristics (file globs and diff-token patterns) live in [`detect-angles.sh`](https://github.com/howarewoo/woostack/blob/main/skills/woostack-review/scripts/detect-angles.sh), the source of truth. This table summarizes them in plain language.
 
 <Callout type="info">
-  `bugs` and `security` run on every review and can never be skipped. Listing either under `review.angles.skip` is silently ignored.
+  `bugs`, `security`, and `simplify` run on every review and can never be skipped. Listing any of them under `review.angles.skip` is silently ignored.
 </Callout>
 
 <Callout type="info">

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -76,13 +76,13 @@ finding explicitly marked blocking always surfaces regardless of the floor.
 ### Choosing angles
 
 Angles are auto-detected from the diff. Force an angle to run it regardless of detection; skip one
-to keep it off. `force` wins when an angle appears in both. The `bugs` and `security` angles can
-never be skipped. They are silently kept even if listed.
+to keep it off. `force` wins when an angle appears in both. The `bugs`, `security`, and `simplify`
+angles can never be skipped. They are silently kept even if listed.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `review.angles.force` | array of string | `[]` | Angles always enabled. |
-| `review.angles.skip` | array of string | `[]` | Angles never enabled (except `bugs` / `security`). |
+| `review.angles.skip` | array of string | `[]` | Angles never enabled (except `bugs` / `security` / `simplify`). |
 
 See [Review angles](/docs/concepts/review-angles) for the full catalog of all 21 angles: what each one
 audits, when it auto-fires, and its model tier.

--- a/skills/woostack-audit/SKILL.md
+++ b/skills/woostack-audit/SKILL.md
@@ -27,17 +27,19 @@ and **never merges**. It points findings at [`woostack-fix`](../woostack-fix/SKI
   bare default — auditing a whole repo is opt-in, not accidental).
 - `/woostack-audit --all` — audit the repo root (the sanctioned whole-repo opt-in).
 - `/woostack-audit <target> --fast | --deep` — one-run tier override (review's `FORCE_TIER`).
-- `/woostack-audit <target> --simplify | --prod-only` — narrow to one lens; `bugs` + `security`
-  remain on as a safety floor.
+- `/woostack-audit <target> --simplify | --prod-only` — narrow audit emphasis; `--simplify`
+  keeps only simplification, `--prod-only` emphasizes production-readiness while keeping
+  simplification, and `bugs` + `security` remain on as a safety floor.
 
 ## Angles
 
-Audit runs on the synthetic diff with **`simplify`** and **`production-readiness`** always-on
-(plus the `bugs` + `security` safety floor), and auto-detects review's other angles
-(`observability`, `types`, `deps`, `tests`, `conventions`, …) on the target. The `architecture`
-angle is skipped — `simplify` owns the full simplification surface when it is absent (see
-[`prompts/angles/simplify.md`](../woostack-review/prompts/angles/simplify.md)). Both new angles are
-shared with `woostack-review`, which also runs them on source-touching diffs.
+Audit runs on the synthetic diff with **`simplify`** and **`production-readiness`** by default
+(plus the `bugs` + `security` safety floor). `--simplify` narrows the audit to simplification;
+`--prod-only` emphasizes production-readiness while keeping simplification. It also auto-detects
+review's other angles (`observability`, `types`, `deps`, `tests`, `conventions`, …) on the target.
+The `architecture` angle is skipped — `simplify` owns the full simplification surface when it is
+absent (see [`prompts/angles/simplify.md`](../woostack-review/prompts/angles/simplify.md)). Both
+new angles are shared with `woostack-review`, which also runs them on source-touching diffs.
 
 ## Per-repo configuration
 

--- a/skills/woostack-audit/scripts/load-audit-config.sh
+++ b/skills/woostack-audit/scripts/load-audit-config.sh
@@ -30,10 +30,13 @@ if lens == "simplify":
     force = ["simplify"]
 elif lens == "prod":
     force = ["production-readiness"]
+if "simplify" not in force:
+    force.append("simplify")
 ang = audit.get("angles", {}) or {}
+skip = [a for a in (ang.get("skip", []) or []) if a != "simplify"]
 out_cfg = {
     "angles": {"force": force + (ang.get("force", []) or []),
-               "skip": ["architecture"] + (ang.get("skip", []) or [])},
+               "skip": ["architecture"] + skip},
     "severity_floor": audit.get("severity_floor", "high"),
     "ignore": audit.get("ignore", []),
     "models": audit.get("models", {}),

--- a/skills/woostack-audit/scripts/tests/test-load-audit-config.sh
+++ b/skills/woostack-audit/scripts/tests/test-load-audit-config.sh
@@ -30,11 +30,11 @@ cfg="$(cat "$OUTDIR/config.json")"
 assert_contains "$cfg" "simplify" "lens simplify forces simplify"
 assert_not_contains "$cfg" "production-readiness" "lens simplify drops prod-readiness"
 
-# Lens flag prod forces production-readiness only, drops simplify.
+# Lens flag prod narrows production-readiness but still keeps simplify.
 run '{}' 'prod'; assert_eq "$EC" "0" "lens prod ok"
 cfg="$(cat "$OUTDIR/config.json")"
 assert_contains "$cfg" "production-readiness" "lens prod forces production-readiness"
-assert_not_contains "$cfg" "simplify" "lens prod drops simplify"
+assert_contains "$cfg" "simplify" "lens prod keeps simplify"
 
 # angles:null is coerced to {} by the `or {}` guard, not treated as an error.
 run '{"audit":{"angles":null}}'; assert_eq "$EC" "0" "angles:null coerced, not an error"
@@ -44,6 +44,13 @@ run '{"audit":{"angles":{"force":["bugs"],"skip":["docs"]}}}'; assert_eq "$EC" "
 cfg="$(cat "$OUTDIR/config.json")"
 assert_contains "$cfg" "bugs" "user angles.force merged onto defaults"
 assert_contains "$cfg" "docs" "user angles.skip merged onto architecture"
+
+# simplify is invariant for audit and cannot be disabled through user skip config.
+run '{"audit":{"angles":{"skip":["simplify","docs"]}}}'; assert_eq "$EC" "0" "simplify skip ignored"
+cfg="$(cat "$OUTDIR/config.json")"
+assert_contains "$cfg" "simplify" "simplify remains forced"
+assert_eq "$(jq -r '.angles.skip | index("simplify") == null' "$OUTDIR/config.json")" "true" "simplify removed from skip"
+assert_contains "$cfg" "docs" "other user skips remain"
 
 # Unknown lens flag falls back to running both audit angles, not an error.
 run '{}' 'bogus'; assert_eq "$EC" "0" "unknown lens falls back, no error"

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -194,7 +194,7 @@ Full schema (every key shown; all optional):
 ```
 
 Key reference (JSON has no comments, so the per-key semantics live here):
-- **`angles.force`** — always run these, even if not auto-detected. **`angles.skip`** — never run these (`bugs`/`security` cannot be skipped).
+- **`angles.force`** — always run these, even if not auto-detected. **`angles.skip`** — never run these (`bugs`/`security`/`simplify` cannot be skipped).
 - **`severity_floor`** — one of `low` | `medium` | `high`; a blocking/visibility threshold, **not** a drop gate. **Default `high`**. Findings below the floor surface as non-blocking nits (see `nits`); set `low`/`medium` to treat more findings as normal (at/above-floor). Applied once by `intersect-findings.sh` (Stage 4c).
 - **`nits`** — `true` | `false`; default **`true`**. When `true`, validated findings below `severity_floor` surface as non-blocking nits instead of being dropped. Set `false` to drop them (the pre-reframe behavior). Below-floor `blocking` findings always surface regardless of this knob.
 - **`defer_markers`** — `true` | `false`; default **`true`**. When `true`, the defender validator honors inline `woostack-defer(<ref>)` markers (authored by `woostack-execute` under an approved plan): a finding that flags work a later increment intentionally completes is demoted to a non-blocking `Deferred to <ref>` nit instead of a normal finding (issue #224). Set `false` to ignore the markers. Never defers `security` findings or wrong code present in this PR; reads the marker from the PR's own diff, so it fetches no other PRs.
@@ -295,7 +295,7 @@ bash "$WOO_REVIEW_ACTION_PATH/scripts/load-config.sh"   # parses .woostack/confi
 bash "$WOO_REVIEW_ACTION_PATH/scripts/detect-angles.sh"
 ```
 
-Read the result from `$OUTDIR/angles.txt` (one angle per line). Always-on angles: `bugs`, `security`. Conditional (auto-detected from changed paths + diff body): `conventions` (when `rules.md` is present), `seo`, `aeo`, `design`, `react`, `database`, `tests`, `api`, `infra`, `observability`, `types`, `i18n`, `docs`, `deps`, `skills` (when a `SKILL.md` is in the diff), `architecture`, `comments`, `simplify`, and `production-readiness` (when the diff touches general-purpose source files). See `scripts/detect-angles.sh` for per-angle gating heuristics.
+Read the result from `$OUTDIR/angles.txt` (one angle per line). Always-on angles: `bugs`, `security`, `simplify`. Conditional (auto-detected from changed paths + diff body): `conventions` (when `rules.md` is present), `seo`, `aeo`, `design`, `react`, `database`, `tests`, `api`, `infra`, `observability`, `types`, `i18n`, `docs`, `deps`, `skills` (when a `SKILL.md` is in the diff), `architecture`, `comments`, and `production-readiness` (when the diff touches general-purpose source files). See `scripts/detect-angles.sh` for per-angle gating heuristics.
 
 Prefetch also produces optional chunking artifacts when the post-ignore diff exceeds `chunking.max_loc` (default 4000 LOC). When present, the host MUST fan out one sub-agent per `(angle, chunk)` pair in Stage 3:
 

--- a/skills/woostack-review/scripts/detect-angles.sh
+++ b/skills/woostack-review/scripts/detect-angles.sh
@@ -7,6 +7,7 @@
 # Angle gating:
 #   bugs      — always on
 #   security  — always on
+#   simplify  — always on
 #   seo       — HARD files (fire on path alone): robots.txt, sitemap.{xml,ts},
 #               app/manifest.{ts,json}. SOFT surfaces (*.html, head/layout.{ts,tsx,js,jsx},
 #               next.config.*) no longer gate on path — they fire only via a diff token:
@@ -76,9 +77,8 @@
 #   comments  — reuses the general-purpose source-file signal (any *.{ts,js,py,go,…}
 #               in the diff, same as architecture). Audits whether code comments still
 #               match the code the PR changed (comment rot). Always non-blocking.
-#   simplify  — general-purpose source files in the diff (same signal as architecture).
-#               YAGNI / dead-code / duplication delete-list. Defers structural-shape to
-#               architecture when both are enabled.
+#   simplify  — every review. YAGNI / dead-code / duplication delete-list. Defers
+#               structural-shape to architecture when both are enabled.
 #   production-readiness — general-purpose source files in the diff. Resilience/operability
 #               posture (timeouts, retries, idempotency, degradation, resource limits).
 
@@ -265,7 +265,7 @@ has_skills_file() {
   echo "$CHANGED_PATHS" | grep -qE '(^|/)SKILL\.md$'
 }
 
-ANGLES=("bugs" "security")
+ANGLES=("bugs" "security" "simplify")
 
 if [ -f "$OUTDIR/rules.md" ]; then
   ANGLES+=("conventions")
@@ -336,10 +336,6 @@ if has_code_file; then
 fi
 
 if has_code_file; then
-  ANGLES+=("simplify")
-fi
-
-if has_code_file; then
   ANGLES+=("production-readiness")
 fi
 
@@ -357,7 +353,7 @@ if [ -f "$CFG" ] && jq -e '.angles.skip // empty' "$CFG" >/dev/null 2>&1; then
   fi
 fi
 
-# Apply disable list. bugs + security cannot be disabled.
+# Apply disable list. bugs + security + simplify cannot be disabled.
 if [ -n "$DISABLE" ]; then
   IFS=',' read -ra DIS_ARRAY <<< "$DISABLE"
   FILTERED=()
@@ -365,7 +361,7 @@ if [ -n "$DISABLE" ]; then
     keep=1
     for d in "${DIS_ARRAY[@]}"; do
       d_trim=$(echo "$d" | xargs)
-      if [ "$a" = "$d_trim" ] && [ "$a" != "bugs" ] && [ "$a" != "security" ]; then
+      if [ "$a" = "$d_trim" ] && [ "$a" != "bugs" ] && [ "$a" != "security" ] && [ "$a" != "simplify" ]; then
         keep=0
         break
       fi

--- a/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
@@ -7,16 +7,23 @@ SCRIPT="$DIR/detect-angles.sh"
 setup() { work="$(mktemp -d)"; export OUTDIR="$work/out"; mkdir -p "$OUTDIR"; \
   printf '%s\n' "$1" | jq -R . | jq -s '{files: [.[] | {path: .}]}' > "$OUTDIR/meta.json"; : > "$OUTDIR/diff.txt"; }
 
-# Source file enables both new angles (same gate as architecture).
+# simplify always runs; source file also enables production-readiness.
 setup "src/index.ts"; bash "$SCRIPT" >/dev/null 2>&1
 assert_contains "$(cat "$OUTDIR/angles.txt")" "simplify" "source enables simplify"
 assert_contains "$(cat "$OUTDIR/angles.txt")" "production-readiness" "source enables production-readiness"
 rm -rf "$work"
 
-# Docs-only PR enables neither.
+# Docs-only PR still gets simplify, but not production-readiness.
 setup "README.md"; bash "$SCRIPT" >/dev/null 2>&1
-assert_eq "$(grep -cx 'simplify' "$OUTDIR/angles.txt" || true)" "0" "docs-only: no simplify"
+assert_eq "$(grep -cx 'simplify' "$OUTDIR/angles.txt" || true)" "1" "docs-only: simplify remains on"
 assert_eq "$(grep -cx 'production-readiness' "$OUTDIR/angles.txt" || true)" "0" "docs-only: no production-readiness"
+rm -rf "$work"
+
+# simplify cannot be disabled by input skip or config skip.
+setup "README.md"
+printf '{"angles":{"skip":["simplify"]}}\n' > "$OUTDIR/config.json"
+INPUT_DISABLE_ANGLES="simplify" bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(grep -cx 'simplify' "$OUTDIR/angles.txt" || true)" "1" "skip cannot disable simplify"
 rm -rf "$work"
 
 # Site 3 (load-config.sh VALID_ANGLES): both new angles must be registered, else


### PR DESCRIPTION
## Goal

Ensure the `simplify` review lens is always present for both standing-code audits and PR reviews, even when the diff is docs-only or users try to disable the angle.

## Summary

- Makes `simplify` a non-disableable base angle in `woostack-review`, alongside `bugs` and `security`.
- Keeps `simplify` forced for `woostack-audit`, including `--prod-only`, and strips it from audit skip config.
- Updates review/audit docs and action input text so the public configuration contract matches the detector behavior.
- Adds regression coverage for docs-only review diffs, skip attempts, audit lens modes, and audit skip config.

## Test plan

### Automated

- [ ] `for t in skills/woostack-review/scripts/tests/test-*.sh; do bash "$t"; done` exited 0.
- [ ] `bash skills/woostack-audit/scripts/tests/test-load-audit-config.sh && bash skills/woostack-audit/scripts/tests/test-audit-smoke.sh && bash skills/woostack-audit/scripts/tests/test-build-target-diff.sh && bash skills/woostack-audit/scripts/tests/test-render-report.sh` passed.
- [ ] `pnpm -C site build` passed.
- [ ] `git diff --check` passed.

### Manual

**Before merge**

- [ ] Review `detect-angles.sh` and confirm `simplify` is initialized with `bugs` and `security` and is ignored by disable filtering.
- [ ] Review the docs/action text and confirm `simplify` is documented as always-on and non-disableable.
