### PR TITLE
fix: tighten review angle gates

### DIFF
--- a/.woostack/fixes/2026-07-03-issue-449-angle-gates.md
+++ b/.woostack/fixes/2026-07-03-issue-449-angle-gates.md
@@ -1,0 +1,74 @@
+---
+type: fix
+status: hardened
+branch: fix/issue-449-angle-gates
+---
+
+# Fix: Reduce zero-signal review angle fan-out
+
+## 1. Root Cause
+
+Issue #449 reports that several review angles, especially `aeo` and `seo`, launch on many PRs but produce no blocking findings in consumer metrics. The root cause is over-broad angle detection plus missing aggregate feedback:
+
+- `skills/woostack-review/scripts/detect-angles.sh` treats every changed `*.md`, `*.mdx`, or `*.html` file as AEO-relevant (`has_aeo_file`), so ordinary README, `SKILL.md`, changelog, or generic HTML changes launch the AEO worker even when the diff has no AI-answer-engine surface. The AEO prompt is narrower: crawler access, `llms.txt`, pricing/product content, JSON-LD/schema, answer passages, and citability. Synthetic reproduction in the diagnosis showed a README typo diff and a prose-only `SKILL.md` diff both enabling `aeo`.
+- `has_seo_diff_token()` scans the whole diff and `detect-angles.sh` enables `seo` when any SEO token appears anywhere. That means a backend/API/source file containing `generateMetadata`, `export const metadata`, `hreflang`, or legacy meta/canonical/sitemap tokens can launch SEO without being an SEO/head/content surface. Existing SEO tests cover positive soft surfaces and some negatives, but not the backend/source-token leak.
+- `skills/woostack-review/scripts/metrics-fold.sh` already folds per-angle `runs_present`, `raw_total`, `kept_total`, `blocking_total`, and `nit_total`, but it only prints a generic folded-run message. The docs provide a manual validator-drop ranking query, which misses zero-ever angles (`raw_total == 0`) and gives users no data-driven `review.angles.skip` suggestion.
+
+Relevant repo memory from diagnosis: angle triggers must be high-signal, angle changes require detection tests, and docs/tests must be updated lockstep with review-script changes.
+
+## 2. Proposed Fix
+
+Make the review angle gates match the prompts and add advisory-only metrics feedback:
+
+- Tighten AEO path detection so only high-signal hard surfaces fire by path alone: `robots.txt`, `llms.txt`, and pricing pages/files. Add a narrow public-content predicate for marketing/content/blog/docs-site/pricing/product/landing page markdown/MDX/HTML. Do not fire AEO for arbitrary `README.md`, `SKILL.md`, changelog, internal docs, generic docs paths, or generic HTML unless the diff contains an AEO token.
+- Tighten SEO token detection by requiring soft SEO/content paths before soft tokens can enable `seo`. Keep existing hard SEO path triggers for `robots.txt`, `sitemap.{xml,ts}`, and `app/manifest.{ts,json}` because `test-detect-angles-seo.sh` already treats `app/manifest.ts` as an intentional path-alone SEO surface.
+- Add metrics-fold skip advisories after aggregation. When `review.metrics: true` and `ANGLE_SKIP_SUGGEST_MIN_RUNS=20` is met, print non-mutating suggestions for zero-kept/zero-blocking or nit-only/no-blocking angles, pointing users to `review.angles.skip`. Do not edit `.woostack/config.json` automatically, and never suggest unskippable core angles (`bugs`, `security`, `simplify`).
+- Update `woostack-review/SKILL.md` Stage 6.5 to document the advisory output and correct the aggregate schema version already used by `metrics-fold.sh`. Authored docs-site pages that summarize angle selection or metrics also need lockstep updates: `site/content/docs/configuration.mdx` and `site/content/docs/concepts/review-angles.mdx`.
+
+## 3. Implementation Plan
+
+- [ ] **Step 1: Reproduce with failing detection tests**
+  - Add `skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh` covering:
+    - `README.md` prose-only diff does not enable `aeo` and still enables `docs`.
+    - `skills/example/SKILL.md` prose-only diff does not enable `aeo` and still enables `skills`.
+    - `public/llms.txt` and/or `public/robots.txt` still enables `aeo` by path.
+    - A selected public-content/pricing path, such as `content/blog/answer-engines.mdx` or `app/pricing/page.mdx`, still enables `aeo`.
+    - A generic internal docs markdown path does not enable `aeo` unless it includes an AEO token.
+    - A diff containing an AEO token such as `GPTBot` or JSON-LD `"@type": "Article"` still enables `aeo`.
+  - Extend `skills/woostack-review/scripts/tests/test-detect-angles-seo.sh` so `app/api/users/route.ts` with `+export const metadata = { internal: true }` and a non-SEO source file with `+const hreflang = "en"` do not enable `seo`.
+  - Run the new/changed detection tests before implementation and confirm the new cases fail for the current gate behavior.
+
+- [ ] **Step 2: Reproduce with failing metrics-fold tests**
+  - Add `skills/woostack-review/scripts/tests/test-metrics-fold-suggestions.sh` covering:
+    - An angle at the sample-size threshold with `raw_total=0`, `kept_total=0`, and `blocking_total=0` prints a `consider review.angles.skip` advisory.
+    - An angle at the threshold with `kept_total == nit_total` and `blocking_total == 0` prints a nit-only advisory.
+    - An angle below threshold prints no advisory.
+    - An angle with any blocking finding prints no advisory.
+    - The advisory is output-only and does not modify `.woostack/config.json`.
+  - Run the new metrics test before implementation and confirm it fails for missing advisory output.
+
+- [ ] **Step 3: Tighten AEO and SEO detection**
+  - Update `detect-angles.sh` comments and helper functions to distinguish hard path-only surfaces from soft path-plus-token surfaces.
+  - Replace the generic AEO `\.(md|mdx|html)$` path trigger with explicit hard surfaces plus a narrow public-content/pricing predicate.
+  - Add a SEO soft-file predicate and change the SEO append condition to hard-path OR soft-path-plus-token.
+  - Preserve always-on `bugs`, `security`, and `simplify`, and preserve existing unrelated angle behavior.
+
+- [ ] **Step 4: Add metrics-driven skip advisories**
+  - Update `metrics-fold.sh` after the aggregate write to compute advisory-only recommendations from the folded aggregate.
+  - Use a conservative constant `ANGLE_SKIP_SUGGEST_MIN_RUNS=20` so small-sample angles like four-run `react` do not get noisy suggestions.
+  - Exclude unskippable core angles (`bugs`, `security`, `simplify`) from suggestions.
+  - Print concise advisory lines such as `metrics-fold: angle aeo: 35 runs, 0 blocking, 0 kept — consider review.angles.skip += ["aeo"]`.
+  - Do not auto-edit config; this is guidance for maintainers.
+
+- [ ] **Step 5: Update review docs**
+  - Update `skills/woostack-review/SKILL.md` metrics configuration text to say aggregate schema v3.
+  - Update Stage 6.5 to document zero-signal and nit-only advisory output, including the `review.angles.skip` destination and the sample-size caveat.
+  - Update authored docs-site pages that state the changed behavior: `site/content/docs/configuration.mdx` for metrics/skip guidance and `site/content/docs/concepts/review-angles.mdx` for the tightened AEO summary.
+
+- [ ] **Step 6: Verification**
+  - Run `bash skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`.
+  - Run `bash skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh`.
+  - Run `bash skills/woostack-review/scripts/tests/test-metrics-fold-suggestions.sh`.
+  - Run `bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh`.
+  - Run `bash skills/woostack-review/scripts/tests/test-metrics-fold-root.sh`.
+  - If docs-site authored pages change, run `pnpm -C site build`; otherwise record that generated per-skill pages need no manual edit.

