### PR TITLE
Add per-tier OMP model fallbacks

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -1,4 +1,36 @@
 {
+	"models": {
+		"deep": [
+			{
+				"model": "anthropic/claude-opus-4-8",
+				"effort": "high"
+			},
+			{
+				"model": "openai-codex/gpt-5.6-sol",
+				"effort": "high"
+			}
+		],
+		"standard": [
+			{
+				"model": "anthropic/claude-opus-4-8",
+				"effort": "medium"
+			},
+			{
+				"model": "openai-codex/gpt-5.6-sol",
+				"effort": "medium"
+			}
+		],
+		"fast": [
+			{
+				"model": "anthropic/claude-opus-4-8",
+				"effort": "low"
+			},
+			{
+				"model": "openai-codex/gpt-5.6-sol",
+				"effort": "low"
+			}
+		]
+	},
 	"review": {
 		"metrics": true
 	},


### PR DESCRIPTION
## Goal

Give each woostack tier an Anthropic Opus primary with an OpenAI Codex fallback so OMP can continue work when the primary model is unavailable.

## Summary

- Add ordered model lists for the `deep`, `standard`, and `fast` tiers in `.woostack/config.json`.
- Use `anthropic/claude-opus-4-8` as entry 0 and `openai-codex/gpt-5.6-sol` as entry 1 for every tier.
- Apply `high`, `medium`, and `low` effort to the deep, standard, and fast tiers respectively.

## Test plan

### Automated

- [ ] `jq empty .woostack/config.json` — passed; the config is valid JSON.
- [ ] `bash skills/woostack-doctor/scripts/checks/models-leaf-shape.sh .` — passed; all model leaves use supported shapes.
- [ ] `bash skills/woostack-init/scripts/gen-omp-agents.sh` — passed; generated definitions contained the ordered Opus-to-Codex selectors and expected tier effort.

### Manual

**Before merge**

- [ ] Regenerate the OMP agents and confirm deep, standard, and fast resolve to the Opus primary followed by the Codex fallback at high, medium, and low effort respectively.
