### PR TITLE
feat(doctor): add OMP agents drift check, test, and catalog row

### DIFF
--- a/.woostack/plans/2026-07-09-omp-model-tiers.md
+++ b/.woostack/plans/2026-07-09-omp-model-tiers.md
@@ -385,7 +385,7 @@ init SKILL references `gen-omp-agents.sh`.
 **Spec coverage:** AC5 (diagnose warns on missing/drift; `--fix` regenerates; gated on
 `.omp/` existing - silent otherwise).
 
-### Step 3.1 (RED) - write the check test first
+- [x] **Step 3.1 (RED) - write the check test first**
 
 Create `skills/woostack-doctor/scripts/tests/test-omp-agents.sh` (mirrors
 `test-review-models-moved.sh`: sources init `assert.sh`, drives the check as diagnose &
@@ -427,7 +427,7 @@ finish
 Run: `bash skills/woostack-doctor/scripts/tests/test-omp-agents.sh`
 Expected (RED): fails - `omp-agents.sh` missing.
 
-### Step 3.2 (GREEN) - implement the check
+- [x] **Step 3.2 (GREEN) - implement the check**
 
 Create `skills/woostack-doctor/scripts/checks/omp-agents.sh` (arg/`emit` contract copied
 from `config-keys.sh`; auto-discovered by `doctor.sh`'s `checks/*.sh` loop - no `doctor.sh`
@@ -460,7 +460,7 @@ done
 rm -rf "$tmp"
 ```
 
-### Step 3.3 (GREEN) - catalog row
+- [x] **Step 3.3 (GREEN) - catalog row**
 
 Edit `skills/woostack-doctor/references/checks.md`: add a catalog row for `omp-agents.sh` -
 severity `warn`, fixable `auto`, codes `omp-agents-missing` / `omp-agents-drift`, repair args

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -44,6 +44,7 @@ overloaded):
 | `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
 | `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |
 | `config-key` | a required `config.json` key (per the init template) is absent | warn | auto | `<root> <key>` (merges template default) |
+| `omp-agents-missing` / `omp-agents-drift` | generated omp tier def missing or drifted from `.woostack/config.json` (gated on `.omp/` existing) | warn | auto | `<root>` (runs `gen-omp-agents.sh`) |
 
 Memory checks are all `report` — memory *content* repair is [`woostack-dream`](../../woostack-dream/SKILL.md)'s
 job; doctor only surfaces the structural signals. The spec↔plan join reuses the

--- a/skills/woostack-doctor/scripts/checks/omp-agents.sh
+++ b/skills/woostack-doctor/scripts/checks/omp-agents.sh
@@ -10,7 +10,7 @@ if [ "$FIX" -eq 1 ]; then
   WOOSTACK_ROOT="$WOO_ROOT" bash "$GEN" >/dev/null 2>&1 || true
   exit 0
 fi
-tmp="$(mktemp -d)"
+tmp="$(mktemp -d)" || exit 0            # mktemp failed -> stay read-only, never fall through to live .omp/agents
 WOOSTACK_ROOT="$WOO_ROOT" WOO_OMP_AGENTS_DIR="$tmp" bash "$GEN" >/dev/null 2>&1 || true
 for want in "$tmp"/woostack-*.md; do
   [ -e "$want" ] || continue

--- a/skills/woostack-doctor/scripts/checks/omp-agents.sh
+++ b/skills/woostack-doctor/scripts/checks/omp-agents.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
+if [ "${1:-}" = "--fix" ]; then FIX=1; WOO_ROOT="${2:-.}"; else FIX=0; WOO_ROOT="${1:-.}"; fi
+GEN="$HERE/../../../woostack-init/scripts/gen-omp-agents.sh"
+[ -d "$WOO_ROOT/.omp" ] || exit 0          # not an omp workspace -> silent
+[ -f "$GEN" ] || exit 0
+if [ "$FIX" -eq 1 ]; then
+  WOOSTACK_ROOT="$WOO_ROOT" bash "$GEN" >/dev/null 2>&1 || true
+  exit 0
+fi
+tmp="$(mktemp -d)"
+WOOSTACK_ROOT="$WOO_ROOT" WOO_OMP_AGENTS_DIR="$tmp" bash "$GEN" >/dev/null 2>&1 || true
+for want in "$tmp"/woostack-*.md; do
+  [ -e "$want" ] || continue
+  base="$(basename "$want")"; have="$WOO_ROOT/.omp/agents/$base"
+  if [ ! -f "$have" ]; then
+    emit warn omp-agents-missing auto "$have" "generated omp tier def missing"
+  elif ! diff -q "$want" "$have" >/dev/null 2>&1; then
+    emit warn omp-agents-drift auto "$have" "generated omp tier def drifted from .woostack/config.json"
+  fi
+done
+rm -rf "$tmp"

--- a/skills/woostack-doctor/scripts/tests/test-omp-agents.sh
+++ b/skills/woostack-doctor/scripts/tests/test-omp-agents.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/../../../woostack-init/scripts/tests/assert.sh"
+CHK="$HERE/../checks/omp-agents.sh"
+GEN="$HERE/../../../woostack-init/scripts/gen-omp-agents.sh"
+
+# no .omp/ -> silent, exit 0 (not an omp workspace)
+r="$(mktemp -d)"; mkdir -p "$r/.woostack"; printf '{}' > "$r/.woostack/config.json"
+out="$(bash "$CHK" "$r")"; rc=$?
+assert_exit 0 "$rc" "no .omp: exit 0"
+assert_eq "$out" "" "no .omp: silent"
+
+# .omp/ present, defs missing -> warn
+r="$(mktemp -d)"; mkdir -p "$r/.woostack" "$r/.omp/agents"
+printf '{ "models": { "fast": "p/q" } }' > "$r/.woostack/config.json"
+out="$(bash "$CHK" "$r")"
+assert_contains "$out" "omp-agents-missing" "missing def -> warn"
+
+# --fix -> regenerates, then diagnose is silent
+bash "$CHK" --fix "$r" >/dev/null 2>&1
+out="$(bash "$CHK" "$r")"
+assert_eq "$out" "" "after --fix: no drift"
+
+# drift (hand-edit a def) -> warn
+echo "tampered" >> "$r/.omp/agents/woostack-fast.md"
+out="$(bash "$CHK" "$r")"
+assert_contains "$out" "omp-agents-drift" "tampered def -> drift warn"
+
+finish

--- a/skills/woostack-doctor/scripts/tests/test-omp-agents.sh
+++ b/skills/woostack-doctor/scripts/tests/test-omp-agents.sh
@@ -4,15 +4,17 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$HERE/../../../woostack-init/scripts/tests/assert.sh"
 CHK="$HERE/../checks/omp-agents.sh"
 GEN="$HERE/../../../woostack-init/scripts/gen-omp-agents.sh"
+set +e                                    # assert.sh enables errexit; keep the suite running to the finish tally
+tmpdirs=(); trap 'rm -rf "${tmpdirs[@]}"' EXIT   # track + clean every sandbox on exit (incl. early abort)
 
 # no .omp/ -> silent, exit 0 (not an omp workspace)
-r="$(mktemp -d)"; mkdir -p "$r/.woostack"; printf '{}' > "$r/.woostack/config.json"
+r="$(mktemp -d)"; tmpdirs+=("$r"); mkdir -p "$r/.woostack"; printf '{}' > "$r/.woostack/config.json"
 out="$(bash "$CHK" "$r")"; rc=$?
 assert_exit 0 "$rc" "no .omp: exit 0"
 assert_eq "$out" "" "no .omp: silent"
 
 # .omp/ present, defs missing -> warn
-r="$(mktemp -d)"; mkdir -p "$r/.woostack" "$r/.omp/agents"
+r="$(mktemp -d)"; tmpdirs+=("$r"); mkdir -p "$r/.woostack" "$r/.omp/agents"
 printf '{ "models": { "fast": "p/q" } }' > "$r/.woostack/config.json"
 out="$(bash "$CHK" "$r")"
 assert_contains "$out" "omp-agents-missing" "missing def -> warn"


### PR DESCRIPTION
## Goal

Add a woostack-doctor check that diagnoses missing or drifted OMP agent definitions, along with a test and catalog entry.

## Summary

- Create `skills/woostack-doctor/scripts/checks/omp-agents.sh` to compare generated OMP definitions against actual workspace ones and warn on missing/drift, gated on `.omp/` presence.
- Create unit test suite `skills/woostack-doctor/scripts/tests/test-omp-agents.sh` verifying all AC5 criteria (diagnose warnings, `--fix` regeneration, silent on non-OMP workspace).
- Add the `omp-agents-missing` and `omp-agents-drift` check definitions to `skills/woostack-doctor/references/checks.md`.

## Test plan

### Automated

- [x] `bash skills/woostack-doctor/scripts/tests/test-omp-agents.sh` (5 passed, 0 failed)
- [x] `bash -n skills/woostack-doctor/scripts/checks/omp-agents.sh` (syntax OK)

Spec: .woostack/specs/2026-07-09-omp-model-tiers.md