### PR TITLE
docs: correct woostack-fix distill memory target

### DIFF
--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -187,10 +187,14 @@ investigation.
 
    Tear down the **single** fix worktree after the one PR is open/updated and the `status:
    in-review` lifecycle update is committed and submitted; the branch/commits/PR persist. **Leave
-   the worktree in place on failure** and report its path. The memory
-   distill (run by `woostack-execute` in step 5) targets the primary tree via the `WOOSTACK_ROOT`
-   export of the [worktree contract](../woostack-init/references/worktrees.md) §5, so it survives
-   teardown.
+   the worktree in place on failure** and report its path. The memory distill (run by
+   `woostack-execute` in step 5) writes its note **and** the rebuilt `MEMORY.md` **inside the fix
+   worktree** and commits them onto `fix/<slug>` with the increment (per the
+   [worktree contract](../woostack-init/references/worktrees.md) §5 and
+   `tracked-memory-rides-increment-commit`) — so the distilled memory rides the one fix PR and
+   survives teardown **because it is committed**, not because it lives in the primary tree. Only the
+   metrics/telemetry/watermark sidecars resolve to the primary checkout via `WOOSTACK_ROOT`. Never
+   leave the distilled note uncommitted in the primary tree.
 
 ## Hard constraints
 


### PR DESCRIPTION
## Goal

Fix a wrong claim in `woostack-fix` SKILL.md step 6 that led an agent to leave a distilled memory note uncommitted in the primary tree.

## Summary

Step 6 said the memory distill *"targets the primary tree via the WOOSTACK_ROOT export … so it survives teardown."* That contradicts the authoritative sources:

- **worktree contract** (`worktrees.md` §3 L75-78, §5): tracked memory notes are written in the worktree and ride the increment's commit; only `metrics.json` / `.telemetry.tsv` / `.dream-watermark` (gitignored sidecars) resolve to the primary checkout via `WOOSTACK_ROOT`.
- **`tracked-memory-rides-increment-commit`** (memory note): "distillation writes notes and rebuilds `MEMORY.md` in the active increment worktree … Only metrics, telemetry, and watermark sidecars resolve to the primary checkout."
- **`woostack-execute`** SKILL.md already states this correctly (rebuild `MEMORY.md` in the worktree; note + index ride the increment commit).

Corrected the step-6 line so the fix loop's closeout matches: the note **and** rebuilt `MEMORY.md` are written inside the fix worktree and committed onto `fix/<slug>` with the increment (surviving teardown *because committed*), sidecars go to the primary tree via `WOOSTACK_ROOT`, and it explicitly forbids leaving the distilled note uncommitted in the primary tree.

## Test plan

### Automated
- [x] Docs-only edit to one SKILL.md; no scripts/tests touched. `woostack-fix` now consistent with `woostack-execute`, `worktrees.md`, and the convention note.

### Manual
- [ ] Skim the corrected step-6 paragraph for accuracy. The per-skill site page regenerates from `SKILL.md` (no manual site edit).