### PR TITLE
docs(init,using): add OMP host bucket to model-tiers.md and scaffold caller

### DIFF
--- a/.woostack/plans/2026-07-09-omp-model-tiers.md
+++ b/.woostack/plans/2026-07-09-omp-model-tiers.md
@@ -332,12 +332,12 @@ scalar (`systemPrompt: |`) instead; re-run the probe. Record the outcome in the 
 
 **Spec coverage:** AC8 (bucket present; provider table columns unchanged), §4.1/§4.4.
 
-### Step 2.1 (RED) - assert the bucket & column-stability before writing
+- [x] **Step 2.1 (RED) - assert the bucket & column-stability before writing**
 
 Command: `grep -c 'agent-by-tier' skills/using-woostack/references/model-tiers.md`
 Expected (RED): `0`.
 
-### Step 2.2 (GREEN) - add the omp host bucket to `model-tiers.md`
+- [x] **Step 2.2 (GREEN) - add the omp host bucket to model-tiers.md**
 
 Below the four-provider table (leave the table's column header **byte-unchanged**:
 `| Tier | Use for | Anthropic | OpenAI (Codex) | Google (Gemini) | OpenRouter |`), add a new
@@ -360,7 +360,7 @@ subsection. Use the exact token `agent-by-tier` (pinned by the Increment 5 locks
 > and `resolve-model.sh` are untouched; the omp bucket is informational only. A consumer
 > can still set provider-specific columnar models for those hosts.
 
-### Step 2.3 (GREEN) - `woostack-init` scaffold caller
+- [x] **Step 2.3 (GREEN) - woostack-init scaffold caller**
 
 Edit `skills/woostack-init/SKILL.md`: in the scaffolding steps, add that when running under
 omp (host applies its own capability knowledge), init runs

--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -31,6 +31,9 @@ implicitly `fast`.
   never substitute a mapping that is not configured here.
 - **Single model per session** (Codex Action without subagent model overrides, Antigravity CLI): resolve
   one run model up front; per-tier behavior collapses onto that one model for the whole job.
+- **Per-call routing via agent-by-tier (omp / Oh My Pi)** — omp's `task` tool has **no per-call `model`/`tier`/`effort` argument**, so per-spawn tier routing is not available. Instead, omp resolves a subagent's model from the **agent definition** (`model` + `thinkingLevel`). woostack ships three generated defs `.omp/agents/woostack-{fast,standard,deep}.md` (from `.woostack/config.json` via `skills/woostack-init/scripts/gen-omp-agents.sh`) and the driver selects `agent: woostack-<effective-tier>` per spawn - **agent-by-tier** routing. This is a routing pattern over the existing flat `models.<tier>` config, **not a fifth provider column** and **not a new config key**. An unset tier -> `thinkingLevel`-only def (fast->low, standard->medium, deep->xhigh) inheriting the session model. woostack effort (`minimal|low|medium|high|xhigh`) maps 1:1 to omp `thinkingLevel` (which also allows `off`).
+
+  **Cross-consumer coexistence.** On CI/single-session hosts the flat provider table above and `resolve-model.sh` are untouched; the omp bucket is informational only. A consumer can still set provider-specific columnar models for those hosts.
 
 ## Override precedence (generic)
 

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -58,6 +58,10 @@ Two callers:
    `main`). Resolution lives in [`scripts/resolve-base.sh`](scripts/resolve-base.sh); the per-PR
    worktree lifecycle that consumes it is the [worktree contract](references/worktrees.md).
 
+   **Under omp (Oh My Pi):** after writing `config.json` (or if it is already present), `woostack-init`
+   runs `skills/woostack-init/scripts/gen-omp-agents.sh` to generate the `.omp/agents/woostack-{fast,standard,deep}.md`
+   tier definitions. These generated definitions are gitignored via `.omp/agents/.gitignore` (written by the generator).
+
 3. **Handle existing files.** For any file that already exists and `--force`
    is not active: prompt the user to keep or overwrite it. Under `--no-clobber`
    skip all existing files silently without prompting. After the run, state


### PR DESCRIPTION
## Goal

Add the OMP host bucket to model-tiers.md to document agent-by-tier routing, and update the woostack-init procedure to run the OMP generator on first scaffold.

## Summary

- Add the `agent-by-tier` routing bucket for OMP under `Routing by host capability (generic)` in `skills/using-woostack/references/model-tiers.md`.
- Update `skills/woostack-init/SKILL.md` to note that `woostack-init` executes `gen-omp-agents.sh` when running under OMP so generated definitions exist initially.

## Test plan

### Automated

- [x] Verified `grep -c 'agent-by-tier'` is `1` on `model-tiers.md`
- [x] Verified provider table columns in `model-tiers.md` remain unchanged to protect the review orchestrator prompt inline

Spec: .woostack/specs/2026-07-09-omp-model-tiers.md