### PR TITLE
fix: woostack-status mislabels done zero-checkbox plans as executing

### DIFF
--- a/.woostack/fixes/2026-07-04-status-zero-checkbox-done.md
+++ b/.woostack/fixes/2026-07-04-status-zero-checkbox-done.md
@@ -1,0 +1,103 @@
+---
+type: fix
+status: in-review
+branch: fix/status-zero-checkbox-done
+---
+
+# Fix: woostack-status mislabels done zero-checkbox plans as executing
+
+Fixes [#456](https://github.com/howarewoo/woostack/issues/456).
+
+## 1. Root Cause
+
+`/woostack-status` shows a feature as `executing` when its plan is authored `status: done`,
+all discovered increment PRs are merged, but the plan has zero markdown task checkboxes.
+
+Traced in `skills/woostack-status/scripts/status.sh`:
+
+- Line 374: `frac=0; [ "$total" -gt 0 ] && frac=$(( done * 100 / total ))` — with
+  `total=0`, `frac` stays `"0"` and can never reach `"100"`.
+- `resolve_phase()` (lines 177–202), called with `frac="0"`, `authored="done"`,
+  `hasPlan=1`, `merged=3`, `prcount=3`, `open=0`:
+  - L180 discovered-PR done path requires `frac = 100` → never fires for a 0/0 plan.
+  - L186 authored-done fallback requires `frac = 100` **and** `prcount -eq 0` → fails
+    both (PRs were discovered).
+  - Falls through to the `case "$authored"` branch (L192–199): authored `done` with
+    `hasPlan=1` echoes **`executing`**.
+- `next_action()` (L226) then renders `finish plan (0/0); 3/3 increments shipped`,
+  matching the reported output exactly.
+
+`frac` is local to `status.sh` (not exported, not sourced elsewhere), so the defect is
+fully contained to this script.
+
+## 2. Proposed Fix
+
+Trust an explicit authored `done` for zero-checkbox plans, mirroring the existing
+narrow-trust precedent at L181–187. **Rejected alternative:** defaulting `frac=100`
+when `total=0` (vacuous truth) — too broad, because L180 ignores `authored`, so a
+zero-checkbox plan authored `executing` with one merged PR would silently flip to
+`done`; conventions.md says the board derives truth and flags drift, and a 0-box plan
+carries no progress signal to derive from.
+
+Concrete change in `skills/woostack-status/scripts/status.sh`:
+
+1. Pass `total` into `resolve_phase` as a 9th parameter (single call site, L381).
+2. Add two authored-done zero-checkbox rules after the existing L186 fallback:
+
+```bash
+# A zero-checkbox plan carries no progress signal; trust an explicit authored
+# done when every discovered increment PR is merged (closed-unmerged keeps the
+# feature visible), or — mirroring the legacy rule above — when nothing was
+# discovered at all.
+if [ "$authored" = "done" ] && [ "$total" -eq 0 ]; then
+  if [ "$merged" -gt 0 ] && [ "$merged" -eq "$prcount" ]; then echo "done"; return; fi
+  if [ "$prcount" -eq 0 ] && [ "$hasCommits" -eq 0 ]; then echo "done"; return; fi
+fi
+```
+
+Effects:
+
+- Authored `done` + 0 checkboxes + all discovered PRs merged → `done` (the bug).
+- Authored `done` + 0 checkboxes + no PRs + no branch commits → `done` (legacy
+  no-trailer case, symmetric with L186).
+- Closed-but-unmerged PRs stay visible: `merged < prcount` fails the first rule and
+  `prcount > 0` fails the second.
+- The `open > 0 → in-review` gate (L179) still runs first — unaffected.
+- Authored `executing`/`in-review` zero-checkbox plans are untouched (guard requires
+  `authored = done`).
+- Plans with real checkboxes are untouched (`total > 0`).
+- `frac` derivation (L374) and the HTML progress bar are untouched.
+
+No change to `plan_progress()` (correctly returns `0 0`) and no change to when
+`status: done` gets authored — per memory `execute-authors-terminal-plan-done`, the
+board-derivation logic in `resolve_phase` is the right place for this fix.
+
+Doc touch: `skills/woostack-status/references/conventions.md` `done` bullet gains a
+one-line note that a zero-checkbox plan relies on its authored `done` plus merged PRs.
+
+## 3. Implementation Plan
+
+- [x] **Step 1: Reproduce with failing tests**
+  - In `skills/woostack-status/scripts/tests/test-status.sh`, following the existing
+    `oscar`/`oscardone` fixture pattern (mkspec + mkplan + `FAKE_GH_JSON` + `run_status`,
+    ~L265–297), add:
+    - Zero-checkbox authored-done + all PRs MERGED → phase `done` (the bug; must fail
+      before the fix).
+    - Zero-checkbox authored-done + one PR CLOSED (unmerged) → phase **not** `done`.
+    - Zero-checkbox authored-done + no PRs + no branch commits → phase `done` (legacy
+      rule; must fail before the fix).
+    - Zero-checkbox authored-**executing** + all PRs MERGED → stays `executing`
+      (guards against the rejected broad fix).
+    - Zero-checkbox authored-done + one PR OPEN → phase `in-review` (L179 gate sanity).
+  - Run `bash skills/woostack-status/scripts/tests/run-tests.sh`; confirm the two
+    marked tests fail with the current code.
+- [x] **Step 2: Apply the minimal fix**
+  - In `status.sh`: pass `total` into `resolve_phase` (9th param, call site L381) and
+    add the authored-done zero-checkbox rules from §2 after the L186 fallback.
+  - Add the one-line zero-checkbox note to the `done` bullet in
+    `skills/woostack-status/references/conventions.md`.
+- [x] **Step 3: Verification**
+  - Run `bash skills/woostack-status/scripts/tests/run-tests.sh` — all tests pass,
+    including the pre-existing 100%-checkbox `oscar`/`oscardone` regression guards and
+    the HTML board tests (`test-html-board.sh`).
+  - Bash 3.2 / `set -u` compatible: plain `[` arithmetic tests, no arrays.

--- a/skills/woostack-status/references/conventions.md
+++ b/skills/woostack-status/references/conventions.md
@@ -42,7 +42,9 @@ These definitions are the source of truth for the `/woostack-status` board and t
   - `in-review` — increment PR open
   - `done` — authored by `woostack-execute` at the final increment (all boxes `[x]`, plan files);
     the board also derives/confirms it from artifacts (100% + all PRs merged) and shows `in-review`
-    while the final PR is still open
+    while the final PR is still open; a zero-checkbox plan has no progress signal, so the board
+    trusts its authored `done` only when every discovered increment PR is merged (or none exist
+    and the branch has no active commits)
   - `abandoned` — intentionally stopped
 
 `/woostack-status` derives truth from artifacts and flags drift instead of rewriting it:

--- a/skills/woostack-status/scripts/status.sh
+++ b/skills/woostack-status/scripts/status.sh
@@ -175,9 +175,17 @@ prs_for_branch() {
 }
 
 resolve_phase() {
-  local authored="$1" hasPlan="$2" frac="$3" open="$4" merged="$5" prcount="$6" branchExists="$7" hasCommits="$8"
+  local authored="$1" hasPlan="$2" frac="$3" open="$4" merged="$5" prcount="$6" branchExists="$7" hasCommits="$8" total="${9:-0}"
   if [ "$open" -gt 0 ]; then echo "in-review"; return; fi
   if [ "$frac" = "100" ] && [ "$merged" -gt 0 ] && [ "$merged" -eq "$prcount" ]; then echo "done"; return; fi
+  # A zero-checkbox plan carries no progress signal (frac stays 0, so the rules
+  # above and below can never confirm done). Trust an explicit authored done when
+  # every discovered increment PR is merged (a closed-unmerged PR keeps the feature
+  # visible), or — mirroring the legacy rule below — when nothing was discovered.
+  if [ "$authored" = "done" ] && [ "$total" -eq 0 ]; then
+    if [ "$merged" -gt 0 ] && [ "$merged" -eq "$prcount" ]; then echo "done"; return; fi
+    if [ "$prcount" -eq 0 ] && [ "$hasCommits" -eq 0 ]; then echo "done"; return; fi
+  fi
   # Legacy/untrailered features have no discoverable PR, so the rule above can't confirm
   # done. Trust an explicit authored `done` only when the plan is 100% complete, no
   # increment PR was found, and no active branch commits are visible; discovered increments
@@ -378,7 +386,7 @@ for f in "${specs[@]}"; do
     [ -n "$(branch_ref "$br")" ] && branchExists=1
     branch_has_commits "$br" && hasCommits=1
   fi
-  eff="$(resolve_phase "$phase" "$hasPlan" "$frac" "$open" "$merged" "$prcount" "$branchExists" "$hasCommits")"
+  eff="$(resolve_phase "$phase" "$hasPlan" "$frac" "$open" "$merged" "$prcount" "$branchExists" "$hasCommits" "$total")"
 
   if [ -z "$br" ] || [ "$br" = unknown ]; then
     case "$eff" in executing|in-review|done) flag "$name: branch is '${br:-empty}' - set branch:" ;; esac

--- a/skills/woostack-status/scripts/tests/test-status.sh
+++ b/skills/woostack-status/scripts/tests/test-status.sh
@@ -296,6 +296,51 @@ assert_contains "$OUT" "executing" "authored done does not override closed-unmer
 assert_contains "$OUT" "0 done" "authored done with closed-unmerged increment not counted done"
 unset FAKE_GH_JSON
 
+# Zero-checkbox plans carry no progress signal (issue #456): trust an explicit
+# authored done when all discovered increment PRs are merged...
+zd="$(mktemp -d)/.woostack"; mkspec "$zd" zuludone done feature/zuludone
+mkplan "$zd" zuludone 2026-06-01-zuludone.md 0 0 done feature/zuludone
+export FAKE_GH_JSON='[{"number":21,"state":"MERGED","headRefName":"feature/zuludone-1","author":{"login":"a"},"updatedAt":"2026-06-02T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-zuludone.md"},{"number":22,"state":"MERGED","headRefName":"feature/zuludone-2","author":{"login":"a"},"updatedAt":"2026-06-03T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-zuludone.md"}]'
+PATH="$g/bin:$PATH" run_status "$zd"
+assert_contains "$OUT" "1 done" "zero-checkbox authored done + all merged counts as done"
+assert_not_contains "$OUT" "zuludone " "zero-checkbox done hidden by default"
+unset FAKE_GH_JSON
+
+# ...but a closed-unmerged increment still blocks done, exactly like checkbox plans.
+zc="$(mktemp -d)/.woostack"; mkspec "$zc" zuluclosed done feature/zuluclosed
+mkplan "$zc" zuluclosed 2026-06-01-zuluclosed.md 0 0 done feature/zuluclosed
+export FAKE_GH_JSON='[{"number":23,"state":"MERGED","headRefName":"feature/zuluclosed-1","author":{"login":"a"},"updatedAt":"2026-06-02T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-zuluclosed.md"},{"number":24,"state":"CLOSED","headRefName":"feature/zuluclosed-2","author":{"login":"a"},"updatedAt":"2026-06-03T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-zuluclosed.md"}]'
+PATH="$g/bin:$PATH" run_status "$zc"
+assert_contains "$OUT" "zuluclosed" "zero-checkbox done with closed-unmerged increment stays visible"
+assert_contains "$OUT" "executing" "zero-checkbox done does not override closed-unmerged increment"
+assert_contains "$OUT" "0 done" "zero-checkbox done with closed-unmerged increment not counted done"
+unset FAKE_GH_JSON
+
+# ...and the legacy no-PR no-commits case mirrors the 100%-plan legacy rule.
+zl="$(mktemp -d)/.woostack"; mkspec "$zl" zululeg done feature/zululeg
+mkplan "$zl" zululeg 2026-06-01-zululeg.md 0 0 done feature/zululeg
+FAKE_GH_JSON='[]' PATH="$g/bin:$PATH" run_status "$zl"
+assert_contains "$OUT" "1 done" "zero-checkbox authored done + no PRs + no commits counts as done"
+assert_not_contains "$OUT" "zululeg " "zero-checkbox legacy done hidden by default"
+
+# Authored executing with zero checkboxes must NOT flip to done on merged PRs —
+# only an explicit authored done is trusted for a plan with no progress signal.
+ze="$(mktemp -d)/.woostack"; mkspec "$ze" zuluexec executing feature/zuluexec
+mkplan "$ze" zuluexec 2026-06-01-zuluexec.md 0 0 executing feature/zuluexec
+export FAKE_GH_JSON='[{"number":25,"state":"MERGED","headRefName":"feature/zuluexec-1","author":{"login":"a"},"updatedAt":"2026-06-02T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-zuluexec.md"}]'
+PATH="$g/bin:$PATH" run_status "$ze"
+assert_contains "$OUT" "executing" "zero-checkbox authored executing stays executing on merged PRs"
+assert_contains "$OUT" "0 done" "zero-checkbox authored executing not counted done"
+unset FAKE_GH_JSON
+
+# An open increment PR still wins: in-review is derived before any done rule.
+zo="$(mktemp -d)/.woostack"; mkspec "$zo" zuluopen done feature/zuluopen
+mkplan "$zo" zuluopen 2026-06-01-zuluopen.md 0 0 done feature/zuluopen
+export FAKE_GH_JSON='[{"number":26,"state":"OPEN","headRefName":"feature/zuluopen-1","author":{"login":"a"},"updatedAt":"2026-06-03T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-zuluopen.md"}]'
+PATH="$g/bin:$PATH" run_status "$zo"
+assert_contains "$OUT" "in-review" "zero-checkbox done with open PR derives in-review"
+unset FAKE_GH_JSON
+
 mkspec "$o" papa abandoned feature/papa
 run_status "$o"
 assert_contains "$OUT" "abandoned" "abandoned counted in footer"


### PR DESCRIPTION
## Goal

`/woostack-status` mislabeled a feature as `executing` when its plan was authored `status: done`, all discovered increment PRs were merged, but the plan had zero markdown task checkboxes (`frac` could never reach 100). Fixes #456.

## Summary

- `status.sh`: pass the plan's checkbox `total` into `resolve_phase` and trust an explicit authored `done` for zero-checkbox plans when every discovered increment PR is merged, or when no PRs and no active branch commits exist (mirrors the legacy 100%-plan rule). Closed-unmerged PRs still block `done`; open PRs still derive `in-review`; authored `executing` zero-checkbox plans are unchanged.
- `test-status.sh`: five new cases — bug repro (done + all merged), closed-unmerged guard, legacy no-PR case, executing-stays-executing guard, open-PR → in-review sanity.
- `conventions.md`: note the zero-checkbox `done` derivation on the `done` bullet.
- `.woostack/fixes/2026-07-04-status-zero-checkbox-done.md`: hardened fix plan (root cause, rejected `frac=100` vacuous-default alternative, checked-off implementation plan).

## Test plan

### Automated

- [ ] `bash skills/woostack-status/scripts/tests/run-tests.sh` — 82 passed (test-status.sh) + 55 passed (test-html-board.sh), 0 failed. New bug-repro tests failed before the fix, pass after.

### Manual

**Before merge**

- [ ] In a repo with a `status: done` plan containing zero checkboxes and all increment PRs merged, run `/woostack-status` and confirm the row lands in the `done` band instead of `executing` with `finish plan (0/0)`.

Spec: .woostack/fixes/2026-07-04-status-zero-checkbox-done.md
