### PR TITLE
Add artifact backend resolver and Markdown adapter

### DIFF
--- a/.woostack/plans/2026-07-11-linear-artifact-backend.md
+++ b/.woostack/plans/2026-07-11-linear-artifact-backend.md
@@ -45,20 +45,20 @@ branch: feature/linear-artifact-backend
 - Modify: `skills/woostack-init/templates/config.json`
 - Modify: `skills/woostack-init/scripts/tests/run-tests.sh`
 
-- [ ] **Step 1: Add failing selector tests**
+- [x] **Step 1: Add failing selector tests**
   Add cases to `test-artifact-backends.sh` that invoke `resolve-backend.sh` against temporary repositories and assert exact JSON output for: missing selector → `markdown`; explicit `markdown`; complete `linear`; unsupported selector; missing `linear.workspace`, `linear.team`, lifecycle mappings, or repository override when no GitHub remote; and rejection of credential-shaped config keys such as `apiKey`, `token`, or `credentialFile`.
 
-- [ ] **Step 2: Run the selector suite and confirm red**
+- [x] **Step 2: Run the selector suite and confirm red**
   Run: `bash skills/woostack-init/scripts/tests/test-artifact-backends.sh`
   Expected: FAIL because `scripts/artifacts/resolve-backend.sh` does not exist.
 
-- [ ] **Step 3: Implement the resolver**
+- [x] **Step 3: Implement the resolver**
   Implement `resolve-backend.sh <repo-root>` with `set -euo pipefail`. Read `.woostack/config.json` with `jq`; emit one canonical JSON object with keys `backend`, `repository`, and `linear` (the last is `null` for Markdown). Resolve repository identity from an explicit `linear.repository` override, otherwise from the canonical GitHub `owner/repo` remote. Validate `artifacts.specPlan` against `markdown|linear`, require every configured semantic project/issue state in Linear mode, and reject secret-bearing Linear config keys. Diagnostics name only non-secret config paths.
 
-- [ ] **Step 4: Update the config template**
+- [x] **Step 4: Update the config template**
   Add `"artifacts": { "specPlan": "markdown" }` to `skills/woostack-init/templates/config.json`. Do not add a populated `linear` block or secret placeholder to the default template; document the conditional Linear object in the relevant reference increment.
 
-- [ ] **Step 5: Run selector tests green**
+- [x] **Step 5: Run selector tests green**
   Run: `bash skills/woostack-init/scripts/tests/test-artifact-backends.sh`
   Expected: PASS for default compatibility, complete Linear config, repository identity, invalid shape, and secret-key rejection.
 
@@ -68,21 +68,21 @@ branch: feature/linear-artifact-backend
 - Create: `skills/woostack-init/scripts/artifacts/markdown.sh`
 - Modify: `skills/woostack-init/scripts/tests/test-artifact-backends.sh`
 
-- [ ] **Step 1: Add failing Markdown normalization tests**
+- [x] **Step 1: Add failing Markdown normalization tests**
   Create temporary canonical spec/plan pairs and assert `markdown.sh feature <spec-path>` emits the normalized fields `backend`, `feature`, `spec`, and ordered `increments`. Cover the wikilink and legacy source-line forms, statuses, branch, checkbox progress, missing/duplicate plans, and filenames containing valid slug punctuation.
 
-- [ ] **Step 2: Run and confirm the missing adapter fails**
+- [x] **Step 2: Run and confirm the missing adapter fails**
   Run: `bash skills/woostack-init/scripts/tests/test-artifact-backends.sh`
   Expected: FAIL at the first Markdown normalization case because `markdown.sh` does not exist.
 
-- [ ] **Step 3: Implement Markdown normalization without changing semantics**
+- [x] **Step 3: Implement Markdown normalization without changing semantics**
   Implement `markdown.sh` as a read-only adapter over existing frontmatter and source-line contracts. Preserve current basename/source resolution and emit canonical JSON; fail on ambiguous 1:1 joins. Do not rewrite files. Add `# woostack-defer(increment 5): workflow skills begin consuming the backend adapter in increment 5` beside the adapter entry point.
 
-- [ ] **Step 4: Run focused and existing init tests**
+- [x] **Step 4: Run focused and existing init tests**
   Run: `bash skills/woostack-init/scripts/tests/test-artifact-backends.sh && bash skills/woostack-init/scripts/tests/run-tests.sh`
   Expected: PASS; existing Markdown init behavior remains unchanged.
 
-- [ ] **Step 5: Commit Increment 1**
+- [x] **Step 5: Commit Increment 1**
   Run: `gt create -m "feat(artifacts): add backend resolver and Markdown adapter"`
   Expected: one reviewable PR containing only config selection and Markdown normalization.
 

--- a/.woostack/plans/2026-07-11-linear-artifact-backend.md
+++ b/.woostack/plans/2026-07-11-linear-artifact-backend.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-11-linear-artifact-backend.md
-status: ready
+status: executing
 branch: feature/linear-artifact-backend
 ---
 

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -6,13 +6,16 @@ description: Every key in the .woostack/config.json file, what it tunes, its typ
 woostack reads optional settings from `.woostack/config.json` at the repository root.
 [woostack-init](/docs/skills/woostack-init) creates the file, and every key is optional: when a
 key is absent, the skill that reads it falls back to a built-in default. The init template
-ships four top-level keys: `models`, `review`, `respond`, and `status`.
-[woostack-doctor](/docs/skills/woostack-doctor) checks that all four are present and validates response metadata without querying a provider.
+ships five top-level keys: `artifacts`, `models`, `review`, `respond`, and `status`.
+[woostack-doctor](/docs/skills/woostack-doctor) checks the scaffolded namespaces and validates
+response metadata without querying a provider.
 
-There are eight top-level settings:
+There are ten top-level settings:
 
 | Setting | Read by | Tunes |
 | --- | --- | --- |
+| `artifacts` | spec/plan workflows | selects the Markdown or Linear artifact backend |
+| `linear` | spec/plan workflows when `artifacts.specPlan` is `linear` | secret-free Linear workspace, repository, and lifecycle mappings |
 | `review` | [woostack-review](/docs/skills/woostack-review) | the PR review engine: angles, noise, validation |
 | `models` | [woostack-review](/docs/skills/woostack-review), [woostack-audit](/docs/skills/woostack-audit), and local subagent drivers | shared model selection and tier parameters |
 | `audit` | [woostack-audit](/docs/skills/woostack-audit) | standing-code audit angles, filtering, chunking, and output |
@@ -29,6 +32,30 @@ explained in the sections below.
 
 ```json
 {
+  "artifacts": { "specPlan": "markdown" },
+  "linear": {
+    "workspace": "acme",
+    "team": "ENG",
+    "repository": "acme/widgets",
+    "projectStatuses": {
+      "draft": "Draft",
+      "hardened": "Hardened",
+      "approved": "Approved",
+      "planning": "Planning",
+      "ready": "Ready",
+      "executing": "In Progress",
+      "inReview": "In Review",
+      "done": "Completed",
+      "abandoned": "Canceled"
+    },
+    "issueStates": {
+      "planned": "Backlog",
+      "executing": "In Progress",
+      "inReview": "In Review",
+      "done": "Done",
+      "blocked": "Blocked"
+    }
+  },
   "review": {
     "severity_floor": "high",
     "nits": true,
@@ -67,6 +94,38 @@ explained in the sections below.
   "base_branch": "main"
 }
 ```
+
+## Artifact backend
+
+`artifacts.specPlan` accepts `markdown` (the default) or the reserved `linear` selector. Markdown
+reads tracked `.woostack/specs/*.md` and `.woostack/plans/*.md` files. This increment validates
+the complete, secret-free `linear` namespace shown above; later stacked increments add Linear
+project and issue persistence before the selector becomes operational.
+
+| Key | Required for `linear` | Meaning |
+| --- | --- | --- |
+| `linear.workspace` | yes | Linear workspace slug or identifier. |
+| `linear.team` | yes | Team key or identifier used for increment issues. |
+| `linear.repository` | when no GitHub `origin` can be resolved | Canonical `owner/repository` identity. An explicit value takes precedence over Git remote discovery. |
+| `linear.projectStatuses.draft` | yes | Project status for draft specs. |
+| `linear.projectStatuses.hardened` | yes | Project status for hardened specs. |
+| `linear.projectStatuses.approved` | yes | Project status for approved specs. |
+| `linear.projectStatuses.planning` | yes | Project status while a plan is being written. |
+| `linear.projectStatuses.ready` | yes | Project status for an approved plan awaiting execution. |
+| `linear.projectStatuses.executing` | yes | Project status while increments are being implemented. |
+| `linear.projectStatuses.inReview` | yes | Project status while increment PRs are under review. |
+| `linear.projectStatuses.done` | yes | Project status after every increment is complete. |
+| `linear.projectStatuses.abandoned` | yes | Project status for abandoned work. |
+| `linear.issueStates.planned` | yes | Issue state for planned increments. |
+| `linear.issueStates.executing` | yes | Issue state for active increments. |
+| `linear.issueStates.inReview` | yes | Issue state for increments under review. |
+| `linear.issueStates.done` | yes | Issue state for completed increments. |
+| `linear.issueStates.blocked` | yes | Issue state for blocked increments. |
+
+Only the keys listed above are accepted; unknown keys fail closed. The namespace must not contain
+credentials at any depth. Keep API keys, tokens, authorization headers, passwords, private or
+access keys, client secrets, credential files, and provider authentication in the host's native
+secret store.
 
 ## Response
 

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -44,17 +44,24 @@ Two callers:
    | `.woostack/wisdom/.gitkeep` | `templates/wisdom/.gitkeep` |
    | `.woostack/respond/` directory | (create empty — tracked sanitized response reports) |
    | `.woostack/respond/.gitkeep` | `templates/respond/.gitkeep` |
