### PR TITLE
docs(site): update configuration and concepts for OMP; add lockstep test

### DIFF
--- a/.woostack/plans/2026-07-09-omp-model-tiers.md
+++ b/.woostack/plans/2026-07-09-omp-model-tiers.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-09-omp-model-tiers.md
-status: executing
+status: done
 date: 2026-07-09
 branch: feature/omp-model-tiers
 links:
@@ -552,7 +552,7 @@ Delete the `# woostack-defer(increment 4): ...` line from `gen-omp-agents.sh`.
 **Spec coverage:** AC9 (docs-site sync), AC8 (structural lockstep enumerating the omp-host
 site-list).
 
-### Step 5.1 (RED) - write the lockstep test first
+- [x] **Step 5.1 (RED) - write the lockstep test first**
 
 Create `skills/woostack-init/scripts/tests/test-omp-lockstep.sh`:
 
@@ -590,7 +590,7 @@ resolution is already covered by the existing
 `skills/woostack-review/scripts/tests/test-load-prompt-models.sh`**, which this increment
 re-runs to confirm the append did not break the CI inline.
 
-### Step 5.2 (GREEN) - docs-site sync
+- [x] **Step 5.2 (GREEN) - docs-site sync**
 
 - `site/content/docs/configuration.mdx` (the `models.<tier>` / `models.<provider>.<tier>`
   section, ~line 111+): add a short note that **under omp**, the flat `models.<tier>`
@@ -603,7 +603,7 @@ re-runs to confirm the append did not break the CI inline.
 Per-skill reference pages regenerate from `SKILL.md` at build time (gitignored) - no manual
 edit.
 
-### Step 5.3 (GREEN) - verify
+- [x] **Step 5.3 (GREEN) - verify**
 
 - `bash skills/woostack-init/scripts/tests/test-omp-lockstep.sh` -> `N passed, 0 failed`.
 - `pnpm -C site build` -> succeeds (authored pages compile).

--- a/site/content/docs/concepts.mdx
+++ b/site/content/docs/concepts.mdx
@@ -120,9 +120,8 @@ compact result, so the heavy reading and reasoning never land in the main thread
   artifacts directly — not the full review orchestrator skill — then two opposing validator passes
   keep only the findings both agree on.
 
-Each subagent runs at a tier matched to the work, so cheap tasks don't burn an expensive model. The
-tiers map to a concrete model per provider in
-[model-tiers.md](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/model-tiers.md):
+Each subagent runs at a tier matched to the work, so cheap tasks don't burn an expensive model. Hosts that support per-call model routing map these tiers to a concrete model per provider in
+[model-tiers.md](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/model-tiers.md). Under omp (Oh My Pi), which does not support per-call overrides, the tiers map to generated agent-definition files (`.omp/agents/woostack-<tier>.md`) baked from your `.woostack/config.json` `models` settings.
 
 | Tier | Use for | Anthropic model |
 | --- | --- | --- |

--- a/site/content/docs/concepts.mdx
+++ b/site/content/docs/concepts.mdx
@@ -120,8 +120,9 @@ compact result, so the heavy reading and reasoning never land in the main thread
   artifacts directly — not the full review orchestrator skill — then two opposing validator passes
   keep only the findings both agree on.
 
-Each subagent runs at a tier matched to the work, so cheap tasks don't burn an expensive model. Hosts that support per-call model routing map these tiers to a concrete model per provider in
-[model-tiers.md](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/model-tiers.md). Under omp (Oh My Pi), which does not support per-call overrides, the tiers map to generated agent-definition files (`.omp/agents/woostack-<tier>.md`) baked from your `.woostack/config.json` `models` settings.
+Each subagent runs at a tier matched to the work, so cheap tasks don't burn an expensive model. The
+tiers map to a concrete model per provider in
+[model-tiers.md](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/model-tiers.md):
 
 | Tier | Use for | Anthropic model |
 | --- | --- | --- |

