### PR TITLE
feat(dispatch-wiring): wire OMP agent-by-tier dispatches

### DIFF
--- a/.woostack/plans/2026-07-09-omp-model-tiers.md
+++ b/.woostack/plans/2026-07-09-omp-model-tiers.md
@@ -491,14 +491,14 @@ Removes the Increment 1 deferral marker (generator now has its execute caller).
 **Spec coverage:** AC6 (execute agent-by-tier + ensure-then-select), AC7 (commit fast-draft ->
 `woostack-fast`; review-local angle workers -> `woostack-<tier>`, validator -> `woostack-deep`).
 
-### Step 4.1 (RED) - assert the omp dispatch tokens are absent
+- [x] **Step 4.1 (RED) - assert the omp dispatch tokens are absent**
 
 Commands (all expected `0` at RED):
 - `grep -c 'woostack-<effective-tier>' skills/woostack-execute/references/subagent-driver.md`
 - `grep -c 'woostack-fast' skills/woostack-commit/SKILL.md`
 - `grep -c 'woostack-<tier>' skills/woostack-review/SKILL.md`
 
-### Step 4.2 (GREEN) - `subagent-driver.md` "Dispatch model"
+- [x] **Step 4.2 (GREEN) - subagent-driver.md "Dispatch model"**
 
 Append a paragraph to the **Dispatch model** section (after line 135, the "say so"
 degraded line), using the exact token `woostack-<effective-tier>`:
@@ -512,13 +512,13 @@ degraded line), using the exact token `woostack-<effective-tier>`:
 > cannot route per call" - it is **not** degraded: the tier's model/effort are applied via
 > the def, so do not "run at session model + say so" under omp.
 
-### Step 4.3 (GREEN) - `commit/SKILL.md` fast-draft
+- [x] **Step 4.3 (GREEN) - commit/SKILL.md fast-draft**
 
 Extend the fast-tier routing bullet (lines 53-57): under omp, since `task` has no per-call
 model knob, select `agent: woostack-fast` for the drafting spawn (ensure defs first via the
 generator). Use the exact token `woostack-fast`.
 
-### Step 4.4 (GREEN) - `review/SKILL.md` Stage 3 local swarm
+- [x] **Step 4.4 (GREEN) - review/SKILL.md Stage 3 local swarm**
 
 Add an omp bullet to the per-host primitive list (after line 337, the opencode bullet),
 consistent with the "plain/general-purpose/default worker" mandate (lines 328-332). Use the
@@ -530,7 +530,7 @@ exact token `woostack-<tier>`:
 >   `skills/woostack-init/scripts/gen-omp-agents.sh`. **Local only** - the CI single-session
 >   `load-prompt.sh` / `resolve-model.sh` path is unchanged.
 
-### Step 4.5 - remove deferral marker
+- [x] **Step 4.5 - remove deferral marker**
 
 Delete the `# woostack-defer(increment 4): ...` line from `gen-omp-agents.sh`.
 

--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -51,10 +51,11 @@ Rules:
 - Pass a bounded prompt containing the staged diff, changed-file list, commands run and
   results, relevant user intent, and any existing PR title/body that should be preserved.
 - Route the subagent at the `fast` tier when the host can select it explicitly: resolve the
-  tier through the shared
-  [Model Tiers table](../using-woostack/references/model-tiers.md) and pass what it resolves
-  to on the spawn. If the host cannot route a subagent per call, draft inline in the main
-  session.
+  tier through the shared [Model Tiers table](../using-woostack/references/model-tiers.md) and pass
+  what it resolves to on the spawn. Under omp (Oh My Pi), since `task` has no per-call model knob,
+  select `agent: woostack-fast` for the drafting spawn (ensuring defs exist first via the generator
+  `skills/woostack-init/scripts/gen-omp-agents.sh`). If the host cannot route a subagent per call
+  and does not support agent-by-tier selection, draft inline in the main session.
 - The subagent must return only proposed text. It must not run commands, stage files,
   commit, push, edit PRs, or decide whether dirty files are relevant.
 - Before using any draft, compare it against the staged diff and command results. Rewrite or

--- a/skills/woostack-execute/references/subagent-driver.md
+++ b/skills/woostack-execute/references/subagent-driver.md
@@ -134,6 +134,8 @@ defeating tier routing and burning multiples of the tokens on cheap work — the
 states for its angle spawns. **When the host cannot route per call**, run at the session model and
 **say so** (degraded, not equivalent) — never pretend a tier ran.
 
+**Under omp (agent-by-tier).** omp's `task` tool has no per-call `model`/`tier`/`effort` arg, so instead of passing resolved values on the spawn, select `agent: woostack-<effective-tier>` — the generated tier def carries `model` + `thinkingLevel`. **Ensure-then-select:** before dispatch, ensure the defs exist and are current by running `skills/woostack-init/scripts/gen-omp-agents.sh` (idempotent); then select the per-task effective tier's agent. This is the omp branch of "when the host cannot route per call" — it is **not** degraded: the tier's model/effort are applied via the def, so do not "run at session model + say so" under omp.
+
 ## Review
 
 Subagent mode's automated review **is** the per-task spec + quality loops above — it does **not**

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -335,6 +335,7 @@ profile (Claude Code: `general-purpose`) and pass only the brief below plus the 
 - Cursor / Composer: parallel subagent dispatch, letting the host schedule or queue workers.
 - Antigravity CLI (`agy`): dynamically orchestrated subagents — the orchestrator instantiates one isolated-context subagent per angle on demand (see `prompts/google.md`). Dispatch the independent angle tasks in a single turn to run them in parallel; rely on the isolation pattern for token economy.
 - opencode: subagent dispatch via the OpenCode runtime's primitive (see `prompts/opencode.md`), letting the runtime schedule workers; use an explicit cap such as `N=1` only when the build does not support parallelism.
+- omp (Oh My Pi): dispatch each angle worker as `agent: woostack-<tier>` (the omp general-purpose worker profile, tier-pinned by the generated def) and the deep validator as `agent: woostack-deep`; ensure defs first via `skills/woostack-init/scripts/gen-omp-agents.sh`. **Local only** — the CI single-session `load-prompt.sh` / `resolve-model.sh` path is unchanged.
 
 **Shell helper path.** Shell-capable local hosts can use the shipped bounded queue runner:
 


### PR DESCRIPTION
## Goal

Wire the OMP (agent-by-tier) dispatch logic across execute, commit, and review skills.

## Summary

- **Execute:** Append dispatch logic under `subagent-driver.md` to select `agent: woostack-<effective-tier>` after ensuring definitions exist via `gen-omp-agents.sh`.
- **Commit:** Update `commit/SKILL.md` to select `agent: woostack-fast` for fast-drafting spawns.
- **Review:** Update `review/SKILL.md` to run angle workers at `agent: woostack-<tier>` and deep validator at `agent: woostack-deep`.
- **Ignore:** Clean up deferral marker from generator.

## Verification

- `grep -c` checks passed on dispatch tokens.
- `skills/woostack-init/scripts/tests/test-gen-omp-agents.sh` (19 passed, 0 failed)

Spec: .woostack/specs/2026-07-09-omp-model-tiers.md