### PR TITLE
Document Linear artifact backend adoption

### DIFF
--- a/.woostack/plans/2026-07-11-linear-artifact-backend.md
+++ b/.woostack/plans/2026-07-11-linear-artifact-backend.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-11-linear-artifact-backend.md
-status: executing
+status: done
 branch: feature/linear-artifact-backend
 ---
 

--- a/.woostack/plans/2026-07-11-linear-artifact-backend.md
+++ b/.woostack/plans/2026-07-11-linear-artifact-backend.md
@@ -479,17 +479,17 @@ branch: feature/linear-artifact-backend
 - Modify: `skills/woostack-init/references/worktrees.md`
 - Modify: `skills/woostack-status/references/conventions.md`
 
-- [ ] **Step 1: Add failing documentation contract assertions**
+- [x] **Step 1: Add failing documentation contract assertions**
   Extend the structural artifact-reader test to assert: Markdown is described as the default, not universal; Linear auth is environment-only; project/document/issues and native states are canonical in Linear mode; three gates remain; no docs-only base PR exists in Linear mode; status always reconciles terminal states; no public command count/routing row is added.
 
-- [ ] **Step 2: Run docs contract red**
+- [x] **Step 2: Run docs contract red**
   Run: `bash skills/using-woostack/tests/test-artifact-reader-contract.sh`
   Expected: FAIL on stale Markdown-only statements.
 
-- [ ] **Step 3: Update authored skill/repository references**
-  Cross-link the backend and lifecycle authorities instead of duplicating query details. Keep the twenty-skill public surface and twenty-two fixed `SKILL.md` locations unchanged. Document `LINEAR_API_KEY` without showing a real value or suggesting checked-in env files.
+- [x] **Step 3: Update authored skill/repository references**
+  Cross-link the backend and lifecycle authorities instead of duplicating query details. Keep the twenty-one-skill public/adoption surface and twenty-four fixed `SKILL.md` locations unchanged. Document `LINEAR_API_KEY` without showing a real value or suggesting checked-in env files.
 
-- [ ] **Step 4: Run docs contract green**
+- [x] **Step 4: Run docs contract green**
   Run: `bash skills/using-woostack/tests/test-artifact-reader-contract.sh`
   Expected: PASS.
 
@@ -500,25 +500,26 @@ branch: feature/linear-artifact-backend
 - Modify: `site/content/docs/getting-started.mdx`
 - Modify: `site/content/docs/concepts.mdx`
 - Modify: `site/content/docs/configuration.mdx`
-- Modify: `site/content/docs/build-loop.mdx`
-- Modify: `site/content/docs/status.mdx`
+- Modify: `site/content/docs/concepts/building-rules.mdx`
+- Modify: `site/content/docs/concepts/status-tracking.mdx`
 
-- [ ] **Step 1: Update the authored framing pages**
+- [x] **Step 1: Update the authored framing pages**
   Explain backend selection, environment authentication, Linear artifact mapping, native lifecycle behavior, gate differences, status reconciliation, migration boundary, and Markdown compatibility. Do not manually edit generated per-skill pages.
 
-- [ ] **Step 2: Run all focused shell suites**
+- [x] **Step 2: Run all focused shell suites**
   Run: `bash skills/woostack-init/scripts/tests/run-tests.sh && bash skills/woostack-build/tests/test-linear-build-contract.sh && bash skills/woostack-execute/tests/test-linear-execute-contract.sh && bash skills/woostack-commit/tests/test-linear-attribution.sh && bash skills/woostack-status/scripts/tests/run-tests.sh && bash skills/woostack-doctor/scripts/tests/run-tests.sh && bash skills/using-woostack/tests/test-artifact-reader-contract.sh`
   Expected: PASS.
 
-- [ ] **Step 3: Build the documentation site**
+- [x] **Step 3: Build the documentation site**
   Run: `pnpm -C site build`
   Expected: PASS; authored pages compile and generated skill references remain valid.
 
-- [ ] **Step 4: Run the opt-in Linear sandbox smoke test**
+- [x] **Step 4: Run the opt-in Linear sandbox smoke test**
   With `LINEAR_API_KEY` and an explicitly configured disposable sandbox team, run the documented smoke operation to preflight, create/read/update/abandon a managed project, spec document, two related increment issues, and read-back receipts.
   Expected: PASS and the disposable project ends in configured `abandoned`; if no sandbox credentials are available, record this manual check as not run rather than substituting mocks.
+  Result: **NOT RUN** — `LINEAR_API_KEY` and an explicitly configured disposable sandbox team were unavailable; no mocks were substituted.
 
-- [ ] **Step 5: Commit Increment 10**
+- [x] **Step 5: Commit Increment 10**
   Run: `gt create -m "docs: document Linear artifact backend"`
   Expected: final reviewable PR containing authored documentation and lockstep verification only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,18 @@ source code / no app lockfile" rule above. Its per-skill reference pages are **g
 from `skills/*/SKILL.md` at build time and are gitignored; only the app shell and authored
 framing pages are committed. Deploy notes live in [`site/README.md`](site/README.md).
 
