### PR TITLE
fix: route subagent dispatch through configured model tiers only

### DIFF
--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -25,9 +25,10 @@ implicitly `fast`.
 
 - **Per-call routing** (Claude Code `Task`, Codex local subagents with a `model` override,
   opencode `@subagent`): resolve the effective tier = a forced tier if the host sets one, else
-  the prompt's own `tier:` frontmatter; map it to the column for the active provider; **pass that
-  model on every spawn.** Never rely on inherited parent-session model selection when a spawn API
-  accepts an explicit model.
+  the prompt's own `tier:` frontmatter; resolve it through the active provider's column plus the
+  override precedence below; **pass everything the resolved tier specifies on every spawn.**
+  Never rely on inherited parent-session settings when a spawn API accepts them explicitly, and
+  never substitute a mapping that is not configured here.
 - **Single model per session** (Codex Action without subagent model overrides, Antigravity CLI): resolve
   one run model up front; per-tier behavior collapses onto that one model for the whole job.
 

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -50,12 +50,11 @@ Rules:
   Summary bullets, and Test plan bullets (Automated and Manual).
 - Pass a bounded prompt containing the staged diff, changed-file list, commands run and
   results, relevant user intent, and any existing PR title/body that should be preserved.
-- Use the host's fast model when it can be selected explicitly. Follow the `fast` tier in
-  [`../woostack-review/prompts/_header.md`](../woostack-review/prompts/_header.md) for
-  provider-specific defaults, such as `claude-haiku-4-5` for Anthropic,
-  `gpt-5.3-codex-spark` for OpenAI Codex, `gemini-3-5-flash` for Gemini, or
-  `openrouter/deepseek/deepseek-v4-flash` for OpenRouter. If the host cannot route a
-  subagent to a fast model, draft inline in the main session.
+- Route the subagent at the `fast` tier when the host can select it explicitly: resolve the
+  tier through the shared
+  [Model Tiers table](../using-woostack/references/model-tiers.md) and pass what it resolves
+  to on the spawn. If the host cannot route a subagent per call, draft inline in the main
+  session.
 - The subagent must return only proposed text. It must not run commands, stage files,
   commit, push, edit PRs, or decide whether dirty files are relevant.
 - Before using any draft, compare it against the staged diff and command results. Rewrite or

--- a/skills/woostack-execute/references/subagent-driver.md
+++ b/skills/woostack-execute/references/subagent-driver.md
@@ -112,16 +112,16 @@ from complexity and risk — this table is the single home for the choice:
 ### Dispatch model (resolve → map → pass)
 
 Before each subagent dispatch, resolve the task's **effective tier** (role default, adjusted per
