### PR TITLE
chore(config): configure model routing options

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -2,6 +2,11 @@
 	"review": {
 		"metrics": true
 	},
+	"models": {
+		"fast": { "model": "openai-codex/gpt-5.6-sol", "effort": "low" },
+		"standard": { "model": "openai-codex/gpt-5.6-sol", "effort": "medium" },
+		"deep": { "model": "openai-codex/gpt-5.6-sol", "effort": "high" }
+	},
 	"status": {
 		"staleDays": 14
 	}


### PR DESCRIPTION
## Goal

Configure model routing and effort levels in `.woostack/config.json` to ensure tasks are routed to the `openai-codex/gpt-5.6-sol` model with appropriate reasoning effort for each tier.

## Summary

- Added `models` configuration block to `.woostack/config.json`.
- Defined `fast` model tier using `openai-codex/gpt-5.6-sol` with `low` effort.
- Defined `standard` model tier using `openai-codex/gpt-5.6-sol` with `medium` effort.
- Defined `deep` model tier using `openai-codex/gpt-5.6-sol` with `high` effort.

## Test plan

### Manual

**Before merge**

- [ ] Verify that `.woostack/config.json` compiles and parses correctly on the branch.
