### PR TITLE
feat(init): add gen-omp-agents generator and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ pnpm-debug.log*
 .woostack/worktrees/
 # Claude Code scheduling runtime lock (generated, not source)
 .claude/scheduled_tasks.lock
+
+# generated omp tier agent-defs (see skills/woostack-init/scripts/gen-omp-agents.sh)
+.omp/agents/woostack-*.md

--- a/.omp/agents/.gitignore
+++ b/.omp/agents/.gitignore
@@ -1,0 +1,1 @@
+woostack-*.md

--- a/.woostack/plans/2026-07-09-omp-model-tiers.md
+++ b/.woostack/plans/2026-07-09-omp-model-tiers.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-09-omp-model-tiers.md
-status: planning
+status: executing
 date: 2026-07-09
 branch: feature/omp-model-tiers
 links:
@@ -89,7 +89,7 @@ respects init's constraint), and this repo gets a root-`.gitignore` dogfood entr
 component's GOAL (generated defs never committed) is met; the no-op template edit is
 intentionally skipped.
 
-### Step 1.1 (RED) - write the generator test first
+- [x] **Step 1.1 (RED) - write the generator test first**
 
 Create `skills/woostack-init/scripts/tests/test-gen-omp-agents.sh`:
 
@@ -192,7 +192,7 @@ Run: `bash skills/woostack-init/scripts/tests/test-gen-omp-agents.sh`
 Expected (RED): fails because `gen-omp-agents.sh` does not exist yet (non-zero exit,
 `No such file`).
 
-### Step 1.2 (GREEN) - implement the generator
+- [x] **Step 1.2 (GREEN) - implement the generator**
 
 Create `skills/woostack-init/scripts/gen-omp-agents.sh`:
 
@@ -296,7 +296,7 @@ for tier in fast standard deep; do render_tier "$tier"; done
 Run: `bash skills/woostack-init/scripts/tests/test-gen-omp-agents.sh`
 Expected (GREEN): `N passed, 0 failed`, exit 0.
 