--- a/.woostack/fixes/2026-07-03-issue-449-angle-gates.md
+++ b/.woostack/fixes/2026-07-03-issue-449-angle-gates.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: hardened
+status: executing
 branch: fix/issue-449-angle-gates
 ---
 
@@ -27,7 +27,7 @@ Make the review angle gates match the prompts and add advisory-only metrics feed
 
 ## 3. Implementation Plan
 
-- [ ] **Step 1: Reproduce with failing detection tests**
+- [x] **Step 1: Reproduce with failing detection tests**
   - Add `skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh` covering:
     - `README.md` prose-only diff does not enable `aeo` and still enables `docs`.
     - `skills/example/SKILL.md` prose-only diff does not enable `aeo` and still enables `skills`.
@@ -38,7 +38,7 @@ Make the review angle gates match the prompts and add advisory-only metrics feed
   - Extend `skills/woostack-review/scripts/tests/test-detect-angles-seo.sh` so `app/api/users/route.ts` with `+export const metadata = { internal: true }` and a non-SEO source file with `+const hreflang = "en"` do not enable `seo`.
   - Run the new/changed detection tests before implementation and confirm the new cases fail for the current gate behavior.
 
-- [ ] **Step 2: Reproduce with failing metrics-fold tests**
+- [x] **Step 2: Reproduce with failing metrics-fold tests**
   - Add `skills/woostack-review/scripts/tests/test-metrics-fold-suggestions.sh` covering:
     - An angle at the sample-size threshold with `raw_total=0`, `kept_total=0`, and `blocking_total=0` prints a `consider review.angles.skip` advisory.
     - An angle at the threshold with `kept_total == nit_total` and `blocking_total == 0` prints a nit-only advisory.
@@ -47,25 +47,25 @@ Make the review angle gates match the prompts and add advisory-only metrics feed
     - The advisory is output-only and does not modify `.woostack/config.json`.
   - Run the new metrics test before implementation and confirm it fails for missing advisory output.
 
-- [ ] **Step 3: Tighten AEO and SEO detection**
+- [x] **Step 3: Tighten AEO and SEO detection**
   - Update `detect-angles.sh` comments and helper functions to distinguish hard path-only surfaces from soft path-plus-token surfaces.
   - Replace the generic AEO `\.(md|mdx|html)$` path trigger with explicit hard surfaces plus a narrow public-content/pricing predicate.
   - Add a SEO soft-file predicate and change the SEO append condition to hard-path OR soft-path-plus-token.
   - Preserve always-on `bugs`, `security`, and `simplify`, and preserve existing unrelated angle behavior.
 
-- [ ] **Step 4: Add metrics-driven skip advisories**
+- [x] **Step 4: Add metrics-driven skip advisories**
   - Update `metrics-fold.sh` after the aggregate write to compute advisory-only recommendations from the folded aggregate.
   - Use a conservative constant `ANGLE_SKIP_SUGGEST_MIN_RUNS=20` so small-sample angles like four-run `react` do not get noisy suggestions.
   - Exclude unskippable core angles (`bugs`, `security`, `simplify`) from suggestions.
   - Print concise advisory lines such as `metrics-fold: angle aeo: 35 runs, 0 blocking, 0 kept — consider review.angles.skip += ["aeo"]`.
   - Do not auto-edit config; this is guidance for maintainers.
 
-- [ ] **Step 5: Update review docs**
+- [x] **Step 5: Update review docs**
   - Update `skills/woostack-review/SKILL.md` metrics configuration text to say aggregate schema v3.
   - Update Stage 6.5 to document zero-signal and nit-only advisory output, including the `review.angles.skip` destination and the sample-size caveat.
   - Update authored docs-site pages that state the changed behavior: `site/content/docs/configuration.mdx` for metrics/skip guidance and `site/content/docs/concepts/review-angles.mdx` for the tightened AEO summary.
 
-- [ ] **Step 6: Verification**
+- [x] **Step 6: Verification**
   - Run `bash skills/woostack-review/scripts/tests/test-detect-angles-seo.sh`.
   - Run `bash skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh`.
   - Run `bash skills/woostack-review/scripts/tests/test-metrics-fold-suggestions.sh`.

--- a/.woostack/fixes/2026-07-03-issue-449-angle-gates.md
+++ b/.woostack/fixes/2026-07-03-issue-449-angle-gates.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: executing
+status: in-review
 branch: fix/issue-449-angle-gates
 ---
 

