### PR TITLE
chore: prefer gpt-5.6-sol model across all tiers

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -2,31 +2,31 @@
 	"models": {
 		"deep": [
 			{
-				"model": "anthropic/claude-opus-4-8",
+				"model": "openai-codex/gpt-5.6-sol",
 				"effort": "high"
 			},
 			{
-				"model": "openai-codex/gpt-5.6-sol",
+				"model": "anthropic/claude-opus-4-8",
 				"effort": "high"
 			}
 		],
 		"standard": [
 			{
-				"model": "anthropic/claude-opus-4-8",
+				"model": "openai-codex/gpt-5.6-sol",
 				"effort": "medium"
 			},
 			{
-				"model": "openai-codex/gpt-5.6-sol",
+				"model": "anthropic/claude-opus-4-8",
 				"effort": "medium"
 			}
 		],
 		"fast": [
 			{
-				"model": "anthropic/claude-opus-4-8",
+				"model": "openai-codex/gpt-5.6-sol",
 				"effort": "low"
 			},
 			{
-				"model": "openai-codex/gpt-5.6-sol",
+				"model": "anthropic/claude-opus-4-8",
 				"effort": "low"
 			}
 		]


### PR DESCRIPTION
## Goal

Prioritize the `openai-codex/gpt-5.6-sol` model over `anthropic/claude-opus-4-8` across all model tiers (`deep`, `standard`, and `fast`) in the woostack configuration.

## Summary

- Swapped the order of models in `.woostack/config.json` so that `openai-codex/gpt-5.6-sol` is the first choice for `deep`, `standard`, and `fast` tiers.
- Moved `anthropic/claude-opus-4-8` to the second position for all tiers.

## Test plan

### Manual

**Before merge**

- [ ] Inspect the diff of `.woostack/config.json` to verify that `openai-codex/gpt-5.6-sol` is positioned as the primary model (index 0) for the `deep`, `standard`, and `fast` arrays.