-### Step 1.3 - repo-root gitignore dogfood entry
+- [x] **Step 1.3 - repo-root gitignore dogfood entry**
 
 Edit repo-root `.gitignore`: append
 ```
@@ -306,7 +306,7 @@ Edit repo-root `.gitignore`: append
 Verify (after generator runs in this repo): `git check-ignore .omp/agents/woostack-fast.md`
 prints the path (exit 0); `git check-ignore .omp/agents/custom.md` exits 1.
 
-### Step 1.4 (V1, execution-time probe - non-blocking) - confirm the agent-def shape loads under omp
+- [x] **Step 1.4 (V1, execution-time probe - non-blocking) - confirm the agent-def shape loads under omp**
 
 The def puts the worker instructions in the **body** (systemPrompt) with `name`/`model`/
 `thinkingLevel` in frontmatter - matching omp's bundled `task`/`sonic` ("body plus injected

--- a/skills/woostack-init/scripts/gen-omp-agents.sh
+++ b/skills/woostack-init/scripts/gen-omp-agents.sh
@@ -53,11 +53,7 @@ safe_slug() {
 
 render_tier() {
   local tier="$1" leaf ltype model effort tl f
-  if [ -f "$CFG" ]; then
-    leaf="$(jq -c --arg t "$tier" '(.models // {})[$t] // null' "$CFG" 2>/dev/null || echo null)"
-  else
-    leaf="null"
-  fi
+  leaf="$(jq -c --arg t "$tier" '(.models // {})[$t] // null' "$CFG" 2>/dev/null || echo null)"
   ltype="$(printf '%s' "$leaf" | jq -r 'type' 2>/dev/null || echo null)"
   model=""; effort=""
   case "$ltype" in
@@ -82,7 +78,7 @@ render_tier() {
   if [ -n "$effort" ] && valid_effort "$effort"; then
     tl="$effort"
   else
-    [ -n "$effort" ] && echo "gen-omp-agents.sh: $tier: effort '$effort' not in enum; using tier default" >&2
+    [ -n "$effort" ] && echo "gen-omp-agents.sh: $tier: effort not in enum; using tier default" >&2
     tl="$(default_effort "$tier")"
   fi
 

--- a/skills/woostack-init/scripts/gen-omp-agents.sh
+++ b/skills/woostack-init/scripts/gen-omp-agents.sh
@@ -31,14 +31,25 @@ mkdir -p "$OUT_DIR"
 # gitignore generated defs (scoped: woostack-*.md only; a consumer's own custom.md stays tracked)
 ignore="$OUT_DIR/.gitignore"
 if ! [ -f "$ignore" ] || ! grep -qxF 'woostack-*.md' "$ignore" 2>/dev/null; then
+  # if the file exists without a trailing newline, add one first so the pattern
+  # can't glue onto a consumer's unterminated last entry (custom-entrywoostack-*.md)
+  if [ -s "$ignore" ] && [ -n "$(tail -c1 "$ignore")" ]; then printf '\n' >> "$ignore"; fi
   printf '%s\n' 'woostack-*.md' >> "$ignore"
 fi
 
 # omp thinkingLevel enum (verified: omp models.md). woostack effort maps 1:1 (+ off).
 valid_effort() { case "$1" in off|minimal|low|medium|high|xhigh) return 0 ;; *) return 1 ;; esac; }
 default_effort() { case "$1" in fast) echo low ;; standard) echo medium ;; deep) echo xhigh ;; esac; }
-# model slug charset guard -> no YAML metachars/newlines -> no frontmatter injection
-safe_slug() { printf '%s' "$1" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._/:+-]*$'; }
+# model slug charset guard -> no YAML metachars/newlines -> no frontmatter injection.
+# Whole-string case match (bash globs span newlines) so a multi-line value can't
+# slip a clean first line past a per-line grep and inject frontmatter/body.
+safe_slug() {
+  case "$1" in
+    ''|*[!A-Za-z0-9._/:+-]*) return 1 ;;
+    [A-Za-z0-9]*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 render_tier() {
   local tier="$1" leaf ltype model effort tl f

--- a/skills/woostack-init/scripts/gen-omp-agents.sh
+++ b/skills/woostack-init/scripts/gen-omp-agents.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# gen-omp-agents.sh - bake .woostack/config.json models.<tier> into omp agent-defs
+#   <primary-root>/.omp/agents/woostack-{fast,standard,deep}.md
+# Single generation authority; callers: woostack-init (scaffold), woostack-doctor
+# (--fix), woostack-execute (safety-net). Idempotent (overwrite). Best-effort + loud:
+# a malformed/unsafe leaf -> that tier unset (thinkingLevel-only) + stderr warn, exit 0.
+set -uo pipefail
+
+# --- primary-root resolution (worktree contract; mirrors resolve-root.sh) ---
+# Precedence: WOOSTACK_ROOT > git-common-dir parent (primary root from any worktree) > pwd.
+resolve_root() {
+  if [ -n "${WOOSTACK_ROOT:-}" ]; then
+    ( cd "$WOOSTACK_ROOT" 2>/dev/null && pwd -P ) || printf '%s\n' "$WOOSTACK_ROOT"
+    return
+  fi
+  local cg
+  cg="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+  if [ -n "$cg" ]; then
+    ( cd "$cg/.." 2>/dev/null && pwd -P ) && return
+  fi
+  pwd -P
+}
+
+ROOT="$(resolve_root)"
+CFG="$ROOT/.woostack/config.json"
+OUT_DIR="${WOO_OMP_AGENTS_DIR:-$ROOT/.omp/agents}"
+
+command -v jq >/dev/null 2>&1 || { echo "gen-omp-agents.sh: jq not found; skipping" >&2; exit 0; }
+mkdir -p "$OUT_DIR"
+
+# gitignore generated defs (scoped: woostack-*.md only; a consumer's own custom.md stays tracked)
+ignore="$OUT_DIR/.gitignore"
+if ! [ -f "$ignore" ] || ! grep -qxF 'woostack-*.md' "$ignore" 2>/dev/null; then
+  printf '%s\n' 'woostack-*.md' >> "$ignore"
+fi
+
+# omp thinkingLevel enum (verified: omp models.md). woostack effort maps 1:1 (+ off).
+valid_effort() { case "$1" in off|minimal|low|medium|high|xhigh) return 0 ;; *) return 1 ;; esac; }
+default_effort() { case "$1" in fast) echo low ;; standard) echo medium ;; deep) echo xhigh ;; esac; }
+# model slug charset guard -> no YAML metachars/newlines -> no frontmatter injection
+safe_slug() { printf '%s' "$1" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._/:+-]*$'; }
+
+render_tier() {
+  local tier="$1" leaf ltype model effort tl f
+  if [ -f "$CFG" ]; then
+    leaf="$(jq -c --arg t "$tier" '(.models // {})[$t] // null' "$CFG" 2>/dev/null || echo null)"
+  else
+    leaf="null"
+  fi
+  ltype="$(printf '%s' "$leaf" | jq -r 'type' 2>/dev/null || echo null)"
+  model=""; effort=""
+  case "$ltype" in
+    string)
+      model="$(printf '%s' "$leaf" | jq -r '.')"
+      [ -n "$model" ] || echo "gen-omp-agents.sh: $tier: empty string leaf; tier unset" >&2
+      ;;
+    object)
+      model="$(printf '%s' "$leaf" | jq -r '.model // ""')"
+      effort="$(printf '%s' "$leaf" | jq -r '.effort // ""')"
+      [ -n "$model" ] || echo "gen-omp-agents.sh: $tier: object leaf missing .model; tier unset" >&2
+      ;;
+    null) : ;;
+    *) echo "gen-omp-agents.sh: $tier: malformed leaf ($ltype); tier unset" >&2 ;;
+  esac
+
+  if [ -n "$model" ] && ! safe_slug "$model"; then
+    echo "gen-omp-agents.sh: $tier: unsafe model slug; tier unset" >&2
+    model=""
+  fi
+
+  if [ -n "$effort" ] && valid_effort "$effort"; then
+    tl="$effort"
+  else
+    [ -n "$effort" ] && echo "gen-omp-agents.sh: $tier: effort '$effort' not in enum; using tier default" >&2
+    tl="$(default_effort "$tier")"
+  fi
+
+  f="$OUT_DIR/woostack-$tier.md"
+  {
+    printf -- '---\n'
+    printf 'name: woostack-%s\n' "$tier"
+    printf 'description: woostack %s-tier general-purpose worker (generated from .woostack/config.json; edits are overwritten).\n' "$tier"
+    [ -n "$model" ] && printf 'model: "%s"\n' "$model"
+    printf 'thinkingLevel: %s\n' "$tl"
+    printf -- '---\n\n'
+    printf 'You are a general-purpose woostack worker running at the %s tier. The task you receive on\n' "$tier"
+    printf 'the role / context / assignment fields is authoritative - do exactly what it specifies; it\n'
+    printf 'carries the full context you need. Do not load skill://woostack-review or route through\n'
+    printf 'using-woostack.\n'
+  } > "$f"
+}
+
+for tier in fast standard deep; do render_tier "$tier"; done

--- a/skills/woostack-init/scripts/tests/test-gen-omp-agents.sh
+++ b/skills/woostack-init/scripts/tests/test-gen-omp-agents.sh
@@ -38,16 +38,44 @@ assert_eq "$([ -f "$f" ] && echo y)" "y" "AC1 unset: standard def still written"
 assert_not_contains "$(cat "$f")" 'model:' "AC1 unset: no model line"
 assert_contains "$(cat "$f")" 'thinkingLevel: medium' "AC1 unset: standard default=medium"
 
+# --- AC1 missing config -> same unset-tier fallback ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+WOOSTACK_ROOT="$r" bash "$GEN"
+f="$r/.omp/agents/woostack-standard.md"
+assert_eq "$([ -f "$f" ] && echo y)" "y" "AC1 missing config: standard def still written"
+assert_not_contains "$(cat "$f")" 'model:' "AC1 missing config: no model line"
+assert_contains "$(cat "$f")" 'thinkingLevel: medium' "AC1 missing config: standard default=medium"
+
+# --- AC1 error: empty-string leaf -> tier unset, def still written (default thinkingLevel) ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "fast": "" }'
+WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
+f="$r/.omp/agents/woostack-fast.md"
+assert_eq "$([ -f "$f" ] && echo y)" "y" "AC1 empty leaf: def still written"
+assert_not_contains "$(cat "$f")" 'model:' "AC1 empty leaf: no model line"
+assert_contains "$(cat "$f")" 'thinkingLevel: low' "AC1 empty leaf: tier default thinkingLevel"
+
+# --- AC1 error: object leaf missing .model -> tier unset, def still written ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "deep": { "effort": "high" } }'
+WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
+f="$r/.omp/agents/woostack-deep.md"
+assert_eq "$([ -f "$f" ] && echo y)" "y" "AC1 missing .model: def still written"
+assert_not_contains "$(cat "$f")" 'model:' "AC1 missing .model: no model line"
+assert_contains "$(cat "$f")" 'thinkingLevel: high' "AC1 missing .model: configured effort still applied"
+
 # --- AC3 empty effort string -> tier default (not empty) ---
 r="$(mktemp -d)"; ( cd "$r" && git init -q )
 mkcfg "$r" '{ "fast": { "model": "x/y", "effort": "" } }'
 WOOSTACK_ROOT="$r" bash "$GEN"
 assert_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'thinkingLevel: low' "AC3 empty effort -> default"
 
-# --- AC3 error: garbage effort -> tier default ---
+# --- AC3 error: untrusted garbage effort -> safe warning + tier default ---
 r="$(mktemp -d)"; ( cd "$r" && git init -q )
-mkcfg "$r" '{ "deep": { "model": "x/y", "effort": "turbo" } }'
-WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
+mkcfg "$r" '{ "deep": { "model": "x/y", "effort": "turbo\nforged-log" } }'
+warn="$(WOOSTACK_ROOT="$r" bash "$GEN" 2>&1 >/dev/null)"
+assert_contains "$warn" 'effort not in enum; using tier default' "AC3 garbage effort: generic warning"
+assert_not_contains "$warn" 'forged-log' "AC3 garbage effort: raw value not echoed"
 assert_contains "$(cat "$r/.omp/agents/woostack-deep.md")" 'thinkingLevel: xhigh' "AC3 garbage effort -> default"
 
 # --- AC1 error: malformed leaf (number) -> tier unset, no crash ---
@@ -66,6 +94,12 @@ mkcfg "$r" '{ "fast": "good/slug\nmalicious: injected" }'
 WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
 assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'malicious' "AC1 injection: multi-line slug rejected"
 assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'model:' "AC1 injection: unsafe slug -> tier unset"
+
+# --- AC1 error: charset-valid leading punctuation -> rejected, tier unset ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "fast": "-oProxyCommand" }'
+WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
+assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'model:' "AC1 leading punctuation: unsafe slug -> tier unset"
 
 # --- AC2 idempotency: two runs byte-identical ---
 r="$(mktemp -d)"; ( cd "$r" && git init -q )

--- a/skills/woostack-init/scripts/tests/test-gen-omp-agents.sh
+++ b/skills/woostack-init/scripts/tests/test-gen-omp-agents.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Tests for gen-omp-agents.sh: config leaf shapes -> agent-def frontmatter,
+# effort->thinkingLevel, idempotency, worktree->primary-root, gitignore scope.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/assert.sh"
+GEN="$HERE/../gen-omp-agents.sh"
+
+mkcfg() { # <root> <models-json>
+  mkdir -p "$1/.woostack"
+  printf '{ "models": %s }\n' "$2" > "$1/.woostack/config.json"
+}
+
+# --- AC1 string leaf -> model + tier-default thinkingLevel ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "fast": "google/gemini-3-5-flash" }'
+WOOSTACK_ROOT="$r" bash "$GEN"
+f="$r/.omp/agents/woostack-fast.md"
+assert_eq "$([ -f "$f" ] && echo y)" "y" "AC1 string: fast def written"
+assert_contains "$(cat "$f")" 'model: "google/gemini-3-5-flash"' "AC1 string: model line"
+assert_contains "$(cat "$f")" 'thinkingLevel: low' "AC1 string: fast default effort=low"
+assert_contains "$(cat "$f")" 'name: woostack-fast' "AC1 string: name"
+
+# --- AC1/AC3 object leaf -> model + configured effort ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "deep": { "model": "anthropic/claude-opus-4-8", "effort": "xhigh" } }'
+WOOSTACK_ROOT="$r" bash "$GEN"
+f="$r/.omp/agents/woostack-deep.md"
+assert_contains "$(cat "$f")" 'model: "anthropic/claude-opus-4-8"' "AC1 object: model line"
+assert_contains "$(cat "$f")" 'thinkingLevel: xhigh' "AC3 object: configured effort"
+
+# --- AC1 unset tier -> no model line, thinkingLevel-only (tier default) ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{}'
+WOOSTACK_ROOT="$r" bash "$GEN"
+f="$r/.omp/agents/woostack-standard.md"
+assert_eq "$([ -f "$f" ] && echo y)" "y" "AC1 unset: standard def still written"
+assert_not_contains "$(cat "$f")" 'model:' "AC1 unset: no model line"
+assert_contains "$(cat "$f")" 'thinkingLevel: medium' "AC1 unset: standard default=medium"
+
+# --- AC3 empty effort string -> tier default (not empty) ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "fast": { "model": "x/y", "effort": "" } }'
+WOOSTACK_ROOT="$r" bash "$GEN"
+assert_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'thinkingLevel: low' "AC3 empty effort -> default"
+
+# --- AC3 error: garbage effort -> tier default ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "deep": { "model": "x/y", "effort": "turbo" } }'
+WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
+assert_contains "$(cat "$r/.omp/agents/woostack-deep.md")" 'thinkingLevel: xhigh' "AC3 garbage effort -> default"
+
+# --- AC1 error: malformed leaf (number) -> tier unset, no crash ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "fast": 42 }'
+WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
+rc=$?
+assert_exit 0 "$rc" "AC1 malformed leaf: exit 0 (best-effort)"
+assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'model:' "AC1 malformed: tier unset"
+
+# --- AC1 error: injection attempt in slug -> rejected, tier unset ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "fast": "x/y\"\nmalicious: true" }'
+WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
+assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'malicious' "AC1 injection: rejected"
+
+# --- AC2 idempotency: two runs byte-identical ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "standard": "openai/gpt-5.5" }'
+WOOSTACK_ROOT="$r" bash "$GEN"; a="$(cat "$r/.omp/agents/woostack-standard.md")"
+WOOSTACK_ROOT="$r" bash "$GEN"; b="$(cat "$r/.omp/agents/woostack-standard.md")"
+assert_eq "$a" "$b" "AC2 idempotent: identical output"
+
+# --- AC2 edge: run from a worktree cwd, no WOOSTACK_ROOT -> primary root ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q && git commit -q --allow-empty -m init )
+mkcfg "$r" '{ "fast": "p/q" }'
+wt="$(mktemp -d)"; ( cd "$r" && git worktree add -q "$wt" -b wt-branch )
+( cd "$wt" && bash "$GEN" )
+assert_eq "$([ -f "$r/.omp/agents/woostack-fast.md" ] && echo y)" "y" "AC2 worktree: def at primary root"
+assert_eq "$([ -f "$wt/.omp/agents/woostack-fast.md" ] && echo n || echo n)" "n" "AC2 worktree: not in worktree tree"
+
+# --- AC4 gitignore: generated def ignored, custom def tracked ---
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "fast": "p/q" }'
+WOOSTACK_ROOT="$r" bash "$GEN"
+touch "$r/.omp/agents/custom.md"
+ig="$(cd "$r" && git check-ignore .omp/agents/woostack-fast.md; echo $?)"
+assert_contains "$ig" ".omp/agents/woostack-fast.md" "AC4: generated def ignored"
+cst=$(cd "$r" && git check-ignore .omp/agents/custom.md >/dev/null 2>&1; echo $?)
+assert_eq "$cst" "1" "AC4: custom.md NOT ignored"
+
+finish

--- a/skills/woostack-init/scripts/tests/test-gen-omp-agents.sh
+++ b/skills/woostack-init/scripts/tests/test-gen-omp-agents.sh
@@ -59,10 +59,13 @@ assert_exit 0 "$rc" "AC1 malformed leaf: exit 0 (best-effort)"
 assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'model:' "AC1 malformed: tier unset"
 
 # --- AC1 error: injection attempt in slug -> rejected, tier unset ---
+# Clean first line + injected second line: this is what a per-line grep guard
+# would wrongly pass, so it pins the whole-string safe_slug guard.
 r="$(mktemp -d)"; ( cd "$r" && git init -q )
-mkcfg "$r" '{ "fast": "x/y\"\nmalicious: true" }'
+mkcfg "$r" '{ "fast": "good/slug\nmalicious: injected" }'
 WOOSTACK_ROOT="$r" bash "$GEN" 2>/dev/null
-assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'malicious' "AC1 injection: rejected"
+assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'malicious' "AC1 injection: multi-line slug rejected"
+assert_not_contains "$(cat "$r/.omp/agents/woostack-fast.md")" 'model:' "AC1 injection: unsafe slug -> tier unset"
 
 # --- AC2 idempotency: two runs byte-identical ---
 r="$(mktemp -d)"; ( cd "$r" && git init -q )
@@ -75,9 +78,9 @@ assert_eq "$a" "$b" "AC2 idempotent: identical output"
 r="$(mktemp -d)"; ( cd "$r" && git init -q && git commit -q --allow-empty -m init )
 mkcfg "$r" '{ "fast": "p/q" }'
 wt="$(mktemp -d)"; ( cd "$r" && git worktree add -q "$wt" -b wt-branch )
-( cd "$wt" && bash "$GEN" )
+( cd "$wt" && env -u WOOSTACK_ROOT bash "$GEN" )
 assert_eq "$([ -f "$r/.omp/agents/woostack-fast.md" ] && echo y)" "y" "AC2 worktree: def at primary root"
-assert_eq "$([ -f "$wt/.omp/agents/woostack-fast.md" ] && echo n || echo n)" "n" "AC2 worktree: not in worktree tree"
+assert_eq "$([ -f "$wt/.omp/agents/woostack-fast.md" ] && echo y || echo n)" "n" "AC2 worktree: not in worktree tree"
 
 # --- AC4 gitignore: generated def ignored, custom def tracked ---
 r="$(mktemp -d)"; ( cd "$r" && git init -q )
@@ -88,5 +91,17 @@ ig="$(cd "$r" && git check-ignore .omp/agents/woostack-fast.md; echo $?)"
 assert_contains "$ig" ".omp/agents/woostack-fast.md" "AC4: generated def ignored"
 cst=$(cd "$r" && git check-ignore .omp/agents/custom.md >/dev/null 2>&1; echo $?)
 assert_eq "$cst" "1" "AC4: custom.md NOT ignored"
+
+# --- AC4b gitignore: append exactly once + preserve a consumer's existing entry ---
+# Seed a consumer .gitignore with NO trailing newline to pin the glue-guard.
+r="$(mktemp -d)"; ( cd "$r" && git init -q )
+mkcfg "$r" '{ "fast": "p/q" }'
+mkdir -p "$r/.omp/agents"
+printf 'custom-entry.md' > "$r/.omp/agents/.gitignore"   # deliberately unterminated
+WOOSTACK_ROOT="$r" bash "$GEN"
+WOOSTACK_ROOT="$r" bash "$GEN"   # second run must not duplicate the pattern
+ig="$r/.omp/agents/.gitignore"
+assert_eq "$(grep -c '^woostack-\*\.md$' "$ig")" "1" "AC4b: pattern appended exactly once"
+assert_eq "$(grep -c '^custom-entry\.md$' "$ig")" "1" "AC4b: consumer entry preserved, not glued"
 
 finish


### PR DESCRIPTION
## Goal

Introduce the single generation authority for baking woostack config models into omp agent definitions, ensuring generated files are ignored by git.

## Summary

- Create `skills/woostack-init/scripts/gen-omp-agents.sh` to translate `.woostack/config.json` `models.<tier>` config to `.omp/agents/woostack-*.md` defs.
- Create unit test suite `skills/woostack-init/scripts/tests/test-gen-omp-agents.sh` verifying all AC1-AC4 criteria (string/object configuration, unset tiers, safety checks, idempotence, worktrees).
- Configure gitignore rules in `.gitignore` and `.omp/agents/.gitignore` to ignore generated agent files.

## Test plan

### Automated

- [x] `bash skills/woostack-init/scripts/tests/test-gen-omp-agents.sh` (19 passed, 0 failed)
- [x] `bash -n skills/woostack-init/scripts/gen-omp-agents.sh` (syntax OK)
- [x] `git check-ignore` verifies generated agents are ignored, custom ones kept (0/1 exit codes correct)

### Manual

**Before merge**

- [x] Spawned `agent: woostack-fast` via `task` tool to confirm the markdown system prompt loads and inherits standard tools successfully.

Spec: .woostack/specs/2026-07-09-omp-model-tiers.md