### PR TITLE
spec: tier fallback lists (multi-config models.<tier> with host-enacted failover)

### DIFF
--- a/.woostack/plans/2026-07-10-tier-fallback-list.md
+++ b/.woostack/plans/2026-07-10-tier-fallback-list.md
@@ -1,0 +1,114 @@
+---
+type: plan
+source: .woostack/specs/2026-07-10-tier-fallback-list.md
+status: ready
+date: 2026-07-10
+branch: feature/tier-fallback
+links:
+  - "[[2026-07-10-tier-fallback-list]]"
+---
+
+**Source:** [[specs/2026-07-10-tier-fallback-list]]
+
+# Tier fallback lists — Implementation Plan
+
+**Goal:** every tier leaf accepts an ordered array of `{model, effort}`; entry 0 keeps
+today's semantics everywhere; the omp generator enacts entries 1..n as project-scoped
+`retry.fallbackChains` (V1-gated, non-clobbering); other hosts document the order.
+
+## Architecture
+
+1. **One normalization idiom, two jq homes.** `resolve-model.sh:70,75`
+   (`provider_tier_model`, sourced by `load-prompt.sh:69` — CI and local share it) and
+   `load-prompt.sh:74-81` (`config_effort_for`) each gain
+   `if type=="array" then .[0] else . end` ahead of the existing object/string handling.
+   `gen-omp-agents.sh:render_tier` (leaf read at :56) normalizes the same way in one place
+   before its existing string/object case.
+2. **Chain emission is a new generator stage**, downstream of def rendering: collect
+   `(primary → [entries 1..n models])` per tier, dedupe by primary, error on conflicting
+   orders, then non-clobbering-merge `retry.fallbackChains` into `<repo>/.omp/config.yml`.
+3. **Docs follow the hosts/ taxonomy**: leaf grammar in `model-tiers.md`; per-host
+   entries-1..n posture inside each existing "Host-level fallback" section (no new
+   section header — the 6×6 contract loop stays untouched); site sync in
+   `configuration.mdx`.
+
+## Increment 1 — leaf grammar + entry-0 resolution (PR 1)
+
+**Deliverable:** array leaves parse everywhere; behavior byte-identical for entry 0.
+AC1, AC2, AC3, AC6.
+
+- [ ] **Step 1 (red):** add failing tests — `test-gen-omp-agents.sh`: array leaf renders
+      entry-0 model+effort; empty-array leaf → tier unset + stderr warn; review script
+      test (existing suite home): `resolve-model.sh` returns entry-0 for array flat and
+      provider-scoped leaves.
+- [ ] **Step 2:** `gen-omp-agents.sh`: normalize array→first in `render_tier` (guard:
+      empty array = malformed leaf branch, loud, exit 0 law unchanged).
+- [ ] **Step 3:** `resolve-model.sh:70,75` + `load-prompt.sh:78`: prepend array
+      normalization in the jq filters (both provider-scoped and flat reads).
+- [ ] **Step 4:** doctor config check: leaf schema `string|object|array(1..)`; empty
+      array or non-(string|object) entry → error.
+- [ ] **Step 5 (green):** new tests pass; full init suite + review script tests green;
+      `git diff` on `prompts/` clean; existing fixtures byte-identical (AC1 proof: run
+      generator on an object-leaf fixture before/after, diff defs).
+- [ ] **Step 6:** commit; task-scoped spec+quality review; distill if durable.
+
+## Increment 2 — omp chain enactment (PR 2)
+
+**Deliverable:** entries 1..n become project-scoped omp fallback chains, or the loud
+degraded branch. AC4.
+
+- [ ] **Step 1 (V1 probe):** verify `retry.fallbackChains` record merge semantics at the
+      project layer + live pickup (omp docs / `omp config get` in a scratch dir).
+      Negative → skip Steps 2-4, document informational-only in `hosts/omp.md`, jump to
+      Step 5 with the §7-unsupported wording.
+- [ ] **Step 2 (red):** generator tests — multi-entry tier emits chain keyed by primary;
+      dedupe identical primaries; conflicting orders for one primary → loud error;
+      pre-existing user `.omp/config.yml` content preserved (merge test); parse-failure
+      file → refusal + printed block, no write.
+- [ ] **Step 3:** chain-emission stage in `gen-omp-agents.sh` (jq/python-free YAML
+      handling decided at implementation; refusal branch on anything unparseable);
+      slug quote-or-reject reused from def rendering.
+- [ ] **Step 4:** gitignore: only a generator-created `.omp/config.yml` is added to
+      `.omp/.gitignore` (defs precedent); doctor warns when a fallback list exists but
+      the host cannot enact it.
+- [ ] **Step 5 (green):** suite green; idempotency proof (run generator twice, second run
+      no-diff).
+- [ ] **Step 6:** commit; task-scoped review; distill.
+
+## Increment 3 — docs + site sync + closeout (PR 3)
+
+**Deliverable:** taxonomy documented; site builds; plan closes. AC5, AC7.
+
+- [ ] **Step 1 (red):** grep — array-form absent from `model-tiers.md` leaf paragraph,
+      `hosts/*.md` fallback sections, `configuration.mdx`.
+- [ ] **Step 2:** `model-tiers.md` leaf-shape paragraph (array form + entry-0 law +
+      per-host enactment pointer); one entries-1..n sentence in each of the six
+      `hosts/*.md` "Host-level fallback" sections; `configuration.mdx` array example
+      (MDX escaping per memory `authored-mdx-escapes-jsx-and-table-pipes`).
+- [ ] **Step 3 (green):** `test-host-references.sh` green (no contract change); provider
+      table + `WOO_MODEL_TIERS_TABLE` marker byte-stable; real install +
+      `pnpm -C site build` green.
+- [ ] **Step 4:** commit; final task-scoped review; distill durable memory; set plan
+      `status: done` (terminal transition authored by execute, conventions.md).
+
+## Verification map (AC → proof)
+
+| AC | Proof |
+|---|---|
+| AC1 | fixture defs byte-diff clean pre/post (Inc 1 Step 5) |
+| AC2 | entry-0 tests in generator + resolver suites (Inc 1 Steps 1/5) |
+| AC3 | empty-array tests: generator warn + doctor error (Inc 1 Steps 1/4) |
+| AC4 | chain tests + idempotency no-diff, or documented degraded branch (Inc 2) |
+| AC5 | hosts/*.md sentences + `test-host-references.sh` green (Inc 3) |
+| AC6 | prompts/ diff-clean + marker assertion (Inc 1 Step 5, Inc 3 Step 3) |
+| AC7 | site build green (Inc 3 Step 3) |
+
+## Rollback
+
+Graphite stack on `feature/tier-fallback` (parented on the host-references stack);
+revert = drop the PR. Increment 1 is behavior-preserving normalization; Increment 2 is
+the only host-config writer and carries its own refusal branch; Increment 3 is docs-only.
+
+---
+
+_Hardened 2026-07-10 — decomposition verified (3 PR-sized increments; Inc 1 behavior-preserving with fixture byte-diff proof; Inc 2 probe-gated with defined degraded branch and refusal-not-corruption law; Inc 3 docs-only). Test-first per increment; resolver test homes verified (`test-resolve-model.sh`, `test-load-prompt-models.sh`, `test-gen-omp-agents.sh`). Both review resolution paths move through the single sourced authority. No open branches._

--- a/.woostack/specs/2026-07-10-tier-fallback-list.md
+++ b/.woostack/specs/2026-07-10-tier-fallback-list.md
@@ -82,7 +82,8 @@ project-scoped artifacts, same boundary as the existing gitignored tier defs
 ## 5. Validation & doctor
 
 - Schema: leaf = `string | {model, effort} | array(1..) of (string | {model, effort})`.
-  Empty array → hard config error (same class as `review.models`).
+  Empty array → generator warns loudly and leaves the tier unset (exit-0 install law
+  preserved, same malformed-leaf posture as other bad shapes); doctor errors.
 - `woostack-doctor` warns when a fallback list is declared but the current host cannot
   enact entries 1..n (informational-only posture), and errors on malformed entries.
 
@@ -103,11 +104,14 @@ project-scoped artifacts, same boundary as the existing gitignored tier defs
 
 ## 7. V1 probe (verify in plan, non-blocking)
 
-**Does omp honor project-scoped retry fallback config** (e.g. `<project>/.omp/config.yml`
-`retry.fallbackChains`), and what are the exact key path + file location? Grounding so far:
-omp docs describe `retry.fallbackChains` in omp settings and project-level config overlays
-(`omp://settings.md`, `omp://providers.md`), but the project-scope behavior of the retry
-block is unverified.
+**Does omp honor project-scoped retry fallback config?** Doc evidence so far
+(`omp://settings.md`): project `.omp/config.yml` is a real settings layer (precedence:
+defaults < global < project < overlays < runtime), mappings merge per-key (worked
+example), and `retry.fallbackChains` is a settings-schema record key — the chain artifact
+home and merge posture in §10.3 build on this. Remaining plan-time verification
+(non-blocking): (a) record-value merge semantics for `retry.fallbackChains` specifically
+(per-key merge vs whole-record replace), (b) a live session picks up the project layer
+for retry settings. Negative on either → the unsupported branch below.
 
 - **Supported** → generator emits the chain file idempotently (gitignored, like the defs),
   keyed primary-model → fallback models from entries 1..n.
@@ -129,7 +133,8 @@ block is unverified.
   existing fixtures).
 - AC2: array leaf resolves to entry 0 in `load-prompt.sh`, `resolve-model.sh`, and
   `gen-omp-agents.sh` (test-pinned in each).
-- AC3: empty array → loud config error in generator + doctor; no silent fallback.
+- AC3: empty array → generator warns loudly and leaves the tier unset; doctor errors;
+  never a silent fallback to another entry.
 - AC4: with the probe positive, omp fallback chain artifact generated idempotently and
   project-scoped; with it negative, zero host-config writes.
 - AC5: six host files document the entries-1..n posture; `test-host-references.sh` still
@@ -150,9 +155,9 @@ All resolved during harden (2026-07-10):
    across tiers dedupe naturally. Two tiers declaring the *same primary with different
    fallback orders* → loud generator error (no silent choice; law from
    `autonomy-needs-structural-proof`).
-3. **Chain artifact home** — the probe (§7) resolved to `<repo>/.omp/config.yml`
-   (omp's documented project settings layer, merged over global; `omp://settings.md`
-   §Where-settings-live, §Project-local-config). Because that file is user-editable, the
+3. **Chain artifact home** — `<repo>/.omp/config.yml` (see §7; omp's documented project
+   settings layer, merged over global; `omp://settings.md` §Where-settings-live,
+   §Project-local-config). Because that file is user-editable, the
    generator performs a **non-clobbering merge**: it owns only the
    `retry.fallbackChains.<primary>` keys it derives, preserves everything else, and on any
    parse failure refuses loudly and prints the block for manual addition (degraded, never
@@ -162,16 +167,6 @@ All resolved during harden (2026-07-10):
 4. **Slug injection** (security angle) — YAML/JSON metachars in a configured slug follow
    the same quote-or-reject rule the def generator already enforces
    (spec `2026-07-09-omp-model-tiers` §140).
-
-### V1 probe — narrowed by doc evidence
-
-`omp://settings.md` confirms: project `.omp/config.yml` is a real settings layer
-(precedence: defaults < global < project < overlays < runtime), mappings merge per-key
-(worked example), and `retry.fallbackChains` is a settings-schema record key. Remaining
-plan-time verification (non-blocking): (a) record-value merge semantics for
-`retry.fallbackChains` specifically (per-key merge vs whole-record replace), (b) a live
-session picks up the project layer for retry settings. Negative on either → the §7
-unsupported branch (informational list, zero writes).
 
 ---
 

--- a/.woostack/specs/2026-07-10-tier-fallback-list.md
+++ b/.woostack/specs/2026-07-10-tier-fallback-list.md
@@ -1,6 +1,6 @@
 ---
 type: spec
-status: hardened
+status: approved
 date: 2026-07-10
 branch: feature/tier-fallback
 links:

--- a/.woostack/specs/2026-07-10-tier-fallback-list.md
+++ b/.woostack/specs/2026-07-10-tier-fallback-list.md
@@ -1,0 +1,181 @@
+---
+type: spec
+status: hardened
+date: 2026-07-10
+branch: feature/tier-fallback
+links:
+  - "[[2026-07-10-tier-fallback-list]]"
+---
+
+**Plan:** [[plans/2026-07-10-tier-fallback-list]]
+
+# Tier fallback lists — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth.
+
+> `status:` is the build-loop phase enum defined once in
+> [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+## 1. Problem
+
+A `.woostack/config.json` tier leaf holds exactly one configuration (`"slug"` or
+`{ model, effort }`). When that model's provider runs out of usage (e.g. a Codex
+subscription hits its limit), woostack has no declared alternative: on omp the user must
+hand-maintain `retry.fallbackChains` in omp's own settings (outside the repo, unshared,
+unversioned); on other hosts there is nothing to consult. Multi-provider consumers want to
+declare, in the one shared config, an ordered list of configurations per tier so agents can
+fall back across providers.
+
+## 2. Approved design (Option A, ideate 2026-07-10)
+
+Every tier leaf — flat `models.<tier>` and provider-scoped `models.<provider>.<tier>` —
+additionally accepts an **ordered array** of leaf values:
+
+```json
+{
+  "models": {
+    "deep": [
+      { "model": "openai/gpt-5.3-codex", "effort": "xhigh" },
+      { "model": "anthropic/claude-opus-4-8", "effort": "high" }
+    ],
+    "standard": "openai/gpt-5.5"
+  }
+}
+```
+
+- **Entry 0 is the primary** and carries today's exact semantics. A one-element array is
+  equivalent to the bare value (back-compat: string and object forms unchanged).
+- **Entries 1..n are static preference order owned by woostack.** The array declares
+  *intent*; **runtime enactment is exclusively per-host** and each
+  `hosts/<host>.md` "Host-level fallback" section states what its host does with them.
+- **The layer boundary from `omp-host-fallback-is-host-owned` is preserved**: woostack still
+  never performs mid-run failover; it only *feeds* the host machinery that does.
+
+## 3. Per-host enactment
+
+| Host | Entries 1..n become |
+|---|---|
+| omp | Real runtime fallback: `gen-omp-agents.sh` derives a **project-scoped** omp retry fallback chain (primary model → [fallback models]) alongside the generated tier defs. **V1 probe gates this** (§7). |
+| Claude Code / Codex / Cursor / Antigravity / opencode | Documented preference order only: no spawn-time auth probe exists, so the consumer switches manually (or re-runs after editing config). The host file says so; no automation is pretended. |
+
+Never written: user-global host config (`~/.omp/**`) — the generator writes only
+project-scoped artifacts, same boundary as the existing gitignored tier defs
+(memory `review-host-distinct-from-model-provider`).
+
+## 4. Resolution contract (all consumers)
+
+1. **Resolvers read entry 0.** `load-prompt.sh` (CI single-session), `resolve-model.sh`
+   (local per-call), and `gen-omp-agents.sh` (def generation) treat an array leaf as its
+   first element — both review paths move in lockstep
+   (wisdom `review-ci-local-asymmetry`; one shared array-normalization point per script
+   pair, not two divergent parsers).
+2. **Per-candidate effort.** Each array entry carries its own optional `effort`. Under omp
+   *mid-run* fallback the def's `thinkingLevel` continues to apply to the substitute model
+   (host semantics — a chain swaps `model` only); a candidate's own `effort` takes effect
+   when that candidate is *statically* resolved (promoted to entry 0, or selected by a
+   future host that supports it). Documented, not hidden.
+3. **Precedence unchanged.** The array changes leaf *shape*, not the override ladder
+   (forced tier → explicit model → per-provider → flat → table default,
+   `model-tiers.md` §Override precedence). An explicit model input still beats the whole
+   list.
+
+## 5. Validation & doctor
+
+- Schema: leaf = `string | {model, effort} | array(1..) of (string | {model, effort})`.
+  Empty array → hard config error (same class as `review.models`).
+- `woostack-doctor` warns when a fallback list is declared but the current host cannot
+  enact entries 1..n (informational-only posture), and errors on malformed entries.
+
+## 6. Edit sites (lockstep, wisdom `lockstep-edit-sites`)
+
+1. `skills/using-woostack/references/model-tiers.md` — leaf-shape paragraph (§54-57 today).
+2. `skills/woostack-init/scripts/gen-omp-agents.sh` + its tests — entry-0 def generation +
+   fallback-chain emission (V1-gated).
+3. `skills/woostack-review/scripts/load-prompt.sh` and `scripts/resolve-model.sh` — array
+   normalization (entry 0) in both paths; CI prompt content otherwise untouched.
+4. `skills/woostack-doctor/scripts/checks/` — schema/enactment checks.
+5. `skills/using-woostack/references/hosts/*.md` — each "Host-level fallback" section gains
+   one entries-1..n sentence (six files; contract loop in `test-host-references.sh` keeps
+   passing untouched — no new section header).
+6. `site/content/docs/configuration.mdx` — leaf-shape + fallback semantics (authored page).
+7. Structural tests: extend `gen-omp-agents` tests (array leaf, empty-array error) and add
+   a leaf-shape assertion to the init suite.
+
+## 7. V1 probe (verify in plan, non-blocking)
+
+**Does omp honor project-scoped retry fallback config** (e.g. `<project>/.omp/config.yml`
+`retry.fallbackChains`), and what are the exact key path + file location? Grounding so far:
+omp docs describe `retry.fallbackChains` in omp settings and project-level config overlays
+(`omp://settings.md`, `omp://providers.md`), but the project-scope behavior of the retry
+block is unverified.
+
+- **Supported** → generator emits the chain file idempotently (gitignored, like the defs),
+  keyed primary-model → fallback models from entries 1..n.
+- **Unsupported** → generator emits nothing; the list stays informational on omp too
+  (documented in `hosts/omp.md`); no other site changes. The feature degrades to
+  shared-and-versioned preference order, never to a broken write.
+
+## 8. Non-goals
+
+- No mid-run failover logic in woostack (host-owned, unchanged).
+- No writes to user-global host config (`~/.omp/**`).
+- No change to the override precedence ladder or the provider table (CI-inlined; byte-stable).
+- No spawn-time provider-auth probing on per-call hosts.
+- No translation for non-omp hosts.
+
+## 9. Acceptance criteria
+
+- AC1: bare string / object leaves behave byte-identically (resolver outputs unchanged on
+  existing fixtures).
+- AC2: array leaf resolves to entry 0 in `load-prompt.sh`, `resolve-model.sh`, and
+  `gen-omp-agents.sh` (test-pinned in each).
+- AC3: empty array → loud config error in generator + doctor; no silent fallback.
+- AC4: with the probe positive, omp fallback chain artifact generated idempotently and
+  project-scoped; with it negative, zero host-config writes.
+- AC5: six host files document the entries-1..n posture; `test-host-references.sh` still
+  green with no contract change.
+- AC6: provider table + `WOO_MODEL_TIERS_TABLE` marker byte-stable; review `prompts/`
+  diff-clean.
+- AC7: site builds; `configuration.mdx` documents the array form.
+
+## 10. Open questions
+
+All resolved during harden (2026-07-10):
+
+1. **Provider-scoped arrays too** — one uniform leaf grammar everywhere
+   (`string | {model, effort} | array`), so every reader shares a single normalization
+   point (wisdom `lockstep-edit-sites`). A provider-scoped array expresses same-provider
+   model fallback (e.g. `gpt-5.3-codex` → `gpt-5.5`), which is coherent.
+2. **Chain keying** — one chain entry per distinct primary selector; identical primaries
+   across tiers dedupe naturally. Two tiers declaring the *same primary with different
+   fallback orders* → loud generator error (no silent choice; law from
+   `autonomy-needs-structural-proof`).
+3. **Chain artifact home** — the probe (§7) resolved to `<repo>/.omp/config.yml`
+   (omp's documented project settings layer, merged over global; `omp://settings.md`
+   §Where-settings-live, §Project-local-config). Because that file is user-editable, the
+   generator performs a **non-clobbering merge**: it owns only the
+   `retry.fallbackChains.<primary>` keys it derives, preserves everything else, and on any
+   parse failure refuses loudly and prints the block for manual addition (degraded, never
+   a corrupting write). Gitignore follows the defs precedent: only a file the generator
+   itself created is added to `.omp/.gitignore`; a pre-existing user file is never
+   ignored or rewritten wholesale.
+4. **Slug injection** (security angle) — YAML/JSON metachars in a configured slug follow
+   the same quote-or-reject rule the def generator already enforces
+   (spec `2026-07-09-omp-model-tiers` §140).
+
+### V1 probe — narrowed by doc evidence
+
+`omp://settings.md` confirms: project `.omp/config.yml` is a real settings layer
+(precedence: defaults < global < project < overlays < runtime), mappings merge per-key
+(worked example), and `retry.fallbackChains` is a settings-schema record key. Remaining
+plan-time verification (non-blocking): (a) record-value merge semantics for
+`retry.fallbackChains` specifically (per-key merge vs whole-record replace), (b) a live
+session picks up the project layer for retry settings. Negative on either → the §7
+unsupported branch (informational list, zero writes).
+
+---
+
+_Hardened 2026-07-10 — ideate forks resolved by user (shape=A, probe=V1-in-plan); leaf
+grammar uniform; chain keyed by primary with conflict-error; non-clobbering project-config
+merge with loud refusal branch; slug quoting inherited from the def generator; angle
+pre-flight (security / observability / bugs / tests / api / deps / infra) walk clean._


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices
