### PR TITLE
chore(config): remove custom models configuration

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -2,11 +2,6 @@
 	"review": {
 		"metrics": true
 	},
-	"models": {
-		"fast": { "model": "openai-codex/gpt-5.6-sol", "effort": "low" },
-		"standard": { "model": "openai-codex/gpt-5.6-sol", "effort": "medium" },
-		"deep": { "model": "openai-codex/gpt-5.6-sol", "effort": "high" }
-	},
 	"status": {
 		"staleDays": 14
 	}


### PR DESCRIPTION
## Goal

Clean up repository-level configurations by removing the obsolete custom models block since model routing is managed dynamically by the host/OMP environment. This ensures we rely on OMP's native routing/handling instead of maintaining redundant local configurations.

## Summary

- Remove the custom `models` block from `.woostack/config.json` (defining fast, standard, and deep tiers).

## Test plan

### Automated

- [ ] Validated config.json structure with `jq . .woostack/config.json` (succeeded)

### Manual

**Before merge**

- [ ] Confirm `.woostack/config.json` is clean and does not contain obsolete model configurations.