### PR TITLE
feat(hosts): add per-host reference home (contract README + six host files)

### DIFF
--- a/.woostack/plans/2026-07-10-host-references.md
+++ b/.woostack/plans/2026-07-10-host-references.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-10-host-references.md
-status: ready
+status: executing
 date: 2026-07-10
 branch: feature/host-references
 links:
@@ -71,13 +71,13 @@ Shell tests use `skills/woostack-init/scripts/tests/assert.sh` idioms; grep toke
 sections (spec §2). Content authored by **moving text semantically** from the seven donor
 sites (spec §1) - sources edited in Increment 2.
 
-- [ ] **Step 1 (red):** `ls skills/using-woostack/references/hosts/ 2>&1` -> no such
+- [x] **Step 1 (red):** `ls skills/using-woostack/references/hosts/ 2>&1` -> no such
       directory; `bash skills/woostack-init/scripts/tests/test-omp-lockstep.sh` -> passes
       (baseline stays green through this increment).
-- [ ] **Step 2:** write `hosts/README.md` - the six-section contract, one paragraph on the
+- [x] **Step 2:** write `hosts/README.md` - the six-section contract, one paragraph on the
       load directive + degradation default, and the rule that host files hold *mechanics*
       while consuming skills hold *law*.
-- [ ] **Step 3:** write the six host files from donor content:
+- [x] **Step 3:** write the six host files from donor content:
       - `omp.md` - agent-by-tier dispatch (`agent: woostack-<effective-tier>`), generated defs
         + `gen-omp-agents.sh` ensure-then-select (from `subagent-driver.md:136-137`,
         `model-tiers.md:35`), host-level fallback + woostack boundary (from
@@ -106,11 +106,11 @@ sites (spec §1) - sources edited in Increment 2.
       - `opencode.md` - `@subagent` per-call routing + `N=1` cap note
         (`model-tiers.md:27-32`, `woostack-review/SKILL.md:337`).
       Each file: `<!-- woostack-defer(increment-2): donor sites still carry this text until the extraction increment -->`.
-- [ ] **Step 4 (green):** `for f in skills/using-woostack/references/hosts/*.md; do ...` grep
+- [x] **Step 4 (green):** `for f in skills/using-woostack/references/hosts/*.md; do ...` grep
       each non-README file for the six headers `## Detection`, `## Subagent spawn`,
       `## Tier routing`, `## Host-level fallback`, `## Per-skill notes`, `## Degradation` ->
       6 files x 6 headers, zero misses; lockstep test still green.
-- [ ] **Step 5:** commit via woostack-commit conventions; PR body Spec trailer ->
+- [x] **Step 5:** commit via woostack-commit conventions; PR body Spec trailer ->
       `.woostack/specs/2026-07-10-host-references.md`. Task-scoped quality review (inline
       bounded); distill memory only if a durable non-obvious rule emerged.
 

--- a/skills/using-woostack/references/hosts/README.md
+++ b/skills/using-woostack/references/hosts/README.md
@@ -1,0 +1,30 @@
+# Host references
+
+One file per host, loaded **only when a skill runs under that host**. Consuming skills keep
+their generic invariants (law) inline — never-silent degradation, gates, the capability
+questions to answer — and reach the per-host mechanics here through one canonical directive:
+
+**Host mechanics:** before any host-dependent step (subagent dispatch, scaffold, draft), load `skills/using-woostack/references/hosts/<current-host>.md`; no matching file -> treat the host as having no per-call routing and say so (degraded).
+
+Host files hold *mechanics* (primitive names, knob forms, agent selectors, generator
+invocations); consuming skills hold *law*. A mechanics sentence must live in exactly one
+host file — never duplicated back into a skill.
+
+## Section contract
+
+Every host file carries these six sections, in order:
+
+1. **Detection** — capability signals that identify the host.
+2. **Subagent spawn** — primitive name; per-call `model`/`effort` knob (yes/no + form);
+   per-call `cwd` (yes/no); parallel dispatch shape.
+3. **Tier routing** — how `fast | standard | deep` resolves on this host, and the config it
+   reads. The tier→model table and override precedence live in
+   [`../model-tiers.md`](../model-tiers.md) — link, never restate.
+4. **Host-level fallback** — what the host itself does on usage-limit/provider errors, and
+   the boundary: woostack documents this layer, never manages host config.
+5. **Per-skill notes** — host-specific steps consumed by named skills.
+6. **Degradation** — the host-specific fallback path when a capability is absent (the
+   say-so-on-degrade law itself stays inline in each consuming skill).
+
+Review's CI path never reads these files: CI runners follow no links, so review-orchestration
+host content stays self-contained in `skills/woostack-review/prompts/*.md`.

--- a/skills/using-woostack/references/hosts/antigravity.md
+++ b/skills/using-woostack/references/hosts/antigravity.md
@@ -1,0 +1,40 @@
+<!-- woostack-defer(increment-2): donor sites still carry this text until the extraction increment -->
+
+# Antigravity CLI (`agy`)
+
+## Detection
+
+The `agy` CLI; reads `AGENTS.md` natively; authenticates via system keyring / Google Sign-In
+(no documented non-interactive API-key path, so it cannot run headless in ephemeral CI).
+
+## Subagent spawn
+
+- **Primitive:** dynamically orchestrated subagents — the orchestrator instantiates one
+  isolated-context subagent per task on demand. Dispatch independent tasks in a single turn
+  to run them in parallel; rely on the isolation pattern for token economy.
+- **Per-call model/effort knob:** no — single model per session.
+- **Per-call cwd:** not exposed — fill the dispatch-prompt worktree pin; the subagent
+  self-pins.
+
+## Tier routing
+
+**Single model per session.** Resolve one run model up front (a forced fast/deep tier if
+set, otherwise standard); per-tier behavior collapses onto that one model for the whole job.
+Split into multiple jobs for per-tier split behavior. Tier→model values:
+[`../model-tiers.md`](../model-tiers.md).
+
+## Host-level fallback
+
+None documented — provider exhaustion surfaces as errors; recovery is account-level, outside
+woostack's scope.
+
+## Per-skill notes
+
+- **woostack-review (local swarm):** orchestrate isolated-context subagents per angle (see
+  `skills/woostack-review/prompts/google.md` for the orchestration narrative); the CI runner
+  remains `run-gemini-cli` (Antigravity cannot run headless there).
+
+## Degradation
+
+Single-session collapse is the documented mode, not a degradation. A run that cannot resolve
+any model → session default + say so, per the inline law of the dispatching skill.

--- a/skills/using-woostack/references/hosts/claude-code.md
+++ b/skills/using-woostack/references/hosts/claude-code.md
@@ -1,0 +1,47 @@
+<!-- woostack-defer(increment-2): donor sites still carry this text until the extraction increment -->
+
+# Claude Code
+
+## Detection
+
+The `Task` tool with named subagent profiles (`general-purpose` is the plain worker) and a
+per-call `model` parameter; project rules load from `CLAUDE.md`.
+
+## Subagent spawn
+
+- **Primitive:** `Task` tool; dispatch every independent task in one turn and let the host
+  handle concurrency.
+- **Per-call model/effort knob:** yes — pass the resolved model (and effort form where the
+  model family carries one) explicitly on every spawn.
+- **Per-call cwd:** no (the `Agent`/`Task` spawn takes no cwd) — fill the dispatch-prompt
+  worktree pin; the subagent self-pins and aborts if not in `$wt`.
+- **Worker profile:** plain `general-purpose` for fan-out workers; never a skill-scoped
+  profile.
+
+## Tier routing
+
+**Per-call routing.** Resolve the effective tier — a forced tier if set, else the prompt's
+own `tier:` frontmatter — through the active provider's column in
+[`../model-tiers.md`](../model-tiers.md) plus its override precedence, and **pass everything
+the resolved tier specifies on every spawn** (the pass-or-inherit law lives in the
+dispatching skill).
+
+## Host-level fallback
+
+None documented — Claude Code applies no host-owned usage-limit failover to spawned
+subagents; provider exhaustion surfaces as errors on the spawn. Recovery is account-level
+(plan limits), outside woostack's scope.
+
+## Per-skill notes
+
+- **woostack-execute (dispatch):** the no-per-call-cwd case — prompt pin + self-pin guard —
+  is the normal path here.
+- **woostack-commit (fast drafting):** route the drafting subagent at the `fast` tier
+  per-call.
+- **woostack-review (local swarm):** dispatch every active angle task via `Task`, letting the
+  host schedule; workers are `general-purpose`.
+
+## Degradation
+
+A spawn that cannot carry `model` → the subagent inherits the session model: run it, and say
+so (degraded), per the inline law of the dispatching skill.

--- a/skills/using-woostack/references/hosts/codex.md
+++ b/skills/using-woostack/references/hosts/codex.md
@@ -1,0 +1,43 @@
+<!-- woostack-defer(increment-2): donor sites still carry this text until the extraction increment -->
+
+# Codex
+
+## Detection
+
+Codex CLI locally (subagent spawns accept a `model` override); Codex Action in CI
+(single-session, no subagent model overrides).
+
+## Subagent spawn
+
+- **Primitive:** local subagent dispatch with a per-call `model` override; dispatch
+  independent tasks together and let the runtime schedule.
+- **Per-call model/effort knob:** yes locally — `model` plus `reasoning_effort` (GPT-5-family
+  reasoning is a parameter on the same slug, not a slug suffix). No, under Codex Action.
+- **Per-call cwd:** pass it when the spawn accepts one; fill the dispatch-prompt worktree pin
+  regardless.
+
+## Tier routing
+
+- **Local (per-call routing):** resolve the effective tier through the OpenAI column in
+  [`../model-tiers.md`](../model-tiers.md) plus its override precedence; pass the resolved
+  slug + `reasoning_effort` on every spawn.
+- **Codex Action (single model per session):** resolve one run model up front (a forced
+  fast/deep tier if set, otherwise standard); per-tier behavior collapses onto that model for
+  the whole job. Split into multiple jobs for per-tier split behavior.
+
+## Host-level fallback
+
+None documented at the subagent layer — usage-limit exhaustion surfaces as provider errors.
+Account-level recovery (a second login, plan quota) is outside woostack's scope.
+
+## Per-skill notes
+
+- **woostack-review (local swarm):** per-call bucket — honor each angle prompt's `tier:` and
+  resolve each spawn's model via the review scripts' resolver; (CI) the single-session
+  `load-prompt.sh` / `resolve-model.sh` path owns routing and is self-contained.
+
+## Degradation
+
+Single-session context (Codex Action) is not a degradation — it is the documented
+one-run-model collapse. A local spawn that cannot carry `model` → session model + say so
+(degraded), per the inline law of the dispatching skill.

--- a/skills/using-woostack/references/hosts/cursor.md
+++ b/skills/using-woostack/references/hosts/cursor.md
@@ -1,0 +1,38 @@
+<!-- woostack-defer(increment-2): donor sites still carry this text until the extraction increment -->
+
+# Cursor / Composer
+
+## Detection
+
+Cursor's Composer agent runtime; project rules load from `.cursorrules`.
+
+## Subagent spawn
+
+- **Primitive:** parallel subagent dispatch — submit independent tasks and let the host
+  schedule or queue workers.
+- **Per-call model/effort knob:** not exposed to woostack dispatch; workers run on the
+  host-selected model.
+- **Per-call cwd:** not exposed — fill the dispatch-prompt worktree pin; the subagent
+  self-pins.
+
+## Tier routing
+
+No per-call tier mechanism is documented for Cursor dispatch. Treat the session's model as
+the run model (single-model collapse); a forced tier applies only by changing the session
+model before the run. Tier→model semantics:
+[`../model-tiers.md`](../model-tiers.md).
+
+## Host-level fallback
+
+None documented — provider exhaustion surfaces as errors; recovery is account-level, outside
+woostack's scope.
+
+## Per-skill notes
+
+- **woostack-review (local swarm):** dispatch angle workers in parallel and let the host
+  schedule or queue them.
+
+## Degradation
+
+Tier requested but not routable per call → run at the session model and say so (degraded),
+per the inline law of the dispatching skill.

--- a/skills/using-woostack/references/hosts/omp.md
+++ b/skills/using-woostack/references/hosts/omp.md
@@ -1,0 +1,76 @@
+<!-- woostack-defer(increment-2): donor sites still carry this text until the extraction increment -->
+
+# omp (Oh My Pi)
+
+## Detection
+
+The `task` tool exposes an `agent:` selector but **no per-call `model`/`tier`/`effort`
+argument**; generated agent definitions live under `.omp/agents/`; host config lives in
+`~/.omp/` (user-global) and `.omp/` (project).
+
+## Subagent spawn
+
+- **Primitive:** `task` tool, one subagent per task; dispatch independent tasks in a single
+  turn to run them in parallel.
+- **Per-call model/effort knob:** none — model routing rides the agent definition.
+- **Per-call cwd:** pass it when the spawn accepts one; the dispatch-prompt worktree pin is
+  filled regardless (the guard double-checks).
+
+## Tier routing
+
+**Agent-by-tier.** omp resolves a subagent's model from the **agent definition** (`model` +
+`thinkingLevel`). woostack ships three generated defs
+`.omp/agents/woostack-{fast,standard,deep}.md` — baked from `.woostack/config.json` flat
+`models.<tier>` by `skills/woostack-init/scripts/gen-omp-agents.sh` — and the dispatching
+skill selects `agent: woostack-<effective-tier>` per spawn. **Ensure-then-select:** before
+dispatch, run the generator (idempotent) so the defs exist and are current, then select the
+per-task effective tier's agent. This is a routing pattern over the existing flat
+`models.<tier>` config — **not a fifth provider column** and **not a new config key**. An
+unset tier resolves to a `thinkingLevel`-only def (fast→low, standard→medium, deep→xhigh)
+inheriting the session model. This is the "host cannot route per call" branch done right —
+it is **not** degraded: the tier's model/effort apply via the def, so never "run at session
+model + say so" under omp. Tier→model values and override precedence:
+[`../model-tiers.md`](../model-tiers.md).
+
+**Cross-consumer coexistence.** On CI/single-session hosts the flat provider table and
+`resolve-model.sh` are untouched; this bucket is informational there. A consumer can still
+set provider-specific columnar models for those hosts.
+
+## Host-level fallback
+
+Tier routing above is **static**; usage-limit failover is **host-owned**. The tier def picks
+the subagent session's *starting* model; on provider exhaustion omp walks its ladder —
+rotate sibling credentials (same provider), then apply its own `retry.fallbackChains` as a
+**temporary, self-announcing** model switch (`retry_fallback_applied` events) that reverts on
+cooldown expiry, then informed waiting against the provider's retry-after, then loud failure —
+beneath, not instead of, the tier's configured model. Credential-cooldown state is
+store-level, so a sibling spawn of the same tier agent falls over at spawn time rather than
+mid-task; the temporary model switch itself is per-session. woostack documents this layer but
+never reads or writes omp host config (`~/.omp/`).
+
+## Per-skill notes
+
+- **woostack-init (scaffold):** after writing `.woostack/config.json` (or when it already
+  exists), run `skills/woostack-init/scripts/gen-omp-agents.sh` to generate the three tier
+  defs; the generator writes an adjacent `.omp/agents/.gitignore` so defs stay untracked.
+- **woostack-commit (fast drafting):** select `agent: woostack-fast` for the drafting spawn
+  (ensure defs first via the generator).
+- **woostack-review (local swarm only):** dispatch each angle worker as
+  `agent: woostack-<tier>` (tier-pinned general-purpose worker) and the deep validator as
+  `agent: woostack-deep`; ensure defs first. The CI single-session
+  `load-prompt.sh` / `resolve-model.sh` path is unchanged. If a worker hits a usage limit,
+  omp recovers inside the worker (rotation/fallback) and the worker finishes on the fallback
+  model — receipt `model` stays the configured slug while the transcript records the concrete
+  model. An unrecovered worker writes no execution receipt, so review's receipt gate
+  hard-fails the run — no silently thinner review.
+- **woostack-execute-overnight (preflight advisory):** check usage-exhaustion resilience — a
+  second provider login or `retry.fallbackChains` covering the tier models — before an
+  unattended run; without it, mid-run exhaustion halts the track through the normal blocker
+  path (recommendation, not a refusal condition).
+
+## Degradation
+
+- Defs missing or stale → run the generator (idempotent) and re-select; that is the fix, not
+  a degradation.
+- Generator cannot run (no shell) → treat as no-per-call-routing: run at the session model
+  and say so (degraded), per the inline law of the dispatching skill.