-[Tier selection](#tier-selection) above), map it to the host's model via the shared
-[model-tiers.md](../../using-woostack/references/model-tiers.md) (use the column for the host's
-provider — usually the session's), and **pass that model on the dispatch** (the `model:` arg of
-the `Agent`/`Task` call). Pass whatever value the host's subagent API accepts — a concrete slug
-where it takes slugs, or the tier's model **family** (`haiku`/`sonnet`/`opus`) where it takes
-families.
+[Tier selection](#tier-selection) above) and resolve it through the shared
+[model-tiers.md](../../using-woostack/references/model-tiers.md) (the host provider's column plus
+any configured overrides, per that file's precedence rules). **Pass exactly what the resolved
+tier specifies** on the dispatch, in whatever form the host's spawn API accepts. The configured
+tiers are the single source of what a tier resolves to — never invent a mapping that is not
+configured there.
 
-**When the host supports per-call routing, every dispatch MUST pass the resolved model.** Omitting
-it makes the subagent inherit the parent session's model (typically Opus), silently defeating tier
-routing and burning multiples of the tokens on cheap work — the same rationale
+**When the host supports per-call routing, every dispatch MUST pass the tier's resolved
+values.** Omitting them makes the subagent inherit the parent session's settings, silently
+defeating tier routing and burning multiples of the tokens on cheap work — the same rationale
 `woostack-review`'s [`prompts/anthropic.md`](../../woostack-review/prompts/anthropic.md) already
 states for its angle spawns. **When the host cannot route per call**, run at the session model and
 **say so** (degraded, not equivalent) — never pretend a tier ran.

--- a/skills/woostack-review/prompts/validator.md
+++ b/skills/woostack-review/prompts/validator.md
@@ -24,7 +24,7 @@ printf '[]\n' > "${OUTDIR:-/tmp/pr-review}/findings.defender.json"
 ```
 
 ### Step 1 — Review Summary
-Launch one Haiku subagent. Task:
+Launch one `fast`-tier subagent (resolve the tier per the shared Model Tiers table — this is the implicitly-`fast` context/summary helper). Task:
 - Read /tmp/pr-review/diff.txt, /tmp/pr-review/meta.json, /tmp/pr-review/angles.txt, and /tmp/pr-review/rules.md if it exists.
 - Produce a 1–2 sentence summary of the changes and the review focus.
 - **DO NOT** edit the PR title or body. The summary will be used in the native Review payload.

--- a/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
+++ b/skills/woostack-review/scripts/tests/test-detect-angles-audit-angles.sh
@@ -33,11 +33,11 @@ VA_LINE="$(grep 'VALID_ANGLES' "$DIR/load-config.sh")"
 assert_contains "$VA_LINE" "simplify" "VALID_ANGLES includes simplify"
 assert_contains "$VA_LINE" "production-readiness" "VALID_ANGLES includes production-readiness"
 
-# Site 10 (anthropic.md Sonnet-tier list): both angles must appear so the
+# Site 10 (anthropic.md standard-tier angle list): both angles must appear so the
 # per-provider tier table doesn't silently drop them (memory: review-add-angle-sites,
 # the site historically missed for the comments angle).
-ANTHRO_LINE="$(grep 'Sonnet for' "$DIR/../prompts/anthropic.md")"
-assert_contains "$ANTHRO_LINE" "simplify" "anthropic Sonnet tier lists simplify"
-assert_contains "$ANTHRO_LINE" "production-readiness" "anthropic Sonnet tier lists production-readiness"
+ANTHRO_LINE="$(grep 'effort: medium.*(' "$DIR/../prompts/anthropic.md")"
+assert_contains "$ANTHRO_LINE" "simplify" "anthropic standard tier lists simplify"
+assert_contains "$ANTHRO_LINE" "production-readiness" "anthropic standard tier lists production-readiness"
 
 finish


### PR DESCRIPTION
## Goal

Subagent tier routing was drifting off the shared Model Tiers table: dispatch docs listed `haiku`/`sonnet`/`opus` model families and hardcoded fast-model slugs, so executing agents invented their own tier→family ladder (e.g. `standard` → sonnet) instead of resolving through the configured tiers.

## Summary

- `woostack-execute` subagent-driver: dispatch section no longer names model families or effort values — resolve the effective tier through the shared `model-tiers.md` (provider column + configured overrides) and pass exactly what the resolved tier specifies; never invent a mapping not configured there.
- `using-woostack` model-tiers: per-call routing rule now says to resolve via the provider column plus override precedence and pass everything the resolved tier specifies, with no inline model/effort names.
- `woostack-commit` SKILL: fast-subagent drafting drops the hardcoded per-provider fast-model slugs and routes through the shared table instead.
- `woostack-review` validator prompt: "Launch one Haiku subagent" → launch a `fast`-tier subagent resolved per the table.
- Fixed `test-detect-angles-audit-angles.sh`, which was failing on HEAD: it grepped a stale `'Sonnet for'` line removed when `anthropic.md` moved to opus+effort tiering; now greps the current standard-tier angle list.

## Test plan

### Automated

- [ ] `skills/woostack-review/scripts/tests/` full suite — all tests pass (including the previously-failing `test-detect-angles-audit-angles.sh`, verified failing on clean HEAD before the fix)

### Manual

**Before merge**

- [ ] Read the updated dispatch sections and confirm no concrete model slug, family name, or effort value appears in consumer routing guidance — only tier vocabulary plus a pointer to `model-tiers.md`
- [ ] Run `/woostack-execute` on a plan and confirm subagent dispatches resolve models through the Model Tiers table (Anthropic column → opus + per-tier effort) instead of sonnet