-   | `.woostack/config.json` | `templates/config.json` (`{ "models": {}, "review": {}, "respond": {}, "status": { "staleDays": 14 } }`) |
+   | `.woostack/config.json` | `templates/config.json` (`{ "artifacts": { "specPlan": "markdown" }, "models": {}, "review": {}, "respond": {}, "status": { "staleDays": 14 } }`) |
    | `.woostack/.gitignore` | `templates/gitignore` |
    | `.woostack/worktrees/` directory | (create empty — per-PR git worktrees, gitignored) |
 
-   `config.json` ships as `{ "models": {}, "review": {}, "respond": {}, "status": { "staleDays": 14 } }`.
-   Each tool owns its namespace. The optional `respond` namespace accepts only non-secret workflow
-   defaults: `provider`, `environment`, `window`, `max_groups`, and `remediation`; provider
-   credentials remain in provider-native stores. The `status` namespace holds `staleDays`
-   (default 14 — the age in days past which an executing spec is flagged stale on the
-   `/woostack-status` board), defined in
-   [../woostack-status/references/conventions.md](../woostack-status/references/conventions.md).
+   `config.json` ships as `{ "artifacts": { "specPlan": "markdown" }, "models": {}, "review": {},
+   "respond": {}, "status": { "staleDays": 14 } }`. Each tool owns its namespace.
+   `artifacts.specPlan` selects the spec/plan backend: `markdown` keeps tracked `.woostack`
+   artifacts; the reserved `linear` selector currently validates secret-free configuration only.
+   Later stacked increments add Linear project and issue persistence before workflows consume it.
+   The accepted keys and lifecycle mappings are defined in the
+   [artifact backend configuration reference](references/artifact-backends.md). Provider
+   credentials never belong in this file.
+
+   The optional `respond` namespace accepts only non-secret workflow defaults: `provider`,
+   `environment`, `window`, `max_groups`, and `remediation`; provider credentials remain in
+   provider-native stores. The `status` namespace holds `staleDays` (default 14 — the age in
+   days past which an executing spec is flagged stale on the `/woostack-status` board), defined
+   in [../woostack-status/references/conventions.md](../woostack-status/references/conventions.md).
 
    The optional top-level `base_branch` key sets the integration/trunk branch that base branches
    are cut from and PRs target; unset, it auto-detects the remote default (`origin/HEAD`, else

--- a/skills/woostack-init/references/artifact-backends.md
+++ b/skills/woostack-init/references/artifact-backends.md
@@ -1,0 +1,22 @@
+# Artifact backend configuration
+
+`artifacts.specPlan` accepts `markdown` (the default) or the reserved `linear` selector.
+Markdown reads tracked `.woostack/specs/*.md` and `.woostack/plans/*.md` files. The
+`linear` selector currently validates configuration only; later stacked increments add
+Linear project and issue persistence before workflows consume it.
+
+A Linear configuration accepts only these keys:
+
+- `linear.workspace`
+- `linear.team`
+- optional `linear.repository` (`owner/repository`); when omitted, the resolver derives it
+  from a GitHub `origin`
+- every `linear.projectStatuses` mapping: `draft`, `hardened`, `approved`, `planning`,
+  `ready`, `executing`, `inReview`, `done`, and `abandoned`
+- every `linear.issueStates` mapping: `planned`, `executing`, `inReview`, `done`, and
+  `blocked`
+
+Every value must be a non-empty string. Unknown keys fail closed. The `linear` namespace
+must not contain credentials at any depth: keep API keys, tokens, authorization headers,
+passwords, private or access keys, client secrets, credential files, and provider
+authentication in the host's native secret store.

--- a/skills/woostack-init/references/memory.md
+++ b/skills/woostack-init/references/memory.md
@@ -25,13 +25,15 @@ The `/woostack-init` scaffold verb creates this tree in a consumer repo:
 ├── respond/
 │   ├── .gitkeep     tracked sanitized response reports live beside it
 │   └── evidence/    ignored transient provider evidence; created per run
-├── config.json      { "models": {}, "review": {}, "respond": {}, "status": { "staleDays": 14 } } skeleton
+├── config.json      { "artifacts": { "specPlan": "markdown" }, "models": {}, "review": {}, "respond": {}, "status": { "staleDays": 14 } } skeleton
 └── .gitignore       ignores transient response evidence and local sidecars; tracks specs/plans/fixes/respond/config/memory notes
 ```
 
-The `config.json` file uses a top-level namespace-per-tool convention: `"review"` is the key for
-woostack-review settings; `"respond"` holds non-secret production-response workflow defaults;
-`"models"` is shared across tools. Provider credentials never belong in this file.
+The `config.json` file uses a top-level namespace-per-tool convention: `"artifacts"` selects the
+spec/plan backend, `"review"` configures woostack-review, `"respond"` holds non-secret
+production-response workflow defaults, and `"models"` is shared across tools. The full backend
+schema and Linear mappings are documented in the
+[init skill](../SKILL.md#workflow). Provider credentials never belong in this file.
 
 The `.gitignore` ignores `metrics.json`, `*.local.*`, `respond/evidence/`, memory telemetry, and
 the dream watermark. Sanitized response reports remain tracked shared decision evidence alongside

--- a/skills/woostack-init/scripts/artifacts/markdown.sh
+++ b/skills/woostack-init/scripts/artifacts/markdown.sh
@@ -35,49 +35,141 @@ read_field() {
 
 # woostack-defer(increment 5): workflow skills begin consuming the backend adapter in increment 5
 feature() {
-  local requested="$1" spec_dir spec_path woo_root basename stem plan_dir plan_path
-  spec_dir="$(cd "$(dirname "$requested")" 2>/dev/null && pwd -P)" || fail "spec directory not found"
+  local requested="$1" requested_dir repo_hint repo_root spec_dir spec_path woo_root
+  local basename stem plan_dir plan_path spec_slug spec_name
+  requested_dir="$(dirname "$requested")"
+  [[ "$(basename "$requested_dir")" == 'specs' && "$(basename "$(dirname "$requested_dir")")" == '.woostack' ]] \
+    || fail "spec path must be under .woostack/specs"
+  repo_hint="$(dirname "$(dirname "$requested_dir")")"
+  [[ ! -L "$repo_hint/.woostack" && ! -L "$repo_hint/.woostack/specs" ]] \
+    || fail "spec directory symlinks are not allowed"
+  repo_root="$(git -C "$repo_hint" rev-parse --show-toplevel 2>/dev/null)" \
+    || fail "repository root not found"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  spec_dir="$(cd "$requested_dir" 2>/dev/null && pwd -P)" || fail "spec directory not found"
+  [[ "$spec_dir" == "$repo_root/.woostack/specs" ]] || fail "spec path must be under repository .woostack/specs"
   spec_path="$spec_dir/$(basename "$requested")"
   [[ ! -L "$requested" && ! -L "$spec_path" ]] || fail "spec symlinks are not allowed"
   validate_frontmatter "$spec_path"
   [[ "$(read_field "$spec_path" type)" == 'spec' ]] || fail "artifact is not a spec"
 
-  [[ "$(basename "$spec_dir")" == 'specs' && "$(basename "$(dirname "$spec_dir")")" == '.woostack' ]] \
-    || fail "spec path must be under .woostack/specs"
-  woo_root="$(dirname "$spec_dir")"
+  woo_root="$repo_root/.woostack"
   basename="$(basename "$spec_path")"
   stem="${basename%.md}"
+  spec_slug="${stem#????-??-??-}"
+  spec_name="$(read_field "$spec_path" name)"
   plan_dir="$woo_root/plans"
   [[ -d "$plan_dir" ]] || fail "matching plan not found"
   [[ ! -L "$plan_dir" ]] || fail "plan symlink escapes are not allowed"
 
   local -a matches=()
-  local candidate line canonical legacy
+  local candidate candidate_base candidate_slug candidate_source canonical canonical_md legacy
   canonical="**Source:** [[specs/$stem]]"
+  canonical_md="**Source:** [[specs/$basename]]"
   legacy="**Source:** .woostack/specs/$basename"
   shopt -s nullglob
   for candidate in "$plan_dir"/*.md; do
     [[ ! -L "$candidate" ]] || fail "plan symlinks are not allowed"
-    line="$(awk '
-      $0 == "---" { fences++; next }
-      fences >= 2 && $0 !~ /^[[:space:]]*$/ {
-        value=$0
+    if awk -v canonical="$canonical" -v canonical_md="$canonical_md" -v legacy="$legacy" '
+      function trim(value) {
         sub(/^[[:space:]]*/, "", value)
         sub(/[[:space:]]*$/, "", value)
-        print value
-        exit
+        return value
       }
-    ' "$candidate")"
-    if [[ "$line" == "$canonical" || "$line" == "$legacy" ]]; then
+      function matches_token(value, token) {
+        return index(value, token) == 1 &&
+          (length(value) == length(token) || substr(value, length(token) + 1, 1) ~ /[[:space:]]/)
+      }
+      function run_length(value, marker, count) {
+        marker=substr(value, 1, 1)
+        if (marker != "`" && marker != "~") return 0
+        count=1
+        while (substr(value, count + 1, 1) == marker) count++
+        return count
+      }
+      $0 == "---" && frontmatter_fences < 2 { frontmatter_fences++; next }
+      frontmatter_fences < 2 { next }
+      {
+        value=$0
+        sub(/^[[:space:]]*/, "", value)
+        run=run_length(value)
+        marker=substr(value, 1, 1)
+        rest=substr(value, run + 1)
+        if (in_fence) {
+          if (marker == fence_marker && run >= fence_length && rest ~ /^[[:space:]]*$/) {
+            in_fence=0
+          }
+          next
+        }
+        if (run >= 3) {
+          in_fence=1
+          fence_marker=marker
+          fence_length=run
+          next
+        }
+        value=trim($0)
+        if (matches_token(value, canonical) ||
+            matches_token(value, canonical_md) ||
+            matches_token(value, legacy)) found=1
+      }
+      END { exit !found }
+    ' "$candidate"; then
       matches+=("$candidate")
     fi
   done