--- a/skills/using-woostack/references/hosts/opencode.md
+++ b/skills/using-woostack/references/hosts/opencode.md
@@ -1,0 +1,40 @@
+<!-- woostack-defer(increment-2): donor sites still carry this text until the extraction increment -->
+
+# opencode
+
+## Detection
+
+The OpenCode runtime; subagent dispatch via `@subagent` with per-call model selection.
+
+## Subagent spawn
+
+- **Primitive:** `@subagent` dispatch via the runtime's primitive, letting the runtime
+  schedule workers; use an explicit cap such as `N=1` only when the build does not support
+  parallelism.
+- **Per-call model/effort knob:** yes — pass the resolved model explicitly per spawn.
+- **Per-call cwd:** pass it when the spawn accepts one; fill the dispatch-prompt worktree pin
+  regardless.
+
+## Tier routing
+
+**Per-call routing.** Resolve the effective tier — forced tier if set, else the prompt's
+`tier:` frontmatter — through the active provider's column in
+[`../model-tiers.md`](../model-tiers.md) plus its override precedence, and pass everything
+the resolved tier specifies on every spawn (the pass-or-inherit law lives in the dispatching
+skill).
+
+## Host-level fallback
+
+None documented — provider exhaustion surfaces as errors; recovery is account-level, outside
+woostack's scope.
+
+## Per-skill notes
+
+- **woostack-review (local swarm):** dispatch angle workers via the runtime primitive (see
+  `skills/woostack-review/prompts/opencode.md`); cap concurrency (`N=1`) only when the build
+  lacks parallelism.
+
+## Degradation
+
+A spawn that cannot carry the resolved model → session model + say so (degraded), per the
+inline law of the dispatching skill.


### PR DESCRIPTION
## Goal
Increment 1 of centralized host references: create `skills/using-woostack/references/hosts/` — a contract README plus six per-host files (claude-code, codex, cursor, antigravity, opencode, omp), each answering the fixed six-section capability contract. Donor sites untouched (defer markers mark the extraction increment).

## Summary
- `hosts/README.md`: section contract + canonical directive, law/mechanics split.
- Six host files sourced from model-tiers.md, subagent-driver.md, review/commit/init/overnight SKILL.md content.
- omp.md carries the host-level fallback ladder + receipt-gate interplay narrative.

## Test plan
### Automated
- [x] `test-omp-lockstep.sh` still green (donors untouched)
- [x] contract-header loop: 6 files x 6 headers, 0 misses
### Manual
- [x] spec-compliance + quality reviews (task-scoped): clean after nit fixes

Spec: .woostack/specs/2026-07-10-host-references.md
