### PR TITLE
Manage Linear feature projects and specification documents

### DIFF
--- a/.woostack/plans/2026-07-11-linear-artifact-backend.md
+++ b/.woostack/plans/2026-07-11-linear-artifact-backend.md
@@ -160,27 +160,27 @@ branch: feature/linear-artifact-backend
 - Create: `skills/woostack-init/scripts/tests/fixtures/linear/project-*.json`
 - Create: `skills/woostack-init/scripts/tests/fixtures/linear/document-*.json`
 
-- [ ] **Step 1: Add failing feature discovery tests**
+- [x] **Step 1: Add failing feature discovery tests**
   Test explicit UUID, Linear URL, and repository/status discovery. Exactly one eligible managed project succeeds; zero returns not-found; multiple returns a deterministic candidate list containing UUID/title/status/URL; same titles and foreign repository markers never resolve implicitly.
 
-- [ ] **Step 2: Add failing create/resume tests**
+- [x] **Step 2: Add failing create/resume tests**
   Simulate project create, unknown mutation outcome, discovery of the created project, spec document create, document read-back, duplicate managed resources, and retry after partial completion. Assert no duplicate create mutation occurs and each successful mutation emits a receipt with observed, attempted, returned, verified, and pending fields.
 
-- [ ] **Step 3: Run resource tests red**
+- [x] **Step 3: Run resource tests red**
   Run: `bash skills/woostack-init/scripts/tests/test-linear-resources.sh`
   Expected: FAIL because `linear.sh` and operation documents do not exist.
 
-- [ ] **Step 4: Implement project/spec commands**
+- [x] **Step 4: Implement project/spec commands**
   Implement `linear.sh preflight`, `feature-resolve`, `feature-create`, `feature-transition`, `spec-read`, and `spec-write`. Call only `linear-request.sh`; use discovery-before-create; verify repository/schema markers; compare revisions before update; use canonical metadata replacement; and read back every mutation. Never accept title-only adoption.
 
-- [ ] **Step 5: Implement required lifecycle enforcement**
+- [x] **Step 5: Implement required lifecycle enforcement**
   Resolve every semantic project status uniquely and require `abandoned`. `feature-transition` permits only workflow-valid forward transitions plus explicit abandon, rejects archive/delete behavior, and includes current/target status in its receipt.
 
-- [ ] **Step 6: Run resource and transport suites**
+- [x] **Step 6: Run resource and transport suites**
   Run: `bash skills/woostack-init/scripts/tests/test-linear-resources.sh && bash skills/woostack-init/scripts/tests/test-linear-transport.sh && bash skills/woostack-init/scripts/tests/test-linear-metadata.sh`
   Expected: PASS.
 
-- [ ] **Step 7: Commit Increment 3**
+- [x] **Step 7: Commit Increment 3**
   Run: `gt create -m "feat(linear): manage feature projects and specs"`
   Expected: one PR that can preflight, create, resume, harden, approve, and abandon a Linear feature/spec without plan issues.
 