-  shopt -u nullglob
 
   if (( ${#matches[@]} == 0 )); then
-    candidate="$plan_dir/$basename"
-    [[ -f "$candidate" ]] && matches+=("$candidate")
+    for candidate in "$plan_dir"/*.md; do
+      candidate_base="$(basename "$candidate" .md)"
+      candidate_slug="${candidate_base#????-??-??-}"
+      candidate_source="$(read_field "$candidate" source)"
+      if [[ -n "$candidate_source" && "$candidate_source" != ".woostack/specs/$basename" ]]; then
+        continue
+      fi
+      if awk '
+        function trim(value) {
+          sub(/^[[:space:]]*/, "", value)
+          sub(/[[:space:]]*$/, "", value)
+          return value
+        }
+        function run_length(value, marker, count) {
+          marker=substr(value, 1, 1)
+          if (marker != "`" && marker != "~") return 0
+          count=1
+          while (substr(value, count + 1, 1) == marker) count++
+          return count
+        }
+        $0 == "---" && frontmatter_fences < 2 { frontmatter_fences++; next }
+        frontmatter_fences < 2 { next }
+        {
+          value=$0
+          sub(/^[[:space:]]*/, "", value)
+          run=run_length(value)
+          marker=substr(value, 1, 1)
+          rest=substr(value, run + 1)
+          if (in_fence) {
+            if (marker == fence_marker && run >= fence_length && rest ~ /^[[:space:]]*$/) in_fence=0
+            next
+          }
+          if (run >= 3) {
+            in_fence=1
+            fence_marker=marker
+            fence_length=run
+            next
+          }
+          if (trim($0) ~ /^\*\*Source:\*\*/) found=1
+        }
+        END { exit !found }
+      ' "$candidate"; then
+        continue
+      fi
+      if [[ "$candidate_slug" == "$spec_slug" || ( -n "$spec_name" && "$candidate_slug" == "$spec_name" ) ]]; then
+        matches+=("$candidate")
+      fi
+    done
   fi
+  shopt -u nullglob
+
   (( ${#matches[@]} > 0 )) || fail "matching plan not found"
   (( ${#matches[@]} == 1 )) || fail "multiple plans join to spec"
   plan_path="${matches[0]}"
@@ -106,23 +198,67 @@ with open(plan_path, encoding="utf-8") as handle:
 
 heading = re.compile(r"^## Increment ([0-9]+)(?::| [-—] | \([^)\r\n]+\):)")
 checkbox = re.compile(r"^[ \t]*-[ \t]+\[([ xX])\]")
+
+frontmatter_fences = 0
+body_start = None
+for index, line in enumerate(lines):
+    if line.rstrip("\r\n") == "---":
+        frontmatter_fences += 1
+        if frontmatter_fences == 2:
+            body_start = index + 1
+            break
+body_lines = lines[body_start:]
+
+def fence_marker(line):
+    stripped = line.lstrip()
+    if not stripped or stripped[0] not in (chr(96), "~"):
+        return None
+    marker = stripped[0]
+    run = len(stripped) - len(stripped.lstrip(marker))
+    if run < 3:
+        return None
+    return marker, run, stripped[run:].rstrip("\r\n")
+
+def checkbox_values(section_lines):
+    values = []
+    active_marker = None
+    active_length = 0
+    for line in section_lines:
+        fence = fence_marker(line)
+        if fence is not None:
+            marker, run, remainder = fence
+            if active_marker is None:
+                active_marker = marker
+                active_length = run
+            elif marker == active_marker and run >= active_length and not remainder.strip():
+                active_marker = None
+                active_length = 0
+            continue
+        if active_marker is None and (match := checkbox.match(line)):
+            values.append(match.group(1))
+    return values
+
 sections = []
 current = None
-in_fence = False
-fence_length = 0
+active_marker = None
+active_length = 0
 
-for line in lines:
-    stripped = line.lstrip()
-    tick_run = len(stripped) - len(stripped.lstrip(chr(96)))
-    if tick_run >= 3:
-        if not in_fence:
-            in_fence = True
-            fence_length = tick_run
-        elif tick_run >= fence_length:
-            in_fence = False
-            fence_length = 0
+for line in body_lines:
+    fence = fence_marker(line)
+    if fence is not None:
+        marker, run, remainder = fence
+        if active_marker is None:
+            active_marker = marker
+            active_length = run
+        elif marker == active_marker and run >= active_length and not remainder.strip():
+            active_marker = None
+            active_length = 0
+        if current is not None:
+            current["lines"].append(line)
         continue
-    if in_fence:
+    if active_marker is not None:
+        if current is not None:
+            current["lines"].append(line)
         continue
     match = heading.match(line.rstrip("\r\n"))
     if match:
@@ -134,15 +270,16 @@ for line in lines:
 if current is not None:
     sections.append(current)
 
+if not sections:
+    sections = [{"ordinal": 1, "lines": body_lines}]
+
 ordinals = [section["ordinal"] for section in sections]
-if not ordinals:
-    raise SystemExit("plan has no increments")
 if len(ordinals) != len(set(ordinals)):
     raise SystemExit("plan has duplicate increment ordinals")
 
 increments = []
 for section in sorted(sections, key=lambda item: item["ordinal"]):
-    boxes = [match.group(1) for line in section["lines"] if (match := checkbox.match(line))]
+    boxes = checkbox_values(section["lines"])
     done = sum(value.lower() == "x" for value in boxes)
     total = len(boxes)
     status = "done" if total and done == total else "executing" if done else "planned"

--- a/skills/woostack-init/scripts/artifacts/markdown.sh
+++ b/skills/woostack-init/scripts/artifacts/markdown.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/../lib.sh"
+
+fail() {
+  printf 'markdown adapter: %s\n' "$1" >&2
+  exit 1
+}
+
+validate_frontmatter() {
+  local file="$1"
+  [[ -f "$file" ]] || fail "artifact file not found"
+  [[ "$(sed -n '1p' "$file")" == '---' ]] || fail "malformed frontmatter"
+  awk 'NR > 1 && $0 == "---" { found=1; exit } END { exit !found }' "$file" \
+    || fail "malformed frontmatter"
+}
+
+read_field() {
+  local file="$1" key="$2"
+  awk -v key="$key" '
+    NR == 1 && $0 == "---" { in_frontmatter=1; next }
+    in_frontmatter && $0 == "---" { exit }
+    in_frontmatter && index($0, key ":") == 1 {
+      value=substr($0, length(key) + 2)
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+# woostack-defer(increment 5): workflow skills begin consuming the backend adapter in increment 5
+feature() {
+  local requested="$1" spec_dir spec_path woo_root basename stem plan_dir plan_path
+  spec_dir="$(cd "$(dirname "$requested")" 2>/dev/null && pwd -P)" || fail "spec directory not found"
+  spec_path="$spec_dir/$(basename "$requested")"
+  [[ ! -L "$requested" && ! -L "$spec_path" ]] || fail "spec symlinks are not allowed"
+  validate_frontmatter "$spec_path"
+  [[ "$(read_field "$spec_path" type)" == 'spec' ]] || fail "artifact is not a spec"
+
+  [[ "$(basename "$spec_dir")" == 'specs' && "$(basename "$(dirname "$spec_dir")")" == '.woostack' ]] \
+    || fail "spec path must be under .woostack/specs"
+  woo_root="$(dirname "$spec_dir")"
+  basename="$(basename "$spec_path")"
+  stem="${basename%.md}"
+  plan_dir="$woo_root/plans"
+  [[ -d "$plan_dir" ]] || fail "matching plan not found"
+  [[ ! -L "$plan_dir" ]] || fail "plan symlink escapes are not allowed"
+
+  local -a matches=()
+  local candidate line canonical legacy
+  canonical="**Source:** [[specs/$stem]]"
+  legacy="**Source:** .woostack/specs/$basename"
+  shopt -s nullglob
+  for candidate in "$plan_dir"/*.md; do
+    [[ ! -L "$candidate" ]] || fail "plan symlinks are not allowed"
+    line="$(awk '
+      $0 == "---" { fences++; next }
+      fences >= 2 && $0 !~ /^[[:space:]]*$/ {
+        value=$0
+        sub(/^[[:space:]]*/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        print value
+        exit
+      }
+    ' "$candidate")"
+    if [[ "$line" == "$canonical" || "$line" == "$legacy" ]]; then
+      matches+=("$candidate")
+    fi
+  done
+  shopt -u nullglob
+
+  if (( ${#matches[@]} == 0 )); then
+    candidate="$plan_dir/$basename"
+    [[ -f "$candidate" ]] && matches+=("$candidate")
+  fi
+  (( ${#matches[@]} > 0 )) || fail "matching plan not found"
+  (( ${#matches[@]} == 1 )) || fail "multiple plans join to spec"
+  plan_path="${matches[0]}"
+  validate_frontmatter "$plan_path"
+  [[ "$(read_field "$plan_path" type)" == 'plan' ]] || fail "joined artifact is not a plan"
+
+  local feature_name feature_status feature_branch spec_id plan_id parsed revision increments
+  feature_name="$(read_field "$spec_path" name)"
+  [[ -n "$feature_name" ]] || feature_name="${stem#????-??-??-}"
+  feature_status="$(read_field "$plan_path" status)"
+  feature_branch="$(read_field "$plan_path" branch)"
+  [[ -n "$feature_status" ]] || fail "plan status is missing"
+  spec_id=".woostack/specs/$basename"
+  plan_id=".woostack/plans/$(basename "$plan_path")"
+  parsed="$(python3 - "$spec_path" "$plan_path" "$plan_id" <<'PY'
+import hashlib
+import json
+import re
+import sys
+
+spec_path, plan_path, plan_id = sys.argv[1:]
+with open(spec_path, "rb") as handle:
+    spec_bytes = handle.read()
+with open(plan_path, encoding="utf-8") as handle:
+    lines = handle.readlines()
+
+heading = re.compile(r"^## Increment ([0-9]+)(?::| [-—] | \([^)\r\n]+\):)")
+checkbox = re.compile(r"^[ \t]*-[ \t]+\[([ xX])\]")
+sections = []
+current = None
+in_fence = False
+fence_length = 0
+
+for line in lines:
+    stripped = line.lstrip()
+    tick_run = len(stripped) - len(stripped.lstrip(chr(96)))
+    if tick_run >= 3:
+        if not in_fence:
+            in_fence = True
+            fence_length = tick_run
+        elif tick_run >= fence_length:
+            in_fence = False
+            fence_length = 0
+        continue
+    if in_fence:
+        continue
+    match = heading.match(line.rstrip("\r\n"))
+    if match:
+        if current is not None:
+            sections.append(current)
+        current = {"ordinal": int(match.group(1)), "lines": []}
+    elif current is not None:
+        current["lines"].append(line)
+if current is not None:
+    sections.append(current)
+
+ordinals = [section["ordinal"] for section in sections]
+if not ordinals:
+    raise SystemExit("plan has no increments")
+if len(ordinals) != len(set(ordinals)):
+    raise SystemExit("plan has duplicate increment ordinals")
+
+increments = []
+for section in sorted(sections, key=lambda item: item["ordinal"]):
+    boxes = [match.group(1) for line in section["lines"] if (match := checkbox.match(line))]
+    done = sum(value.lower() == "x" for value in boxes)
+    total = len(boxes)
+    status = "done" if total and done == total else "executing" if done else "planned"
+    ordinal = section["ordinal"]
+    increments.append({
+        "id": f"{plan_id}#increment-{ordinal}",
+        "identifier": None,
+        "ordinal": ordinal,
+        "status": status,
+        "dependencies": [],
+        "branch": None,
+        "pullRequest": None,
+        "content": "".join(section["lines"]).strip("\r\n"),
+    })
+
+print(json.dumps({
+    "revision": hashlib.sha256(spec_bytes).hexdigest(),
+    "increments": increments,
+}, separators=(",", ":")))
+PY
+  )" || fail "plan increments could not be parsed"
+  revision="$(jq -r '.revision' <<<"$parsed")"
+  increments="$(jq -c '.increments' <<<"$parsed")"
+
+  jq -cn \
+    --arg feature_id "$spec_id" \
+    --arg title "$feature_name" \
+    --arg status "$feature_status" \
+    --arg branch "$feature_branch" \
+    --arg spec_id "$spec_id" \
+    --rawfile content "$spec_path" \
+    --arg revision "$revision" \
+    --argjson increments "$increments" '
+      {
+        backend: "markdown",
+        feature: {
+          id: $feature_id,
+          url: null,
+          title: $title,
+          status: $status,
+          branch: (if $branch == "" then null else $branch end)
+        },
+        spec: {
+          id: $spec_id,
+          url: null,
+          content: $content,
+          revision: $revision
+        },
+        increments: $increments
+      }
+    '
+}
+
+[[ "${1:-}" == 'feature' ]] || fail "usage: markdown.sh feature <spec-path>"
+[[ $# -eq 2 ]] || fail "usage: markdown.sh feature <spec-path>"
+feature "$2"

--- a/skills/woostack-init/scripts/artifacts/resolve-backend.sh
+++ b/skills/woostack-init/scripts/artifacts/resolve-backend.sh
@@ -34,13 +34,31 @@ secret_path="$(jq -r '
       end
     ) as $key |
     select(
-      ($key | test("(apikey|token|credentials?(file|path)|authorization|password|secret)"))
+      ($key | test("(apikey|token|credentials?(file|path)|authorization|password|secret|privatekey|accesskey)"))
     ) |
     $path | map(if type == "number" then "[\(.)]" else . end) | join(".")
   ) // empty
 ' <<<"$config")"
 if [ -n "$secret_path" ]; then
   error_path "linear.$secret_path"
+fi
+
+unknown_linear_path="$(jq -r '
+  first(
+    (.linear? | objects | keys[] as $key |
+      select(["workspace", "team", "repository", "projectStatuses", "issueStates"] | index($key) | not) |
+      ["linear", $key]),
+    (.linear?.projectStatuses? | objects | keys[] as $key |
+      select(["draft", "hardened", "approved", "planning", "ready", "executing", "inReview", "done", "abandoned"] | index($key) | not) |
+      ["linear", "projectStatuses", $key]),
+    (.linear?.issueStates? | objects | keys[] as $key |
+      select(["planned", "executing", "inReview", "done", "blocked"] | index($key) | not) |
+      ["linear", "issueStates", $key])
+  ) // empty |
+  join(".")
+' <<<"$config")"
+if [ -n "$unknown_linear_path" ]; then
+  error_path "$unknown_linear_path"
 fi
 
 if ! jq -e '

--- a/skills/woostack-init/scripts/artifacts/resolve-backend.sh
+++ b/skills/woostack-init/scripts/artifacts/resolve-backend.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  printf 'usage: %s <repo-root>\n' "${0##*/}" >&2
+  exit 2
+}
+
+error_path() {
+  printf 'resolve-backend: invalid config at %s\n' "$1" >&2
+  exit 1
+}
+
+[ "$#" -eq 1 ] || usage
+repo_root="$1"
+config_path="$repo_root/.woostack/config.json"
+
+if [ -e "$config_path" ]; then
+  if ! config="$(jq -c 'if type == "object" then . else error("root must be an object") end' "$config_path" 2>/dev/null)"; then
+    error_path '.woostack/config.json'
+  fi
+else
+  config='{}'
+fi
+
+secret_path="$(jq -r '
+  first(
+    .linear? // {} |
+    paths as $path |
+    ($path[-1] |
+      if type == "string"
+      then ascii_downcase | gsub("[^a-z0-9]"; "")
+      else ""
+      end
+    ) as $key |
+    select(
+      ($key | test("(apikey|token|credentials?(file|path)|authorization|password|secret)"))
+    ) |
+    $path | map(if type == "number" then "[\(.)]" else . end) | join(".")
+  ) // empty
+' <<<"$config")"
+if [ -n "$secret_path" ]; then
+  error_path "linear.$secret_path"
+fi
+
+if ! jq -e '
+  (has("artifacts") | not) or
+  ((.artifacts | type) == "object")
+' >/dev/null 2>&1 <<<"$config"; then
+  error_path 'artifacts'
+fi
+if ! jq -e '
+  ((.artifacts // {}) | has("specPlan") | not) or
+  ((.artifacts.specPlan | type) == "string")
+' >/dev/null 2>&1 <<<"$config"; then
+  error_path 'artifacts.specPlan'
+fi
+
+backend="$(jq -r '.artifacts.specPlan // "markdown"' <<<"$config")"
+case "$backend" in
+  markdown)
+    printf '%s\n' '{"backend":"markdown","repository":null,"linear":null}'
+    exit 0
+    ;;
+  linear)
+    ;;
+  *)
+    error_path 'artifacts.specPlan'
+    ;;
+esac
+
+if ! jq -e '.linear | type == "object"' >/dev/null 2>&1 <<<"$config"; then
+  error_path 'linear'
+fi
+
+require_string() {
+  local path="$1"
+  if ! jq -e --arg path "$path" '
+    getpath($path | split(".")) as $value |
+    ($value | type) == "string" and ($value | test("\\S"))
+  ' >/dev/null 2>&1 <<<"$config"; then
+    error_path "$path"
+  fi
+}
+
+require_string 'linear.workspace'
+require_string 'linear.team'
+
+project_mappings=(draft hardened approved planning ready executing inReview "done" abandoned)
+for mapping in "${project_mappings[@]}"; do
+  require_string "linear.projectStatuses.$mapping"
+done
+
+issue_mappings=(planned executing inReview "done" blocked)
+for mapping in "${issue_mappings[@]}"; do
+  require_string "linear.issueStates.$mapping"
+done
+
+valid_repository_identity() {
+  local identity="$1"
+  local name="${identity#*/}"
+  [[ "$identity" =~ ^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])/[A-Za-z0-9._-]+$ ]] &&
+    [ "$name" != '.' ] &&
+    [ "$name" != '..' ]
+}
+
+if jq -e '.linear | has("repository")' >/dev/null <<<"$config"; then
+  if ! jq -e '.linear.repository | type == "string"' >/dev/null 2>&1 <<<"$config"; then
+    error_path 'linear.repository'
+  fi
+  repository="$(jq -r '.linear.repository' <<<"$config")"
+  if ! valid_repository_identity "$repository"; then
+    error_path 'linear.repository'
+  fi
+else
+  remote="$(git -C "$repo_root" config --get remote.origin.url 2>/dev/null || true)"
+  case "$remote" in
+    git@github.com:*) repository="${remote#git@github.com:}" ;;
+    https://github.com/*) repository="${remote#https://github.com/}" ;;
+    http://github.com/*) repository="${remote#http://github.com/}" ;;
+    ssh://git@github.com/*) repository="${remote#ssh://git@github.com/}" ;;
+    git://github.com/*) repository="${remote#git://github.com/}" ;;
+    *) repository='' ;;
+  esac
+  repository="${repository%/}"
+  repository="${repository%.git}"
+  if ! valid_repository_identity "$repository"; then
+    error_path 'linear.repository'
+  fi
+fi
+
+jq -c --arg repository "$repository" '{
+  backend: "linear",
+  repository: $repository,
+  linear: {
+    workspace: .linear.workspace,
+    team: .linear.team,
+    projectStatuses: {
+      draft: .linear.projectStatuses.draft,
+      hardened: .linear.projectStatuses.hardened,
+      approved: .linear.projectStatuses.approved,
+      planning: .linear.projectStatuses.planning,
+      ready: .linear.projectStatuses.ready,
+      executing: .linear.projectStatuses.executing,
+      inReview: .linear.projectStatuses.inReview,
+      done: .linear.projectStatuses.done,
+      abandoned: .linear.projectStatuses.abandoned
+    },
+    issueStates: {
+      planned: .linear.issueStates.planned,
+      executing: .linear.issueStates.executing,
+      inReview: .linear.issueStates.inReview,
+      done: .linear.issueStates.done,
+      blocked: .linear.issueStates.blocked
+    }
+  }
+}' <<<"$config"

--- a/skills/woostack-init/scripts/tests/test-artifact-backends.sh
+++ b/skills/woostack-init/scripts/tests/test-artifact-backends.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$TEST_DIR/../artifacts/resolve-backend.sh"
+MARKDOWN="$TEST_DIR/../artifacts/markdown.sh"
+TEMPLATE="$TEST_DIR/../../templates/config.json"
+# shellcheck disable=SC1091
+source "$TEST_DIR/assert.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+make_repo() {
+  local name="$1"
+  local repo="$TMP/$name"
+  mkdir -p "$repo/.woostack"
+  git -C "$repo" init -q
+  printf '%s\n' "$repo"
+}
+
+write_config() {
+  local repo="$1"
+  local config="$2"
+  printf '%s\n' "$config" > "$repo/.woostack/config.json"
+}
+
+complete_linear_config() {
+  local repository="${1:-}"
+  jq -cn --arg repository "$repository" '
+    {
+      artifacts: {specPlan: "linear"},
+      linear: ({
+        workspace: "acme",
+        team: "ENG",
+        projectStatuses: {
+          draft: "Draft",
+          hardened: "Hardened",
+          approved: "Approved",
+          planning: "Planning",
+          ready: "Ready",
+          executing: "In Progress",
+          inReview: "In Review",
+          done: "Completed",
+          abandoned: "Canceled"
+        },
+        issueStates: {
+          planned: "Backlog",
+          executing: "In Progress",
+          inReview: "In Review",
+          done: "Done",
+          blocked: "Blocked"
+        }
+      } + if $repository == "" then {} else {repository: $repository} end)
+    }'
+}
+
+run_failure() {
+  local repo="$1"
+  local output
+  if output="$(bash "$SCRIPT" "$repo" 2>&1)"; then
+    fail "resolver should reject invalid config"
+    RUN_FAILURE_OUTPUT="$output"
+    return
+  fi
+  pass
+  RUN_FAILURE_OUTPUT="$output"
+}
+
+repo="$(make_repo default-markdown)"
+write_config "$repo" '{}'
+actual="$(bash "$SCRIPT" "$repo")"
+assert_eq "$actual" '{"backend":"markdown","repository":null,"linear":null}' "missing selector defaults to Markdown"
+
+repo="$(make_repo explicit-markdown)"
+write_config "$repo" '{"artifacts":{"specPlan":"markdown"}}'
+actual="$(bash "$SCRIPT" "$repo")"
+assert_eq "$actual" '{"backend":"markdown","repository":null,"linear":null}' "explicit Markdown resolves without Linear config"
+
+repo="$(make_repo linear-override)"
+git -C "$repo" remote add origin https://github.com/ignored/by-override.git
+config="$(complete_linear_config acme/widgets)"
+write_config "$repo" "$config"
+actual="$(bash "$SCRIPT" "$repo")"
+expected="$(jq -c '{backend:"linear",repository:.linear.repository,linear:(.linear | del(.repository))}' <<<"$config")"
+assert_eq "$actual" "$expected" "explicit repository identity takes precedence over GitHub origin"
+
+repo="$(make_repo linear-github-https)"
+git -C "$repo" remote add origin https://github.com/example/remote-repo.git
+config="$(complete_linear_config)"
+write_config "$repo" "$config"
+actual="$(bash "$SCRIPT" "$repo")"
+assert_eq "$(jq -r '.repository' <<<"$actual")" 'example/remote-repo' "HTTPS GitHub origin supplies repository identity"
+
+repo="$(make_repo linear-github-ssh)"
+git -C "$repo" remote add origin git@github.com:example/ssh-repo.git
+write_config "$repo" "$config"
+actual="$(bash "$SCRIPT" "$repo")"
+assert_eq "$(jq -r '.repository' <<<"$actual")" 'example/ssh-repo' "SSH GitHub origin supplies repository identity"
+
+repo="$(make_repo linear-github-ssh-url)"
+git -C "$repo" remote add origin ssh://git@github.com/example/ssh-url-repo.git
+write_config "$repo" "$config"
+actual="$(bash "$SCRIPT" "$repo")"
+assert_eq "$(jq -r '.repository' <<<"$actual")" 'example/ssh-url-repo' "SSH URL GitHub origin supplies repository identity"
+
+repo="$(make_repo linear-github-git-url)"
+git -C "$repo" remote add origin git://github.com/example/git-url-repo.git
+write_config "$repo" "$config"
+actual="$(bash "$SCRIPT" "$repo")"
+assert_eq "$(jq -r '.repository' <<<"$actual")" 'example/git-url-repo' "git URL GitHub origin supplies repository identity"
+
+repo="$(make_repo invalid-selector)"
+write_config "$repo" '{"artifacts":{"specPlan":"database"}}'
+run_failure "$repo"
+assert_contains "$RUN_FAILURE_OUTPUT" 'artifacts.specPlan' "unsupported selector diagnostic names config path"
+assert_not_contains "$RUN_FAILURE_OUTPUT" 'database' "unsupported selector diagnostic does not echo config value"
+
+repo="$(make_repo invalid-json)"
+write_config "$repo" '{"artifacts":'
+run_failure "$repo"
+assert_contains "$RUN_FAILURE_OUTPUT" '.woostack/config.json' "malformed JSON diagnostic names only the config path"
+assert_not_contains "$RUN_FAILURE_OUTPUT" '{"artifacts":' "malformed JSON diagnostic does not echo config content"
+
+repo="$(make_repo invalid-artifacts-shape)"
+write_config "$repo" '{"artifacts":"not-an-object"}'
+run_failure "$repo"
+assert_contains "$RUN_FAILURE_OUTPUT" 'artifacts' "invalid artifacts object is diagnosed by path"
+assert_not_contains "$RUN_FAILURE_OUTPUT" 'not-an-object' "invalid artifacts diagnostic does not echo config value"
+
+for required_path in linear.workspace linear.team; do
+  repo="$(make_repo "missing-${required_path#linear.}")"
+  config="$(complete_linear_config acme/widgets)"
+  config="$(jq -c "del(.$required_path)" <<<"$config")"
+  write_config "$repo" "$config"
+  run_failure "$repo"
+  assert_contains "$RUN_FAILURE_OUTPUT" "$required_path" "missing $required_path is diagnosed"
+done
+
+assert_invalid_required_value() {
+  local path="$1"
+  local value="$2"
+  local label="$3"
+  repo="$(make_repo "invalid-required-$label")"
+  config="$(complete_linear_config acme/widgets)"
+  config="$(jq -c --arg path "$path" --argjson value "$value" 'setpath($path | split("."); $value)' <<<"$config")"
+  write_config "$repo" "$config"
+  run_failure "$repo"
+  assert_contains "$RUN_FAILURE_OUTPUT" "$path" "$label required-string value is rejected by path"
+}
+
+assert_invalid_required_value linear.workspace '123' workspace-number
+assert_invalid_required_value linear.workspace '""' workspace-empty
+assert_invalid_required_value linear.workspace '"   "' workspace-whitespace
+assert_invalid_required_value linear.team '{}' team-object
+assert_invalid_required_value linear.team '[]' team-array
+assert_invalid_required_value linear.team '"\t"' team-whitespace
+assert_invalid_required_value linear.projectStatuses.draft '""' project-status-empty
+assert_invalid_required_value linear.projectStatuses.draft '"  "' project-status-whitespace
+assert_invalid_required_value linear.issueStates.blocked 'null' issue-state-null
+assert_invalid_required_value linear.issueStates.blocked '{}' issue-state-object
+
+for mapping in draft hardened approved planning ready executing inReview "done" abandoned; do
+  repo="$(make_repo "missing-project-$mapping")"
+  config="$(complete_linear_config acme/widgets)"
+  config="$(jq -c --arg mapping "$mapping" 'del(.linear.projectStatuses[$mapping])' <<<"$config")"
+  write_config "$repo" "$config"
+  run_failure "$repo"
+  assert_contains "$RUN_FAILURE_OUTPUT" "linear.projectStatuses.$mapping" "missing project status $mapping is diagnosed"
+done
+
+for mapping in planned executing inReview "done" blocked; do
+  repo="$(make_repo "missing-issue-$mapping")"
+  config="$(complete_linear_config acme/widgets)"
+  config="$(jq -c --arg mapping "$mapping" 'del(.linear.issueStates[$mapping])' <<<"$config")"
+  write_config "$repo" "$config"
+  run_failure "$repo"
+  assert_contains "$RUN_FAILURE_OUTPUT" "linear.issueStates.$mapping" "missing issue state $mapping is diagnosed"
+done
+
+repo="$(make_repo missing-repository)"
+write_config "$repo" "$(complete_linear_config)"
+run_failure "$repo"
+assert_contains "$RUN_FAILURE_OUTPUT" 'linear.repository' "repository override is required without a GitHub origin"
+
+for invalid_repository in '123' '{}' '[]' '""' '"   "' '"../repo"' '"acme/.."' '"https:/github.com"' '"acme/repo/extra"'; do
+  repo="$(make_repo "invalid-repository-$PASS-$FAIL")"
+  git -C "$repo" remote add origin https://github.com/fallback/must-not-be-used.git
+  config="$(complete_linear_config)"
+  config="$(jq -c --argjson repository "$invalid_repository" '.linear.repository = $repository' <<<"$config")"
+  write_config "$repo" "$config"
+  run_failure "$repo"
+  assert_contains "$RUN_FAILURE_OUTPUT" 'linear.repository' "invalid explicit repository is rejected instead of falling back"
+  assert_not_contains "$RUN_FAILURE_OUTPUT" 'must-not-be-used' "repository diagnostic does not expose or select fallback remote"
+done
+
+secret_keys=(
+  apiKey
+  API_KEY
+  api_token
+  token
+  access-token
+  personal-token
+  Personal_Access_Token
+  credentialFile
+  credentials_path
+  Authorization
+  authorization_header
+  dbPassword
+  passwordHash
+  clientSecret
+  secretKey
+)
+secret_index=0
+for secret_key in "${secret_keys[@]}"; do
+  repo="$(make_repo "secret-$secret_index")"
+  config="$(complete_linear_config acme/widgets)"
+  secret_value="DO-NOT-LEAK-$secret_index"
+  config="$(jq -c --arg key "$secret_key" --arg value "$secret_value" '.linear.nested = [{safe: true}, {($key): $value}]' <<<"$config")"
+  write_config "$repo" "$config"
+  run_failure "$repo"
+  assert_contains "$RUN_FAILURE_OUTPUT" "$secret_key" "recursive credential-key rejection names only its path"
+  assert_not_contains "$RUN_FAILURE_OUTPUT" "$secret_value" "credential-key diagnostic does not leak its value"
+  secret_index=$((secret_index + 1))
+done
+
+assert_eq "$(jq -c '.artifacts' "$TEMPLATE")" '{"specPlan":"markdown"}' "config template selects Markdown by default"
+assert_eq "$(jq -r '[paths(scalars) as $p | ($p[-1] | tostring) | select(test("apiKey|token|credentialFile"; "i"))] | length' "$TEMPLATE")" '0' "config template contains no credential placeholders"
+
+write_feature_pair() {
+  local repo="$1"
+  local basename="$2"
+  local source_line="$3"
+  mkdir -p "$repo/.woostack/specs" "$repo/.woostack/plans"
+  cat > "$repo/.woostack/specs/$basename.md" <<EOF
+---
+name: ${basename#????-??-??-}
+type: spec
+status: approved
+date: 2026-07-12
+branch: feature/${basename#????-??-??-}
+---
+
+# Adapter spec
+
+Spec body.
+EOF
+  cat > "$repo/.woostack/plans/$basename.md" <<EOF
+---
+type: plan
+source: .woostack/specs/$basename.md
+status: executing
+branch: feature/${basename#????-??-??-}
+---
+
+$source_line
+
+# Adapter plan
+
+## Increment 2 - Second
+
+  - [x] completed task
+    - [ ] pending task
+
+## Increment 1 (stacked follow-up): First
+
+- [x] completed task
+- [x] completed follow-up
+
+\`\`\`\`markdown
+## Increment 99: fenced heading
+- [ ] fenced checkbox
+\`\`\`text
+- [ ] nested fenced checkbox
+\`\`\`
+\`\`\`\`
+
+## Increment 3: Third
+
+    - [ ] pending task
+
+## Increment 4: Partial plan at EOF
+
+Work remains to be decomposed.
+EOF
+}
+
+run_markdown_failure() {
+  local spec="$1"
+  local output
+  if output="$(bash "$MARKDOWN" feature "$spec" 2>&1)"; then
+    fail "Markdown adapter should reject invalid artifact join"
+    MARKDOWN_FAILURE_OUTPUT="$output"
+    return
+  fi
+  pass
+  MARKDOWN_FAILURE_OUTPUT="$output"
+}
+
+repo="$(make_repo markdown-canonical)"
+basename='2026-07-12-feature.v2+api_core'
+write_feature_pair "$repo" "$basename" "**Source:** [[specs/$basename]]"
+spec_path="$repo/.woostack/specs/$basename.md"
+spec_before="$(shasum -a 256 "$spec_path" | cut -d ' ' -f 1)"
+plan_before="$(shasum -a 256 "$repo/.woostack/plans/$basename.md" | cut -d ' ' -f 1)"
+actual="$(bash "$MARKDOWN" feature "$spec_path")"
+assert_eq "$(jq -c 'keys' <<<"$actual")" '["backend","feature","increments","spec"]' "Markdown model has deterministic top-level fields"
+assert_eq "$(jq -c '.backend' <<<"$actual")" '"markdown"' "Markdown model identifies its backend"
+assert_eq "$(jq -c '.feature | {id,url,title,status,branch}' <<<"$actual")" \
+  "$(jq -cn --arg id ".woostack/specs/$basename.md" --arg title 'feature.v2+api_core' --arg branch 'feature/feature.v2+api_core' '{id:$id,url:null,title:$title,status:"executing",branch:$branch}')" \
+  "canonical wikilink preserves feature identity, lifecycle status, and branch"
+assert_eq "$(jq -c '.spec | {id,url,content:(.content | contains("Spec body.")),revisionLength:(.revision | length)}' <<<"$actual")" \
+  "$(jq -cn --arg id ".woostack/specs/$basename.md" '{id:$id,url:null,content:true,revisionLength:64}')" \
+  "spec content and deterministic revision are normalized"
+assert_eq "$(jq -c '[.increments[] | {ordinal,status,dependencies,branch,pullRequest}]' <<<"$actual")" \
+  '[{"ordinal":1,"status":"done","dependencies":[],"branch":null,"pullRequest":null},{"ordinal":2,"status":"executing","dependencies":[],"branch":null,"pullRequest":null},{"ordinal":3,"status":"planned","dependencies":[],"branch":null,"pullRequest":null},{"ordinal":4,"status":"planned","dependencies":[],"branch":null,"pullRequest":null}]' \
+  "out-of-order plan sections are sorted by ordinal with matching checkbox-derived statuses"
+assert_eq "$(shasum -a 256 "$spec_path" | cut -d ' ' -f 1)" "$spec_before" "adapter does not rewrite the spec"
+assert_eq "$(shasum -a 256 "$repo/.woostack/plans/$basename.md" | cut -d ' ' -f 1)" "$plan_before" "adapter does not rewrite the plan"
+
+repo="$(make_repo markdown-legacy)"
+basename='2026-07-12-legacy.feature-test'
+write_feature_pair "$repo" "$basename" "**Source:** .woostack/specs/$basename.md"
+cat > "$repo/.woostack/plans/unrelated-example.md" <<EOF
+---
+type: plan
+status: planning
+branch: feature/unrelated
+---
+
+# Documentation example
+
+\`\`\`\`markdown
+**Source:** .woostack/specs/$basename.md
+## Increment 99: Example
+- [ ] example only
+\`\`\`
+\`\`\`\`
+EOF
+actual="$(bash "$MARKDOWN" feature "$repo/.woostack/specs/$basename.md")"
+assert_eq "$(jq -r '.feature.id' <<<"$actual")" ".woostack/specs/$basename.md" "legacy source line resolves the plan"
+assert_eq "$(jq -r '.increments | length' <<<"$actual")" '4' "legacy plan emits every increment including a partial final section"
+assert_eq "$(jq -r '.increments | map(.ordinal) | join(",")' <<<"$actual")" '1,2,3,4' "fenced example headings are ignored"
+
+repo="$(make_repo markdown-large-plan)"
+basename='2026-07-12-large-plan'
+write_feature_pair "$repo" "$basename" "**Source:** [[specs/$basename]]"
+awk 'BEGIN { for (i=0; i<20000; i++) print "Large trailing body line " i }' >> "$repo/.woostack/plans/$basename.md"
+actual="$(bash "$MARKDOWN" feature "$repo/.woostack/specs/$basename.md")"
+assert_eq "$(jq -r '.increments | length' <<<"$actual")" '4' "large valid plans resolve without a pipefail SIGPIPE"
+
+repo="$(make_repo markdown-missing)"
+mkdir -p "$repo/.woostack/specs" "$repo/.woostack/plans"
+printf '%s\n' '---' 'name: orphan' 'type: spec' 'status: approved' 'branch: feature/orphan' '---' '# Orphan' > "$repo/.woostack/specs/2026-07-12-orphan.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-orphan.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'plan' "missing plan join is diagnosed"
+
+repo="$(make_repo markdown-duplicate)"
+write_feature_pair "$repo" '2026-07-12-duplicate' '**Source:** [[specs/2026-07-12-duplicate]]'
+cp "$repo/.woostack/plans/2026-07-12-duplicate.md" "$repo/.woostack/plans/another-plan.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-duplicate.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'multiple' "duplicate plan joins are rejected"
+
+repo="$(make_repo markdown-malformed)"
+mkdir -p "$repo/.woostack/specs"
+printf '%s\n' 'name: malformed' '# no frontmatter' > "$repo/.woostack/specs/2026-07-12-malformed.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-malformed.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'frontmatter' "malformed spec frontmatter is rejected"
+
+repo="$(make_repo markdown-unterminated-spec)"
+mkdir -p "$repo/.woostack/specs"
+printf '%s\n' '---' 'name: unterminated' 'type: spec' 'status: approved' '# no closing fence' > "$repo/.woostack/specs/2026-07-12-unterminated.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-unterminated.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'frontmatter' "unterminated spec frontmatter is rejected"
+
+repo="$(make_repo markdown-malformed-plan)"
+write_feature_pair "$repo" '2026-07-12-malformed-plan' '**Source:** [[specs/2026-07-12-malformed-plan]]'
+printf '%s\n' '**Source:** [[specs/2026-07-12-malformed-plan]]' '# no frontmatter' > "$repo/.woostack/plans/2026-07-12-malformed-plan.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-malformed-plan.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'frontmatter' "joined plan without frontmatter is rejected"
+
+repo="$(make_repo markdown-unterminated-plan)"
+write_feature_pair "$repo" '2026-07-12-unterminated-plan' '**Source:** [[specs/2026-07-12-unterminated-plan]]'
+printf '%s\n' '---' 'type: plan' 'status: planning' '**Source:** [[specs/2026-07-12-unterminated-plan]]' '# no closing fence' > "$repo/.woostack/plans/2026-07-12-unterminated-plan.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-unterminated-plan.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'frontmatter' "unterminated joined-plan frontmatter is rejected"
+
+repo="$(make_repo markdown-duplicate-ordinal)"
+write_feature_pair "$repo" '2026-07-12-duplicate-ordinal' '**Source:** [[specs/2026-07-12-duplicate-ordinal]]'
+cat >> "$repo/.woostack/plans/2026-07-12-duplicate-ordinal.md" <<'EOF'
+
+## Increment 2: Duplicate
+
+- [ ] duplicate ordinal
+EOF
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-duplicate-ordinal.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'increments' "duplicate increment ordinals fail normalization"
+
+repo="$(make_repo markdown-zero-increments)"
+write_feature_pair "$repo" '2026-07-12-zero-increments' '**Source:** [[specs/2026-07-12-zero-increments]]'
+awk '/^## Increment / { exit } { print }' "$repo/.woostack/plans/2026-07-12-zero-increments.md" > "$repo/.woostack/plans/zero.tmp"
+mv "$repo/.woostack/plans/zero.tmp" "$repo/.woostack/plans/2026-07-12-zero-increments.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-zero-increments.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'increments' "plans with zero increments fail closed"
+
+repo="$(make_repo markdown-spec-symlink)"
+mkdir -p "$repo/.woostack/specs" "$repo/.woostack/plans" "$repo/outside"
+printf '%s\n' '---' 'name: escaped' 'type: spec' 'status: approved' '---' '# escaped' > "$repo/outside/escaped.md"
+ln -s "$repo/outside/escaped.md" "$repo/.woostack/specs/2026-07-12-escaped.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-escaped.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'symlink' "spec symlink escapes are rejected"
+
+repo="$(make_repo markdown-plan-symlink)"
+write_feature_pair "$repo" '2026-07-12-plan-link' '**Source:** [[specs/2026-07-12-plan-link]]'
+mv "$repo/.woostack/plans/2026-07-12-plan-link.md" "$repo/outside-plan.md"
+ln -s "$repo/outside-plan.md" "$repo/.woostack/plans/2026-07-12-plan-link.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-plan-link.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'symlink' "plan symlink escapes are rejected"
+
+finish

--- a/skills/woostack-init/scripts/tests/test-artifact-backends.sh
+++ b/skills/woostack-init/scripts/tests/test-artifact-backends.sh
@@ -67,6 +67,10 @@ run_failure() {
   RUN_FAILURE_OUTPUT="$output"
 }
 
+repo="$(make_repo missing-config)"
+actual="$(bash "$SCRIPT" "$repo")"
+assert_eq "$actual" '{"backend":"markdown","repository":null,"linear":null}' "absent config defaults to Markdown"
+
 repo="$(make_repo default-markdown)"
 write_config "$repo" '{}'
 actual="$(bash "$SCRIPT" "$repo")"
@@ -76,6 +80,13 @@ repo="$(make_repo explicit-markdown)"
 write_config "$repo" '{"artifacts":{"specPlan":"markdown"}}'
 actual="$(bash "$SCRIPT" "$repo")"
 assert_eq "$actual" '{"backend":"markdown","repository":null,"linear":null}' "explicit Markdown resolves without Linear config"
+
+repo="$(make_repo markdown-secret)"
+secret_value='DO-NOT-LEAK-MARKDOWN'
+write_config "$repo" "$(jq -cn --arg value "$secret_value" '{artifacts:{specPlan:"markdown"},linear:{nested:{apiKey:$value}}}')"
+run_failure "$repo"
+assert_contains "$RUN_FAILURE_OUTPUT" 'linear.nested.apiKey' "Markdown mode still rejects Linear credential keys"
+assert_not_contains "$RUN_FAILURE_OUTPUT" "$secret_value" "Markdown credential diagnostic does not leak its value"
 
 repo="$(make_repo linear-override)"
 git -C "$repo" remote add origin https://github.com/ignored/by-override.git
@@ -194,6 +205,15 @@ for invalid_repository in '123' '{}' '[]' '""' '"   "' '"../repo"' '"acme/.."' '
   assert_not_contains "$RUN_FAILURE_OUTPUT" 'must-not-be-used' "repository diagnostic does not expose or select fallback remote"
 done
 
+repo="$(make_repo unknown-linear-key)"
+config="$(complete_linear_config acme/widgets)"
+unknown_value='DO-NOT-LEAK-UNKNOWN'
+config="$(jq -c --arg value "$unknown_value" '.linear.auth = $value' <<<"$config")"
+write_config "$repo" "$config"
+run_failure "$repo"
+assert_contains "$RUN_FAILURE_OUTPUT" 'linear.auth' "unknown Linear keys are rejected by path"
+assert_not_contains "$RUN_FAILURE_OUTPUT" "$unknown_value" "unknown-key diagnostic does not leak its value"
+
 secret_keys=(
   apiKey
   API_KEY
@@ -202,6 +222,8 @@ secret_keys=(
   access-token
   personal-token
   Personal_Access_Token
+  privateKey
+  accessKey
   credentialFile
   credentials_path
   Authorization
@@ -225,7 +247,7 @@ for secret_key in "${secret_keys[@]}"; do
 done
 
 assert_eq "$(jq -c '.artifacts' "$TEMPLATE")" '{"specPlan":"markdown"}' "config template selects Markdown by default"
-assert_eq "$(jq -r '[paths(scalars) as $p | ($p[-1] | tostring) | select(test("apiKey|token|credentialFile"; "i"))] | length' "$TEMPLATE")" '0' "config template contains no credential placeholders"
+assert_eq "$(jq -r '[paths(scalars) as $p | ($p[-1] | tostring | ascii_downcase | gsub("[^a-z0-9]"; "")) | select(test("(apikey|token|credentials?(file|path)|authorization|password|secret|privatekey|accesskey)"))] | length' "$TEMPLATE")" '0' "config template contains no credential placeholders"
 
 write_feature_pair() {
   local repo="$1"
@@ -253,9 +275,9 @@ status: executing
 branch: feature/${basename#????-??-??-}
 ---
 
-$source_line
-
 # Adapter plan
+
+$source_line
 
 ## Increment 2 - Second
 
@@ -274,6 +296,11 @@ $source_line
 - [ ] nested fenced checkbox
 \`\`\`
 \`\`\`\`
+
+~~~markdown
+## Increment 98: tilde-fenced heading
+- [ ] tilde-fenced checkbox
+~~~~
 
 ## Increment 3: Third
 
@@ -309,14 +336,33 @@ assert_eq "$(jq -c '.backend' <<<"$actual")" '"markdown"' "Markdown model identi
 assert_eq "$(jq -c '.feature | {id,url,title,status,branch}' <<<"$actual")" \
   "$(jq -cn --arg id ".woostack/specs/$basename.md" --arg title 'feature.v2+api_core' --arg branch 'feature/feature.v2+api_core' '{id:$id,url:null,title:$title,status:"executing",branch:$branch}')" \
   "canonical wikilink preserves feature identity, lifecycle status, and branch"
-assert_eq "$(jq -c '.spec | {id,url,content:(.content | contains("Spec body.")),revisionLength:(.revision | length)}' <<<"$actual")" \
-  "$(jq -cn --arg id ".woostack/specs/$basename.md" '{id:$id,url:null,content:true,revisionLength:64}')" \
-  "spec content and deterministic revision are normalized"
-assert_eq "$(jq -c '[.increments[] | {ordinal,status,dependencies,branch,pullRequest}]' <<<"$actual")" \
-  '[{"ordinal":1,"status":"done","dependencies":[],"branch":null,"pullRequest":null},{"ordinal":2,"status":"executing","dependencies":[],"branch":null,"pullRequest":null},{"ordinal":3,"status":"planned","dependencies":[],"branch":null,"pullRequest":null},{"ordinal":4,"status":"planned","dependencies":[],"branch":null,"pullRequest":null}]' \
-  "out-of-order plan sections are sorted by ordinal with matching checkbox-derived statuses"
+assert_eq "$(jq -c '.spec | {id,url,content:(.content | contains("Spec body."))}' <<<"$actual")" \
+  "$(jq -cn --arg id ".woostack/specs/$basename.md" '{id:$id,url:null,content:true}')" \
+  "spec content is normalized"
+assert_eq "$(jq -r '.spec.revision' <<<"$actual")" "$spec_before" "spec revision is the deterministic content digest"
+assert_eq "$(jq -c '[.increments[] | keys]' <<<"$actual")" \
+  '[["branch","content","dependencies","id","identifier","ordinal","pullRequest","status"],["branch","content","dependencies","id","identifier","ordinal","pullRequest","status"],["branch","content","dependencies","id","identifier","ordinal","pullRequest","status"],["branch","content","dependencies","id","identifier","ordinal","pullRequest","status"]]' \
+  "every increment exposes the complete normalized contract"
+assert_eq "$(jq -c '[.increments[] | {id,identifier,ordinal,status,dependencies,branch,pullRequest}]' <<<"$actual")" \
+  "$(jq -cn --arg plan ".woostack/plans/$basename.md" '[
+    {id:($plan + "#increment-1"),identifier:null,ordinal:1,status:"done",dependencies:[],branch:null,pullRequest:null},
+    {id:($plan + "#increment-2"),identifier:null,ordinal:2,status:"executing",dependencies:[],branch:null,pullRequest:null},
+    {id:($plan + "#increment-3"),identifier:null,ordinal:3,status:"planned",dependencies:[],branch:null,pullRequest:null},
+    {id:($plan + "#increment-4"),identifier:null,ordinal:4,status:"planned",dependencies:[],branch:null,pullRequest:null}
+  ]')" \
+  "out-of-order plan sections have deterministic IDs and checkbox-derived statuses"
+assert_eq "$(jq -c '[
+  (.increments[0].content | contains("completed follow-up") and contains("tilde-fenced heading") and (contains("Second") | not)),
+  (.increments[1].content | contains("completed task") and (contains("First") | not)),
+  (.increments[2].content | contains("pending task") and (contains("Partial plan") | not)),
+  (.increments[3].content == "Work remains to be decomposed.")
+]' <<<"$actual")" '[true,true,true,true]' "increment content preserves each section boundary"
 assert_eq "$(shasum -a 256 "$spec_path" | cut -d ' ' -f 1)" "$spec_before" "adapter does not rewrite the spec"
 assert_eq "$(shasum -a 256 "$repo/.woostack/plans/$basename.md" | cut -d ' ' -f 1)" "$plan_before" "adapter does not rewrite the plan"
+printf '\nChanged spec body.\n' >> "$spec_path"
+changed_spec_revision="$(shasum -a 256 "$spec_path" | cut -d ' ' -f 1)"
+changed_actual="$(bash "$MARKDOWN" feature "$spec_path")"
+assert_eq "$(jq -r '.spec.revision' <<<"$changed_actual")" "$changed_spec_revision" "spec revision changes with content"
 
 repo="$(make_repo markdown-legacy)"
 basename='2026-07-12-legacy.feature-test'
@@ -337,10 +383,44 @@ branch: feature/unrelated
 \`\`\`
 \`\`\`\`
 EOF
+
 actual="$(bash "$MARKDOWN" feature "$repo/.woostack/specs/$basename.md")"
 assert_eq "$(jq -r '.feature.id' <<<"$actual")" ".woostack/specs/$basename.md" "legacy source line resolves the plan"
 assert_eq "$(jq -r '.increments | length' <<<"$actual")" '4' "legacy plan emits every increment including a partial final section"
 assert_eq "$(jq -r '.increments | map(.ordinal) | join(",")' <<<"$actual")" '1,2,3,4' "fenced example headings are ignored"
+
+repo="$(make_repo markdown-annotated-source)"
+basename='2026-07-12-annotated-source'
+write_feature_pair "$repo" "$basename" "**Source:** [[specs/$basename]] (stacked feature)"
+mv "$repo/.woostack/plans/$basename.md" "$repo/.woostack/plans/different-plan-name.md"
+actual="$(bash "$MARKDOWN" feature "$repo/.woostack/specs/$basename.md")"
+assert_eq "$(jq -r '.feature.id' <<<"$actual")" ".woostack/specs/$basename.md" "annotated canonical source resolves a differently named plan"
+
+repo="$(make_repo markdown-canonical-md)"
+basename='2026-07-12-canonical-md'
+write_feature_pair "$repo" "$basename" "**Source:** [[specs/$basename.md]]"
+mv "$repo/.woostack/plans/$basename.md" "$repo/.woostack/plans/different-md-plan-name.md"
+actual="$(bash "$MARKDOWN" feature "$repo/.woostack/specs/$basename.md")"
+assert_eq "$(jq -r '.feature.id' <<<"$actual")" ".woostack/specs/$basename.md" "optional .md wikilink resolves a differently named plan"
+
+repo="$(make_repo markdown-basename-fallback)"
+basename='2026-07-12-basename-fallback'
+write_feature_pair "$repo" "$basename" ""
+actual="$(bash "$MARKDOWN" feature "$repo/.woostack/specs/$basename.md")"
+assert_eq "$(jq -r '.feature.id' <<<"$actual")" ".woostack/specs/$basename.md" "same-basename plan resolves without a Source line"
+
+repo="$(make_repo markdown-slug-fallback)"
+basename='2026-07-12-slug-fallback'
+write_feature_pair "$repo" "$basename" ""
+mv "$repo/.woostack/plans/$basename.md" "$repo/.woostack/plans/2026-07-13-slug-fallback.md"
+actual="$(bash "$MARKDOWN" feature "$repo/.woostack/specs/$basename.md")"
+assert_eq "$(jq -r '.feature.id' <<<"$actual")" ".woostack/specs/$basename.md" "date-stripped slug fallback preserves legacy joins"
+
+repo="$(make_repo markdown-slug-fallback-owned)"
+write_feature_pair "$repo" '2026-07-13-owned-slug' '**Source:** [[specs/2026-07-13-owned-slug]]'
+cp "$repo/.woostack/specs/2026-07-13-owned-slug.md" "$repo/.woostack/specs/2026-07-12-owned-slug.md"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-owned-slug.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'matching plan not found' "slug fallback excludes plans explicitly owned by another spec"
 
 repo="$(make_repo markdown-large-plan)"
 basename='2026-07-12-large-plan'
@@ -396,12 +476,26 @@ EOF
 run_markdown_failure "$repo/.woostack/specs/2026-07-12-duplicate-ordinal.md"
 assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'increments' "duplicate increment ordinals fail normalization"
 
-repo="$(make_repo markdown-zero-increments)"
-write_feature_pair "$repo" '2026-07-12-zero-increments' '**Source:** [[specs/2026-07-12-zero-increments]]'
-awk '/^## Increment / { exit } { print }' "$repo/.woostack/plans/2026-07-12-zero-increments.md" > "$repo/.woostack/plans/zero.tmp"
-mv "$repo/.woostack/plans/zero.tmp" "$repo/.woostack/plans/2026-07-12-zero-increments.md"
-run_markdown_failure "$repo/.woostack/specs/2026-07-12-zero-increments.md"
-assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'increments' "plans with zero increments fail closed"
+repo="$(make_repo markdown-headingless)"
+basename='2026-07-12-headingless'
+write_feature_pair "$repo" "$basename" "**Source:** [[specs/$basename]]"
+cat > "$repo/.woostack/plans/$basename.md" <<EOF
+---
+type: plan
+status: executing
+branch: feature/headingless
+---
+
+# Legacy plan
+
+**Source:** [[specs/$basename]]
+
+- [x] completed legacy task
+- [ ] pending legacy task
+EOF
+actual="$(bash "$MARKDOWN" feature "$repo/.woostack/specs/$basename.md")"
+assert_eq "$(jq -c '.increments | map({ordinal,status,content:(.content | contains("Legacy plan") and contains("pending legacy task"))})' <<<"$actual")" \
+  '[{"ordinal":1,"status":"executing","content":true}]' "headingless legacy plan becomes one checkbox-derived increment"
 
 repo="$(make_repo markdown-spec-symlink)"
 mkdir -p "$repo/.woostack/specs" "$repo/.woostack/plans" "$repo/outside"
@@ -409,6 +503,22 @@ printf '%s\n' '---' 'name: escaped' 'type: spec' 'status: approved' '---' '# esc
 ln -s "$repo/outside/escaped.md" "$repo/.woostack/specs/2026-07-12-escaped.md"
 run_markdown_failure "$repo/.woostack/specs/2026-07-12-escaped.md"
 assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'symlink' "spec symlink escapes are rejected"
+
+repo="$(make_repo markdown-directory-symlink)"
+outside_repo="$(make_repo markdown-directory-target)"
+write_feature_pair "$outside_repo" '2026-07-12-directory-link' '**Source:** [[specs/2026-07-12-directory-link]]'
+ln -s "$outside_repo/.woostack/specs" "$repo/.woostack/specs"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-directory-link.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'symlink' "spec directory symlink escapes are rejected"
+
+repo="$(make_repo markdown-plan-directory-symlink)"
+outside_repo="$(make_repo markdown-plan-directory-target)"
+write_feature_pair "$repo" '2026-07-12-plan-directory-link' '**Source:** [[specs/2026-07-12-plan-directory-link]]'
+write_feature_pair "$outside_repo" '2026-07-12-plan-directory-link' '**Source:** [[specs/2026-07-12-plan-directory-link]]'
+rm -rf "$repo/.woostack/plans"
+ln -s "$outside_repo/.woostack/plans" "$repo/.woostack/plans"
+run_markdown_failure "$repo/.woostack/specs/2026-07-12-plan-directory-link.md"
+assert_contains "$MARKDOWN_FAILURE_OUTPUT" 'symlink' "plan directory symlink escapes are rejected"
 
 repo="$(make_repo markdown-plan-symlink)"
 write_feature_pair "$repo" '2026-07-12-plan-link' '**Source:** [[specs/2026-07-12-plan-link]]'

--- a/skills/woostack-init/templates/config.json
+++ b/skills/woostack-init/templates/config.json
@@ -1,4 +1,7 @@
 {
+  "artifacts": {
+    "specPlan": "markdown"
+  },
   "models": {},
   "review": {},
   "respond": {},


### PR DESCRIPTION
## Goal

Introduce the artifact-backend resolver and normalized, read-only Markdown adapter while preserving Markdown as the backward-compatible default.

## Summary

- Resolve the configured spec/plan backend and validate complete, secret-free Linear configuration plus canonical repository identity.
- Keep Markdown as the default and add a normalized, read-only Markdown feature model.
- Preserve existing source joins and increment heading forms while ignoring fenced examples, rejecting ambiguous identities, and enforcing artifact containment.
- Add deterministic offline coverage for backend configuration, secret rejection, repository identity, Markdown compatibility, and parser edge cases.

## Test plan

### Automated

- [ ] `bash skills/woostack-init/scripts/tests/test-artifact-backends.sh` (175 passed, 0 failed)
- [ ] `bash skills/woostack-init/scripts/tests/run-tests.sh` (all 12 suites passed)
- [ ] `bash -n` on changed shell scripts (passed)
- [ ] `shellcheck` on changed shell scripts (passed)
- [ ] Task-scoped spec-compliance and code-quality reviews (passed)

### Manual

**Before merge**

- [ ] Confirm the diff contains no credentials or secret Linear configuration values.
- [ ] Confirm the PR is stacked on `feature/linear-artifact-backend`.

Spec: .woostack/specs/2026-07-11-linear-artifact-backend.md