--- a/.woostack/memory/review-angle-trigger-precision.md
+++ b/.woostack/memory/review-angle-trigger-precision.md
@@ -4,8 +4,8 @@ type: gotcha
 scope: skills/woostack-review/**
 tags: detect-angles, angle, trigger, diff-gated, enrichment, tier, observability
 hook: Enriching a diff-gated angle's prompt is dead unless detect-angles.sh also matches the new pattern — and never broaden a trigger on a common token.
-updated: 2026-06-06
-source: [[plans/2026-06-06-review-self-contained]]
+updated: 2026-07-03
+source: [[fixes/2026-07-03-issue-449-angle-gates]]
 ---
 Most review angles are **diff-gated**: `detect-angles.sh` decides whether the angle
 runs at all by grepping the diff for trigger tokens (`has_<angle>_diff_token()` /
@@ -23,6 +23,14 @@ only when the angle already fires for another reason. The `?.`/`??` suppressor c
 with the `catch` / `.catch` / logging changes that already trigger the angle, so the
 relevant PRs are in scope anyway; accept the rare miss (a lone common-token case with no
 other trigger) over universal firing.
+
+For expensive optional angles, a high-signal token is still too broad if it appears in
+normal backend/source files. Bind SEO/AEO-style tokens to a reviewable surface where
+possible: hard path-only files for unambiguous controls (`robots.txt`, `llms.txt`,
+`sitemap.*`), soft path-plus-token checks for public content/head surfaces, and token-only
+overrides only for rare answer-engine/schema markers. Metrics with 20+ runs and zero
+blocking findings are evidence the gate is too loose or the repo should set
+`review.angles.skip`.
 
 Tier follows reasoning load: when an angle gains design-judgment checks (silent-failure
 depth, invariant design), bump `fast → standard` in **both** the prompt frontmatter and

--- a/site/content/docs/concepts/review-angles.mdx
+++ b/site/content/docs/concepts/review-angles.mdx
@@ -19,7 +19,7 @@ Every angle, what it reviews, a plain-language summary of when it auto-fires, an
 
 | Angle | Audits | Fires when | Tier |
 | --- | --- | --- | --- |
-| `aeo` | Answer-engine optimization: AI-crawler access and structured data for answer engines | `robots.txt`, `llms.txt`, Markdown or HTML content, or AI-crawler / JSON-LD tokens in the diff | fast |
+| `aeo` | Answer-engine optimization: AI-crawler access and structured data for answer engines | `robots.txt`, `llms.txt`, pricing/public content surfaces, or AI-crawler / JSON-LD tokens in the diff | fast |
 | `api` | API contracts: routes, OpenAPI / GraphQL / proto schemas, HTTP handlers | OpenAPI / GraphQL / proto files, route trees, or HTTP-verb route bindings in the diff | standard |
 | `architecture` | Structural quality of source: boundaries, coupling, code health | any general-purpose source file changes (skips doc-only and config-only PRs) | standard |
 | `bugs` | Correctness: logic errors and broken behavior | always (cannot be skipped) | standard |

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -151,7 +151,7 @@ PR → the action's `force_tier` input → `review.force_tier` → the action's 
 | `review.chunking.max_loc` | integer ≥ 0 | `4000` | Changed-line threshold; a larger diff is split into chunks and each angle fans out across them. `0` disables chunking. |
 | `review.disable_adversarial` | boolean | `false` | `true` skips the skeptical prosecutor pass and uses the defender pass alone, a cost opt-out. |
 | `review.defer_markers` | boolean | `true` | `true` honors inline `woostack-defer(<ref>)` markers, demoting a matching finding to a non-blocking nit. `security` findings are never deferred. |
-| `review.metrics` | boolean | `false` | `true` writes a per-angle signal/noise breakdown, folds a rolling local `.woostack/metrics.json`, and prints advisory `review.angles.skip` suggestions when an optional angle has enough zero-blocking local history. |
+| `review.metrics` | boolean | `false` | `true` writes a per-angle signal/noise breakdown, folds a rolling local `.woostack/metrics.json`, and prints advisory `review.angles.skip` suggestions when an optional angle has at least 20 local runs with zero blockers and either zero kept findings or only nit findings. |
 | `review.fix_commands` | array of string | `[]` | Reserved for a future loop mode; parsed but not yet consumed. |
 
 ## Sweep rounds

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -151,7 +151,7 @@ PR → the action's `force_tier` input → `review.force_tier` → the action's 
 | `review.chunking.max_loc` | integer ≥ 0 | `4000` | Changed-line threshold; a larger diff is split into chunks and each angle fans out across them. `0` disables chunking. |
 | `review.disable_adversarial` | boolean | `false` | `true` skips the skeptical prosecutor pass and uses the defender pass alone, a cost opt-out. |
 | `review.defer_markers` | boolean | `true` | `true` honors inline `woostack-defer(<ref>)` markers, demoting a matching finding to a non-blocking nit. `security` findings are never deferred. |
-| `review.metrics` | boolean | `false` | `true` writes a per-angle signal/noise breakdown and folds a rolling local `.woostack/metrics.json`. |
+| `review.metrics` | boolean | `false` | `true` writes a per-angle signal/noise breakdown, folds a rolling local `.woostack/metrics.json`, and prints advisory `review.angles.skip` suggestions when an optional angle has enough zero-blocking local history. |
 | `review.fix_commands` | array of string | `[]` | Reserved for a future loop mode; parsed but not yet consumed. |
 
 ## Sweep rounds

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -206,7 +206,7 @@ Key reference (JSON has no comments, so the per-key semantics live here):
 - **`models`** — **root-level** per-tier model overrides (moved out of `review.models`; a lingering `review.models` is now a hard loader error — `woostack-doctor` warns on it too). Each tier leaf is a model-slug string **or** an object `{ "model": "<slug>", "effort": "<level>" }`, where `effort` is one of `minimal | low | medium | high | xhigh` (empty = unset). Use flat `models.fast` / `.standard` / `.deep` as provider-agnostic fallbacks, or provider-scoped maps such as `models.openai.deep`, `models.anthropic.standard`, `models.google.standard`, and `models.openrouter.fast` when the same repo is reviewed by multiple coding agents. The action input `inputs.model` still wins. Effort is consumed by OpenAI/Codex (`load-prompt.sh`) and by Anthropic per-call spawns (`prompts/anthropic.md`, where it is the sole tier differentiator now that every Anthropic tier is `claude-opus-4-8`), config-first over the built-in tier default.
 - **`fix_commands`** — reserved for `--loop` mode (issue #15).
 - **`disable_adversarial`** — cost-sensitive opt-out for the prosecutor+defender validator (issue #13). When `true`, only the defender pass runs and its output becomes `findings.json` directly.
-- **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). Each angle also carries `overlap_total` + `overlap_with` (how often another angle raised the same issue, on the raw pre-validation set — a redundancy signal). Aggregate schema is v2; an older v1 aggregate is reseeded on first fold. See Stage 6.5.
+- **`metrics`**: opt in to per-angle signal/noise metrics (bool, default `false`) — emit `findings.metrics.json` per run and fold a rolling `.woostack/metrics.json` aggregate (local only). Each angle also carries `overlap_total` + `overlap_with` (how often another angle raised the same issue, on the raw pre-validation set — a redundancy signal). Aggregate schema is v3; an older aggregate is reseeded on first fold. See Stage 6.5.
 - **`chunking.max_loc`** — diff-chunking threshold (issue #14). When the post-ignore diff exceeds this many changed lines, prefetch splits it into chunks honoring workspace package roots > top-level dirs > file-LOC-balanced groups; each angle fans out as angles × chunks parallel sub-agents. `0` disables chunking; missing => 4000.
 
 **Precedence**: for the angle set, `angles.force` beats `angles.skip` when the same angle is listed in both. For model resolution, precedence is: explicit comment override (`--fast` / `--deep`) → action input `inputs.force_tier` → `review.force_tier` in config → action input `inputs.model` → `models.<provider>.<tier>` → flat `models.<tier>` → table default in `prompts/_orchestrator-header.md`. `ignore` is applied to both file paths and the per-file diff sections before angle gates evaluate.
@@ -525,7 +525,20 @@ This is a no-op when `metrics` is off or no per-run record exists. As with memor
 GitHub Action does **not** fold — its job is `contents: read` + post; metrics persistence
 is local only (the action uploads `findings.metrics.json` as a build artifact instead).
 
-**Reading the aggregate.** Rank angles by validator-drop rate (noise candidates first):
+**Reading the aggregate.** `metrics-fold.sh` prints advisory-only skip suggestions when a
+single clone has enough local evidence that an optional angle is not paying for itself. The
+default floor is 20 recorded runs for that angle. At or above that floor, an angle with zero
+blocking findings and either zero kept findings or only nit findings prints a line like:
+
+```text
+metrics-fold: angle aeo: 35 runs, 0 blocking, 0 kept — consider review.angles.skip += ["aeo"]
+```
+
+The script never edits `.woostack/config.json`; maintainers decide whether to add the suggested
+angle to `review.angles.skip`. It also never suggests the unskippable core angles: `bugs`,
+`security`, or `simplify`.
+
+For deeper diagnosis, rank angles by validator-drop rate (noise candidates first):
 
 ```bash
 jq -r '.angles | to_entries

--- a/skills/woostack-review/scripts/detect-angles.sh
+++ b/skills/woostack-review/scripts/detect-angles.sh
@@ -9,16 +9,19 @@
 #   security  — always on
 #   simplify  — always on
 #   seo       — HARD files (fire on path alone): robots.txt, sitemap.{xml,ts},
-#               app/manifest.{ts,json}. SOFT surfaces (*.html, head/layout.{ts,tsx,js,jsx},
-#               next.config.*) no longer gate on path — they fire only via a diff token:
-#               legacy <meta / og: / twitter: / rel=canonical / name=robots / <loc> /
-#               Sitemap:, OR a changed-line (^[+-]) metadata co-signal generateMetadata /
-#               export const metadata / hreflang (additions and removals). <title and
-#               <link rel= are excluded (SVG <title> / stylesheet-link collisions).
-#   aeo       — robots.txt, llms.txt, pricing.{md,txt}, *.{md,mdx,html}, OR diff
-#               body contains AI-crawler tokens (GPTBot / PerplexityBot /
+#               app/manifest.{ts,json}. SOFT surfaces (*.html, head/layout/page
+#               files, next.config.*) fire only via a diff token: legacy <meta /
+#               og: / twitter: / rel=canonical / name=robots / <loc> / Sitemap:,
+#               OR a changed-line (^[+-]) metadata co-signal generateMetadata /
+#               export const metadata / hreflang (additions and removals). <title
+#               and <link rel= are excluded (SVG <title> / stylesheet-link
+#               collisions).
+#   aeo       — HARD files (fire on path alone): robots.txt, llms.txt,
+#               pricing.{md,txt}. Public content surfaces such as app/pages
+#               pricing/product/blog/docs/marketing MDX/HTML also fire on path.
+#               Otherwise only AI-crawler tokens (GPTBot / PerplexityBot /
 #               ClaudeBot / Google-Extended / anthropic-ai) or JSON-LD schema
-#               types (FAQPage / HowTo / Article / Product / ItemList)
+#               types (FAQPage / HowTo / Article / Product / ItemList) fire it.
 #   design    — *.{tsx,jsx,vue,svelte,html,css,scss,sass,less,styl,astro}
 #   react     — *.{tsx,jsx} in the diff. The angle handles non-React .tsx
 #               (e.g. Solid, Preact-only) gracefully, so a package.json check is
@@ -115,6 +118,13 @@ has_seo_file() {
   return 1
 }
 
+has_seo_soft_file() {
+  echo "$CHANGED_PATHS" | grep -qE '\.html$' && return 0
+  echo "$CHANGED_PATHS" | grep -qE '(^|/)(app|pages)/([^/]+/)*(head|layout|page)\.(ts|tsx|js|jsx|mdx)$' && return 0
+  echo "$CHANGED_PATHS" | grep -qE '(^|/)next\.config\.(ts|js|mjs|cjs)$' && return 0
+  return 1
+}
+
 has_seo_diff_token() {
   # Legacy unanchored tokens: meta tags, og:/twitter: prefixed props, rel=canonical,
   # name=robots, <loc> sitemap entries, Sitemap: directive.
@@ -129,8 +139,12 @@ has_seo_diff_token() {
 }
 
 has_aeo_file() {
+  # Hard AEO surfaces only — unambiguous crawler/answer-engine controls.
   echo "$CHANGED_PATHS" | grep -qE '(^|/)(robots\.txt|llms\.txt|pricing\.(md|txt))$' && return 0
-  echo "$CHANGED_PATHS" | grep -qE '\.(md|mdx|html)$' && return 0
+  # Public content surfaces where answer engines may quote product/pricing/docs
+  # copy. Generic README/SKILL/internal docs stay on docs/skills unless an AEO
+  # diff token is present.
+  echo "$CHANGED_PATHS" | grep -qE '(^|/)((app|pages)/(pricing|products?|blog|content|docs|marketing|landing)(/|$)|site/content/docs/|content/(blog|docs|guides|marketing|pricing|products?)/|marketing/|public/(pricing|docs|blog)/).*\.(md|mdx|html)$' && return 0
   return 1
 }
 
@@ -271,7 +285,7 @@ if [ -f "$OUTDIR/rules.md" ]; then
   ANGLES+=("conventions")
 fi
 
-if has_seo_file || has_seo_diff_token; then
+if has_seo_file || { has_seo_soft_file && has_seo_diff_token; }; then
   ANGLES+=("seo")
 fi
 

--- a/skills/woostack-review/scripts/detect-angles.sh
+++ b/skills/woostack-review/scripts/detect-angles.sh
@@ -118,23 +118,54 @@ has_seo_file() {
   return 1
 }
 
-has_seo_soft_file() {
-  echo "$CHANGED_PATHS" | grep -qE '\.html$' && return 0
-  echo "$CHANGED_PATHS" | grep -qE '(^|/)(app|pages)/([^/]+/)*(head|layout|page)\.(ts|tsx|js|jsx|mdx)$' && return 0
-  echo "$CHANGED_PATHS" | grep -qE '(^|/)next\.config\.(ts|js|mjs|cjs)$' && return 0
+is_seo_soft_path() {
+  local path="$1"
+  printf '%s\n' "$path" | grep -qE '\.html$' && return 0
+  printf '%s\n' "$path" | grep -qE '(^|/)app/([^/]+/)*(head|layout|page)\.(ts|tsx|js|jsx|mdx)$' && return 0
+  if printf '%s\n' "$path" | grep -qE '(^|/)pages/api(/|$)'; then
+    return 1
+  fi
+  printf '%s\n' "$path" | grep -qE '(^|/)pages/.+\.(ts|tsx|js|jsx|mdx)$' && return 0
+  printf '%s\n' "$path" | grep -qE '(^|/)next\.config\.(ts|js|mjs|cjs)$' && return 0
   return 1
 }
 
-has_seo_diff_token() {
-  # Legacy unanchored tokens: meta tags, og:/twitter: prefixed props, rel=canonical,
-  # name=robots, <loc> sitemap entries, Sitemap: directive.
-  grep -qE "</?meta\b|\bog:[a-z_-]+|\btwitter:[a-z_-]+|rel=[\"']canonical|name=[\"']robots|<loc>|(^|[[:space:]])Sitemap:" "$DIFF" && return 0
-  # Soft-surface co-signal: Next.js metadata edits in head/layout/*.html files.
-  # Anchored to CHANGED lines (^[+-]) so a styling-only edit near an unchanged
-  # metadata export does not fire, and a REMOVED export (an SEO regression) does.
-  # <title and <link rel= are intentionally excluded (SVG <title> / stylesheet-link
-  # collisions; rel=canonical + hreflang already cover SEO links).
-  grep -qE "^[+-].*(\bgenerateMetadata\b|export[[:space:]]+const[[:space:]]+metadata\b|\bhreflang\b)" "$DIFF" && return 0
+has_seo_soft_file() {
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    is_seo_soft_path "$path" && return 0
+  done <<EOF
+$CHANGED_PATHS
+EOF
+  return 1
+}
+
+has_seo_soft_diff_token() {
+  has_seo_soft_file || return 1
+  # A real PR diff carries per-file headers. Require the SEO token to appear on a
+  # changed line in the same soft-surface file so unrelated files cannot combine
+  # into a false SEO trigger.
+  if grep -q '^diff --git ' "$DIFF"; then
+    awk '
+      /^diff --git / {
+        path=$4
+        sub(/^b\//, "", path)
+        in_soft = (
+          path ~ /\.html$/ ||
+          path ~ /(^|\/)app\/([^\/]+\/)*(head|layout|page)\.(ts|tsx|js|jsx|mdx)$/ ||
+          (path ~ /(^|\/)pages\/.+\.(ts|tsx|js|jsx|mdx)$/ && path !~ /(^|\/)pages\/api(\/|$)/) ||
+          path ~ /(^|\/)next\.config\.(ts|js|mjs|cjs)$/
+        )
+        next
+      }
+      in_soft && /^[+-]/ && (/<\/?meta[[:>:]]/ || /og:[a-z_-]+/ || /twitter:[a-z_-]+/ || /rel=["'\'']canonical/ || /name=["'\'']robots/ || /<loc>/ || /(^|[[:space:]])Sitemap:/ || /generateMetadata/ || /export[[:space:]]+const[[:space:]]+metadata/ || /hreflang/) { found=1 }
+      END { exit(found ? 0 : 1) }
+    ' "$DIFF" && return 0
+    return 1
+  fi
+  # Unit-test fallback: synthetic diffs in this repo omit diff --git headers and
+  # usually carry a single changed path in meta.json.
+  grep -qE "^[+-].*(</?meta\b|\bog:[a-z_-]+|\btwitter:[a-z_-]+|rel=[\"']canonical|name=[\"']robots|<loc>|(^|[[:space:]])Sitemap:|\bgenerateMetadata\b|export[[:space:]]+const[[:space:]]+metadata\b|\bhreflang\b)" "$DIFF" && return 0
   return 1
 }
 
@@ -144,7 +175,7 @@ has_aeo_file() {
   # Public content surfaces where answer engines may quote product/pricing/docs
   # copy. Generic README/SKILL/internal docs stay on docs/skills unless an AEO
   # diff token is present.
-  echo "$CHANGED_PATHS" | grep -qE '(^|/)((app|pages)/(pricing|products?|blog|content|docs|marketing|landing)(/|$)|site/content/docs/|content/(blog|docs|guides|marketing|pricing|products?)/|marketing/|public/(pricing|docs|blog)/).*\.(md|mdx|html)$' && return 0
+  echo "$CHANGED_PATHS" | grep -qE '(^|/)((app|pages)/(pricing|products?|blog|content|docs|marketing|landing)(/|$)|site/content/docs/|content/(blog|docs|guides|marketing|pricing|products?)/|marketing/|public/(pricing|docs|blog)/).*\.(ts|tsx|js|jsx|md|mdx|html)$' && return 0
   return 1
 }
 
@@ -285,7 +316,7 @@ if [ -f "$OUTDIR/rules.md" ]; then
   ANGLES+=("conventions")
 fi
 
-if has_seo_file || { has_seo_soft_file && has_seo_diff_token; }; then
+if has_seo_file || has_seo_soft_diff_token; then
   ANGLES+=("seo")
 fi
 

--- a/skills/woostack-review/scripts/metrics-fold.sh
+++ b/skills/woostack-review/scripts/metrics-fold.sh
@@ -85,6 +85,9 @@ except (ValueError, OSError):
     sys.stderr.write("metrics-fold: aggregate corrupt — backed up to .bak, reseeding\n")
 
 SEVS = ("HIGH", "MEDIUM", "LOW")
+ANGLE_SKIP_SUGGEST_MIN_RUNS = 20
+UNSKIPPABLE_ANGLES = {"bugs", "security", "simplify"}
+
 
 def num(v):
     return v if isinstance(v, int) else 0
@@ -134,4 +137,24 @@ with open(tmp_p, "w") as fh:
 os.replace(tmp_p, rolling_p)
 
 print("metrics-fold: folded run -> {} ({} runs total)".format(rolling_p, agg["runs"]))
+
+for angle in sorted(agg["angles"]):
+    if angle in UNSKIPPABLE_ANGLES:
+        continue
+    slot = agg["angles"].get(angle) or {}
+    runs = num(slot.get("runs_present"))
+    raw = num(slot.get("raw_total"))
+    kept = num(slot.get("kept_total"))
+    blocking = num(slot.get("blocking_total"))
+    nit = num(slot.get("nit_total"))
+    if runs < ANGLE_SKIP_SUGGEST_MIN_RUNS or blocking > 0:
+        continue
+    if raw == 0 or kept == 0:
+        print('metrics-fold: angle {}: {} runs, {} blocking, {} kept — consider review.angles.skip += ["{}"]'.format(
+            angle, runs, blocking, kept, angle
+        ))
+    elif nit == kept:
+        print('metrics-fold: angle {}: {} runs, {} blocking, nit-only kept findings ({}/{}) — consider review.angles.skip += ["{}"]'.format(
+            angle, runs, blocking, nit, kept, angle
+        ))
 PY

--- a/skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/detect-angles.sh"
+
+# setup_diff $1 = changed file path, $2 = diff body (literal +/- prefixes)
+setup_diff() {
+  work="$(mktemp -d)"
+  export OUTDIR="$work/out"
+  mkdir -p "$OUTDIR"
+  printf '{"files":[{"path":"%s"}]}\n' "$1" > "$OUTDIR/meta.json"
+  printf '%s\n' "$2" > "$OUTDIR/diff.txt"
+}
+absent() { grep -cx 'aeo' "$OUTDIR/angles.txt" || true; }  # "0" when aeo not enabled
+
+# README prose is documentation, not an answer-engine surface.
+setup_diff "README.md" "+Fix setup wording for the local development guide."
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "README prose-only diff does not enable aeo"
+assert_contains "$(cat "$OUTDIR/angles.txt")" "docs" "README prose-only diff still enables docs"
+rm -rf "$work"
+
+# Skill manifest prose routes to the skills angle, not the AEO angle.
+setup_diff "skills/example/SKILL.md" "+Clarify when to use this skill."
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "SKILL.md prose-only diff does not enable aeo"
+assert_contains "$(cat "$OUTDIR/angles.txt")" "skills" "SKILL.md prose-only diff still enables skills"
+rm -rf "$work"
+
+# AI crawler control files are hard AEO surfaces by path alone.
+setup_diff "public/llms.txt" "+Allow: /docs"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "aeo" "llms.txt enables aeo on path alone"
+rm -rf "$work"
+
+setup_diff "public/robots.txt" "+User-agent: GPTBot"
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "aeo" "robots.txt enables aeo on path alone"
+rm -rf "$work"
+
+# Public pricing/product content is an answer-engine citation surface.
+setup_diff "app/pricing/page.mdx" "+Compare plan limits and enterprise pricing."
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "aeo" "pricing content page enables aeo"
+rm -rf "$work"
+
+# Internal docs are not AEO unless the changed text carries an answer-engine token.
+setup_diff "docs/internal/runbook.md" "+Rotate the staging database password after a drill."
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "internal docs prose-only diff does not enable aeo"
+assert_contains "$(cat "$OUTDIR/angles.txt")" "docs" "internal docs prose-only diff still enables docs"
+rm -rf "$work"
+
+setup_diff "docs/internal/runbook.md" "+Allow GPTBot to fetch the public docs index."
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "aeo" "GPTBot token enables aeo even in markdown"
+rm -rf "$work"
+
+setup_diff "src/schema.ts" '+const jsonLd = { "@type": "Article" }'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "aeo" "JSON-LD Article token enables aeo"
+rm -rf "$work"
+
+finish

--- a/skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh
@@ -47,6 +47,12 @@ bash "$SCRIPT" >/dev/null 2>&1
 assert_contains "$(cat "$OUTDIR/angles.txt")" "aeo" "pricing content page enables aeo"
 rm -rf "$work"
 
+
+# Public pricing/product route implementations are also answer-engine citation surfaces.
+setup_diff "app/pricing/page.tsx" "+Compare plan limits and enterprise pricing."
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "aeo" "pricing route implementation enables aeo"
+rm -rf "$work"
 # Internal docs are not AEO unless the changed text carries an answer-engine token.
 setup_diff "docs/internal/runbook.md" "+Rotate the staging database password after a drill."
 bash "$SCRIPT" >/dev/null 2>&1

--- a/skills/woostack-review/scripts/tests/test-detect-angles-seo.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-seo.sh
@@ -71,6 +71,41 @@ bash "$SCRIPT" >/dev/null 2>&1
 assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "html with <meta> enables seo"
 rm -rf "$work"
 
+# 10. Pages Router routes are indexable SEO surfaces.
+setup_diff "pages/about.tsx" '+export const metadata = { title: "About" }'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "$(cat "$OUTDIR/angles.txt")" "seo" "pages route metadata enables seo"
+rm -rf "$work"
+
+# 11. Pages API routes are not SEO surfaces.
+setup_diff "pages/api/users.ts" '+export const metadata = { internal: true }'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "pages api metadata-shaped code does not enable seo"
+rm -rf "$work"
+
+# 12. SEO soft file and unrelated backend token must not combine across files.
+work="$(mktemp -d)"
+export OUTDIR="$work/out"
+mkdir -p "$OUTDIR"
+cat > "$OUTDIR/meta.json" <<'JSON'
+{"files":[{"path":"site/content/docs/configuration.mdx"},{"path":"src/locale.ts"}]}
+JSON
+cat > "$OUTDIR/diff.txt" <<'DIFF'
+diff --git a/site/content/docs/configuration.mdx b/site/content/docs/configuration.mdx
+--- a/site/content/docs/configuration.mdx
++++ b/site/content/docs/configuration.mdx
+@@ -1 +1 @@
++Clarify configuration copy.
+diff --git a/src/locale.ts b/src/locale.ts
+--- a/src/locale.ts
++++ b/src/locale.ts
+@@ -1 +1 @@
++const hreflang = "en"
+DIFF
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "soft docs file and backend token do not combine into seo"
+rm -rf "$work"
+
 # 10. SOFT file, no token: next.config.ts alone does NOT enable seo.
 setup_diff "next.config.ts" '+  images: { remotePatterns: [] },'
 bash "$SCRIPT" >/dev/null 2>&1

--- a/skills/woostack-review/scripts/tests/test-detect-angles-seo.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-seo.sh
@@ -95,4 +95,16 @@ bash "$SCRIPT" >/dev/null 2>&1
 assert_eq "$(absent)" "0" "unchanged-context metadata does not enable seo"
 rm -rf "$work"
 
+
+# 14. Backend API metadata-shaped code is not an SEO surface.
+setup_diff "app/api/users/route.ts" '+export const metadata = { internal: true }'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "API route metadata-shaped code does not enable seo"
+rm -rf "$work"
+
+# 15. Source-local hreflang variable names are not SEO alternate-link edits.
+setup_diff "src/locale.ts" '+const hreflang = "en"'
+bash "$SCRIPT" >/dev/null 2>&1
+assert_eq "$(absent)" "0" "source hreflang variable does not enable seo"
+rm -rf "$work"
 finish

--- a/skills/woostack-review/scripts/tests/test-metrics-fold-suggestions.sh
+++ b/skills/woostack-review/scripts/tests/test-metrics-fold-suggestions.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/metrics-fold.sh"
+
+work="$(mktemp -d)"
+export OUTDIR="$work/out"
+export GITHUB_WORKSPACE="$work/repo"
+mkdir -p "$OUTDIR" "$GITHUB_WORKSPACE/.woostack"
+( cd "$GITHUB_WORKSPACE" && git init -q )
+
+printf '%s\n' '{"metrics": true}' > "$OUTDIR/config.json"
+CONFIG_FILE="$GITHUB_WORKSPACE/.woostack/config.json"
+printf '%s\n' '{"review":{"angles":{"skip":["existing"]}}}' > "$CONFIG_FILE"
+config_before="$(cat "$CONFIG_FILE")"
+
+ROLLING="$GITHUB_WORKSPACE/.woostack/metrics.json"
+cat > "$ROLLING" <<'JSON'
+{
+  "schema_version": 3,
+  "runs": 19,
+  "angles": {
+    "aeo": {
+      "runs_present": 19,
+      "raw_total": 0,
+      "kept_total": 0,
+      "dropped_by_defender_total": 0,
+      "dropped_by_prosecutor_total": 0,
+      "blocking_total": 0,
+      "nit_total": 0,
+      "severity_total": {"HIGH": 0, "MEDIUM": 0, "LOW": 0},
+      "overlap_total": 0,
+      "overlap_with": {}
+    },
+    "docs": {
+      "runs_present": 19,
+      "raw_total": 19,
+      "kept_total": 19,
+      "dropped_by_defender_total": 0,
+      "dropped_by_prosecutor_total": 0,
+      "blocking_total": 0,
+      "nit_total": 19,
+      "severity_total": {"HIGH": 0, "MEDIUM": 0, "LOW": 19},
+      "overlap_total": 0,
+      "overlap_with": {}
+    },
+    "react": {
+      "runs_present": 18,
+      "raw_total": 0,
+      "kept_total": 0,
+      "dropped_by_defender_total": 0,
+      "dropped_by_prosecutor_total": 0,
+      "blocking_total": 0,
+      "nit_total": 0,
+      "severity_total": {"HIGH": 0, "MEDIUM": 0, "LOW": 0},
+      "overlap_total": 0,
+      "overlap_with": {}
+    },
+    "api": {
+      "runs_present": 19,
+      "raw_total": 20,
+      "kept_total": 1,
+      "dropped_by_defender_total": 0,
+      "dropped_by_prosecutor_total": 0,
+      "blocking_total": 1,
+      "nit_total": 0,
+      "severity_total": {"HIGH": 1, "MEDIUM": 0, "LOW": 0},
+      "overlap_total": 0,
+      "overlap_with": {}
+    },
+    "bugs": {
+      "runs_present": 19,
+      "raw_total": 0,
+      "kept_total": 0,
+      "dropped_by_defender_total": 0,
+      "dropped_by_prosecutor_total": 0,
+      "blocking_total": 0,
+      "nit_total": 0,
+      "severity_total": {"HIGH": 0, "MEDIUM": 0, "LOW": 0},
+      "overlap_total": 0,
+      "overlap_with": {}
+    },
+    "security": {
+      "runs_present": 19,
+      "raw_total": 0,
+      "kept_total": 0,
+      "dropped_by_defender_total": 0,
+      "dropped_by_prosecutor_total": 0,
+      "blocking_total": 0,
+      "nit_total": 0,
+      "severity_total": {"HIGH": 0, "MEDIUM": 0, "LOW": 0},
+      "overlap_total": 0,
+      "overlap_with": {}
+    },
+    "simplify": {
+      "runs_present": 19,
+      "raw_total": 0,
+      "kept_total": 0,
+      "dropped_by_defender_total": 0,
+      "dropped_by_prosecutor_total": 0,
+      "blocking_total": 0,
+      "nit_total": 0,
+      "severity_total": {"HIGH": 0, "MEDIUM": 0, "LOW": 0},
+      "overlap_total": 0,
+      "overlap_with": {}
+    }
+  }
+}
+JSON
+
+cat > "$OUTDIR/findings.metrics.json" <<'JSON'
+{
+  "schema_version": 3,
+  "mode": "defender-only",
+  "degraded": false,
+  "angles": {
+    "aeo": {"raw_count": 0, "kept": 0, "blocking_count": 0, "nit_count": 0, "overlap_total": 0, "overlap_with": {}},
+    "docs": {"raw_count": 1, "kept": 1, "blocking_count": 0, "nit_count": 1, "severity": {"LOW": 1}, "overlap_total": 0, "overlap_with": {}},
+    "react": {"raw_count": 0, "kept": 0, "blocking_count": 0, "nit_count": 0, "overlap_total": 0, "overlap_with": {}},
+    "api": {"raw_count": 0, "kept": 0, "blocking_count": 0, "nit_count": 0, "overlap_total": 0, "overlap_with": {}},
+    "bugs": {"raw_count": 0, "kept": 0, "blocking_count": 0, "nit_count": 0, "overlap_total": 0, "overlap_with": {}},
+    "security": {"raw_count": 0, "kept": 0, "blocking_count": 0, "nit_count": 0, "overlap_total": 0, "overlap_with": {}},
+    "simplify": {"raw_count": 0, "kept": 0, "blocking_count": 0, "nit_count": 0, "overlap_total": 0, "overlap_with": {}}
+  }
+}
+JSON
+
+out="$work/metrics-fold-suggestions.out"
+bash "$SCRIPT" >"$out" 2>&1
+out_text="$(cat "$out")"
+
+assert_contains "$out_text" "consider review.angles.skip += [\"aeo\"]" \
+  "zero-signal threshold angle emits skip advisory"
+assert_contains "$out_text" "0 kept" "zero-signal advisory names zero kept findings"
+assert_contains "$out_text" "consider review.angles.skip += [\"docs\"]" \
+  "nit-only threshold angle emits skip advisory"
+assert_contains "$out_text" "nit-only" "nit-only advisory names nit-only findings"
+assert_not_contains "$out_text" "review.angles.skip += [\"react\"]" \
+  "below-threshold angle emits no skip advisory"
+assert_not_contains "$out_text" "review.angles.skip += [\"api\"]" \
+  "angle with blocking findings emits no skip advisory"
+assert_not_contains "$out_text" "review.angles.skip += [\"bugs\"]" \
+  "core bugs angle emits no skip advisory"
+assert_not_contains "$out_text" "review.angles.skip += [\"security\"]" \
+  "core security angle emits no skip advisory"
+assert_not_contains "$out_text" "review.angles.skip += [\"simplify\"]" \
+  "core simplify angle emits no skip advisory"
+assert_eq "$(cat "$CONFIG_FILE")" "$config_before" \
+  "metrics-fold advisory does not edit .woostack/config.json"
+
+rm -rf "$work"
+finish


### PR DESCRIPTION
## Goal

Reduce review cost/noise from optional angle workers that fire on low-signal diffs, especially `aeo` and `seo`, and surface local metrics evidence when a repo should skip an unproductive angle.

## Summary

- Tightens `aeo` detection so generic Markdown/HTML changes no longer launch the angle unless they touch answer-engine surfaces or contain AEO tokens.
- Gates `seo` diff tokens behind SEO/head/content soft surfaces while preserving hard SEO files such as `robots.txt`, `sitemap.*`, and `app/manifest.*`.
- Adds metrics-fold advisory output for optional angles with enough zero-blocking local history, excluding unskippable core angles.
- Adds regression tests for AEO, SEO, and metrics skip suggestions.
- Updates woostack-review docs, docs-site authored pages, and scoped memory for the angle-trigger gotcha.

## Test plan

### Automated

- [ ] `bash skills/woostack-review/scripts/tests/test-detect-angles-aeo.sh` — 10 passed, 0 failed.
- [ ] `bash skills/woostack-review/scripts/tests/test-detect-angles-seo.sh` — 16 passed, 0 failed.
- [ ] `bash skills/woostack-review/scripts/tests/test-metrics-fold-suggestions.sh` — 10 passed, 0 failed.
- [ ] `bash skills/woostack-review/scripts/tests/test-metrics-fold-overlap.sh` — 4 passed, 0 failed.
- [ ] `bash skills/woostack-review/scripts/tests/test-metrics-fold-root.sh` — 11 passed, 0 failed.
- [ ] `pnpm -C site build` — passed after `pnpm -C site install --frozen-lockfile`; build emitted existing Next.js warnings about no cache, deprecated middleware convention, and unset metadataBase.

### Manual

**Before merge**

- [ ] Inspect `detect-angles.sh` gate changes and confirm `aeo`/`seo` match the issue #449 signal/noise intent.
- [ ] Inspect `.woostack/fixes/2026-07-03-issue-449-angle-gates.md` and confirm all plan steps are checked and status is `in-review`.

Spec: .woostack/fixes/2026-07-03-issue-449-angle-gates.md