--- a/skills/woostack-init/scripts/artifacts/graphql/document-create.graphql
+++ b/skills/woostack-init/scripts/artifacts/graphql/document-create.graphql
@@ -1,0 +1,12 @@
+mutation WoostackDocumentCreate($input: DocumentCreateInput!) {
+  documentCreate(input: $input) {
+    success
+    document {
+      id
+      title
+      url
+      updatedAt
+      project { id }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/artifacts/graphql/document-list.graphql
+++ b/skills/woostack-init/scripts/artifacts/graphql/document-list.graphql
@@ -1,0 +1,13 @@
+query WoostackDocumentList($projectId: ID!, $after: String) {
+  documents(first: 250, after: $after, filter: { project: { id: { eq: $projectId } } }) {
+    nodes {
+      id
+      title
+      url
+      content
+      updatedAt
+      project { id }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}

--- a/skills/woostack-init/scripts/artifacts/graphql/document-update.graphql
+++ b/skills/woostack-init/scripts/artifacts/graphql/document-update.graphql
@@ -1,0 +1,12 @@
+mutation WoostackDocumentUpdate($id: String!, $input: DocumentUpdateInput!) {
+  documentUpdate(id: $id, input: $input) {
+    success
+    document {
+      id
+      title
+      url
+      updatedAt
+      project { id }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/artifacts/graphql/project-create.graphql
+++ b/skills/woostack-init/scripts/artifacts/graphql/project-create.graphql
@@ -1,0 +1,14 @@
+mutation WoostackProjectCreate($input: ProjectCreateInput!) {
+  projectCreate(input: $input) {
+    success
+    project {
+      id
+      name
+      url
+      description
+      archivedAt
+      updatedAt
+      status { id name }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/artifacts/graphql/project-list.graphql
+++ b/skills/woostack-init/scripts/artifacts/graphql/project-list.graphql
@@ -1,0 +1,14 @@
+query WoostackProjectList($after: String) {
+  projects(first: 250, after: $after, includeArchived: true) {
+    nodes {
+      id
+      name
+      url
+      description
+      archivedAt
+      updatedAt
+      status { id name }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}

--- a/skills/woostack-init/scripts/artifacts/graphql/project-update.graphql
+++ b/skills/woostack-init/scripts/artifacts/graphql/project-update.graphql
@@ -1,0 +1,14 @@
+mutation WoostackProjectUpdate($id: String!, $input: ProjectUpdateInput!) {
+  projectUpdate(id: $id, input: $input) {
+    success
+    project {
+      id
+      name
+      url
+      description
+      archivedAt
+      updatedAt
+      status { id name }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/artifacts/linear.sh
+++ b/skills/woostack-init/scripts/artifacts/linear.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GRAPHQL="$HERE/graphql"
+REQUEST="${LINEAR_REQUEST_SH:-$HERE/linear-request.sh}"
+METADATA="$HERE/linear-metadata.py"
+UUID_RE='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
+REQUIRED_STATUSES='["draft","hardened","approved","planning","ready","executing","inReview","done","abandoned"]'
+ACTIVE_STATUSES='["draft","hardened","approved","planning","ready","executing","inReview"]'
+
+fail() { printf 'linear resources: %s\n' "$1" >&2; exit 1; }
+usage() {
+  cat >&2 <<'USAGE'
+usage: linear.sh <command> [options]
+commands:
+  preflight --workspace NAME --team KEY --project-statuses JSON --issue-states JSON
+  feature-resolve --repository OWNER/REPO --status-map JSON --eligible-statuses JSON [--reference UUID|LINEAR_URL]
+  feature-create --repository OWNER/REPO --title TITLE --team-id UUID --status-map JSON --spec-file PATH
+  feature-transition --project UUID --repository OWNER/REPO --status-map JSON --target STATUS
+  spec-read --project UUID --repository OWNER/REPO
+  spec-write --project UUID --repository OWNER/REPO --content-file PATH --expected-revision JSON
+USAGE
+  exit 2
+}
+
+require_uuid() { [[ "$1" =~ $UUID_RE ]] || fail "$2 is not a UUID"; }
+require_repository() {
+  [[ "$1" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || fail "repository identity is invalid"
+}
+validate_status_map() {
+  local value="$1"
+  jq -e --argjson required "$REQUIRED_STATUSES" '
+    type == "object" and
+    ((keys | sort) == ($required | sort)) and
+    ([.[]] | length == (unique | length)) and
+    all(.[]; type == "string" and test("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"))
+  ' >/dev/null 2>&1 <<<"$value" || fail "project status map is incomplete or invalid"
+}
+project_marker() {
+  jq -cnS --arg repository "$1" '{repository:$repository,schema:1}' |
+    { printf '%s\n' '+++ Woostack project metadata — managed, do not edit'; cat; printf '%s\n' '+++'; }
+}
+
+request_query() { "$REQUEST" --operation query --document "$1" --variables "$2"; }
+request_mutation() { "$REQUEST" --operation mutation --document "$1" --variables "$2"; }
+
+project_list() {
+  local after='' next='' response nodes='[]' page after_json seen='[]'
+  while :; do
+    after_json=null; [[ -z "$after" ]] || after_json="$(jq -Rn --arg value "$after" '$value')"
+    response="$(request_query "$GRAPHQL/project-list.graphql" "$(jq -cn --argjson after "$after_json" '{after:$after}')")" || return 1
+    jq -e 'type=="object" and (.data.projects.nodes|type=="array") and (.data.projects.pageInfo.hasNextPage|type=="boolean")' >/dev/null 2>&1 <<<"$response" || fail "project list response is invalid"
+    page="$(jq -c '.data.projects.nodes' <<<"$response")"
+    nodes="$(jq -cn --argjson left "$nodes" --argjson right "$page" '$left+$right')"
+    [[ "$(jq -r '.data.projects.pageInfo.hasNextPage' <<<"$response")" == true ]] || break
+    next="$(jq -r '.data.projects.pageInfo.endCursor // empty' <<<"$response")"
+    [[ -n "$next" ]] || fail "project list pagination cursor is missing"
+    jq -e --arg cursor "$next" 'index($cursor)==null' >/dev/null <<<"$seen" || fail "project list pagination cursor repeated"
+    seen="$(jq -c --arg cursor "$next" '.+[$cursor]' <<<"$seen")"
+    after="$next"
+  done
+  jq -cn --argjson nodes "$nodes" '{nodes:$nodes}'
+}
+
+document_list() {
+  local project_id="$1" after='' next='' response nodes='[]' page after_json seen='[]'
+  while :; do
+    after_json=null; [[ -z "$after" ]] || after_json="$(jq -Rn --arg value "$after" '$value')"
+    response="$(request_query "$GRAPHQL/document-list.graphql" "$(jq -cn --arg projectId "$project_id" --argjson after "$after_json" '{projectId:$projectId,after:$after}')")" || return 1
+    jq -e --arg id "$project_id" 'type=="object" and (.data.documents.nodes|type=="array") and (.data.documents.pageInfo.hasNextPage|type=="boolean") and all(.data.documents.nodes[]; .project.id==$id)' >/dev/null 2>&1 <<<"$response" || fail "document list response is invalid"
+    page="$(jq -c '.data.documents.nodes' <<<"$response")"
+    nodes="$(jq -cn --argjson left "$nodes" --argjson right "$page" '$left+$right')"
+    [[ "$(jq -r '.data.documents.pageInfo.hasNextPage' <<<"$response")" == true ]] || break
+    next="$(jq -r '.data.documents.pageInfo.endCursor // empty' <<<"$response")"
+    [[ -n "$next" ]] || fail "document list pagination cursor is missing"
+    jq -e --arg cursor "$next" 'index($cursor)==null' >/dev/null <<<"$seen" || fail "document list pagination cursor repeated"
+    seen="$(jq -c --arg cursor "$next" '.+[$cursor]' <<<"$seen")"
+    after="$next"
+  done
+  jq -cn --argjson nodes "$nodes" '{nodes:$nodes}'
+}
+
+managed_projects() {
+  local projects="$1" repository="$2" status_map="$3" eligible="$4" marker
+  marker="$(project_marker "$repository")"
+  jq -c --arg marker "$marker" --argjson statuses "$status_map" --argjson eligible "$eligible" '
+    [.nodes[] |
+      select(.archivedAt == null) |
+      . as $project |
+      ($statuses | to_entries[] | select(.value == $project.status.id) | .key) as $semantic |
+      select(any($eligible[]; . == $semantic)) |
+      select(.description == $marker) |
+      {id,name,url,status:$semantic,statusId:.status.id,updatedAt}
+    ] | sort_by(.id)
+  ' <<<"$projects"
+}
+
+resolve_from_list() {
+  local projects="$1" repository="$2" status_map="$3" eligible="$4" reference="${5:-}" candidates count wanted raw marker
+  marker="$(project_marker "$repository")"
+  if [[ -n "$reference" ]]; then
+    if [[ "$reference" =~ $UUID_RE ]]; then
+      wanted="$(printf '%s' "$reference" | tr '[:upper:]' '[:lower:]')"
+      raw="$(jq -c --arg id "$wanted" '[.nodes[] | select((.id|ascii_downcase)==$id)]' <<<"$projects")"
+    elif [[ "$reference" == https://linear.app/* ]]; then
+      raw="$(jq -c --arg url "$reference" '[.nodes[] | select(.url==$url)]' <<<"$projects")"
+      wanted="$(jq -r 'if length==1 then (.[0].id|ascii_downcase) else "" end' <<<"$raw")"
+    else
+      fail "feature reference must be an explicit UUID or exact Linear URL"
+    fi
+    count="$(jq 'length' <<<"$raw")"
+    [[ "$count" -eq 1 ]] || { printf 'linear resources: feature not found\n' >&2; return 3; }
+    jq -e --arg marker "$marker" '.[] | .archivedAt==null and .description==$marker' >/dev/null 2>&1 <<<"$raw" || fail "project ownership or schema marker mismatch"
+    candidates="$(managed_projects "$projects" "$repository" "$status_map" "$eligible")"
+    jq -e --arg id "$wanted" 'any(.[]; (.id|ascii_downcase)==$id)' >/dev/null 2>&1 <<<"$candidates" || fail "project is not in an eligible lifecycle status"
+    jq -c --arg id "$wanted" '.[] | select((.id|ascii_downcase)==$id)' <<<"$candidates"
+    return
+  fi
+  candidates="$(managed_projects "$projects" "$repository" "$status_map" "$eligible")"
+  count="$(jq 'length' <<<"$candidates")"
+  case "$count" in
+    0) printf 'linear resources: feature not found\n' >&2; return 3 ;;
+    1) jq -c '.[0]' <<<"$candidates" ;;
+    *)
+      jq -r '.[] | "candidate id=\(.id) title=\(.name|@json) status=\(.status) url=\(.url)"' <<<"$candidates" >&2
+      return 4
+      ;;
+  esac
+}
+
+find_spec() {
+  local project_id="$1" repository="$2" documents="$3" tmp matches='[]' parsed doc
+  tmp="$(mktemp)"
+  while IFS= read -r doc; do
+    jq -j '.content' <<<"$doc" >"$tmp"
+    if grep -qF '+++ Woostack metadata — managed, do not edit' "$tmp"; then
+      if ! parsed="$(python3 "$METADATA" parse --repository "$repository" --project-id "$project_id" <"$tmp" 2>/dev/null)"; then
+        rm -f "$tmp"
+        fail "managed spec metadata is invalid or has foreign ownership"
+      fi
+      [[ "$(jq -r '.artifactType' <<<"$parsed")" == spec ]] || { rm -f "$tmp"; fail "managed spec metadata has the wrong artifact type"; }
+      matches="$(jq -cn --argjson old "$matches" --argjson doc "$doc" '$old+[$doc]')"
+    fi
+  done < <(jq -c '.nodes[]' <<<"$documents")
+  rm -f "$tmp"
+  case "$(jq 'length' <<<"$matches")" in
+    0) return 3 ;;
+    1) jq -c '.[0]' <<<"$matches" ;;
+    *) fail "multiple managed spec documents found" ;;
+  esac
+}
+
+spec_result() {
+  local doc="$1" tmp revision
+  tmp="$(mktemp)"; jq -j '.content' <<<"$doc" >"$tmp"
+  revision="$(python3 "$METADATA" revision --updated-at "$(jq -r '.updatedAt' <<<"$doc")" <"$tmp")" || { rm -f "$tmp"; fail "spec revision could not be computed"; }
+  rm -f "$tmp"
+  jq -cn --argjson doc "$doc" --argjson revision "$revision" '{id:$doc.id,url:$doc.url,content:$doc.content,revision:$revision}'
+}
+
+prepare_spec() {
+  local source="$1" project_id="$2" repository="$3" output="$4" parsed
+  [[ -f "$source" && -r "$source" ]] || fail "spec content file is unreadable"
+  if grep -qF '+++ Woostack metadata — managed, do not edit' "$source"; then
+    parsed="$(python3 "$METADATA" parse --repository "$repository" --project-id "$project_id" <"$source")" || fail "spec metadata is invalid"
+    [[ "$(jq -r '.artifactType' <<<"$parsed")" == spec ]] || fail "spec metadata has the wrong artifact type"
+    cat "$source" >"$output"
+  else
+    cat "$source" >"$output"
+    [[ ! -s "$output" ]] || [[ "$(tail -c 1 "$output" | wc -l | tr -d ' ')" == 1 ]] || printf '\n' >>"$output"
+    {
+      printf '\n%s\n' '+++ Woostack metadata — managed, do not edit'
+      jq -cnS --arg projectId "$project_id" --arg repository "$repository" '{artifactType:"spec",projectId:$projectId,repository:$repository,schema:1}'
+      printf '%s\n' '+++'
+    } >>"$output"
+  fi
+}
+
+command_preflight() {
+  local workspace='' team='' project_statuses='' issue_states='' response tmp
+  while [[ $# -gt 0 ]]; do case "$1" in
+    --workspace) workspace="$2"; shift 2;; --team) team="$2"; shift 2;;
+    --project-statuses) project_statuses="$2"; shift 2;; --issue-states) issue_states="$2"; shift 2;; *) usage;; esac; done
+  [[ -n "$workspace" && -n "$team" && -n "$project_statuses" && -n "$issue_states" ]] || usage
+  jq -e --argjson required "$REQUIRED_STATUSES" '
+    type=="object" and ((keys|sort)==($required|sort)) and
+    all(.[]; type=="string" and length>0) and
+    (([.[]]|unique|length)==([.[]]|length))
+  ' >/dev/null 2>&1 <<<"$project_statuses" || fail "all project statuses must be present, nonblank, and unique"
+  jq -e '
+    type=="object" and ((keys|sort)==(["planned","executing","inReview","done","blocked"]|sort)) and
+    all(.[]; type=="string" and length>0) and
+    (([.[]]|unique|length)==([.[]]|length))
+  ' >/dev/null 2>&1 <<<"$issue_states" || fail "all issue states must be present, nonblank, and unique"
+  response="$(request_query "$GRAPHQL/preflight.graphql" '{}')" || fail "preflight query failed"
+  tmp="$(mktemp)"; printf '%s\n' "$response" >"$tmp"
+  "$HERE/linear-preflight.sh" --response "$tmp" --workspace "$workspace" --team "$team" --project-statuses "$project_statuses" --issue-states "$issue_states"
+  rm -f "$tmp"
+}
+
+command_feature_resolve() {
+  local repository='' status_map='' eligible='' reference='' projects
+  while [[ $# -gt 0 ]]; do case "$1" in
+    --repository) repository="$2"; shift 2;; --status-map) status_map="$2"; shift 2;;
+    --eligible-statuses) eligible="$2"; shift 2;; --reference) reference="$2"; shift 2;; *) usage;; esac; done
+  require_repository "$repository"; validate_status_map "$status_map"
+  jq -e --argjson map "$status_map" 'type=="array" and length>0 and all(.[]; type=="string" and $map[.]!=null)' >/dev/null 2>&1 <<<"$eligible" || fail "eligible statuses are invalid"
+  projects="$(project_list)" || fail "project discovery failed"
+  resolve_from_list "$projects" "$repository" "$status_map" "$eligible" "$reference"
+}
+
+command_feature_create() {
+  local repository='' title='' team_id='' status_map='' spec_file='' projects project='' project_attempted=false returned_project=null
+  local documents doc='' document_attempted=false returned_document=null expected_file observed_file variables response attempted observed pending='[]' verified
+  while [[ $# -gt 0 ]]; do case "$1" in
+    --repository) repository="$2"; shift 2;; --title) title="$2"; shift 2;; --team-id) team_id="$2"; shift 2;;
+    --status-map) status_map="$2"; shift 2;; --spec-file) spec_file="$2"; shift 2;; *) usage;; esac; done
+  require_repository "$repository"; [[ -n "$title" ]] || usage; require_uuid "$team_id" "team id"; validate_status_map "$status_map"; [[ -r "$spec_file" ]] || fail "spec file is unreadable"
+  projects="$(project_list)" || fail "project discovery failed"
+  set +e; project="$(resolve_from_list "$projects" "$repository" "$status_map" "$ACTIVE_STATUSES" '' 2>/dev/null)"; resolve_rc=$?; set -e
+  case "$resolve_rc" in
+    0) ;;
+    3)
+      variables="$(jq -cn --arg name "$title" --arg team "$team_id" --arg status "$(jq -r '.draft' <<<"$status_map")" --arg description "$(project_marker "$repository")" '{input:{name:$name,teamIds:[$team],statusId:$status,description:$description}}')"
+      project_attempted=true
+      if response="$(request_mutation "$GRAPHQL/project-create.graphql" "$variables")"; then
+        if jq -e '.data.projectCreate.success==true and (.data.projectCreate.project.id|type=="string")' >/dev/null 2>&1 <<<"$response"; then
+          returned_project="$(jq -c '.data.projectCreate.project | {id,name,url,status}' <<<"$response")"
+        fi
+      fi
+      if ! projects="$(project_list)"; then
+        jq -cn --argjson returned "$returned_project" '{attempted:["projectCreate"],observed:{project:null,document:null},returned:{project:$returned,document:null},verified:false,pending:["project-read-back"]}'
+        return 1
+      fi
+      set +e; project="$(resolve_from_list "$projects" "$repository" "$status_map" "$ACTIVE_STATUSES" '')"; resolve_rc=$?; set -e
+      if [[ "$resolve_rc" -ne 0 ]]; then
+        jq -cn --argjson returned "$returned_project" '{attempted:["projectCreate"],observed:{project:null,document:null},returned:{project:$returned,document:null},verified:false,pending:["project-discovery"]}'
+        return 1
+      fi
+      ;;
+    4) return 4;; *) return "$resolve_rc";;
+  esac
+  project_id="$(jq -r '.id' <<<"$project")"
+  expected_file="$(mktemp)"; prepare_spec "$spec_file" "$project_id" "$repository" "$expected_file"
+  documents="$(document_list "$project_id")" || { rm -f "$expected_file"; fail "spec discovery failed"; }
+  set +e; doc="$(find_spec "$project_id" "$repository" "$documents")"; doc_rc=$?; set -e
+  case "$doc_rc" in
+    0) ;;
+    3)
+      variables="$(jq -cn --arg title "$title — Spec" --arg projectId "$project_id" --rawfile content "$expected_file" '{input:{title:$title,projectId:$projectId,content:$content}}')"
+      document_attempted=true
+      if response="$(request_mutation "$GRAPHQL/document-create.graphql" "$variables")"; then
+        if jq -e '.data.documentCreate.success==true and (.data.documentCreate.document.id|type=="string")' >/dev/null 2>&1 <<<"$response"; then
+          returned_document="$(jq -c '.data.documentCreate.document | {id,title,url,updatedAt,project}' <<<"$response")"
+        fi
+      fi
+      if ! documents="$(document_list "$project_id")"; then
+        rm -f "$expected_file"
+        jq -cn --arg project "$project_id" --argjson returned "$returned_document" '{attempted:["documentCreate"],observed:{project:$project,document:null},returned:{project:null,document:$returned},verified:false,pending:["document-read-back"]}'
+        return 1
+      fi
+      set +e; doc="$(find_spec "$project_id" "$repository" "$documents")"; doc_rc=$?; set -e
+      [[ "$doc_rc" -eq 0 ]] || pending="$(jq -c '.+["document-discovery"]' <<<"$pending")"
+      ;;
+    *) rm -f "$expected_file"; return "$doc_rc";;
+  esac
+  attempted='[]'; [[ "$project_attempted" == true ]] && attempted="$(jq -c '.+["projectCreate"]' <<<"$attempted")"; [[ "$document_attempted" == true ]] && attempted="$(jq -c '.+["documentCreate"]' <<<"$attempted")"
+  observed="$(jq -cn --arg project "$project_id" --arg document "${doc:+$(jq -r '.id' <<<"$doc")}" '{project:$project,document:(if $document=="" then null else $document end)}')"
+  if [[ -n "$doc" ]]; then
+    observed_file="$(mktemp)"; jq -j '.content' <<<"$doc" >"$observed_file"
+    cmp -s "$expected_file" "$observed_file" || pending="$(jq -c '.+["document-content-verification"]' <<<"$pending")"
+    rm -f "$observed_file"
+  fi
+  rm -f "$expected_file"
+  if [[ "$returned_project" != null ]]; then
+    if [[ "$(jq -r '.id' <<<"$returned_project")" != "$project_id" ||
+          "$(jq -r '.status.id' <<<"$returned_project")" != "$(jq -r '.statusId' <<<"$project")" ]]; then
+      pending="$(jq -c '.+["project-return-mismatch"]' <<<"$pending")"
+    fi
+  fi
+  if [[ "$returned_document" != null ]]; then
+    if [[ "$(jq -r '.id' <<<"$returned_document")" != "$(jq -r '.document' <<<"$observed")" ||
+          "$(jq -r '.project.id' <<<"$returned_document")" != "$project_id" ]]; then
+      pending="$(jq -c '.+["document-return-mismatch"]' <<<"$pending")"
+    fi
+  fi
+  verified=false; [[ "$(jq 'length' <<<"$pending")" -eq 0 ]] && verified=true
+  jq -cn --argjson attempted "$attempted" --argjson observed "$observed" --argjson rp "$returned_project" --argjson rd "$returned_document" --argjson verified "$verified" --argjson pending "$pending" '{attempted:$attempted,observed:$observed,returned:{project:$rp,document:$rd},verified:$verified,pending:$pending}'
+  [[ "$verified" == true ]]
+}
+
+command_spec_read() {
+  local project_id='' repository='' documents doc
+  while [[ $# -gt 0 ]]; do case "$1" in --project) project_id="$2"; shift 2;; --repository) repository="$2"; shift 2;; *) usage;; esac; done
+  require_uuid "$project_id" "project id"; require_repository "$repository"
+  documents="$(document_list "$project_id")" || fail "spec discovery failed"
+  doc="$(find_spec "$project_id" "$repository" "$documents")" || fail "managed spec document not found"
+  spec_result "$doc"
+}
+
+command_spec_write() {
+  local project_id='' repository='' content_file='' expected='' documents doc current expected_file response returned=null readback='' observed_file verified=false pending='[]'
+  while [[ $# -gt 0 ]]; do case "$1" in --project) project_id="$2"; shift 2;; --repository) repository="$2"; shift 2;;
+    --content-file) content_file="$2"; shift 2;; --expected-revision) expected="$2"; shift 2;; *) usage;; esac; done
+  require_uuid "$project_id" "project id"; require_repository "$repository"; [[ -r "$content_file" && -n "$expected" ]] || usage
+  documents="$(document_list "$project_id")" || fail "spec discovery failed"
+  doc="$(find_spec "$project_id" "$repository" "$documents")" || fail "managed spec document not found"
+  current="$(spec_result "$doc")"
+  [[ "$(jq -c '.revision' <<<"$current")" == "$(jq -cS . <<<"$expected" 2>/dev/null)" ]] || fail "optimistic revision mismatch"
+  expected_file="$(mktemp)"; prepare_spec "$content_file" "$project_id" "$repository" "$expected_file"
+  if response="$(request_mutation "$GRAPHQL/document-update.graphql" "$(jq -cn --arg id "$(jq -r '.id' <<<"$doc")" --rawfile content "$expected_file" '{id:$id,input:{content:$content}}')")"; then
+    if jq -e '.data.documentUpdate.success==true and (.data.documentUpdate.document.id|type=="string")' >/dev/null 2>&1 <<<"$response"; then
+      returned="$(jq -c '.data.documentUpdate.document | {id,title,url,updatedAt,project}' <<<"$response")"
+    fi
+  fi
+  if ! documents="$(document_list "$project_id")"; then
+    rm -f "$expected_file"
+    jq -cn --argjson returned "$returned" '{attempted:["documentUpdate"],observed:{document:null},returned:{document:$returned},verified:false,pending:["document-read-back"]}'
+    return 1
+  fi
+  set +e; readback="$(find_spec "$project_id" "$repository" "$documents")"; readback_rc=$?; set -e
+  if [[ "$readback_rc" -ne 0 ]]; then
+    pending='["document-discovery"]'
+  else
+    observed_file="$(mktemp)"; jq -j '.content' <<<"$readback" >"$observed_file"
+    cmp -s "$expected_file" "$observed_file" || pending="$(jq -c '.+["document-content-verification"]' <<<"$pending")"
+    rm -f "$observed_file"
+    [[ "$(jq -r '.id' <<<"$readback")" == "$(jq -r '.id' <<<"$doc")" ]] || pending="$(jq -c '.+["document-identity-verification"]' <<<"$pending")"
+    if [[ "$returned" != null && "$(jq -r '.id' <<<"$returned")" != "$(jq -r '.id' <<<"$readback")" ]]; then pending="$(jq -c '.+["document-return-mismatch"]' <<<"$pending")"; fi
+  fi
+  rm -f "$expected_file"
+  [[ "$(jq 'length' <<<"$pending")" -eq 0 ]] && verified=true
+  jq -cn --arg id "${readback:+$(jq -r '.id' <<<"$readback")}" --argjson returned "$returned" --argjson verified "$verified" --argjson pending "$pending" \
+    '{attempted:["documentUpdate"],observed:{document:(if $id=="" then null else $id end)},returned:{document:$returned},verified:$verified,pending:$pending}'
+  [[ "$verified" == true ]]
+}
+
+command_feature_transition() {
+  local project_id='' repository='' status_map='' target='' projects current current_name current_index target_index response returned readback verified
+  while [[ $# -gt 0 ]]; do case "$1" in --project) project_id="$2"; shift 2;; --repository) repository="$2"; shift 2;;
+    --status-map) status_map="$2"; shift 2;; --target) target="$2"; shift 2;; *) usage;; esac; done
+  require_uuid "$project_id" "project id"; require_repository "$repository"; validate_status_map "$status_map"
+  jq -e --arg target "$target" 'has($target)' >/dev/null 2>&1 <<<"$status_map" || fail "archive, delete, or unknown lifecycle transitions are prohibited"
+  projects="$(project_list)" || fail "project discovery failed"; current="$(resolve_from_list "$projects" "$repository" "$status_map" "$REQUIRED_STATUSES" "$project_id")" || return $?
+  current_name="$(jq -r '.status' <<<"$current")"
+  if [[ "$current_name" == "$target" ]]; then jq -cn --arg current "$current_name" --arg target "$target" --arg id "$project_id" '{current:$current,target:$target,attempted:[],observed:{project:$id},returned:{project:null},verified:true,pending:[]}'; return; fi
+  if [[ "$target" != abandoned ]]; then
+    [[ "$current_name" != abandoned && "$current_name" != "done" ]] || fail "terminal project cannot transition"
+    current_index="$(jq -n --arg current "$current_name" '$ARGS.positional|index($current)' --args draft hardened approved planning ready executing inReview "done")"
+    target_index="$(jq -n --arg target "$target" '$ARGS.positional|index($target)' --args draft hardened approved planning ready executing inReview "done")"
+    [[ "$current_index" != null && "$target_index" != null && "$target_index" -eq $((current_index + 1)) ]] || fail "invalid project lifecycle transition"
+  else
+    [[ "$current_name" != "done" ]] || fail "completed project cannot be abandoned"
+  fi
+  returned=null
+  if response="$(request_mutation "$GRAPHQL/project-update.graphql" "$(jq -cn --arg id "$project_id" --arg statusId "$(jq -r --arg target "$target" '.[$target]' <<<"$status_map")" '{id:$id,input:{statusId:$statusId}}')")"; then
+    if jq -e '.data.projectUpdate.success==true and (.data.projectUpdate.project.id|type=="string")' >/dev/null 2>&1 <<<"$response"; then
+      returned="$(jq -c '.data.projectUpdate.project | {id,name,url,status}' <<<"$response")"
+    fi
+  fi
+  if ! projects="$(project_list)"; then
+    jq -cn --arg current "$current_name" --arg target "$target" --argjson returned "$returned" '{current:$current,target:$target,attempted:["projectUpdate"],observed:{project:null},returned:{project:$returned},verified:false,pending:["project-read-back"]}'
+    return 1
+  fi
+  set +e; readback="$(resolve_from_list "$projects" "$repository" "$status_map" "$REQUIRED_STATUSES" "$project_id" 2>/dev/null)"; readback_rc=$?; set -e
+  verified=false
+  if [[ "$readback_rc" -eq 0 && "$(jq -r '.status' <<<"$readback")" == "$target" ]]; then
+    verified=true
+    if [[ "$returned" != null ]]; then
+      [[ "$(jq -r '.id' <<<"$returned")" == "$project_id" ]] || verified=false
+      [[ "$(jq -r '.status.id' <<<"$returned")" == "$(jq -r --arg target "$target" '.[$target]' <<<"$status_map")" ]] || verified=false
+    fi
+  fi
+  jq -cn --arg current "$current_name" --arg target "$target" --arg id "${readback:+$(jq -r '.id' <<<"$readback")}" --argjson returned "$returned" --argjson verified "$verified" \
+    '{current:$current,target:$target,attempted:["projectUpdate"],observed:{project:(if $id=="" then null else $id end)},returned:{project:$returned},verified:$verified,pending:(if $verified then [] else ["project-status-verification"] end)}'
+  [[ "$verified" == true ]]
+}
+
+[[ $# -gt 0 ]] || usage
+command="$1"; shift
+case "$command" in
+  preflight) command_preflight "$@";;
+  feature-resolve) command_feature_resolve "$@";;
+  feature-create) command_feature_create "$@";;
+  feature-transition) command_feature_transition "$@";;
+  spec-read) command_spec_read "$@";;
+  spec-write) command_spec_write "$@";;
+  *) usage;;
+esac

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-create-partial.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-create-partial.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "documentCreate": {
+      "success": false,
+      "document": null
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-create-success.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-create-success.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "documentCreate": {
+      "success": true,
+      "document": {
+        "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "title": "Feature Alpha \u2014 Spec",
+        "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+        "content": "# Feature Alpha\n\nAcceptance body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+        "updatedAt": "2026-07-12T10:01:00.000Z",
+        "project": {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        }
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-create-wrong-id.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-create-wrong-id.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "documentCreate": {
+      "success": true,
+      "document": {
+        "id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        "title": "Feature Alpha \u2014 Spec",
+        "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+        "content": "# Feature Alpha\n\nAcceptance body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+        "updatedAt": "2026-07-12T10:01:00.000Z",
+        "project": {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        }
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-duplicate-managed.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-duplicate-managed.json
@@ -1,0 +1,32 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [
+        {
+          "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+          "content": "# Feature Alpha\n\nAcceptance body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+          "updatedAt": "2026-07-12T10:01:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        },
+        {
+          "id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/duplicate-eeeeeeee",
+          "content": "# Feature Alpha\n\nAcceptance body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+          "updatedAt": "2026-07-12T10:01:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-duplicate-marker.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-duplicate-marker.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [
+        {
+          "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+          "content": "# Feature\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+          "updatedAt": "2026-07-12T10:01:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-foreign-metadata.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-foreign-metadata.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [
+        {
+          "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+          "content": "# Feature\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"other/repo\",\"schema\":1}\n+++\n",
+          "updatedAt": "2026-07-12T10:01:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-malformed-metadata.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-malformed-metadata.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [
+        {
+          "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+          "content": "# Feature\n\n+++ Woostack metadata \u2014 managed, do not edit\n{bad json}\n+++\n",
+          "updatedAt": "2026-07-12T10:01:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-missing-cursor.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-missing-cursor.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-none.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-none.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-one.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-one.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [
+        {
+          "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+          "content": "# Feature Alpha\n\nAcceptance body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+          "updatedAt": "2026-07-12T10:01:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-page1.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-page1.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "doc-cursor-1"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-page2.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-page2.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [
+        {
+          "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+          "content": "# Feature Alpha\n\nAcceptance body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+          "updatedAt": "2026-07-12T10:01:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-repeat-cursor-1.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-repeat-cursor-1.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "same-doc-cursor"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-repeat-cursor-2.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-repeat-cursor-2.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "same-doc-cursor"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-unsupported-schema.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-unsupported-schema.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [
+        {
+          "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+          "content": "# Feature\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":2}\n+++\n",
+          "updatedAt": "2026-07-12T10:01:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-list-updated.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-list-updated.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "documents": {
+      "nodes": [
+        {
+          "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          "title": "Feature Alpha \u2014 Spec",
+          "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+          "content": "# Feature Alpha\n\nRevised body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+          "updatedAt": "2026-07-12T10:05:00.000Z",
+          "project": {
+            "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-update-partial.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-update-partial.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "documentUpdate": {
+      "success": false,
+      "document": null
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-update-success.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-update-success.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "documentUpdate": {
+      "success": true,
+      "document": {
+        "id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "title": "Feature Alpha \u2014 Spec",
+        "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+        "content": "# Feature Alpha\n\nRevised body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+        "updatedAt": "2026-07-12T10:05:00.000Z",
+        "project": {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        }
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/document-update-wrong-id.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/document-update-wrong-id.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "documentUpdate": {
+      "success": true,
+      "document": {
+        "id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        "title": "Feature Alpha \u2014 Spec",
+        "url": "https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+        "content": "# Feature Alpha\n\nRevised body.\n\n+++ Woostack metadata \u2014 managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++\n",
+        "updatedAt": "2026-07-12T10:05:00.000Z",
+        "project": {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        }
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-create-partial.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-create-partial.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "projectCreate": {
+      "success": false,
+      "project": null
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-create-success.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-create-success.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "projectCreate": {
+      "success": true,
+      "project": {
+        "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "Feature Alpha",
+        "url": "https://linear.app/acme/project/feature-alpha-abc123",
+        "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+        "status": {
+          "id": "10000000-0000-4000-8000-000000000001",
+          "name": "Draft"
+        },
+        "archivedAt": null,
+        "updatedAt": "2026-07-12T10:00:00.000Z"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-create-wrong-id.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-create-wrong-id.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "projectCreate": {
+      "success": true,
+      "project": {
+        "id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        "name": "Feature Alpha",
+        "url": "https://linear.app/acme/project/feature-alpha-abc123",
+        "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+        "status": {
+          "id": "10000000-0000-4000-8000-000000000001",
+          "name": "Draft"
+        },
+        "archivedAt": null,
+        "updatedAt": "2026-07-12T10:00:00.000Z"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-abandoned.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-abandoned.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-abc123",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000009",
+            "name": "Abandoned"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-done.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-done.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-abc123",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000008",
+            "name": "Completed"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-duplicate-managed.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-duplicate-managed.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "name": "Feature Beta",
+          "url": "https://linear.app/acme/project/feature-beta-cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000001",
+            "name": "Draft"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        },
+        {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-abc123",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000001",
+            "name": "Draft"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-foreign.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-foreign.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-abc123",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"other/repo\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000001",
+            "name": "Draft"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-hardened.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-hardened.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-abc123",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000002",
+            "name": "Hardened"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-missing-cursor.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-missing-cursor.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-multiple.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-multiple.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "name": "Feature Beta",
+          "url": "https://linear.app/acme/project/feature-beta-cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000002",
+            "name": "Hardened"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        },
+        {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-abc123",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000001",
+            "name": "Draft"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-none.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-none.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-one.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-one.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-abc123",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000001",
+            "name": "Draft"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-page1.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-page1.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "cursor-1"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-page2.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-page2.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-abc123",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000001",
+            "name": "Draft"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-repeat-cursor-1.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-repeat-cursor-1.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "same-cursor"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-repeat-cursor-2.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-repeat-cursor-2.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "same-cursor"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-list-same-title.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-list-same-title.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "projects": {
+      "nodes": [
+        {
+          "id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "name": "Feature Alpha",
+          "url": "https://linear.app/acme/project/feature-alpha-cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"other/repo\",\"schema\":1}\n+++",
+          "status": {
+            "id": "10000000-0000-4000-8000-000000000001",
+            "name": "Draft"
+          },
+          "archivedAt": null,
+          "updatedAt": "2026-07-12T10:00:00.000Z"
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": null
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-update-abandoned.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-update-abandoned.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "projectUpdate": {
+      "success": true,
+      "project": {
+        "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "Feature Alpha",
+        "url": "https://linear.app/acme/project/feature-alpha-abc123",
+        "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+        "status": {
+          "id": "10000000-0000-4000-8000-000000000009",
+          "name": "Abandoned"
+        },
+        "archivedAt": null,
+        "updatedAt": "2026-07-12T10:00:00.000Z"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-update-hardened.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-update-hardened.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "projectUpdate": {
+      "success": true,
+      "project": {
+        "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "Feature Alpha",
+        "url": "https://linear.app/acme/project/feature-alpha-abc123",
+        "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+        "status": {
+          "id": "10000000-0000-4000-8000-000000000002",
+          "name": "Hardened"
+        },
+        "archivedAt": null,
+        "updatedAt": "2026-07-12T10:00:00.000Z"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-update-partial.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-update-partial.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "projectUpdate": {
+      "success": false,
+      "project": null
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-update-wrong-id.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-update-wrong-id.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "projectUpdate": {
+      "success": true,
+      "project": {
+        "id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        "name": "Feature Alpha",
+        "url": "https://linear.app/acme/project/feature-alpha-abc123",
+        "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+        "status": {
+          "id": "10000000-0000-4000-8000-000000000002",
+          "name": "Hardened"
+        },
+        "archivedAt": null,
+        "updatedAt": "2026-07-12T10:00:00.000Z"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/fixtures/linear/project-update-wrong-status.json
+++ b/skills/woostack-init/scripts/tests/fixtures/linear/project-update-wrong-status.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "projectUpdate": {
+      "success": true,
+      "project": {
+        "id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "name": "Feature Alpha",
+        "url": "https://linear.app/acme/project/feature-alpha-abc123",
+        "description": "+++ Woostack project metadata \u2014 managed, do not edit\n{\"repository\":\"acme/widgets\",\"schema\":1}\n+++",
+        "status": {
+          "id": "10000000-0000-4000-8000-000000000001",
+          "name": "Draft"
+        },
+        "archivedAt": null,
+        "updatedAt": "2026-07-12T10:00:00.000Z"
+      }
+    }
+  }
+}

--- a/skills/woostack-init/scripts/tests/test-linear-resources.sh
+++ b/skills/woostack-init/scripts/tests/test-linear-resources.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ARTIFACTS="$(cd "$HERE/../artifacts" && pwd)"
+FIXTURES="$HERE/fixtures/linear"
+# shellcheck disable=SC1091
+source "$HERE/assert.sh"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/bin" "$work/responses"
+cat >"$work/bin/linear-request.sh" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+operation=''; document=''; variables=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --operation) operation="$2"; shift 2 ;;
+    --document) document="$2"; shift 2 ;;
+    --variables) variables="$2"; shift 2 ;;
+    *) exit 2 ;;
+  esac
+done
+name="$(basename "$document" .graphql)"
+count_file="$LINEAR_FAKE_STATE/$name.count"
+count=0; [ ! -f "$count_file" ] || count="$(cat "$count_file")"
+count=$((count + 1)); printf '%s' "$count" >"$count_file"
+printf '%s\t%s\t%s\n' "$operation" "$name" "$variables" >>"$LINEAR_FAKE_STATE/calls"
+response="$LINEAR_FAKE_RESPONSES/$name.$count.json"
+[ -f "$response" ] || { echo "missing fake response: $name.$count" >&2; exit 1; }
+if [ -f "$LINEAR_FAKE_RESPONSES/$name.$count.fail" ]; then
+  cat "$response"
+  exit 1
+fi
+cat "$response"
+FAKE
+chmod +x "$work/bin/linear-request.sh"
+export LINEAR_REQUEST_SH="$work/bin/linear-request.sh"
+export LINEAR_FAKE_STATE="$work"
+export LINEAR_FAKE_RESPONSES="$work/responses"
+
+reset_fake() { rm -f "$work"/*.count "$work/calls" "$work/responses"/*; }
+queue() { cp "$FIXTURES/$2" "$work/responses/$1.$3.json"; }
+run_capture() {
+  set +e
+  OUTPUT="$("$ARTIFACTS/linear.sh" "$@" 2>&1)"
+  RC=$?
+  set -e
+}
+call_variables() {
+  local name="$1" occurrence="$2"
+  grep $'\t'"$name"$'\t' "$work/calls" | sed -n "${occurrence}p" | cut -f3-
+}
+make_document_list() {
+  local output="$1" content_file="$2" updated_at="$3"
+  jq -n --rawfile content "$content_file" --arg project "$project_id" --arg updated "$updated_at" '
+    {data:{documents:{nodes:[{
+      id:"dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+      title:"Feature Alpha — Spec",
+      url:"https://linear.app/acme/document/feature-alpha-spec-dddddddd",
+      content:$content,
+      updatedAt:$updated,
+      project:{id:$project}
+    }],pageInfo:{hasNextPage:false,endCursor:null}}}}
+  ' >"$output"
+}
+status_map='{"draft":"10000000-0000-4000-8000-000000000001","hardened":"10000000-0000-4000-8000-000000000002","approved":"10000000-0000-4000-8000-000000000003","planning":"10000000-0000-4000-8000-000000000004","ready":"10000000-0000-4000-8000-000000000005","executing":"10000000-0000-4000-8000-000000000006","inReview":"10000000-0000-4000-8000-000000000007","done":"10000000-0000-4000-8000-000000000008","abandoned":"10000000-0000-4000-8000-000000000009"}'
+project_id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+team_id='bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+project_status_names='{"draft":"Draft","hardened":"Hardened","approved":"Approved","planning":"Planning","ready":"Ready","executing":"In Progress","inReview":"In Review","done":"Completed","abandoned":"Canceled"}'
+issue_state_names='{"planned":"Backlog","executing":"In Progress","inReview":"In Review","done":"Done","blocked":"Blocked"}'
+
+# Public preflight resolves the complete configured lifecycle, including abandoned.
+reset_fake; queue preflight http-preflight-success.json 1
+run_capture preflight --workspace acme --team ENG --project-statuses "$project_status_names" --issue-states "$issue_state_names"
+assert_exit 0 "$RC" "preflight resolves complete mappings"
+assert_eq "$(jq -r '.projectStatuses.abandoned' <<<"$OUTPUT")" "ps-abandoned" "preflight resolves required abandoned status"
+reset_fake
+run_capture preflight --workspace acme --team ENG --project-statuses '{"draft":"Draft"}' --issue-states "$issue_state_names"
+assert_exit 1 "$RC" "preflight rejects incomplete project lifecycle before querying"
+if [ -f "$work/calls" ]; then fail "invalid preflight must not query"; else pass; fi
+duplicate_project_status_names="$(jq -c '.hardened=.draft' <<<"$project_status_names")"
+reset_fake
+run_capture preflight --workspace acme --team ENG --project-statuses "$duplicate_project_status_names" --issue-states "$issue_state_names"
+assert_exit 1 "$RC" "preflight rejects aliased project statuses before querying"
+if [ -f "$work/calls" ]; then fail "aliased project statuses must not query"; else pass; fi
+duplicate_issue_state_names="$(jq -c '.blocked=.done' <<<"$issue_state_names")"
+reset_fake
+run_capture preflight --workspace acme --team ENG --project-statuses "$project_status_names" --issue-states "$duplicate_issue_state_names"
+assert_exit 1 "$RC" "preflight rejects aliased issue states before querying"
+if [ -f "$work/calls" ]; then fail "aliased issue states must not query"; else pass; fi
+
+
+# Exact UUID and Linear URL resolve only when canonical ownership/schema markers match.
+reset_fake; queue project-list project-list-one.json 1
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]' --reference "$project_id"
+assert_exit 0 "$RC" "explicit UUID resolves"
+assert_eq "$(jq -r '.id' <<<"$OUTPUT")" "$project_id" "explicit UUID returns stable id"
+reset_fake; queue project-list project-list-one.json 1
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]' --reference "https://linear.app/acme/project/feature-alpha-abc123"
+assert_exit 0 "$RC" "Linear URL resolves"
+reset_fake; queue project-list project-list-foreign.json 1
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]' --reference "$project_id"
+assert_exit 1 "$RC" "explicit foreign project fails closed"
+assert_contains "$OUTPUT" "ownership" "foreign project diagnostic is safe"
+
+# Repository + eligible lifecycle discovery is exact and deterministic.
+reset_fake; queue project-list project-list-one.json 1
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]'
+assert_exit 0 "$RC" "one eligible managed project resolves"
+reset_fake; queue project-list project-list-none.json 1
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]'
+assert_exit 3 "$RC" "zero eligible projects returns not-found"
+reset_fake; queue project-list project-list-multiple.json 1
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft","hardened"]'
+assert_exit 4 "$RC" "multiple eligible projects are ambiguous"
+assert_contains "$OUTPUT" "$project_id" "candidate list includes UUID"
+assert_contains "$OUTPUT" "Feature Alpha" "candidate list includes title"
+first_line="$(printf '%s\n' "$OUTPUT" | grep '^candidate ' | sed -n '1p')"
+assert_contains "$first_line" "$project_id" "candidate list is UUID sorted"
+reset_fake; queue project-list project-list-same-title.json 1
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]'
+assert_exit 3 "$RC" "same title alone is never adopted"
+
+# Create does discovery before mutation, reads back, creates one spec, and verifies it.
+printf '# Feature Alpha\n\nAcceptance body.\n' >"$work/spec.md"
+reset_fake
+queue project-list project-list-none.json 1
+queue project-create project-create-success.json 1
+queue project-list project-list-one.json 2
+queue document-list document-list-none.json 1
+queue document-create document-create-success.json 1
+queue document-list document-list-one.json 2
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 0 "$RC" "project and spec create succeeds"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "true" "create receipt is verified"
+for field in attempted observed returned verified pending; do
+  if jq -e --arg field "$field" 'has($field)' <<<"$OUTPUT" >/dev/null; then pass; else fail "create receipt includes $field"; fi
+done
+assert_eq "$(grep -c $'mutation\tproject-create' "$work/calls")" "1" "project mutation occurs once"
+assert_eq "$(grep -c $'mutation\tdocument-create' "$work/calls")" "1" "document mutation occurs once"
+project_create_variables="$(call_variables project-create 1)"
+assert_eq "$(jq -r '.input.teamIds[0]' <<<"$project_create_variables")" "$team_id" "project create sends configured team ID"
+assert_eq "$(jq -r '.input.statusId' <<<"$project_create_variables")" "$(jq -r '.draft' <<<"$status_map")" "project create sends draft status ID"
+assert_contains "$(jq -r '.input.description' <<<"$project_create_variables")" '"repository":"acme/widgets"' "project create sends canonical repository ownership"
+document_create_variables="$(call_variables document-create 1)"
+assert_eq "$(jq -r '.input.projectId' <<<"$document_create_variables")" "$project_id" "document create sends observed project ID"
+assert_contains "$(jq -r '.input.content' <<<"$document_create_variables")" "Acceptance body." "document create sends exact source content"
+assert_contains "$(jq -r '.input.content' <<<"$document_create_variables")" '"repository":"acme/widgets"' "document create appends canonical spec ownership"
+
+# Unknown mutation outcome is discovered and resumed without repeating the mutation.
+reset_fake
+queue project-list project-list-none.json 1
+queue project-create project-create-success.json 1; touch "$work/responses/project-create.1.fail"
+queue project-list project-list-one.json 2
+queue document-list document-list-none.json 1
+queue document-create document-create-success.json 1
+queue document-list document-list-one.json 2
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 0 "$RC" "unknown project mutation outcome resumes by discovery"
+assert_eq "$(grep -c $'mutation\tproject-create' "$work/calls")" "1" "unknown project mutation is never retried blindly"
+assert_eq "$(jq -r '.observed.project' <<<"$OUTPUT")" "$project_id" "receipt records discovered project"
+
+# Unknown document-create outcome is also discovered without a blind retry.
+reset_fake
+queue project-list project-list-one.json 1
+queue document-list document-list-none.json 1
+queue document-create document-create-success.json 1; touch "$work/responses/document-create.1.fail"
+queue document-list document-list-one.json 2
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 0 "$RC" "unknown document mutation outcome resumes by discovery"
+assert_eq "$(grep -c $'mutation\tdocument-create' "$work/calls")" "1" "unknown document mutation is never retried blindly"
+assert_contains "$(jq -c '.attempted' <<<"$OUTPUT")" "documentCreate" "receipt records unknown mutation attempt"
+
+# Failed recovery reads remain unverified and never repeat an ambiguous mutation.
+reset_fake
+queue project-list project-list-none.json 1
+queue project-create project-create-success.json 1; touch "$work/responses/project-create.1.fail"
+queue project-list project-list-one.json 2; touch "$work/responses/project-list.2.fail"
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 1 "$RC" "failed project-create read-back stays unverified"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "false" "failed project read-back is unverified"
+assert_eq "$(jq -c '.pending' <<<"$OUTPUT")" '["project-read-back"]' "failed project read-back has a precise pending reason"
+assert_not_contains "$OUTPUT" "Acceptance body." "failed project read-back receipt excludes spec content"
+assert_eq "$(grep -c $'mutation\tproject-create' "$work/calls")" "1" "failed project read-back never retries project create"
+
+reset_fake
+queue project-list project-list-one.json 1
+queue document-list document-list-none.json 1
+queue document-create document-create-success.json 1; touch "$work/responses/document-create.1.fail"
+queue document-list document-list-one.json 2; touch "$work/responses/document-list.2.fail"
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 1 "$RC" "failed document-create read-back stays unverified"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "false" "failed document read-back is unverified"
+assert_eq "$(jq -c '.pending' <<<"$OUTPUT")" '["document-read-back"]' "failed document read-back has a precise pending reason"
+assert_not_contains "$OUTPUT" "Acceptance body." "failed document read-back receipt excludes spec content"
+assert_eq "$(grep -c $'mutation\tdocument-create' "$work/calls")" "1" "failed document read-back never retries document create"
+
+# Partial completion resumes existing project and document without duplicate mutation.
+reset_fake
+queue project-list project-list-one.json 1
+queue document-list document-list-one.json 1
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 0 "$RC" "partial completion resumes"
+assert_eq "$(grep -c $'mutation\t' "$work/calls" || true)" "0" "resume performs no duplicate mutations"
+reset_fake; queue project-list project-list-duplicate-managed.json 1
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 4 "$RC" "duplicate managed projects block creation"
+reset_fake; queue project-list project-list-one.json 1; queue document-list document-list-duplicate-managed.json 1
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 1 "$RC" "duplicate managed spec documents block resume"
+assert_not_contains "$(cat "$work/calls")" $'mutation\tdocument-create' "duplicate specs never trigger another create"
+
+# Spec read emits content and optimistic revision; write checks live revision, updates, then reads back.
+reset_fake; queue document-list document-list-one.json 1
+run_capture spec-read --project "$project_id" --repository acme/widgets
+assert_exit 0 "$RC" "spec read succeeds"
+revision="$(jq -c '.revision' <<<"$OUTPUT")"
+printf '# Feature Alpha\n\nRevised body.\n\n+++ Woostack metadata — managed, do not edit\n{"artifactType":"spec","projectId":"%s","repository":"acme/widgets","schema":1}\n+++\n' "$project_id" >"$work/revised.md"
+reset_fake; queue document-list document-list-one.json 1; queue document-update document-update-success.json 1; queue document-list document-list-updated.json 2
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
+assert_exit 0 "$RC" "spec update with matching revision succeeds"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "true" "spec update is read-back verified"
+document_update_variables="$(call_variables document-update 1)"
+assert_eq "$(jq -r '.id' <<<"$document_update_variables")" "dddddddd-dddd-4ddd-8ddd-dddddddddddd" "document update targets the managed spec"
+assert_contains "$(jq -r '.input.content' <<<"$document_update_variables")" "Revised body." "document update sends revised content"
+reset_fake; queue document-list document-list-one.json 1; queue document-update document-update-success.json 1; touch "$work/responses/document-update.1.fail"; queue document-list document-list-updated.json 2
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
+assert_exit 0 "$RC" "unknown spec update outcome resumes by read-back"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "true" "unknown update is verified from observed content"
+assert_eq "$(grep -c $'mutation\tdocument-update' "$work/calls")" "1" "unknown spec update is never retried blindly"
+reset_fake
+queue document-list document-list-one.json 1
+queue document-update document-update-success.json 1; touch "$work/responses/document-update.1.fail"
+queue document-list document-list-updated.json 2; touch "$work/responses/document-list.2.fail"
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
+assert_exit 1 "$RC" "failed spec-write read-back stays unverified"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "false" "failed spec read-back is unverified"
+assert_eq "$(jq -c '.pending' <<<"$OUTPUT")" '["document-read-back"]' "failed spec read-back has a precise pending reason"
+assert_not_contains "$OUTPUT" "Revised body." "failed spec read-back receipt excludes spec content"
+assert_eq "$(grep -c $'mutation\tdocument-update' "$work/calls")" "1" "failed spec read-back never retries document update"
+
+reset_fake; queue document-list document-list-updated.json 1
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
+assert_exit 1 "$RC" "stale spec revision blocks before mutation"
+assert_not_contains "$(cat "$work/calls")" $'mutation\tdocument-update' "stale write does not mutate"
+
+# Forward lifecycle and explicit abandon are permitted; downgrade/archive/delete are rejected.
+reset_fake; queue project-list project-list-one.json 1; queue project-update project-update-hardened.json 1; queue project-list project-list-hardened.json 2
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target hardened
+assert_exit 0 "$RC" "draft to hardened transition succeeds"
+assert_eq "$(jq -r '.current' <<<"$OUTPUT")" "draft" "transition receipt includes current"
+assert_eq "$(jq -r '.target' <<<"$OUTPUT")" "hardened" "transition receipt includes target"
+transition_variables="$(call_variables project-update 1)"
+assert_eq "$(jq -r '.id' <<<"$transition_variables")" "$project_id" "transition targets the managed project"
+assert_eq "$(jq -r '.input.statusId' <<<"$transition_variables")" "$(jq -r '.hardened' <<<"$status_map")" "transition sends the target status ID"
+reset_fake; queue project-list project-list-hardened.json 1
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target draft
+assert_exit 1 "$RC" "lifecycle downgrade is rejected"
+reset_fake; queue project-list project-list-one.json 1; queue project-update project-update-abandoned.json 1; queue project-list project-list-abandoned.json 2
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target abandoned
+assert_exit 0 "$RC" "explicit abandon succeeds"
+reset_fake
+queue project-list project-list-one.json 1
+queue project-update project-update-hardened.json 1; touch "$work/responses/project-update.1.fail"
+queue project-list project-list-hardened.json 2; touch "$work/responses/project-list.2.fail"
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target hardened
+assert_exit 1 "$RC" "failed transition read-back stays unverified"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "false" "failed transition read-back is unverified"
+assert_eq "$(jq -c '.pending' <<<"$OUTPUT")" '["project-read-back"]' "failed transition read-back has a precise pending reason"
+assert_eq "$(grep -c $'mutation\tproject-update' "$work/calls")" "1" "failed transition read-back never retries project update"
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target archive
+assert_exit 1 "$RC" "archive transition is prohibited"
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target delete
+assert_exit 1 "$RC" "delete transition is prohibited"
+
+# Pagination consumes all pages and rejects missing or repeated cursors.
+reset_fake; queue project-list project-list-page1.json 1; queue project-list project-list-page2.json 2
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]'
+assert_exit 0 "$RC" "project discovery consumes a second page"
+assert_eq "$(jq -r '.after' <<<"$(call_variables project-list 2)")" "cursor-1" "project pagination forwards the next cursor"
+reset_fake; queue project-list project-list-missing-cursor.json 1
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]'
+assert_exit 1 "$RC" "project pagination rejects a missing cursor"
+reset_fake; queue project-list project-list-repeat-cursor-1.json 1; queue project-list project-list-repeat-cursor-2.json 2
+run_capture feature-resolve --repository acme/widgets --status-map "$status_map" --eligible-statuses '["draft"]'
+assert_exit 1 "$RC" "project pagination rejects a repeated non-progress cursor"
+reset_fake; queue document-list document-list-page1.json 1; queue document-list document-list-page2.json 2
+run_capture spec-read --project "$project_id" --repository acme/widgets
+assert_exit 0 "$RC" "document discovery consumes a second page"
+assert_eq "$(jq -r '.after' <<<"$(call_variables document-list 2)")" "doc-cursor-1" "document pagination forwards the next cursor"
+reset_fake; queue document-list document-list-missing-cursor.json 1
+run_capture spec-read --project "$project_id" --repository acme/widgets
+assert_exit 1 "$RC" "document pagination rejects a missing cursor"
+reset_fake; queue document-list document-list-repeat-cursor-1.json 1; queue document-list document-list-repeat-cursor-2.json 2
+run_capture spec-read --project "$project_id" --repository acme/widgets
+assert_exit 1 "$RC" "document pagination rejects a repeated non-progress cursor"
+
+# A transport-success response with success=false is still treated as an attempted,
+# unknown outcome and always followed by discovery for all four mutations.
+reset_fake; queue project-list project-list-none.json 1; queue project-create project-create-partial.json 1; queue project-list project-list-one.json 2; queue document-list document-list-one.json 1
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 0 "$RC" "partial project-create response resumes from read-back"
+assert_eq "$(jq -r '.returned.project' <<<"$OUTPUT")" "null" "partial project-create has no claimed return"
+reset_fake; queue project-list project-list-one.json 1; queue document-list document-list-none.json 1; queue document-create document-create-partial.json 1; queue document-list document-list-one.json 2
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 0 "$RC" "partial document-create response resumes from read-back"
+assert_eq "$(jq -r '.returned.document' <<<"$OUTPUT")" "null" "partial document-create has no claimed return"
+assert_not_contains "$OUTPUT" "Acceptance body." "successful create receipt excludes spec text"
+reset_fake; queue document-list document-list-one.json 1; queue document-update document-update-partial.json 1; queue document-list document-list-updated.json 2
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
+assert_exit 0 "$RC" "partial document-update response resumes from read-back"
+assert_eq "$(jq -r '.returned.document' <<<"$OUTPUT")" "null" "partial document-update has no claimed return"
+reset_fake; queue project-list project-list-one.json 1; queue project-update project-update-partial.json 1; queue project-list project-list-hardened.json 2
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target hardened
+assert_exit 0 "$RC" "partial project-update response resumes from read-back"
+assert_eq "$(jq -r '.returned.project' <<<"$OUTPUT")" "null" "partial project-update has no claimed return"
+
+# Returned-versus-observed identity/status mismatches never verify.
+reset_fake; queue project-list project-list-none.json 1; queue project-create project-create-wrong-id.json 1; queue project-list project-list-one.json 2; queue document-list document-list-one.json 1
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 1 "$RC" "project-create returned ID mismatch fails verification"
+assert_contains "$OUTPUT" "project-return-mismatch" "project-create mismatch is pending"
+reset_fake; queue project-list project-list-one.json 1; queue document-list document-list-none.json 1; queue document-create document-create-wrong-id.json 1; queue document-list document-list-one.json 2
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 1 "$RC" "document-create returned ID mismatch fails verification"
+assert_contains "$OUTPUT" "document-return-mismatch" "document-create mismatch is pending"
+reset_fake; queue document-list document-list-one.json 1; queue document-update document-update-wrong-id.json 1; queue document-list document-list-updated.json 2
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
+assert_exit 1 "$RC" "document-update returned ID mismatch fails verification"
+assert_contains "$OUTPUT" "document-return-mismatch" "document-update mismatch is pending"
+reset_fake; queue project-list project-list-one.json 1; queue project-update project-update-wrong-id.json 1; queue project-list project-list-hardened.json 2
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target hardened
+assert_exit 1 "$RC" "project-update returned ID mismatch fails verification"
+reset_fake; queue project-list project-list-one.json 1; queue project-update project-update-wrong-status.json 1; queue project-list project-list-hardened.json 2
+run_capture feature-transition --project "$project_id" --repository acme/widgets --status-map "$status_map" --target hardened
+assert_exit 1 "$RC" "project-update returned status mismatch fails verification"
+
+# Exact spec bytes are authoritative on create/resume, without leaking text in receipts.
+printf '# Feature Alpha\n\nTOP-SECRET-SPEC-TEXT\n' >"$work/mismatch.md"
+reset_fake; queue project-list project-list-one.json 1; queue document-list document-list-one.json 1
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/mismatch.md"
+assert_exit 1 "$RC" "resume rejects observed spec content mismatch"
+assert_contains "$OUTPUT" "document-content-verification" "spec mismatch remains pending"
+assert_not_contains "$OUTPUT" "TOP-SECRET-SPEC-TEXT" "failure receipt excludes spec text"
+
+# Exact comparisons distinguish zero, one, and multiple terminal newlines.
+printf '# Feature Alpha\n\nZero newline.\n\n+++ Woostack metadata — managed, do not edit\n{\"artifactType\":\"spec\",\"projectId\":\"%s\",\"repository\":\"acme/widgets\",\"schema\":1}\n+++' "$project_id" >"$work/zero-newline.md"
+make_document_list "$work/zero-list.json" "$work/zero-newline.md" '2026-07-12T10:06:00.000Z'
+reset_fake; queue document-list document-list-one.json 1; queue document-update document-update-partial.json 1; cp "$work/zero-list.json" "$work/responses/document-list.2.json"
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/zero-newline.md" --expected-revision "$revision"
+assert_exit 0 "$RC" "zero-terminal-newline content verifies exactly"
+printf '\n' >>"$work/zero-newline.md"
+reset_fake; queue document-list document-list-one.json 1; queue document-update document-update-partial.json 1; cp "$work/zero-list.json" "$work/responses/document-list.2.json"
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/zero-newline.md" --expected-revision "$revision"
+assert_exit 1 "$RC" "one versus zero terminal newline mismatch fails"
+printf '\n' >>"$work/zero-newline.md"
+cp "$work/zero-newline.md" "$work/one-newline.md"
+truncate -s -1 "$work/one-newline.md"
+make_document_list "$work/one-list.json" "$work/one-newline.md" '2026-07-12T10:07:00.000Z'
+reset_fake; queue document-list document-list-one.json 1; queue document-update document-update-partial.json 1; cp "$work/one-list.json" "$work/responses/document-list.2.json"
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/zero-newline.md" --expected-revision "$revision"
+assert_exit 1 "$RC" "multiple terminal newlines never collapse to one"
+
+# Terminal projects are preserved as history but do not block the next feature.
+reset_fake
+queue project-list project-list-done.json 1
+queue project-create project-create-success.json 1
+queue project-list project-list-one.json 2
+queue document-list document-list-none.json 1
+queue document-create document-create-success.json 1
+queue document-list document-list-one.json 2
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 0 "$RC" "preserved terminal project does not block the next feature"
+assert_eq "$(grep -c $'mutation\tproject-create' "$work/calls")" "1" "next feature creates one project beside terminal history"
+
+# Duplicate resources discovered after unknown outcomes remain safe and un-retried.
+reset_fake; queue project-list project-list-none.json 1; queue project-create project-create-success.json 1; touch "$work/responses/project-create.1.fail"; queue project-list project-list-duplicate-managed.json 2
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 1 "$RC" "duplicate projects after unknown outcome stay pending"
+assert_eq "$(grep -c $'mutation\tproject-create' "$work/calls")" "1" "duplicate discovery never retries project create"
+reset_fake; queue project-list project-list-one.json 1; queue document-list document-list-none.json 1; queue document-create document-create-success.json 1; touch "$work/responses/document-create.1.fail"; queue document-list document-list-duplicate-managed.json 2
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 1 "$RC" "duplicate specs after unknown outcome stay pending"
+assert_eq "$(grep -c $'mutation\tdocument-create' "$work/calls")" "1" "duplicate discovery never retries document create"
+
+# Marker-bearing invalid metadata is never downgraded to an unmanaged document.
+for invalid_fixture in document-list-malformed-metadata.json document-list-duplicate-marker.json document-list-foreign-metadata.json document-list-unsupported-schema.json; do
+  reset_fake; queue project-list project-list-one.json 1; queue document-list "$invalid_fixture" 1
+  run_capture feature-create --repository acme/widgets --title 'Feature Alpha' --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+  assert_exit 1 "$RC" "$invalid_fixture blocks create/resume"
+  assert_contains "$OUTPUT" "managed spec metadata" "$invalid_fixture returns a safe metadata diagnostic"
+  assert_not_contains "$(cat "$work/calls")" $'mutation\t' "$invalid_fixture causes zero mutation"
+done
+reset_fake; queue document-list document-list-foreign-metadata.json 1
+run_capture spec-read --project "$project_id" --repository acme/widgets
+assert_exit 1 "$RC" "foreign marker ownership blocks spec read"
+assert_contains "$OUTPUT" "foreign ownership" "spec read reports safe ownership diagnostic"
+reset_fake; queue document-list document-list-unsupported-schema.json 1
+run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
+assert_exit 1 "$RC" "unsupported marker schema blocks spec write"
+assert_not_contains "$(cat "$work/calls")" $'mutation\tdocument-update' "invalid metadata blocks update mutation"
+
+finish


### PR DESCRIPTION
## Goal

Add idempotent Linear feature-project and specification-document operations with lifecycle, ownership, concurrency, and read-back guarantees.

## Summary

- Add Linear project and document GraphQL operations plus the `linear.sh` command surface for preflight, feature resolution/creation/transition, and spec read/write.
- Resolve explicit UUIDs and URLs exactly; otherwise discover only canonical repository-marked projects in operation-valid lifecycle states.
- Recover safely from unknown and partial mutation outcomes through discovery and byte-exact read-back; emit content-free receipts with attempted, observed, returned, verified, and pending fields.
- Enforce canonical managed metadata, immutable ownership, optimistic revisions, valid forward lifecycle transitions, explicit abandon, pagination progress, and terminal-state protection.
- Add offline fixtures and tests for create/resume, duplicates, malformed metadata, pagination, read-back mismatches, content privacy, lifecycle transitions, and partial responses.
- Mark Increment 3 complete in the implementation plan.

## Test plan

### Automated

- [x] `bash skills/woostack-init/scripts/tests/test-linear-resources.sh` — 103 passed, 0 failed.
- [x] `bash skills/woostack-init/scripts/tests/test-linear-transport.sh` — 162 passed, 0 failed.
- [x] `bash skills/woostack-init/scripts/tests/test-linear-metadata.sh` — 66 passed, 0 failed.
- [x] `bash -n` passed for changed shell scripts.
- [x] `shellcheck` passed for changed shell scripts.
- [x] Task-level spec-compliance and code-quality reviews approved.

### Manual

- [ ] Confirm PR #499 is stacked on PR #498.
- [ ] Confirm receipts contain identifiers and verification facts but no specification content, credentials, or local paths.
- [ ] Confirm no increment issue or relation operations are included in this increment.

Spec: .woostack/specs/2026-07-11-linear-artifact-backend.md