--- a/site/content/docs/concepts/context-management.mdx
+++ b/site/content/docs/concepts/context-management.mdx
@@ -40,9 +40,8 @@ compact result, so the heavy reading and reasoning never land in the main thread
   artifacts directly — not the full review orchestrator skill — then two opposing validator passes
   keep only the findings both agree on.
 
-Each subagent runs at a tier matched to the work, so cheap tasks don't burn an expensive model. The
-tiers map to a concrete model per provider in
-[model-tiers.md](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/model-tiers.md):
+Each subagent runs at a tier matched to the work, so cheap tasks don't burn an expensive model. Hosts that support per-call model routing map these tiers to a concrete model per provider in
+[model-tiers.md](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/model-tiers.md). Under omp (Oh My Pi), which does not support per-call overrides, the tiers map to generated agent-definition files (`.omp/agents/woostack-<tier>.md`) baked from your `.woostack/config.json` `models` settings.
 
 | Tier | Use for | Anthropic model |
 | --- | --- | --- |

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -118,6 +118,8 @@ provider-agnostic fallback with the flat `models.<tier>`. Each tier leaf is a mo
 over the built-in default). `review.force_tier` pins every subagent to one tier, the config-file
 equivalent of running the review with `--fast` or `--deep`.
 
+**Under omp (Oh My Pi)**, where the host exposes no per-call model overrides, the flat `models.<tier>` (using a fully-qualified `provider/slug` model leaf) drives per-tier cross-provider routing via generated agent-definition files (`.omp/agents/woostack-<tier>.md`). No new config key is required.
+
 **Clean break:** `models` moved out of `review`. A `review.models` block is now a hard config
 error. Move it to the top level. `woostack-doctor` warns on a lingering `review.models`.
 

--- a/skills/woostack-init/scripts/tests/test-omp-lockstep.sh
+++ b/skills/woostack-init/scripts/tests/test-omp-lockstep.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Structural lockstep: every omp-host edit site must carry its pinned marker.
+# Adding an omp host touches all of these in lockstep (wisdom: lockstep-edit-sites).
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$HERE/assert.sh"
+S="$(cd "$HERE/../../.." && pwd)"          # -> repo/skills
+
+mt="$(cat "$S/using-woostack/references/model-tiers.md")"
+assert_contains "$mt" "agent-by-tier" "site: model-tiers.md omp bucket"
+assert_contains "$mt" "| Tier | Use for | Anthropic | OpenAI (Codex) | Google (Gemini) | OpenRouter |" "site: provider table columns unchanged"
+assert_contains "$(cat "$S/woostack-execute/references/subagent-driver.md")" "woostack-<effective-tier>" "site: execute dispatch"
+assert_contains "$(cat "$S/woostack-commit/SKILL.md")" "woostack-fast" "site: commit fast-draft"
+assert_contains "$(cat "$S/woostack-review/SKILL.md")" "woostack-<tier>" "site: review local swarm"
+assert_eq "$([ -f "$S/woostack-init/scripts/gen-omp-agents.sh" ] && echo y)" "y" "site: generator present"
+assert_eq "$([ -f "$S/woostack-doctor/scripts/checks/omp-agents.sh" ] && echo y)" "y" "site: doctor check present"
+assert_contains "$(cat "$S/woostack-review/prompts/_orchestrator-header.md")" "<!-- WOO_MODEL_TIERS_TABLE -->" "site: CI table-inline marker intact"
+finish


### PR DESCRIPTION
## Goal

Update docs site pages for OMP support and add a structural lockstep test to verify all edit sites.

## Summary

- **Docs:** Update `site/content/docs/configuration.mdx` and `concepts.mdx` to explain OMP agent-by-tier routing and generated defs.
- **Test:** Add `skills/woostack-init/scripts/tests/test-omp-lockstep.sh` to enforce that all required OMP-host edit sites carry their pinned markers and remain in sync.

## Verification

- `skills/woostack-init/scripts/tests/test-omp-lockstep.sh` (8 passed)
- `pnpm -C site build` (succeeds)

Spec: .woostack/specs/2026-07-09-omp-model-tiers.md