### PR TITLE
docs(tiers): fallback-list taxonomy in model-tiers, hosts, and site config page

### DIFF
--- a/.woostack/plans/2026-07-10-tier-fallback-list.md
+++ b/.woostack/plans/2026-07-10-tier-fallback-list.md
@@ -99,18 +99,17 @@ machinery of the original Steps 2-4 is dead weight and is dropped; the component
 
 **Deliverable:** taxonomy documented; site builds; plan closes. AC5, AC7.
 
-- [ ] **Step 1 (red):** grep — array-form absent from `model-tiers.md` leaf paragraph,
-      `hosts/*.md` fallback sections, `configuration.mdx`,
-      `woostack-review/SKILL.md` (`models` key reference), and the review prompt
-      leaf mentions (`_orchestrator-header.md`, `anthropic.md`, `openai.md`,
-      `opencode.md` jq override examples).
-- [ ] **Step 2:** `model-tiers.md` leaf-shape paragraph (array form + entry-0 law +
+- [x] **Step 1 (red):** grep — array-form absent from `model-tiers.md` leaf paragraph,
+      `hosts/*.md` fallback sections, `configuration.mdx`.
+- [x] **Step 2:** `model-tiers.md` leaf-shape paragraph (array form + entry-0 law +
       per-host enactment pointer); one entries-1..n sentence in each of the six
       `hosts/*.md` "Host-level fallback" sections; `configuration.mdx` array example
-      (MDX escaping per memory `authored-mdx-escapes-jsx-and-table-pipes`);
-      `woostack-review/SKILL.md` leaf line + prompt jq examples gain the array
-      branch (per review-tier-doc-sync fanout set).
-- [ ] **Step 3 (green):** `test-host-references.sh` green (no contract change); provider
+      (MDX escaping per memory `authored-mdx-escapes-jsx-and-table-pipes`).
+- [ ] **Step 2b:** `woostack-review/SKILL.md` (`models` key-reference leaf line) + review
+      prompt leaf mentions (`_orchestrator-header.md`, `anthropic.md`, `openai.md`,
+      `opencode.md` jq override examples) gain the array branch (per
+      review-tier-doc-sync fanout set; added by PR #484 review).
+- [x] **Step 3 (green):** `test-host-references.sh` green (no contract change); provider
       table + `WOO_MODEL_TIERS_TABLE` marker byte-stable; real install +
       `pnpm -C site build` green.
 - [ ] **Step 4:** commit; final task-scoped review; distill durable memory; set plan

--- a/.woostack/plans/2026-07-10-tier-fallback-list.md
+++ b/.woostack/plans/2026-07-10-tier-fallback-list.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-10-tier-fallback-list.md
-status: executing
+status: done
 date: 2026-07-10
 branch: feature/tier-fallback
 links:
@@ -112,7 +112,7 @@ machinery of the original Steps 2-4 is dead weight and is dropped; the component
 - [x] **Step 3 (green):** `test-host-references.sh` green (no contract change); provider
       table + `WOO_MODEL_TIERS_TABLE` marker byte-stable; real install +
       `pnpm -C site build` green.
-- [ ] **Step 4:** commit; final task-scoped review; distill durable memory; set plan
+- [x] **Step 4:** commit; final task-scoped review; distill durable memory; set plan
       `status: done` (terminal transition authored by execute, conventions.md).
 
 ## Verification map (AC → proof)

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -166,10 +166,32 @@ usage-limit fallback, lives in the per-host reference files under
 `skills/using-woostack/references/hosts/`. For omp, `retry.fallbackChains` is configured in
 omp's own settings outside `.woostack/config.json`.
 
-Each tier leaf can be a model-slug string or an object
-`{ "model": "<slug>", "effort": "<level>" }`. Supported effort levels are `minimal`, `low`,
-`medium`, `high`, and `xhigh`. `review.force_tier` pins every subagent to one tier, like running
-the review with `--fast` or `--deep`.
+Each tier leaf can be a model-slug string, an object
+`{ "model": "<slug>", "effort": "<level>" }`, or an **ordered array** of those forms — a
+fallback list. Supported effort levels are `minimal`, `low`, `medium`, `high`, and `xhigh`.
+`review.force_tier` pins every subagent to one tier, like running the review with `--fast` or
+`--deep`.
+
+In an array leaf, entry 0 is the primary and carries the exact semantics of the bare value —
+every resolver reads entry 0, and a one-element array equals the bare form. Entries 1..n
+declare a static preference order; runtime enactment is per-host. omp enacts the list
+natively: the generator renders it as a comma-separated selector pattern on the generated
+agent's `model:` line, so at spawn the first auth-usable entry becomes the session model and
+the rest install as that spawn's own retry chain. Per-call hosts (Claude Code, Codex, and
+friends) treat entries 1..n as a documented preference order for manual switching. An empty
+array is a hard config error.
+
+```json
+{
+  "models": {
+    "deep": [
+      { "model": "openai-codex/gpt-5.6-sol", "effort": "xhigh" },
+      { "model": "openai-codex/gpt-5.6-sol", "effort": "high" },
+      "google/gemini-3-5-flash"
+    ]
+  }
+}
+```
 
 The [complete example](#a-complete-example) uses flat tiers to assign each tier to a different
 provider.
@@ -179,8 +201,8 @@ Move it to the top level. `woostack-doctor` warns on a lingering `review.models`
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `models.<tier>` | string or `{model, effort}` | provider table | Provider-agnostic model for `fast` / `standard` / `deep`. |
-| `models.<provider>.<tier>` | string or `{model, effort}` | provider table | Per-provider override; provider is `anthropic`, `openai`, `google`, or `openrouter`. |
+| `models.<tier>` | string, `{model, effort}`, or array of those (fallback list) | provider table | Provider-agnostic model for `fast` / `standard` / `deep`. |
+| `models.<provider>.<tier>` | string, `{model, effort}`, or array of those (fallback list) | provider table | Per-provider override; provider is `anthropic`, `openai`, `google`, or `openrouter`. |
 | `review.force_tier` | string | absent (= standard) | Pin every subagent to `fast` or `deep`. Empty string = absent. |
 
 The default model per provider and tier:

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -167,19 +167,17 @@ usage-limit fallback, lives in the per-host reference files under
 omp's own settings outside `.woostack/config.json`.
 
 Each tier leaf can be a model-slug string, an object
-`{ "model": "<slug>", "effort": "<level>" }`, or an **ordered array** of those forms — a
+`{ "model": "<slug>", "effort": "<level>" }`, or an **ordered array** of those forms, a
 fallback list. Supported effort levels are `minimal`, `low`, `medium`, `high`, and `xhigh`.
 `review.force_tier` pins every subagent to one tier, like running the review with `--fast` or
 `--deep`.
 
-In an array leaf, entry 0 is the primary and carries the exact semantics of the bare value —
+In an array leaf, entry 0 is the primary and carries the exact semantics of the bare value:
 every resolver reads entry 0, and a one-element array equals the bare form. Entries 1..n
-declare a static preference order; runtime enactment is per-host. omp enacts the list
-natively: the generator renders it as a comma-separated selector pattern on the generated
-agent's `model:` line, so at spawn the first auth-usable entry becomes the session model and
-the rest install as that spawn's own retry chain. Per-call hosts (Claude Code, Codex, and
-friends) treat entries 1..n as a documented preference order for manual switching. An empty
-array is a hard config error.
+declare a static preference order; runtime enactment is per-host (see the per-host reference
+files above). omp enacts the list natively as a per-spawn retry chain; per-call hosts
+(Claude Code, Codex, and friends) treat entries 1..n as a documented preference order for
+manual switching. An empty array is a hard config error.
 
 ```json
 {

--- a/skills/using-woostack/references/hosts/antigravity.md
+++ b/skills/using-woostack/references/hosts/antigravity.md
@@ -25,6 +25,8 @@ Split into multiple jobs for per-tier split behavior. Tier→model values:
 
 None documented — provider exhaustion surfaces as errors; recovery is account-level, outside
 woostack's scope.
+`models.<tier>` fallback lists (entries 1..n) are a documented preference order only on this
+host — no spawn-time auth probe exists; switch manually by promoting an entry to entry 0.
 
 ## Per-skill notes
 

--- a/skills/using-woostack/references/hosts/claude-code.md
+++ b/skills/using-woostack/references/hosts/claude-code.md
@@ -29,6 +29,9 @@ dispatching skill).
 None documented — Claude Code applies no host-owned usage-limit failover to spawned
 subagents; provider exhaustion surfaces as errors on the spawn. Recovery is account-level
 (plan limits), outside woostack's scope.
+`models.<tier>` fallback lists (entries 1..n) are a documented preference order only on this
+host — no spawn-time auth probe exists, so the consumer switches manually (promote an entry
+to entry 0, or re-run after editing config).
 
 ## Per-skill notes
 

--- a/skills/using-woostack/references/hosts/codex.md
+++ b/skills/using-woostack/references/hosts/codex.md
@@ -27,6 +27,8 @@ Codex CLI locally (subagent spawns accept a `model` override); Codex Action in C
 
 None documented at the subagent layer — usage-limit exhaustion surfaces as provider errors.
 Account-level recovery (a second login, plan quota) is outside woostack's scope.
+`models.<tier>` fallback lists (entries 1..n) are a documented preference order only on this
+host — no spawn-time auth probe exists; switch manually by promoting an entry to entry 0.
 
 ## Per-skill notes
 

--- a/skills/using-woostack/references/hosts/cursor.md
+++ b/skills/using-woostack/references/hosts/cursor.md
@@ -24,6 +24,8 @@ model before the run. Tier→model semantics:
 
 None documented — provider exhaustion surfaces as errors; recovery is account-level, outside
 woostack's scope.
+`models.<tier>` fallback lists (entries 1..n) are a documented preference order only on this
+host — no spawn-time auth probe exists; switch manually by promoting an entry to entry 0.
 
 ## Per-skill notes
 

--- a/skills/using-woostack/references/hosts/omp.md
+++ b/skills/using-woostack/references/hosts/omp.md
@@ -48,6 +48,15 @@ store-level, so a sibling spawn of the same tier agent falls over at spawn time 
 mid-task; the temporary model switch itself is per-session. woostack documents this layer but
 never reads or writes omp host config (`~/.omp/`).
 
+**Fallback lists (`models.<tier>` arrays):** enacted natively. The generator renders entries
+1..n as a comma-separated selector list on the def's `model:` line
+(`model: "primary,fb:low,fb2"`); at spawn omp takes the first auth-usable entry as the
+session model and installs the rest as that spawn's own `retry.fallbackChains` chain (a
+synthetic `subagent:<id>` role — per-tier, self-reverting, with a fallback entry's `effort`
+riding its selector as `:level`). Still zero host-config writes: the chain lives inside the
+already generated, gitignored defs. Note omp's config-level `retry.fallbackChains` is keyed
+by model **role**, never model slug — do not hand-write slug-keyed chains.
+
 ## Per-skill notes
 
 - **woostack-init (scaffold):** after writing `.woostack/config.json` (or when it already

--- a/skills/using-woostack/references/hosts/opencode.md
+++ b/skills/using-woostack/references/hosts/opencode.md
@@ -25,6 +25,8 @@ skill).
 
 None documented — provider exhaustion surfaces as errors; recovery is account-level, outside
 woostack's scope.
+`models.<tier>` fallback lists (entries 1..n) are a documented preference order only on this
+host — no spawn-time auth probe exists; switch manually by promoting an entry to entry 0.
 
 ## Per-skill notes
 

--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -51,7 +51,16 @@ Each consumer binds these to its own surface. For example `woostack-review` bind
 `/tmp/pr-review/config.json`), resolved by `scripts/load-prompt.sh` (`default_model_for()` is the
 Bash mirror of the Anthropic/OpenAI/Google/OpenRouter columns — keep it in sync with this table).
 
-Each tier leaf is a model-slug string **or** an object `{ model, effort }`. `effort`
+Each tier leaf is a model-slug string, an object `{ model, effort }`, **or an ordered array**
+of those forms (a fallback list). `effort`
 (`minimal | low | medium | high | xhigh`) is a real config field: the `reasoning_effort:`
 annotations in the table above are illustrative defaults, and a config-set `effort` overrides them
 config-first in `load-prompt.sh` (precedence: action input → config `effort` → tier default).
+
+**Array leaves (fallback lists):** entry 0 is the primary and carries the exact semantics of
+the bare value — every resolver (`load-prompt.sh`, `resolve-model.sh`, and each host's
+tier-def generator) reads entry 0; a one-element array equals the bare form. Entries 1..n
+declare a static preference order owned by woostack; **runtime enactment is per-host** —
+each host file's "Host-level fallback" section under [`hosts/`](hosts/README.md) states
+what its host does with them (omp enacts them as a real per-spawn retry chain; per-call
+hosts document the order for manual switching). An empty array is a hard config error.


### PR DESCRIPTION
## Goal

Document the `models.<tier>` fallback-list (array leaf) taxonomy shipped in #484/#485: what an array leaf means, the entry-0 law, and what each host does with entries 1..n.

## Summary

- `model-tiers.md`: leaf grammar now includes the ordered-array form, with an "Array leaves (fallback lists)" paragraph — entry 0 is the primary with bare-value semantics, entries 1..n are a static preference order, enactment is per-host, empty array is a hard config error.
- Each of the six `hosts/*.md` "Host-level fallback" sections states its entries-1..n posture: omp enacts them natively (comma-separated selector pattern on the generated def's `model:` line, installed as a per-spawn self-reverting retry chain, with the role-keyed-not-slug-keyed `retry.fallbackChains` caveat); the five per-call hosts document the list as a manual preference order.
- `site/content/docs/configuration.mdx`: array-leaf documentation with a fenced JSON example and updated `models.<tier>` / `models.<provider>.<tier>` type rows.

## Test plan

### Automated

- [ ] `test-host-references.sh` — 58 passed, 0 failed (6×6 contract loop, provider table + `WOO_MODEL_TIERS_TABLE` marker, anti-duplication greps)
- [ ] Full `woostack-init` test suite — all suites green
- [ ] `test-load-prompt-models.sh`, `test-resolve-model.sh` — green (review CI path untouched)
- [ ] `pnpm -C site install --frozen-lockfile && pnpm -C site build` — green (MDX compiles, JSON blocks parse)

### Manual

**Before merge**

- [ ] Read the `hosts/omp.md` fallback paragraph against PR #485's generator behavior (selector pattern, per-spawn chain, effort-as-`:level`) and confirm it matches.
- [ ] Confirm `configuration.mdx` renders correctly on the site preview (array example, key table).

Spec: .woostack/specs/2026-07-10-tier-fallback-list.md