+## Consumer artifact backends
+
+Consumer projects select where feature specs and plans live with `artifacts.specPlan`.
+Markdown is the default, not a universal storage rule; Linear mode keeps one managed project,
+one spec document, and ordered increment issues in Linear. Authentication for Linear comes only
+from `LINEAR_API_KEY` in the process environment — never repository config or a committed env
+file. The adoption contract and links to the build, worktree, and status authorities live in
+[`development.md`](skills/woostack-bootstrap/references/development.md#artifact-backend).
+
+This collection still has twenty-one public command/adoption skills at twenty-four fixed
+`SKILL.md` locations. Backend support adds neither a command-routing row nor a per-backend skill.
+
 ## Modes
 
 Identify the mode before acting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 | You want to... | Edit |
 |---|---|
 | Change project adoption / command routing guidance | `skills/using-woostack/SKILL.md` |
+| Change artifact-backend adoption guidance | `skills/woostack-bootstrap/references/development.md` and its consumers |
 | Add/revise a bootstrap decision or its default | `skills/woostack-bootstrap/references/decisions.md` |
 | Swap a default framework | `skills/woostack-bootstrap/references/frameworks.md` |
 | Document a new gotcha | `skills/woostack-bootstrap/references/frameworks.md` (Known gotchas section) |
@@ -46,17 +47,28 @@ See [AGENTS.md](AGENTS.md) for the full repo contract; this file is the short co
 1. Branch from `main` (`main` is protected — PRs only, never push directly).
 2. Edit the relevant skill files. One concern per PR where possible.
 3. Verify every cross-link still resolves (`[label](path.md#anchor)`).
-4. For shell/JSON skill assets, run the static checks the asset expects (`bash -n`, `jq`) — this repo has no app test runner or CI by design.
+4. For shell/JSON skill assets, run the static checks the asset expects (`bash -n`, `jq`). For
+   artifact adoption docs, run
+   `bash skills/using-woostack/tests/test-artifact-reader-contract.sh`. This repo has no universal
+   app test runner or self-CI by design.
 5. Open a PR — fill out the template.
 
 ## Editing conventions
 
 - **Skill assets only.** Markdown, plus the support files a skill ships (HTML templates and specs, the review engine's shell scripts and prompts, JSON config). No *application* code, app build configs, or app lockfiles belong in this repo.
 - **No fabricated versions.** When a skill needs a version, the procedure resolves it live (`npm view <pkg> version`). Reference frameworks by name, not by version, except in `skills/woostack-bootstrap/references/frameworks.md`, which may pin exact versions when a known incompatibility forces it.
-- **Consumer state lives under `.woostack/`** in the *target* repo a skill runs against — `specs/`, `plans/`, and `config.json` (tracked), plus local-only `memory.md` / `memory/` and `metrics.json` (gitignored). Don't reintroduce the old `.woo-review/` paths.
+- **Consumer feature artifacts are backend-selected.** Markdown remains the default, not a
+  universal requirement; Linear keeps its project, spec document, and increment issues natively.
+  Keep non-design consumer state under `.woostack/`, and follow the
+  [artifact-backend adoption contract](skills/woostack-bootstrap/references/development.md#artifact-backend)
+  rather than restating adapter or lifecycle details. Don't reintroduce the old `.woo-review/`
+  paths.
 - Prefer tables for option matrices, bulleted lists for stepwise procedures.
 - Keep examples short. The skill describes intent; project-local docs cover the specifics.
 - **Cross-link rather than duplicate.** If a fact lives in `architecture.md`, link to it from `patterns.md`; don't restate.
+- **Preserve the public surface.** Artifact backends do not create skills or command-routing rows.
+  Keep the twenty-one public command/adoption skills and all twenty-four fixed `SKILL.md` files
+  named in [AGENTS.md](AGENTS.md).
 - Keep each `SKILL.md` in sync with its references. Its `description` must state *when* to use the skill, not summarize the workflow — a workflow summary causes agents to skip the references.
 
 ## Reviewing

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [2. Initialization](#2-initialization)
   - [3. Project Integration](#3-project-integration)
   - [4. Repository Configuration](#4-repository-configuration)
+  - [5. Artifact Backend](#5-artifact-backend)
 - [The Core Development & Review Loop](#the-core-development--review-loop)
   - [Writing and Modifying Code](#writing-and-modifying-code)
   - [Review and Iterate Flow](#review-and-iterate-flow)
@@ -42,7 +43,11 @@ pnpx skills add howarewoo/woostack
 
 *Note: `pnpm` (and `pnpx`) is the recommended package manager for woostack, as bootstrapped projects default to a pnpm workspace catalog.*
 
-This command registers the public skills (e.g. `using-woostack`, `woostack-init`, `woostack-bootstrap`, `woostack-build`, `woostack-fix`, `woostack-review`, `woostack-address-comments`, etc.) and internal helper skills in `skills-lock.json`.
+This command registers twenty-one public command/adoption skills and three bundled supporting
+skills at twenty-four fixed `SKILL.md` locations. Backend selection does not add another command;
+the collection still includes `using-woostack`, `woostack-init`, `woostack-bootstrap`,
+`woostack-build`, `woostack-fix`, `woostack-review`, and `woostack-address-comments`, among the
+rest, plus its internal and unregistered helpers.
 
 > **Recommended companion — [impeccable](https://github.com/pbakaus/impeccable).** woostack's front-end design skill of choice. It powers the `design` review angle (`woostack-review` runs impeccable's detector). Optional but recommended:
 >
@@ -92,6 +97,25 @@ Example `.woostack/config.json`:
 - **`review.ignore`**: Exclude generated or external code files from PR reviews.
 
 For detailed configurations, see [woostack-review config options](skills/woostack-review/SKILL.md#per-repo-configuration-woostackconfigjson).
+
+### 5. Artifact Backend
+
+Feature specs and plans use a selected artifact backend. Markdown is the default when
+`artifacts.specPlan` is absent and remains available explicitly; it is not the only supported
+storage model. Linear mode uses one repository-owned project for the feature, one managed spec
+document, and ordered increment issues. Native project statuses and team issue states carry
+lifecycle state.
+
+Linear authentication is environment only: provide `LINEAR_API_KEY` to the process running the
+skill. Never put the key in `.woostack/config.json`, a checked-in env file, documentation, or a
+command example. The build loop retains exactly three hard gates under either backend. Markdown
+ships its spec and plan in a docs-only base PR; Linear writes those artifacts natively and has no
+docs-only base PR before implementation. Every Linear `/woostack-status` run verifies evidence and
+reconciles eligible terminal states before rendering; Markdown status remains read-only.
+
+See the [artifact-backend adoption contract](skills/woostack-bootstrap/references/development.md#artifact-backend)
+for selection and migration boundaries. It links the canonical build lifecycle, worktree, and
+status contracts; those references own the details.
 
 ---
 

--- a/site/content/docs/concepts.mdx
+++ b/site/content/docs/concepts.mdx
@@ -6,34 +6,47 @@ description: The build loop, its gates, and how woostack keeps the agent's worki
 import { ContextEconomy } from '@/components/concepts/context-economy';
 
 woostack is a build loop wrapped around one idea: an agent does its best work when its context
-window holds only what the current step needs. This page covers the loop and its gates, then the
-three mechanics that keep the context small: how memory and wisdom are recalled, how shell scripts
-do the heavy lifting, and how subagents carry work off the main thread.
+window holds only what the current step needs. Specs and plans also stay behind one configured
+artifact contract: compatible local Markdown by default, or native Linear resources. This page
+covers that shared loop, then the mechanics that keep context small.
 
 ## The build loop
 
 [woostack-build](/docs/skills/woostack-build) chains the phases in a fixed, gated order:
 
-> ideate → write spec → harden spec → **approve spec** → plan → harden plan → ship spec+plan PR
+> ideate → capture spec → harden spec → **approve spec** → plan → harden plan
 > → **execution handoff** → execute (per increment: implement → commit → review → distill)
 
 Each phase is its own skill. Build is the glue that sequences them and owns the handoffs between
 them.
+
+Artifact persistence around those phases differs by backend. See
+[Building rules](/docs/concepts/building-rules) for the side-by-side handoff.
 
 ## Three hard gates
 
 The chain only advances past these on an explicit "yes":
 
 1. **Design approval** is owned by [woostack-ideate](/docs/skills/woostack-ideate).
-2. **Spec approval** happens when the written spec is presented, before any planning begins.
-3. **Execution handoff** is where you choose Go, Run overnight, or Hand off, after the spec+plan PR.
+2. **Spec approval** happens when the selected backend's written spec is presented, before planning.
+3. **Execution handoff** is where you choose Go, Run overnight, or Hand off after the plan is ready.
 
 ## One spec, one plan, N PRs
 
-Every feature holds the `spec : plan : PRs = 1 : 1 : N` invariant: exactly one plan per spec, and
-that plan owns the N stacked increment PRs. [woostack-status](/docs/skills/woostack-status)
-derives the feature board from these artifacts, so the board is always computed rather than
-hand-maintained.
+Every feature holds the `spec : plan : PRs = 1 : 1 : N` invariant: one spec, one plan, and one
+implementation PR per independently shippable increment. Markdown represents that with joined
+spec and plan files; Linear represents it with one project, one managed spec document, and an
+ordered issue set. [woostack-status](/docs/skills/woostack-status) consumes either normalized
+model rather than maintaining a separate status file.
+
+## One contract, two artifact models
+
+Backend selection changes storage, not the workflow's three gates. Markdown remains the compatible
+default and ships its local spec and plan as a docs-only base PR before execution. Linear makes its
+project, spec document, increment issues, native states, and dependency relations canonical and
+creates no docs-only base PR. Linear lifecycle changes stay on those managed resources; they are
+not mirrored into local spec or plan files. Selection, authentication, and migration are covered
+once in [Configuration](/docs/configuration#artifact-backend).
 
 ## Context economy
 
@@ -94,17 +107,18 @@ result. The agent reads the result, not the inputs that produced it.
   reads the index instead of every note body.
 - `recall.sh` runs the scope match and the one-hop expansion, then emits only the notes that
   matched.
-- `status.sh` reads the specs, plans, and PR state, prints the feature board, and writes a
-  gitignored HTML render of it, so the agent never loads all those artifacts itself. When
-  execution finishes the final increment, `woostack-execute` and `woostack-execute-overnight`
-  author the plan's terminal `status: done`; the board still derives visible state from
-  artifacts and can show `in-review` while the final PR is open.
+- `status.sh` resolves the configured backend and renders its normalized feature model. Markdown
+  stays read-only and derives progress from local artifacts and GitHub state. Linear authenticates,
+  verifies issue-to-PR attribution, and reconciles only eligible merge-backed terminal states
+  before rendering.
 - `prefetch.sh` gathers a PR's diff, metadata, rules, memory, and wisdom once, and the review
   subagents read those files rather than each re-fetching from GitHub.
 
 This is what makes recall scale: on a repo with 500 notes, recall loads only the handful that match
-the changed files, not the full corpus. Because the work happens in the shell, the results are
-deterministic and the scripts are idempotent, so they are safe to run anytime, including in CI.
+the changed files, not the full corpus. The memory and review helpers remain deterministic and
+idempotent. Status has an intentional backend boundary: Markdown is read-only, while Linear may
+perform its narrowly scoped terminal reconciliation described in
+[Status tracking](/docs/concepts/status-tracking).
 
 ### Subagents isolate work
 
@@ -134,6 +148,8 @@ tiers map to a concrete model per provider in
 
 <Cards>
   <Card title="Getting started" href="/docs/getting-started" description="Install, initialize, and wire woostack into your agent." />
+  <Card title="Building rules" href="/docs/concepts/building-rules" description="Compare the Markdown and Linear artifact handoffs around the same three gates." />
+  <Card title="Status tracking" href="/docs/concepts/status-tracking" description="See how the board derives or reconciles backend state." />
   <Card title="woostack-build" href="/docs/skills/woostack-build" description="Drive a feature from idea to a reviewed PR stack." />
   <Card title="woostack-dream" href="/docs/skills/woostack-dream" description="Curate the memory and wisdom stores over time." />
   <Card title="All skills" href="/docs/skills/using-woostack" description="Per-skill reference, generated from each SKILL.md." />

--- a/site/content/docs/concepts/building-rules.mdx
+++ b/site/content/docs/concepts/building-rules.mdx
@@ -1,38 +1,45 @@
 ---
 title: Building rules
-description: The gated build loop, its three hard gates, and the one-spec-one-plan-N-PRs invariant.
+description: The shared three-gate build loop and the artifact handoff for Markdown and Linear.
 ---
 
-woostack drives a feature through a fixed, gated chain. The rules below are what make the loop
-trustworthy: a defined order, three places the chain stops for a human, and one invariant that
-keeps every feature's artifacts joined.
+woostack drives every feature through one fixed loop. The selected backend changes where specs,
+plans, and lifecycle state live; it does not add, remove, or reorder a gate.
 
-## The build loop
+## The shared loop
 
-[woostack-build](/docs/skills/woostack-build) chains the phases in a fixed, gated order:
+[woostack-build](/docs/skills/woostack-build) sequences:
 
-> ideate → write selected spec → harden spec → **approve spec** → plan → harden plan
-> → publish selected artifacts → **execution handoff**
+> ideate → capture spec → harden spec → **approve spec** → plan → harden plan
+> → **execution handoff** → execute (per increment: implement → commit → review → distill)
 
-Each phase is its own skill. Build is the glue that sequences them and owns the handoffs between
-them. Markdown commits the spec before approval, later appends the plan to the same docs-only PR,
-and may continue from the handoff into per-increment execution. Linear writes the managed project,
-spec document, and increment issues directly, creates no spec/plan Git artifact, and currently
-stops at the verified `ready` handoff.
+## Exactly three hard gates
 
-## Three hard gates
+The loop advances only on an explicit answer:
 
-The chain only advances past these on an explicit "yes":
+1. **Design approval** accepts the proposed design before either backend creates a spec artifact.
+2. **Written-spec approval** accepts the hardened spec before planning begins.
+3. **Execution handoff** chooses Go, Run overnight, or Hand off after the plan is ready.
 
-1. **Design approval** is owned by [woostack-ideate](/docs/skills/woostack-ideate).
-2. **Spec approval** happens when the persisted spec is presented, before any planning begins.
-3. **Execution handoff** is where Markdown offers Go, Run overnight, or Hand off. Linear currently
-   supports Hand off only; later execution support adds the other choices.
+Hardening, persistence, read-back, status transitions, and commits are work steps, not extra
+approval gates.
 
-## One spec, one plan, N PRs
+## Backend artifact handoff
 
-Every feature keeps one spec and one plan decomposition. Markdown represents execution as
-`spec : plan : PRs = 1 : 1 : N`; Linear planning represents the same decomposition as
-`project : spec document : increment issues = 1 : 1 : N` until execution support adds
-implementation PRs. [woostack-status](/docs/skills/woostack-status) derives the feature board
-from those selected backend artifacts instead of a hand-maintained file.
+| | Markdown (default) | Linear |
+| --- | --- | --- |
+| Canonical feature model | joined `.woostack/specs/` and `.woostack/plans/` Markdown files | one managed project, one spec document, and one ordered increment-issue set |
+| Lifecycle | authored spec/plan frontmatter plus derived Git and PR state | native project and issue states plus the managed spec lifecycle |
+| Dependencies | plan relationships represented by the implementation stack | native `blocked by` relations, mirrored in managed metadata |
+| Before execution | a docs-only spec+plan PR is open as the stack base | project, document, issue URLs, and a frozen base branch and SHA are presented; no branch, worktree, commit, or PR exists yet |
+| Abandon at the spec gate | close the PR and remove the temporary branch and worktree | retain the project and document audit history in their native abandoned lifecycle |
+
+Both keep the same logical `spec : plan : PRs = 1 : 1 : N` invariant and create one implementation
+PR per independently shippable increment. Linear has no docs-only base PR: after execution is
+explicitly approved, root increments begin at the frozen SHA and dependent increments use their
+declared Git parent.
+
+The [Linear build procedure](https://github.com/howarewoo/woostack/blob/main/skills/woostack-build/SKILL.md#linear-backend-procedure)
+owns the operational lifecycle. [Configuration](/docs/configuration#artifact-backend) owns backend
+selection and environment authentication; [Status tracking](/docs/concepts/status-tracking)
+explains how each model reaches terminal truth.

--- a/site/content/docs/concepts/status-tracking.mdx
+++ b/site/content/docs/concepts/status-tracking.mdx
@@ -1,127 +1,71 @@
 ---
 title: Collaboration with status tracking
-description: "How woostack computes the Markdown feature board and tracks Linear design and planning artifacts before execution."
+description: How the feature board derives Markdown truth and reconciles Linear terminal state.
 ---
 
-woostack never commits a `STATUS.md`. Instead [woostack-status](/docs/skills/woostack-status)
-**computes** a feature board on demand from Markdown specs, plans, fixes, and open PRs. Because
-the board is derived, it cannot drift the way a hand-edited status file does. Linear is also a
-selectable artifact backend for the build and planning phases, but its managed projects,
-documents, and increment issues are not yet inputs to this board.
+woostack never commits a `STATUS.md`. [woostack-status](/docs/skills/woostack-status) resolves the
+configured artifact backend, reads its canonical feature model, and computes a fresh board for the
+terminal and a gitignored HTML view. The board is a view of the artifacts, not another source of
+truth.
 
-## Lifecycle ownership
+## Canonical models
 
-The selected backend owns the pre-execution design and planning artifacts. Markdown continues
-through execution and board reconciliation today; Linear support currently stops at the
-execution handoff:
+The selected backend owns the canonical artifacts and lifecycle state. Markdown remains the
+default; Linear now continues through execution and terminal reconciliation.
 
-> **Markdown:** spec `draft → hardened → approved` · plan `planning → ready → executing → in-review → done`
->
-> **Linear today:** managed spec `designState` `draft → hardened → approved → planning → ready`
-
-Both pre-execution flows can be abandoned. In Linear, `ready` plus the verified frozen base is
-the current handoff endpoint; planned increment issues retain their stable identities and
-ordering. The later execution lifecycle begins with `executionApproved`.
-
-The Markdown lifecycle, board derivation, and joins are defined in the canonical
-[Markdown status conventions](https://github.com/howarewoo/woostack/blob/main/skills/woostack-status/references/conventions.md#markdown-lifecycle-and-joins).
-Linear build and planning use the managed-artifact identity and base-freeze contracts in the
-[Linear lifecycle and joins](https://github.com/howarewoo/woostack/blob/main/skills/woostack-status/references/conventions.md#linear-lifecycle-and-joins);
-later execution states in that contract are not yet implemented by `woostack-execute` or
-displayed by `woostack-status`.
-
-## Status definitions
-
-### Spec statuses
-
-| Status | Meaning |
-| --- | --- |
-| `draft` | The spec exists but has not completed hardening. |
-| `hardened` | The spec has been grilled and refined, but still needs user approval. |
-| `approved` | The spec approval gate is cleared and planning can begin. |
-| `abandoned` | Work intentionally stopped. |
-
-### Plan statuses
-
-| Status | Meaning |
-| --- | --- |
-| `planning` | The implementation plan exists but has not completed hardening. |
-| `ready` | The plan is hardened, no implementation work has started, and the selected artifacts are verified before execution handoff. |
-| `executing` | `woostack-execute` has started plan execution and authored this status for a non-final increment. |
-| `in-review` | The board derives this from an open increment PR; it is not the durable plan frontmatter state. |
-| `done` | `woostack-execute` authored the final plan status after every box is checked; the board confirms completion from merged PR artifacts. |
-| `abandoned` | Work intentionally stopped. |
-
-### Linear managed-spec states available before execution
-
-| `designState` | Meaning |
-| --- | --- |
-| `draft` / `hardened` / `approved` | The persisted spec advances through the design and approval gates. |
-| `planning` / `ready` | Managed increment issues are reconciled, then the plan is hardened and verified. |
-| `executionApproved` | Future execution lifecycle: the execution-handoff gate has cleared and the frozen base is immutable; the project remains `ready`. Current Linear build/planning stops before recording this state. |
-| `abandoned` | Work intentionally stopped; the managed project and document remain as audit history. |
-
-### Fix statuses
-
-| Status | Meaning |
-| --- | --- |
-| `draft` | The fix plan exists but has not completed hardening. |
-| `hardened` | The fix plan has been refined, committed for review, and still needs user approval. |
-| `approved` | The fix approval gate is cleared; execution may start now or be handed off to another session/tool before code is written. |
-| `executing` | `woostack-fix` has delegated execution to `woostack-execute` on the fix worktree. |
-| `in-review` | The fix PR is open for review. |
-| `done` | The fix lifecycle is complete. |
-| `abandoned` | Work intentionally stopped. |
-
-## Who updates status
-
-Each workflow writes only the lifecycle fields owned by the selected backend and phase:
-
-| Backend / flow | Status location | Updates |
+| | Markdown (default) | Linear |
 | --- | --- | --- |
-| Markdown [woostack-build](/docs/skills/woostack-build) | `.woostack/specs/<slug>.md` frontmatter | creates `draft`, then writes `hardened` and `approved` around the spec gate |
-| Markdown [woostack-plan](/docs/skills/woostack-plan) and build | `.woostack/plans/<spec-basename>.md` frontmatter | creates the joined plan at `planning`; build writes `ready` after hardening and verification |
-| Markdown [woostack-execute](/docs/skills/woostack-execute) | plan checkboxes/frontmatter plus Git/PR artifacts | writes `executing` and terminal `done`; the board derives `in-review` from open PRs |
-| Linear [woostack-build](/docs/skills/woostack-build) and [woostack-plan](/docs/skills/woostack-plan) | managed spec `designState`, project status, and increment issues | advances design through verified `ready`, reconciles one issue per increment, freezes the base, and stops at the current handoff |
-| [woostack-fix](/docs/skills/woostack-fix) | `.woostack/fixes/YYYY-MM-DD-<slug>.md` frontmatter | owns the combined fix lifecycle from `draft` through `done` or `abandoned` |
+| Feature source | joined local spec and plan files; self-contained `.woostack/fixes/*.md` rows bypass that join | managed project, spec document, and ordered increment issues |
+| Lifecycle source | authored frontmatter reconciled with branch, commit, and PR state | native project and team issue states plus managed spec lifecycle metadata |
+| PR attribution | exact `Spec:` trailer | exact project/issue trailer pair, verified against the owned resources |
+| Status behavior | read-only derivation and drift flags | authenticated read, narrow terminal reconciliation, then render |
 
-That split is deliberate. Markdown features use the spec/plan pair and appear on the current
-board. Linear features use managed artifacts through the pre-execution handoff, but do not yet
-appear on that board and cannot yet be passed to `woostack-execute`. Fixes remain tracked by
-their combined `.woostack/fixes/` file and one implementation PR.
+Markdown keeps the familiar `draft → hardened → approved → planning → ready → executing →
+in-review → done` feature progression. Linear uses the configured native project-status and
+team issue-state names; normalized Linear lifecycle tokens use `inReview`, not Markdown's
+`in-review`. The full enum, joins, and evidence rules live in the
+[status conventions](https://github.com/howarewoo/woostack/blob/main/skills/woostack-status/references/conventions.md).
 
-During closeout, `woostack-execute` owns the code/checklist commit and `woostack-fix`
-owns the final `status: in-review` lifecycle commit, PR URL handback, verification
-summary, and worktree teardown on that same fix PR.
+Markdown fixes keep their own concise lifecycle because one fix file acts as both spec and plan:
+`draft → hardened → approved → executing → in-review → done`, plus terminal `abandoned`. Each fix
+ships as one PR; it does not acquire a feature plan or enter the Linear project model.
 
-## One spec, one plan decomposition, N PRs
+## Reconciliation
 
-The current board relies on the Markdown topology:
+### Markdown
 
-- `spec : plan : PRs = 1 : 1 : N`. Reciprocal spec/plan links join the tracked files; every PR
-  body carries the exact `Spec: .woostack/specs/<file>.md` trailer.
+Markdown status never changes a spec, plan, fix, branch, commit, or PR. It derives visible
+execution and review phases from local checkboxes and GitHub artifacts, and flags disagreements
+instead of rewriting frontmatter. It also reports malformed joins, missing branches, duplicate
+in-flight branches, and stale execution based on
+[`status.staleDays`](/docs/configuration#status-board).
 
-Linear build and planning preserve the corresponding pre-execution topology:
+### Linear
 
-- `project : spec document : increment issues = 1 : 1 : N`. Managed metadata joins the
-  repository-owned project, document, and issues by exact project/repository identity. Those
-  artifacts prepare the handoff; the current board does not discover them, and the current
-  execution skill does not add branch or pull-request evidence to them.
+Every Linear status run authenticates and performs terminal reconciliation before rendering. It
+verifies that each attributed PR belongs to the managed project and issue and is actually merged,
+previews eligible writes, then permits only `inReview → done` for those issues. After verified
+read-back, it moves the project to `done` only when every managed issue is observed `done`.
 
-## Computed, not authored
+This is deliberately narrower than general lifecycle management: status never reopens,
+downgrades, abandons, or writes a non-terminal Linear state. Missing authentication, foreign or
+ambiguous attribution, API failure, partial evidence, or read-back mismatch fails closed rather
+than becoming a successful or empty board. The
+[woostack-status reference](/docs/skills/woostack-status) owns the exact reconciliation procedure.
+
+## Migration boundary
+
+Only the selected backend participates in the feature board. When Linear is active, local
+`.woostack/specs/` and `.woostack/plans/` files are inactive legacy artifacts: status does not
+merge, synchronize, or fall back to them, and doctor leaves them untouched while reporting the
+migration boundary. Self-contained Markdown fixes remain a separate compatibility model, not a
+way to import or shadow a Linear feature. Switch deliberately and keep one canonical feature
+store.
 
 <Callout type="info">
-  The board is computed fresh each run, printed to the terminal, and mirrored to a gitignored
-  HTML render under `.woostack/visuals/status-board.html`. It never fetches, commits, pushes, or
-  writes a tracked status file. A lagging authored `status:` is reconciled against the artifacts,
-  not trusted blindly.
+  The terminal table is canonical narration. The mirrored
+  `.woostack/visuals/status-board.html` file is gitignored presentation only; no tracked status
+  snapshot is created.
 </Callout>
 
-The board displays the effective phase derived from Markdown artifacts and Git/PR state. A
-disagreement between authored lifecycle and computed evidence is surfaced as a flag, not displayed
-as truth. Drift includes unknown status, missing/duplicate plan, missing execution branch, or PRs
-inconsistent with the plan phase. Executing rows older than `status.staleDays` (a
-[config](/docs/configuration) key, default 14) are stale.
 
-Because `status.sh` exits 0 even when it prints drift flags and only writes the gitignored HTML
-render, the board is safe to run anywhere, including CI, without mutating tracked state.

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -4,18 +4,18 @@ description: Every key in the .woostack/config.json file, what it tunes, its typ
 ---
 
 woostack reads optional settings from `.woostack/config.json` at the repository root.
-[woostack-init](/docs/skills/woostack-init) creates the file, and every key is optional: when a
-key is absent, the skill that reads it falls back to a built-in default. The init template
-ships five top-level keys: `artifacts`, `models`, `review`, `respond`, and `status`.
-[woostack-doctor](/docs/skills/woostack-doctor) checks the scaffolded namespaces and validates
-response metadata without querying a provider.
+[woostack-init](/docs/skills/woostack-init) creates the file. The init template ships five
+top-level keys: `artifacts`, `models`, `review`, `respond`, and `status`; other settings use
+built-in defaults when absent. [woostack-doctor](/docs/skills/woostack-doctor) checks the
+required shape without reading credentials or contacting Linear unless you explicitly request
+`--live`.
 
 There are ten top-level settings:
 
 | Setting | Read by | Tunes |
 | --- | --- | --- |
-| `artifacts` | spec/plan workflows | selects the Markdown or Linear artifact backend |
-| `linear` | spec/plan workflows when `artifacts.specPlan` is `linear` | secret-free Linear workspace, repository, and lifecycle mappings |
+| `artifacts` | all spec/plan consumers | selects the canonical spec and plan backend |
+| `linear` | all spec/plan consumers when Linear is selected | workspace, team, repository, and native state mappings |
 | `review` | [woostack-review](/docs/skills/woostack-review) | the PR review engine: angles, noise, validation |
 | `models` | [woostack-review](/docs/skills/woostack-review), [woostack-audit](/docs/skills/woostack-audit), and local subagent drivers | shared model selection and tier parameters |
 | `audit` | [woostack-audit](/docs/skills/woostack-audit) | standing-code audit angles, filtering, chunking, and output |
@@ -25,37 +25,16 @@ There are ten top-level settings:
 | `status` | [woostack-status](/docs/skills/woostack-status) | when the board flags a spec as stale |
 | `base_branch` | [woostack-init](/docs/skills/woostack-init) | the trunk branch for PRs and worktrees |
 
-## A complete example
+## A complete Markdown example
 
-Every top-level setting is populated as a starting point. JSON has no comments, so each key is
-explained in the sections below.
+Every top-level setting used by the Markdown backend is populated as a starting point. The
+Linear-only mapping is shown separately below. JSON has no comments, so each key is explained in
+the sections that follow.
 
 ```json
 {
   "artifacts": { "specPlan": "markdown" },
-  "linear": {
-    "workspace": "acme",
-    "team": "ENG",
-    "repository": "acme/widgets",
-    "projectStatuses": {
-      "draft": "Draft",
-      "hardened": "Hardened",
-      "approved": "Approved",
-      "planning": "Planning",
-      "ready": "Ready",
-      "executing": "In Progress",
-      "inReview": "In Review",
-      "done": "Completed",
-      "abandoned": "Canceled"
-    },
-    "issueStates": {
-      "planned": "Backlog",
-      "executing": "In Progress",
-      "inReview": "In Review",
-      "done": "Done",
-      "blocked": "Blocked"
-    }
-  },
+
   "review": {
     "severity_floor": "high",
     "nits": true,
@@ -97,36 +76,72 @@ explained in the sections below.
 
 ## Artifact backend
 
-`artifacts.specPlan` accepts `markdown` (the default) or `linear`. Markdown reads and writes
-tracked `.woostack/specs/*.md` and `.woostack/plans/*.md` files. Linear is operational for the
-spec/plan build loop: it stores one repository-owned project, one managed spec document, and one
-managed issue per increment, with verified read-backs after every mutation. Linear mode writes no
-local spec/plan source and opens no docs-only spec+plan PR.
+`artifacts.specPlan` selects one backend for the repository: the default is `markdown`; the alternative is `linear`.
+Skills resolve this selector before touching a spec or plan and never infer storage from files,
+credentials, or command arguments. Markdown reads and writes tracked `.woostack/specs/*.md` and
+`.woostack/plans/*.md` files. Linear stores one repository-owned project, one managed spec
+document, and one managed issue per increment, with verified read-backs after every mutation. It
+writes no local spec/plan source and opens no docs-only spec+plan PR. A Linear failure never falls
+back to Markdown.
 
-| Key | Required for `linear` | Meaning |
-| --- | --- | --- |
-| `linear.workspace` | yes | Linear workspace slug or identifier. |
-| `linear.team` | yes | Team key or identifier used for increment issues. |
-| `linear.repository` | when no GitHub `origin` can be resolved | Canonical `owner/repository` identity. An explicit value takes precedence over Git remote discovery. |
-| `linear.projectStatuses.draft` | yes | Project status for draft specs. |
-| `linear.projectStatuses.hardened` | yes | Project status for hardened specs. |
-| `linear.projectStatuses.approved` | yes | Project status for approved specs. |
-| `linear.projectStatuses.planning` | yes | Project status while a plan is being written. |
-| `linear.projectStatuses.ready` | yes | Project status for an approved plan awaiting execution. |
-| `linear.projectStatuses.executing` | yes | Project status while increments are being implemented. |
-| `linear.projectStatuses.inReview` | yes | Project status while increment PRs are under review. |
-| `linear.projectStatuses.done` | yes | Project status after every increment is complete. |
-| `linear.projectStatuses.abandoned` | yes | Project status for abandoned work. |
-| `linear.issueStates.planned` | yes | Issue state for planned increments. |
-| `linear.issueStates.executing` | yes | Issue state for active increments. |
-| `linear.issueStates.inReview` | yes | Issue state for increments under review. |
-| `linear.issueStates.done` | yes | Issue state for completed increments. |
-| `linear.issueStates.blocked` | yes | Issue state for blocked increments. |
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `artifacts.specPlan` | `"markdown"` or `"linear"` | `"markdown"` | Canonical spec/plan backend for the repository. |
+| `linear.repository` | `owner/repo` string | repository's GitHub origin | Repository identity recorded on managed resources. |
+| `linear.workspace` | non-empty string | required in Linear mode | Linear workspace name or key. |
+| `linear.team` | non-empty string | required in Linear mode | Linear team name or key for increment issues. |
+| `linear.projectStatuses` | complete name map | required in Linear mode | Maps woostack project phases to native Linear project-status names. |
+| `linear.issueStates` | complete name map | required in Linear mode | Maps increment phases to native team workflow-state names. |
 
 Only the keys listed above are accepted; unknown keys fail closed. The namespace must not contain
 credentials at any depth. Keep API keys, tokens, authorization headers, passwords, private or
 access keys, client secrets, credential files, and provider authentication in the host's native
 secret store.
+The configured names are resolved to native IDs during authenticated preflight. Projects are the
+feature, one managed document is the spec, and ordered issues are the plan increments; their
+native states and `blocked by` relations remain canonical. The
+[artifact-backend reference](https://github.com/howarewoo/woostack/blob/main/skills/woostack-bootstrap/references/development.md#artifact-backend)
+owns the selection and resource model, while [Building rules](/docs/concepts/building-rules)
+explains how those resources pass through the three gates.
+
+```json
+{
+  "artifacts": { "specPlan": "linear" },
+  "linear": {
+    "repository": "owner/repository",
+    "workspace": "workspace-key",
+    "team": "TEAM",
+    "projectStatuses": {
+      "draft": "Draft",
+      "hardened": "Hardened",
+      "approved": "Approved",
+      "planning": "Planning",
+      "ready": "Ready",
+      "executing": "In Progress",
+      "inReview": "In Review",
+      "done": "Completed",
+      "abandoned": "Canceled"
+    },
+    "issueStates": {
+      "planned": "Backlog",
+      "executing": "In Progress",
+      "inReview": "In Review",
+      "done": "Done",
+      "blocked": "Blocked"
+    }
+  }
+}
+```
+
+Linear authentication is environment-only. Supply `LINEAR_API_KEY` to the woostack process from
+your shell or secret manager; never add the key to this JSON, a committed `.env` file, generated
+docs, or any artifact. Static doctor checks are credential-free. `/woostack-doctor --live` is the
+explicit authenticated validation path.
+
+Changing the selector does not migrate data. In Linear mode, existing `.woostack/specs/` and
+`.woostack/plans/` files are inactive legacy artifacts: doctor reports them but never imports,
+rewrites, deletes, or synchronizes them. Switch only after a deliberate migration and use one
+backend at a time.
 
 ## Response
 
@@ -370,10 +385,10 @@ worktrees are cut from.
 ## Defaults and doctor
 
 <Callout type="info">
-  Every key is optional. The init template ships `artifacts`, `models`, `review`, `respond`, and
-  `status`; everything else takes its built-in default when absent.
-  [woostack-doctor](/docs/skills/woostack-doctor) validates the five scaffolded keys and can repair
-  a missing one. Each owning skill validates its settings when it runs.
+  Every key is optional in the Markdown default. The init template ships `artifacts`, `models`,
+  `review`, `respond`, and `status`; everything else takes its built-in default when absent.
+  [woostack-doctor](/docs/skills/woostack-doctor) validates all five scaffolded keys and can
+  repair a missing local default. Each owning skill validates its settings when it runs.
 </Callout>
 
 ## Where to go next

--- a/site/content/docs/getting-started.mdx
+++ b/site/content/docs/getting-started.mdx
@@ -36,6 +36,21 @@ pnpx skills add howarewoo/woostack
 Run this **before any other woostack skill**. It sets up the `.woostack/` workspace, default
 config, and gitignores.
 
+### Choose an artifact backend
+
+Markdown is the default and needs no extra setup. To use Linear, set
+`artifacts.specPlan` to `linear`, add the workspace, team, repository, project-status, and
+issue-state mappings described in [Configuration](/docs/configuration#artifact-backend), and
+provide `LINEAR_API_KEY` through the process environment or your secret manager. The key never
+belongs in `.woostack/config.json`, a committed `.env` file, or documentation.
+
+The selector is a clean boundary, not a fallback order. In Linear mode, native projects,
+documents, issues, states, and dependency relations are canonical; existing
+`.woostack/specs/` and `.woostack/plans/` files remain untouched but inactive. Migrate
+deliberately rather than asking woostack to merge or synchronize both stores. The
+[artifact-backend reference](https://github.com/howarewoo/woostack/blob/main/skills/woostack-bootstrap/references/development.md#artifact-backend)
+owns the full adoption contract.
+
 ### Optional production-error response setup
 
 Interactive init offers `Set up production error response? [y/N]` and defaults to no.

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -5,8 +5,9 @@ description: A model-agnostic collection of gated software-development skills.
 
 woostack packages opinionated, gated workflows into installable skills that any AI coding
 agent can follow, covering greenfield bootstrapping, feature building, debugging, automated
-code review, and feedback iteration. It ships a local, token-efficient memory system so later
-agent sessions don't repeat earlier mistakes.
+code review, and feedback iteration. Specs and plans use a configured artifact backend:
+Markdown is the default, while Linear can make native projects, documents, and issues canonical.
+Local, token-efficient memory keeps later agent sessions from repeating earlier mistakes.
 
 ```bash
 pnpx skills add howarewoo/woostack
@@ -16,6 +17,8 @@ pnpx skills add howarewoo/woostack
   Cursor / Composer, and Antigravity CLI](/docs/harnesses), while the skill logic remains portable
   to other harnesses.
 - **Local memory:** learnings retained and routed per clone.
+- **Backend-aware artifacts:** keep the compatible Markdown workflow or use Linear's native
+  project, document, issue, and lifecycle model.
 - **Team-ready:** built for small-to-medium collaborative codebases.
 - **Pairs with [impeccable](https://github.com/pbakaus/impeccable):** woostack's recommended front-end design skill. Install alongside: `pnpx skills add pbakaus/impeccable`.
 
@@ -61,6 +64,8 @@ several narrow tools together.
 <Cards>
   <Card title="Getting started" href="/docs/getting-started" description="Install, initialize, and wire woostack into your agent." />
   <Card title="Core concepts" href="/docs/concepts" description="The build loop, context management, worktrees, and status tracking." />
+  <Card title="Artifact backends" href="/docs/configuration#artifact-backend" description="Choose the Markdown default or configure Linear with environment-only authentication." />
+  <Card title="Building rules" href="/docs/concepts/building-rules" description="See the same three gates and each backend's artifact handoff." />
   <Card title="Harnesses" href="/docs/harnesses" description="Explicitly supported harnesses, native capability differences, and behavior on unsupported hosts." />
   <Card title="woostack-build" href="/docs/skills/woostack-build" description="Drive a feature from idea to a reviewed PR stack." />
   <Card title="All skills" href="/docs/skills/using-woostack" description="Per-skill reference, generated from each SKILL.md." />

--- a/site/scripts/gen-skills.mjs
+++ b/site/scripts/gen-skills.mjs
@@ -8,14 +8,34 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..'); // site/scripts -> repo r
 const SKILLS_DIR = path.join(REPO_ROOT, 'skills');
 const OUT_DIR = path.resolve(__dirname, '..', 'content', 'docs', 'skills');
 const GH_BASE = 'https://github.com/howarewoo/woostack/blob/main';
-const INTERNAL = new Set(['woostack-ideate', 'woostack-harden']);
-
-const ORDER = [
-  'using-woostack', 'woostack-init', 'woostack-bootstrap', 'woostack-build', 'woostack-fix',
-  'woostack-plan', 'woostack-execute', 'woostack-execute-overnight', 'woostack-commit',
-  'woostack-review', 'woostack-address-comments', 'woostack-status', 'woostack-visualize',
-  'woostack-debug', 'woostack-tdd', 'woostack-dream',
+export const PUBLIC_ORDER = [
+  'using-woostack',
+  'woostack-init',
+  'woostack-bootstrap',
+  'woostack-build',
+  'woostack-fix',
+  'woostack-plan',
+  'woostack-execute',
+  'woostack-execute-overnight',
+  'woostack-commit',
+  'woostack-review',
+  'woostack-address-comments',
+  'woostack-status',
+  'woostack-visualize',
+  'woostack-debug',
+  'woostack-tdd',
+  'woostack-dream',
+  'woostack-doctor',
+  'woostack-sweep',
+  'woostack-qa',
+  'woostack-audit',
+  'woostack-respond',
 ];
+export const SUPPORTING_ORDER = ['woostack-ask'];
+export const INTERNAL_ORDER = ['woostack-harden', 'woostack-ideate'];
+
+const ORDER = [...PUBLIC_ORDER, ...SUPPORTING_ORDER, ...INTERNAL_ORDER];
+const INTERNAL = new Set(INTERNAL_ORDER);
 
 export function parseFrontmatter(raw, file = '<input>') {
   const m = /^---\n([\s\S]*?)\n---\n?/.exec(raw);

--- a/site/scripts/gen-skills.test.mjs
+++ b/site/scripts/gen-skills.test.mjs
@@ -3,6 +3,9 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
+  INTERNAL_ORDER,
+  PUBLIC_ORDER,
+  SUPPORTING_ORDER,
   parseFrontmatter,
   stripTitleHeading,
   rewriteLinks,
@@ -99,12 +102,41 @@ test('renderPage emits title/description, source link, internal note for sub-ski
   assert.match(ideate, /Internal sub-skill/);
 });
 
-test('navOrder puts public commands first, internal sub-skills last', () => {
-  const names = ['woostack-harden', 'woostack-build', 'woostack-ideate', 'using-woostack'];
-  const order = navOrder(names);
-  assert.deepEqual(order, ['using-woostack', 'woostack-build', 'woostack-harden', 'woostack-ideate']);
-  assert.ok(order.indexOf('woostack-build') < order.indexOf('woostack-ideate'));
-  assert.ok(order.indexOf('woostack-build') < order.indexOf('woostack-harden'));
+test('navOrder preserves the exact 21-public and 3-supporting/internal skill order', () => {
+  const expectedPublic = [
+    'using-woostack',
+    'woostack-init',
+    'woostack-bootstrap',
+    'woostack-build',
+    'woostack-fix',
+    'woostack-plan',
+    'woostack-execute',
+    'woostack-execute-overnight',
+    'woostack-commit',
+    'woostack-review',
+    'woostack-address-comments',
+    'woostack-status',
+    'woostack-visualize',
+    'woostack-debug',
+    'woostack-tdd',
+    'woostack-dream',
+    'woostack-doctor',
+    'woostack-sweep',
+    'woostack-qa',
+    'woostack-audit',
+    'woostack-respond',
+  ];
+  const expectedSupporting = ['woostack-ask'];
+  const expectedInternal = ['woostack-harden', 'woostack-ideate'];
+  const expected = [...expectedPublic, ...expectedSupporting, ...expectedInternal];
+
+  assert.equal(PUBLIC_ORDER.length, 21);
+  assert.deepEqual(PUBLIC_ORDER, expectedPublic);
+  assert.deepEqual(SUPPORTING_ORDER, expectedSupporting);
+  assert.deepEqual(INTERNAL_ORDER, expectedInternal);
+  assert.equal(expected.length, 24);
+  assert.equal(new Set(expected).size, 24);
+  assert.deepEqual(navOrder([...expected].reverse()), expected);
 });
 
 test('concepts taxonomy keeps context economy under context management', async () => {
@@ -119,7 +151,7 @@ test('concepts taxonomy keeps context economy under context management', async (
   assert.doesNotMatch(overview, /^## Context economy$/m);
 });
 
-test('model configuration docs follow the root models contract', async () => {
+test('configuration docs follow the scaffold and backend contract', async () => {
   const repoRoot = path.resolve(import.meta.dirname, '..', '..');
   const [templateRaw, configuration, auditRaw, memory] = await Promise.all([
     readFile(path.join(repoRoot, 'skills', 'woostack-init', 'templates', 'config.json'), 'utf8'),
@@ -130,23 +162,27 @@ test('model configuration docs follow the root models contract', async () => {
   const template = JSON.parse(templateRaw);
   assert.deepEqual(Object.keys(template), ['artifacts', 'models', 'review', 'respond', 'status']);
 
-  const exampleMatch = /## A complete example[\s\S]*?```json\n([\s\S]*?)\n```/.exec(configuration);
-  assert.ok(exampleMatch, 'configuration page exposes a complete JSON example');
+  const exampleMatch = /## A complete Markdown example[\s\S]*?```json\n([\s\S]*?)\n```/.exec(configuration);
+  assert.ok(exampleMatch, 'configuration page exposes a complete Markdown JSON example');
   const example = JSON.parse(exampleMatch[1]);
   assert.deepEqual(
     Object.keys(example).sort(),
-    ['artifacts', 'audit', 'base_branch', 'commit', 'linear', 'models', 'respond', 'review', 'review_sweep', 'status']
+    ['artifacts', 'audit', 'base_branch', 'commit', 'models', 'respond', 'review', 'review_sweep', 'status']
   );
   assert.ok(example.models);
+  assert.deepEqual(example.artifacts, { specPlan: 'markdown' });
+  assert.equal(example.linear, undefined);
   assert.equal(example.audit.models, undefined);
 
-  assert.match(configuration, /ships five top-level keys: `artifacts`, `models`, `review`, `respond`, and `status`/);
+  assert.match(configuration, /ships five\s+top-level keys: `artifacts`, `models`, `review`, `respond`, and `status`/);
   assert.match(configuration, /There are ten top-level settings:/);
+  assert.match(configuration, /\| `artifacts` \|/);
+  assert.match(configuration, /\| `linear` \|/);
   assert.match(configuration, /\| `audit` \|/);
   assert.match(configuration, /^## Audit engine$/m);
   assert.match(configuration, /`audit\.severity_floor`/);
   assert.match(configuration, /Root model tiers also drive \[woostack-audit\]/);
-  assert.match(configuration, /validates the five scaffolded keys/);
+  assert.match(configuration, /validates all five scaffolded keys/);
 
   const { fm, body } = parseFrontmatter(auditRaw, 'woostack-audit');
   const renderedBody = rewriteLinks(
@@ -166,4 +202,7 @@ test('model configuration docs follow the root models contract', async () => {
     normalizedMemory,
     /\{ "artifacts": \{ "specPlan": "markdown" \}, "models": \{\}, "review": \{\}, "respond": \{\}, "status": \{ "staleDays": 14 \} \}/
   );
+  assert.match(normalizedMemory, /spec\/plan backend and defaults to Markdown/);
+  assert.match(normalizedMemory, /specs\/.*inactive when Linear is selected/);
+  assert.match(normalizedMemory, /plans\/.*inactive when Linear is selected/);
 });

--- a/skills/using-woostack/SKILL.md
+++ b/skills/using-woostack/SKILL.md
@@ -61,6 +61,14 @@ Do not run `/woostack-init`, create `.woostack/`, scaffold code, or add config u
 user explicitly asks for that behavior or the loaded task-specific skill requires it as part
 of an approved workflow.
 
+**Artifact-backend invariant:** Markdown is the default feature spec/plan backend, not a
+universal filesystem requirement. A loaded workflow skill resolves `artifacts.specPlan` and uses
+only the selected backend; routing never infers storage from folders or the presence of
+`LINEAR_API_KEY`. Linear authentication is supplied only through the process environment. The
+[artifact-backend adoption contract](../woostack-bootstrap/references/development.md#artifact-backend)
+defines the model and links the canonical build, worktree, and status authorities; do not
+duplicate their lifecycle or adapter details here.
+
 **Feature-state invariant:** in a woostack project, every spec has exactly one plan
 (`spec : plan : PRs = 1 : 1 : N`), and the spec design `status:` plus plan implementation
 `status:`/`branch:` frontmatter is load-bearing for the `/woostack-status` board. The phase

--- a/skills/using-woostack/tests/test-artifact-reader-contract.sh
+++ b/skills/using-woostack/tests/test-artifact-reader-contract.sh
@@ -13,12 +13,13 @@ TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/woostack-reader-contract.XXXXXX")" || exi
 trap 'rm -rf -- "$TMP_ROOT"' EXIT HUP INT TERM
 
 analyze_root() {
-  python3 - "$1" <<'PY'
+  python3 - "$1" "${2:-repository}" <<'PY'
 import re
 import sys
 from pathlib import Path
 
 root = Path(sys.argv[1])
+validation_mode = sys.argv[2]
 skills_root = root / "skills"
 
 # Every artifact-reading SKILL discovered below must be classified here. This is wider than
@@ -298,7 +299,7 @@ expected_routes = [
 if routes != expected_routes:
     failure("skill-surface", "public command routing rows must remain exactly the ordered 20-command surface")
 
-if (root / "AGENTS.md").is_file():
+if validation_mode == "repository":
     doc_paths = {
         "AGENTS.md": root / "AGENTS.md",
         "README.md": root / "README.md",
@@ -401,7 +402,7 @@ PY
 
 record_analysis() {
   local root="$1" label="$2" output
-  if output="$(analyze_root "$root" 2>&1)"; then
+  if output="$(analyze_root "$root" repository 2>&1)"; then
     pass
   else
     fail "$label: $output"
@@ -409,8 +410,8 @@ record_analysis() {
 }
 
 expect_fixture_failure() {
-  local root="$1" expected="$2" label="$3" output
-  if output="$(analyze_root "$root" 2>&1)"; then
+  local root="$1" expected="$2" label="$3" mode="${4:-fixture}" output
+  if output="$(analyze_root "$root" "$mode" 2>&1)"; then
     fail "$label: injected violation unexpectedly passed"
   elif [[ "$output" == *"$expected"* ]]; then
     pass
@@ -463,6 +464,11 @@ lines[routes[0]], lines[routes[1]] = lines[routes[1]], lines[routes[0]]
 path.write_text("\n".join(lines) + "\n")
 PY
 expect_fixture_failure "$fixture" "ordered 20-command surface" "routing-row order rejection"
+
+fixture="$TMP_ROOT/missing-adoption-contract"
+make_fixture "$fixture"
+expect_fixture_failure "$fixture" "required adoption document is missing" \
+  "missing repository adoption contract" repository
 
 fixture="$TMP_ROOT/new-reader"
 make_fixture "$fixture"

--- a/skills/using-woostack/tests/test-artifact-reader-contract.sh
+++ b/skills/using-woostack/tests/test-artifact-reader-contract.sh
@@ -237,6 +237,161 @@ if not (re.search(r"spec-only", dream, re.I) and re.search(r"(?:absent|missing|w
 if re.search(r"resolve-backend\.sh[^.]{0,120}exactly\s+once", folded, re.I):
     failure("woostack-dream", "claims a false process-wide resolver call count despite doctor runtime isolation")
 
+
+# Adoption documentation mirrors workflow contracts without becoming a second implementation
+# manual. Keep this set closed: adding a SKILL.md or routing row is a deliberate public-surface
+# change, not a side effect of documenting an artifact backend.
+fixed_skills = {
+    "using-woostack",
+    "woostack-address-comments",
+    "woostack-ask",
+    "woostack-audit",
+    "woostack-bootstrap",
+    "woostack-build",
+    "woostack-commit",
+    "woostack-debug",
+    "woostack-doctor",
+    "woostack-dream",
+    "woostack-execute",
+    "woostack-execute-overnight",
+    "woostack-fix",
+    "woostack-harden",
+    "woostack-ideate",
+    "woostack-init",
+    "woostack-plan",
+    "woostack-qa",
+    "woostack-respond",
+    "woostack-review",
+    "woostack-status",
+    "woostack-sweep",
+    "woostack-tdd",
+    "woostack-visualize",
+}
+public_skills = fixed_skills - {"woostack-ask", "woostack-harden", "woostack-ideate"}
+if set(texts) != fixed_skills:
+    failure("skill-surface", f"expected 24 fixed SKILL.md locations, found {len(texts)}")
+
+using = texts.get("using-woostack", "")
+routes = re.findall(r"^\| `/([^`\s]+)", using, re.M)
+expected_routes = [
+    "woostack-init",
+    "woostack-bootstrap",
+    "woostack-build",
+    "woostack-fix",
+    "woostack-plan",
+    "woostack-execute",
+    "woostack-execute-overnight",
+    "woostack-sweep",
+    "woostack-commit",
+    "woostack-review",
+    "woostack-audit",
+    "woostack-qa",
+    "woostack-respond",
+    "woostack-address-comments",
+    "woostack-status",
+    "woostack-visualize",
+    "woostack-debug",
+    "woostack-tdd",
+    "woostack-dream",
+    "woostack-doctor",
+]
+if routes != expected_routes:
+    failure("skill-surface", "public command routing rows must remain exactly the ordered 20-command surface")
+
+if (root / "AGENTS.md").is_file():
+    doc_paths = {
+        "AGENTS.md": root / "AGENTS.md",
+        "README.md": root / "README.md",
+        "CONTRIBUTING.md": root / "CONTRIBUTING.md",
+        "using-woostack": skills_root / "using-woostack" / "SKILL.md",
+        "development": skills_root / "woostack-bootstrap" / "references" / "development.md",
+        "init": skills_root / "woostack-init" / "SKILL.md",
+        "worktrees": skills_root / "woostack-init" / "references" / "worktrees.md",
+        "status-conventions": skills_root / "woostack-status" / "references" / "conventions.md",
+        "site-index": root / "site" / "content" / "docs" / "index.mdx",
+        "site-getting-started": root / "site" / "content" / "docs" / "getting-started.mdx",
+        "site-concepts": root / "site" / "content" / "docs" / "concepts.mdx",
+        "site-configuration": root / "site" / "content" / "docs" / "configuration.mdx",
+        "site-build-loop": root / "site" / "content" / "docs" / "concepts" / "building-rules.mdx",
+        "site-status": root / "site" / "content" / "docs" / "concepts" / "status-tracking.mdx",
+    }
+    doc_texts = {}
+    for name, path in doc_paths.items():
+        if not path.is_file():
+            failure(name, "required adoption document is missing")
+            doc_texts[name] = ""
+        else:
+            doc_texts[name] = path.read_text(encoding="utf-8")
+
+    def require_doc(name: str, pattern: str, message: str):
+        if not re.search(pattern, doc_texts.get(name, ""), re.I | re.S):
+            failure(name, message)
+
+    # development.md owns the adoption overview; related docs link to it and to the existing
+    # build/worktree/status authorities rather than restating adapter commands or GraphQL.
+    for name in ("AGENTS.md", "README.md", "CONTRIBUTING.md", "using-woostack", "init"):
+        require_doc(name, r"development\.md#artifact-backend", "does not link the artifact-backend adoption authority")
+    require_doc("development", r"\.\./\.\./woostack-build/SKILL\.md", "does not link the build lifecycle authority")
+    require_doc("development", r"\.\./\.\./woostack-init/references/worktrees\.md", "does not link the worktree authority")
+    require_doc("development", r"\.\./\.\./woostack-status/references/conventions\.md", "does not link the status authority")
+    require_doc("worktrees", r"woostack-build/SKILL\.md#linear-backend-procedure", "does not link the Linear build authority")
+    require_doc("status-conventions", r"woostack-bootstrap/references/development\.md#artifact-backend", "does not link the adoption authority")
+
+    require_doc("development", r"Markdown.{0,100}\bdefault\b", "does not describe Markdown as the default backend")
+    require_doc("development", r"(?:LINEAR_API_KEY.{0,160}\benvironment\b|\benvironment\b.{0,160}LINEAR_API_KEY)", "does not make Linear authentication environment-only")
+    require_doc("development", r"\bproject\b.{0,160}\bspec document\b.{0,160}\bincrement issues\b", "does not state the canonical Linear artifact model")
+    require_doc("development", r"native project statuses.{0,160}team issue states", "does not preserve native Linear lifecycle state")
+    require_doc("development", r"exactly\s+three\s+hard\s+gates", "does not preserve exactly three workflow gates")
+    require_doc("development", r"Linear.{0,200}no docs-only base PR", "does not exclude the Markdown docs-only base PR from Linear mode")
+    require_doc("status-conventions", r"Every `/woostack-status` run.{0,240}terminal\s+reconciliation", "does not require terminal reconciliation on every status run")
+    require_doc("AGENTS.md", r"twenty-one\s+public.{0,160}twenty-four\s+fixed\s+`SKILL\.md`", "does not preserve the 21-public/24-fixed skill surface")
+
+    # The authored site has six framing-page equivalents. Generated per-skill pages remain out of
+    # scope, but each authored page must preserve the backend fact it presents to consumers.
+    require_doc("site-index", r"Markdown\s+is\s+the\s+default.{0,160}Linear.{0,160}(?:projects|project).{0,100}(?:documents|document).{0,100}(?:issues|issue).{0,80}canonical", "does not frame the default and canonical Linear model")
+    require_doc("site-index", r"/docs/configuration#artifact-backend", "does not link the site backend authority")
+
+    require_doc("site-getting-started", r"artifacts\.specPlan.{0,80}linear", "does not explain Linear selection")
+    require_doc("site-getting-started", r"LINEAR_API_KEY.{0,160}(?:process environment|secret manager)", "does not make Linear authentication environment-only")
+    require_doc("site-getting-started", r"native projects.{0,120}documents.{0,120}issues.{0,120}canonical", "does not identify native Linear artifacts as canonical")
+    require_doc("site-getting-started", r"clean boundary.{0,240}(?:inactive|Migrate deliberately)", "does not explain the migration boundary")
+    require_doc("site-getting-started", r"development\.md#artifact-backend", "does not link the repository adoption authority")
+
+    require_doc("site-concepts", r"Three hard gates", "does not preserve the three-gate overview")
+    require_doc("site-concepts", r"Markdown.{0,120}default.{0,240}Linear.{0,200}project.{0,120}spec document.{0,120}(?:increment issues|ordered issue)", "does not compare canonical backend models")
+    require_doc("site-concepts", r"Linear.{0,240}no docs-only base PR", "does not preserve the Linear handoff difference")
+    require_doc("site-concepts", r"/docs/configuration#artifact-backend", "does not link the site backend authority")
+
+    require_doc("site-configuration", r"artifacts\.specPlan.{0,160}default is `markdown`", "does not document the default selector")
+    require_doc("site-configuration", r"Projects\s+are\s+the\s+feature.{0,160}document\s+is\s+the\s+spec.{0,160}issues\s+are\s+the\s+plan\s+increments", "does not document the canonical Linear resource model")
+    require_doc("site-configuration", r"native states.{0,120}(?:relations|canonical)", "does not preserve native Linear lifecycle state")
+    require_doc("site-configuration", r"LINEAR_API_KEY.{0,120}(?:environment-only|shell or secret manager)", "does not make Linear authentication environment-only")
+    require_doc("site-configuration", r"Changing the selector does not migrate data.{0,320}inactive legacy artifacts", "does not document the migration boundary")
+    require_doc("site-configuration", r"development\.md#artifact-backend", "does not link the repository adoption authority")
+
+    require_doc("site-build-loop", r"Exactly three hard gates", "does not preserve exactly three gates")
+    for gate in ("Design approval", "Written-spec approval", "Execution handoff"):
+        require_doc("site-build-loop", re.escape(gate), f"does not preserve the {gate} gate")
+    require_doc("site-build-loop", r"Markdown \(default\).{0,300}Linear", "does not compare backend handoffs")
+    require_doc("site-build-loop", r"Linear has no docs-only base PR", "does not exclude a Linear docs-only base PR")
+    require_doc("site-build-loop", r"woostack-build/SKILL\.md#linear-backend-procedure", "does not link the Linear lifecycle authority")
+
+    require_doc("site-status", r"Every Linear status run.{0,120}terminal reconciliation before rendering", "does not require per-run terminal reconciliation")
+    require_doc("site-status", r"managed project.{0,120}spec document.{0,120}ordered increment issues", "does not preserve the canonical Linear model")
+    require_doc("site-status", r"native project.{0,120}team issue states", "does not preserve native lifecycle state")
+    require_doc("site-status", r"Migration boundary.{0,400}(?:inactive legacy artifacts|does not.{0,80}fall back)", "does not preserve the status migration boundary")
+    require_doc("site-status", r"woostack-status/references/conventions\.md", "does not link the status authority")
+
+    joined_docs = "\n".join(doc_texts.values())
+    if re.search(r"twenty\s+public|twenty-two\s+fixed|20\s+public|22\s+fixed", joined_docs, re.I):
+        failure("skill-surface", "stale 20-public/22-fixed count remains in adoption docs")
+    for forbidden in (
+        r"api\.linear\.app/graphql",
+        r"\b(?:query|mutation)\s*\{",
+        r"\b(?:project|document|issue)(?:Create|Update)\b",
+    ):
+        if re.search(forbidden, joined_docs):
+            failure("adoption-docs", f"duplicates adapter query detail: {forbidden}")
 if failures:
     print("\n".join(failures))
     raise SystemExit(1)
@@ -290,6 +445,25 @@ fi
 
 # Behavioral fixtures prove discovery and semantic checks cannot be satisfied by sprinkling
 # expected tokens into today's seven files.
+fixture="$TMP_ROOT/duplicate-route"
+make_fixture "$fixture"
+printf '\n| `/woostack-init`, duplicate route | `woostack-init` |\n' \
+  >> "$fixture/skills/using-woostack/SKILL.md"
+expect_fixture_failure "$fixture" "ordered 20-command surface" "duplicate routing-row rejection"
+
+fixture="$TMP_ROOT/reordered-routes"
+make_fixture "$fixture"
+python3 - "$fixture/skills/using-woostack/SKILL.md" <<'PY'
+import sys
+from pathlib import Path
+path = Path(sys.argv[1])
+lines = path.read_text().splitlines()
+routes = [index for index, line in enumerate(lines) if line.startswith("| `/")]
+lines[routes[0]], lines[routes[1]] = lines[routes[1]], lines[routes[0]]
+path.write_text("\n".join(lines) + "\n")
+PY
+expect_fixture_failure "$fixture" "ordered 20-command surface" "routing-row order rejection"
+
 fixture="$TMP_ROOT/new-reader"
 make_fixture "$fixture"
 mkdir -p "$fixture/skills/woostack-injected-reader"

--- a/skills/woostack-bootstrap/references/development.md
+++ b/skills/woostack-bootstrap/references/development.md
@@ -19,10 +19,45 @@ for each phase:
 
 Each command is discrete and ends by offering the next step. Merge stays with the human.
 
-Artifacts live under `.woostack/` in the project: markdown specs in `.woostack/specs/`,
-markdown plans in `.woostack/plans/`, and review config in `.woostack/config.json`
-(review metrics `.woostack/metrics.json` and [local-only memory](../../woostack-init/references/memory.md)
-`.woostack/memory/` are gitignored).
+Review config and non-design project state remain under `.woostack/`; review metrics
+`.woostack/metrics.json` and [local-only memory](../../woostack-init/references/memory.md)
+`.woostack/memory/` are gitignored. Feature specs and plans follow the selected artifact backend.
+
+## Artifact backend
+
+`.woostack/config.json` selects feature storage with `artifacts.specPlan`. A missing selector
+means `markdown`, so Markdown is the default, not a universal requirement. Markdown stores specs
+in `.woostack/specs/` and plans in `.woostack/plans/`. Selecting `linear` instead makes one
+repository-owned Linear project the feature, one managed spec document its specification, and
+ordered increment issues its plan. Native project statuses and team issue states carry lifecycle
+state through the configured semantic mappings; do not mirror them into Markdown source files.
+
+Linear authentication is environment only. The process running a Linear-backed skill must receive
+`LINEAR_API_KEY`; the key never belongs in `.woostack/config.json`, a credential-file path, a
+checked-in env file, or documentation. Backend resolution, validation, and normalized adapter
+behavior are owned by
+[`resolve-backend.sh`](../../woostack-init/scripts/artifacts/resolve-backend.sh) and its sibling
+adapters. Adoption docs must not duplicate their request or query details.
+
+Storage changes neither workflow intent nor approval policy. Both backends preserve exactly three
+hard gates: design approval, written-spec approval, and execution handoff. The
+[`woostack-build` lifecycle](../../woostack-build/SKILL.md) owns their order and backend-specific
+work steps. Markdown opens one docs-only spec+plan base PR before implementation; Linear persists
+the project/document/issues natively and has no docs-only base PR. Linear implementation branches
+begin only after handoff and follow the frozen-base/dependency rules in the
+[worktree contract](../../woostack-init/references/worktrees.md#artifact-backend-boundary).
+
+Every `/woostack-status` run resolves the selected backend. Markdown derives terminal truth
+read-only; Linear verifies merge evidence and reconciles only eligible terminal issue/project
+states before rendering. The
+[feature-state conventions](../../woostack-status/references/conventions.md) own lifecycle
+spelling, attribution joins, reconciliation, and failure behavior.
+
+Backend selection is a clean boundary, not live migration. Existing Markdown specs and plans stay
+authoritative under Markdown. After selecting Linear, local spec/plan files are inactive
+compatibility data: no command imports, adopts, or falls back to them. Move a feature only through
+an explicit, separately reviewed migration; changing the selector alone never copies or adopts
+artifacts.
 
 ## Branching model
 

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: woostack-build
-description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, harden the plan, and ship the selected artifact backend's spec and plan through exactly three gates. Markdown can continue into implementation; Linear currently stops at the ready handoff.
+description: Use when building a feature with the full woostack development loop — ideate a design, harden it, plan it, harden the plan, ship the selected artifact backend's spec and plan, then implement it through exactly three gates.
 ---
 
 # woostack-build
@@ -26,11 +26,11 @@ ideate → capture spec → harden + persist spec → spec approval → plan
   → verify decomposition → harden plan → mark ready → execution handoff
 ```
 
-Markdown may continue from that gate into per-increment execution and a reviewed PR stack.
-Linear currently stops at `designState: ready` and hands off its managed artifacts; Increment 6
-adds execution when the executors accept Linear project references. Markdown preserves its
-existing persistence order:
+Either backend may continue from that gate into per-increment execution and a reviewed PR stack.
+Markdown preserves its existing persistence order:
 `commit spec PR → approve spec → plan → append plan to spec+plan PR → execution handoff`.
+Linear passes its managed project and issue identities directly to execution and creates no
+docs-only base PR.
 
 The only hard stops are **design approval**, **spec approval**, and **execution handoff**.
 Hardening amends the selected artifact in place and owns no gate. Planning, persistence,
@@ -50,7 +50,7 @@ the other.
 
 ## Markdown backend procedure
 
-<!-- markdown-gates: design-approval | spec-approval | execution-handoff -->
+{/* <!-- markdown-gates: design-approval | spec-approval | execution-handoff --> */}
 
 <HARD-GATE backend="markdown" name="design-approval">
 
@@ -231,7 +231,7 @@ the other.
 
 ## Linear backend procedure
 
-<!-- linear-gates: design-approval | spec-approval | execution-handoff -->
+{/* <!-- linear-gates: design-approval | spec-approval | execution-handoff --> */}
 
 All Linear operations below use
 [`linear.sh`](../woostack-init/scripts/artifacts/linear.sh); cross-link its commands rather
@@ -240,9 +240,11 @@ verified mandatory read-back receipt. A failed or incomplete receipt blocks the 
 Treat every returned Linear artifact under the shared
 [artifact trust boundary](../woostack-init/references/artifact-backends.md#linear-artifact-trust-boundary).
 
-1. <HARD-GATE backend="linear" name="design-approval">**Ideate.** Invoke
+{/* <HARD-GATE backend="linear" name="design-approval"> */}
+1. **Ideate.** Invoke
    [`woostack-ideate`](../woostack-ideate/SKILL.md). It writes no artifact and stops until the
-   user explicitly approves the design. Silence or ambiguity does not clear the gate.</HARD-GATE>
+   user explicitly approves the design. Silence or ambiguity does not clear the gate.
+{/* </HARD-GATE> */}
 2. **Preflight, capture run context, discover, then capture the spec.** Before the first
    mutation of the run, invoke `linear.sh preflight` with the resolver's configured workspace,
    team name/key, project-status names, and issue-state names. Capture its normalized receipt
@@ -267,7 +269,8 @@ Treat every returned Linear artifact under the shared
      managed spec document, and one ordered managed issue set** for the feature.
    Linear mode creates **no spec/plan worktree, branch, commit, or docs-only PR**. It writes no
    `.woostack/specs/` or `.woostack/plans/` source file.
-3. <HARD-GATE backend="linear" name="spec-approval">**Harden and approve the Linear spec.**
+{/* <HARD-GATE backend="linear" name="spec-approval"> */}
+3. **Harden and approve the Linear spec.**
    Invoke `linear.sh spec-read`, harden that selected document through `woostack-harden`, and
    persist each revision with `linear.sh spec-write` using the last observed revision. On the
    final verified write, change the managed metadata only from `designState: draft` to
@@ -285,7 +288,8 @@ Treat every returned Linear artifact under the shared
      `designState: abandoned`, verify it, invoke `linear.sh feature-transition --target
      abandoned`, require project read-back, preserve the project/document audit history, and
      stop. Never delete or archive it.
-   Failed read-back, ambiguity, or silence never advances the gate.</HARD-GATE>
+   Failed read-back, ambiguity, or silence never advances the gate.
+{/* </HARD-GATE> */}
 4. **Plan in Linear.** Invoke [`woostack-plan`](../woostack-plan/SKILL.md) with the selected
    project UUID or exact Linear URL plus the retained resolver result and `LINEAR_CONTEXT`.
    The planning skill owns the complete Linear planning procedure and reuses that normalized

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -240,11 +240,11 @@ verified mandatory read-back receipt. A failed or incomplete receipt blocks the 
 Treat every returned Linear artifact under the shared
 [artifact trust boundary](../woostack-init/references/artifact-backends.md#linear-artifact-trust-boundary).
 
-{/* <HARD-GATE backend="linear" name="design-approval"> */}
+<HARD-GATE backend="linear" name="design-approval">
 1. **Ideate.** Invoke
    [`woostack-ideate`](../woostack-ideate/SKILL.md). It writes no artifact and stops until the
    user explicitly approves the design. Silence or ambiguity does not clear the gate.
-{/* </HARD-GATE> */}
+</HARD-GATE>
 2. **Preflight, capture run context, discover, then capture the spec.** Before the first
    mutation of the run, invoke `linear.sh preflight` with the resolver's configured workspace,
    team name/key, project-status names, and issue-state names. Capture its normalized receipt
@@ -269,7 +269,7 @@ Treat every returned Linear artifact under the shared
      managed spec document, and one ordered managed issue set** for the feature.
    Linear mode creates **no spec/plan worktree, branch, commit, or docs-only PR**. It writes no
    `.woostack/specs/` or `.woostack/plans/` source file.
-{/* <HARD-GATE backend="linear" name="spec-approval"> */}
+<HARD-GATE backend="linear" name="spec-approval">
 3. **Harden and approve the Linear spec.**
    Invoke `linear.sh spec-read`, harden that selected document through `woostack-harden`, and
    persist each revision with `linear.sh spec-write` using the last observed revision. On the
@@ -289,7 +289,7 @@ Treat every returned Linear artifact under the shared
      abandoned`, require project read-back, preserve the project/document audit history, and
      stop. Never delete or archive it.
    Failed read-back, ambiguity, or silence never advances the gate.
-{/* </HARD-GATE> */}
+</HARD-GATE>
 4. **Plan in Linear.** Invoke [`woostack-plan`](../woostack-plan/SKILL.md) with the selected
    project UUID or exact Linear URL plus the retained resolver result and `LINEAR_CONTEXT`.
    The planning skill owns the complete Linear planning procedure and reuses that normalized

--- a/skills/woostack-build/tests/test-linear-build-contract.sh
+++ b/skills/woostack-build/tests/test-linear-build-contract.sh
@@ -173,6 +173,7 @@ ordered(linear_branch, (
     "designState: ready",
     "linear.sh feature-read",
     'name="execution-handoff"',
+
 ), "Linear freeze/handoff")
 for token in (
     "pair is provisional",
@@ -213,6 +214,8 @@ for token in (
     "root increment branches start from the frozen SHA",
 ):
     must(linear_branch, token, "Linear execution handoff")
+for token in ("after execution is", "explicitly approved"):
+    must(texts["building_rules"], token, "served build-loop docs")
 
 # Planning propagates preflight UUID context and standalone stops before harden/ready/freeze/handoff.
 for token in (

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -44,12 +44,12 @@ Two callers:
    | `.woostack/wisdom/.gitkeep` | `templates/wisdom/.gitkeep` |
    | `.woostack/respond/` directory | (create empty — tracked sanitized response reports) |
    | `.woostack/respond/.gitkeep` | `templates/respond/.gitkeep` |
-   | `.woostack/config.json` | `templates/config.json` (`{ "artifacts": { "specPlan": "markdown" }, "models": {}, "review": {}, "respond": {}, "status": { "staleDays": 14 } }`) |
+   | `.woostack/config.json` | `templates/config.json` (`artifacts.specPlan` defaults to `markdown`; tool namespaces follow) |
    | `.woostack/.gitignore` | `templates/gitignore` |
    | `.woostack/worktrees/` directory | (create empty — per-PR git worktrees, gitignored) |
 
-   `config.json` ships as `{ "artifacts": { "specPlan": "markdown" }, "models": {}, "review": {},
-   "respond": {}, "status": { "staleDays": 14 } }`. Each tool owns its namespace.
+   `config.json` ships with `artifacts.specPlan` set to `markdown`, plus empty `models`, `review`,
+   and `respond` namespaces and `status.staleDays` set to 14. Each tool owns its namespace.
    `artifacts.specPlan` selects the spec/plan backend: `markdown` keeps tracked `.woostack`
    artifacts; `linear` stores the build and planning lifecycle in one managed project, one
    managed spec document, and ordered managed increment issues. Linear reaches the verified
@@ -60,9 +60,18 @@ Two callers:
 
    The optional `respond` namespace accepts only non-secret workflow defaults: `provider`,
    `environment`, `window`, `max_groups`, and `remediation`; provider credentials remain in
-   provider-native stores. The `status` namespace holds `staleDays` (default 14 — the age in
-   days past which an executing spec is flagged stale on the `/woostack-status` board), defined
-   in [../woostack-status/references/conventions.md](../woostack-status/references/conventions.md).
+   provider-native stores. The `status` namespace holds `staleDays` (default 14 — the age in days
+   past which an executing spec is flagged stale on the `/woostack-status` board), defined in
+   [../woostack-status/references/conventions.md](../woostack-status/references/conventions.md).
+
+   `artifacts.specPlan` accepts `markdown` or `linear`; a missing selector also resolves to
+   Markdown, so Markdown is the default rather than a universal storage requirement. Linear's
+   workspace, team, native project-status, and native issue-state names live in the non-secret
+   `linear` config namespace. `LINEAR_API_KEY` is environment only: never store it, another
+   credential, or a credential-file path in config or a checked-in env file. The
+   [artifact-backend adoption contract](../woostack-bootstrap/references/development.md#artifact-backend)
+   owns the canonical project/document/issues model and migration boundary. The resolver owns
+   validation; do not duplicate its adapter details here.
 
    The optional top-level `base_branch` key sets the integration/trunk branch that base branches
    are cut from and PRs target; unset, it auto-detects the remote default (`origin/HEAD`, else

--- a/skills/woostack-init/references/memory.md
+++ b/skills/woostack-init/references/memory.md
@@ -19,8 +19,8 @@ The `/woostack-init` scaffold verb creates this tree in a consumer repo:
 ├── memory/
 │   ├── MEMORY.md    derived index (build-index writes it)
 │   └── .gitkeep
-├── specs/           woostack-build markdown specs (type: spec)
-├── plans/           woostack-build markdown plans
+├── specs/           Markdown-backend specs (type: spec; inactive when Linear is selected)
+├── plans/           Markdown-backend plans (inactive when Linear is selected)
 ├── wisdom/          generalized findings, wholesale-loaded — see wisdom.md (sibling store)
 ├── respond/
 │   ├── .gitkeep     tracked sanitized response reports live beside it
@@ -29,11 +29,10 @@ The `/woostack-init` scaffold verb creates this tree in a consumer repo:
 └── .gitignore       ignores transient response evidence and local sidecars; tracks specs/plans/fixes/respond/config/memory notes
 ```
 
-The `config.json` file uses a top-level namespace-per-tool convention: `"artifacts"` selects the
-spec/plan backend, `"review"` configures woostack-review, `"respond"` holds non-secret
-production-response workflow defaults, and `"models"` is shared across tools. The full backend
-schema and Linear mappings are documented in the
-[init skill](../SKILL.md#workflow). Provider credentials never belong in this file.
+The `config.json` file uses a top-level namespace-per-tool convention. `"artifacts"` selects the
+spec/plan backend and defaults to Markdown; `"review"` configures woostack-review, `"respond"`
+holds non-secret production-response defaults, and `"models"` is shared across tools. Provider
+credentials never belong in this file.
 
 The `.gitignore` ignores `metrics.json`, `*.local.*`, `respond/evidence/`, memory telemetry, and
 the dream watermark. Sanitized response reports remain tracked shared decision evidence alongside

--- a/skills/woostack-init/references/worktrees.md
+++ b/skills/woostack-init/references/worktrees.md
@@ -37,6 +37,10 @@ docs-only base PR, and implementation increments stack above it. Linear stores t
 in Linear, so it creates no authoring worktree or docs-only base branch; only implementation
 issues receive worktrees.
 
+This boundary implements the backend-specific persistence steps in the
+[`woostack-build` Linear procedure](../../woostack-build/SKILL.md#linear-backend-procedure);
+that workflow remains the lifecycle authority.
+
 For a Linear dependency root, create its implementation branch at the project's exact frozen root
 commit SHA (`baseCommitSha`), while tracking the frozen `baseBranch` as its Graphite parent. Do not
 substitute the branch's newer tip. For a dependent Linear issue, create its branch at the declared

--- a/skills/woostack-status/references/conventions.md
+++ b/skills/woostack-status/references/conventions.md
@@ -16,6 +16,17 @@ them.
 
 ## Markdown lifecycle and joins
 
+Markdown uses the spec/plan/PR joins below. Selection, authentication, and migration boundaries
+live in the
+[artifact-backend adoption contract](../../woostack-bootstrap/references/development.md#artifact-backend).
+
+Every `/woostack-status` run resolves the backend and performs its terminal reconciliation path
+before rendering: Markdown derives terminal truth without writes, while Linear verifies merge
+evidence, reconciles only eligible `inReview` issues to `done`, and marks the project `done` only
+after every managed issue is observed `done`. There is no read-only or presentation-only bypass
+for Linear. Failed authentication, evidence, mutation, or read-back blocks rendering rather than
+presenting stale state.
+
 - Spec frontmatter owns design approval: `draft -> hardened -> approved`.
 - Plan frontmatter owns implementation lifecycle after spec approval:
   `planning -> ready -> executing -> in-review -> done`.


### PR DESCRIPTION
## Goal

Document the Linear artifact backend across repository guidance and the authored docs site, with lockstep contracts for the complete skill surface.

## Summary

- Document Markdown as the default and Linear as the canonical project/document/issue backend when selected.
- Explain environment-only authentication, native lifecycle mapping, exactly three gates, backend-specific PR/worktree behavior, migration boundaries, and mandatory status reconciliation.
- Keep repository guidance and six authored site framing pages synchronized through semantic structural and site tests.
- Lock navigation to the current 21 public/adoption skills and all 24 shipped skill references.
- Make build gate markers MDX-safe at their source without editing generated pages.

## Test plan

### Automated

- [x] Complete focused shell chain passed: init, build, execute, commit attribution, status, doctor, and artifact-reader contracts.
- [x] Artifact-reader/adoption contract — 11 assertions and mutation fixtures passed.
- [x] Site tests — 10 passed.
- [x] `pnpm -C site build` — 24 generated references and 135 static pages.
- [x] Link, diff, count, routing-order, and generated-nav checks passed.

### Manual

- [ ] Linear sandbox smoke: **NOT RUN** because `LINEAR_API_KEY` and an explicitly configured disposable sandbox team were unavailable; no mocks substituted.
- [ ] Confirm Markdown remains the selected default in an existing consumer repo.
- [ ] Confirm switching to Linear leaves local specs/plans untouched and inactive.
- [ ] Confirm generated navigation lists all 21 public/adoption skills before ask/harden/ideate.

Spec: .woostack/specs/2026-07-11-linear-artifact-backend.md