### PR TITLE
fix: link status-board PR chips to GitHub

### DIFF
--- a/.woostack/fixes/2026-07-13-status-board-github-links.md
+++ b/.woostack/fixes/2026-07-13-status-board-github-links.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: executing
+status: in-review
 branch: fix/status-board-github-links
 ---
 

--- a/.woostack/fixes/2026-07-13-status-board-github-links.md
+++ b/.woostack/fixes/2026-07-13-status-board-github-links.md
@@ -1,0 +1,83 @@
+---
+type: fix
+status: hardened
+branch: fix/status-board-github-links
+---
+
+# Fix: Status board PR references are not clickable GitHub links
+
+## 1. Root Cause
+
+This is a small enhancement, not a defect. The `/woostack-status` HTML board
+(`.woostack/visuals/status-board.html`) renders every increment PR in the
+`Increments` column as a static, non-clickable text chip. The evidence:
+
+- `skills/woostack-status/scripts/status.sh:272` — `chip()` emits
+  `<span class="chip c-%s">#%s %s</span>`. A `<span>` can never be a link.
+- `prs_for_spec` (`status.sh:144-165`) and `prs_for_branch`
+  (`status.sh:167-175`) request `--json number,state,headRefName,author,updatedAt[,body]`
+  and emit those fields as TSV. The PR **`url`** field GitHub returns is never
+  requested, so the renderer has no destination to link to even if it wanted one.
+
+Net: the board already names PRs by number (`#123`) but strips away the one datum
+(`.url`) needed to turn that reference into a navigable GitHub link.
+
+The terminal table is the "canonical narration surface" (SKILL.md), a fixed-width
+plain-text table with byte-exact tests; it stays plain text. Only the HTML board —
+"the status board" the user means — gains links.
+
+## 2. Proposed Fix
+
+Thread the PR `url` through the existing PR-resolution path and let `chip()` render
+an anchor when a URL is present, falling back to today's `<span>` when it is not
+(gh absent, older gh without `url`, or any empty value):
+
+1. `prs_for_spec` / `prs_for_branch` — add `url` to the `gh pr list --json` field
+   list and append `(.url // "")` as a trailing TSV column. `@tsv` renders a null
+   as an empty field, so stubs/gh that omit `url` degrade cleanly to "no link".
+2. The two increment loops in the main body read the new trailing `url` column and
+   pass it to `chip()`. Position is trailing, so the existing `${upd:0:10}` and all
+   terminal-cell logic (`inc_parts`, `inc_cell`) are untouched — terminal output is
+   byte-identical.
+3. `chip()` gains a 4th `url` argument: when non-empty it emits
+   `<a class="chip c-MARK" href="ESCAPED_URL" target="_blank" rel="noopener noreferrer">#N LABEL</a>`
+   (href HTML-escaped via the existing `html_escape`; `target="_blank"` +
+   `rel="noopener noreferrer"` so a click opens the PR in a new tab and the board
+   stays put); when empty it emits the current `<span>`, keeping the gh-absent /
+   no-url path pixel-identical to today.
+4. `board-template.html` — add chip-anchor styling so a linked chip reads as a chip,
+   not a default underlined blue link: `a.chip { text-decoration: none; color:
+   inherit; }` and `a.chip:hover { text-decoration: underline; }`. No URL is added to
+   the template file itself (the offline-template test forbids `http(s)://` there).
+
+Non-goals: no links in the terminal table; no linking of the spec/fix name column
+(blob URLs for in-flight files on feature branches are unreliable and out of scope).
+
+## 3. Implementation Plan
+
+- [ ] **Step 1: Reproduce with a failing test**
+  - In `skills/woostack-status/scripts/tests/test-html-board.sh`, extend the
+    multi-PR `gh` stub (the `#11/#10/#9` case) to emit a `url` field per PR, and
+    change the three chip assertions to expect the anchor form, e.g.
+    `<a class="chip c-open" href="https://github.com/o/r/pull/11" target="_blank" rel="noopener noreferrer">#11 open</a>`.
+  - Extend the branch-fallback stub (`#77`) to emit a `url` and assert the partial
+    chip is now an anchor:
+    `<a class="chip c-partial" href="...">#77 (partial)</a>`.
+  - Add one assertion proving graceful fallback: a PR with no `url` (or gh absent)
+    still renders the plain `<span class="chip ...">` (no `<a`), so the degradation
+    path is pinned.
+  - Confirm these fail against the current `chip()` (`<span>` only).
+- [ ] **Step 2: Apply the minimal fix**
+  - `status.sh`: add `url` to both `gh pr list --json` field lists; append
+    `(.url // "")` to both jq `@tsv` outputs; read the trailing `url` in both
+    loops; give `chip()` the 4th `url` arg with the anchor (new-tab) / span branch and
+    an `html_escape`d href.
+  - `board-template.html`: add the `a.chip` / `a.chip:hover` CSS rules.
+- [ ] **Step 3: Verification**
+  - Run `bash skills/woostack-status/scripts/tests/run-tests.sh` — both
+    `test-html-board.sh` and `test-status.sh` green (terminal assertions unchanged,
+    HTML chip assertions now expect links).
+  - Sanity-render the real board in this repo
+    (`WOO_STATUS_NO_OPEN=1 bash skills/woostack-status/scripts/status.sh`) and
+    confirm any PR chip in `.woostack/visuals/status-board.html` is an `<a href>` to
+    the real GitHub PR (or a `<span>` when gh is unauthenticated).

--- a/.woostack/fixes/2026-07-13-status-board-github-links.md
+++ b/.woostack/fixes/2026-07-13-status-board-github-links.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: hardened
+status: executing
 branch: fix/status-board-github-links
 ---
 
@@ -55,7 +55,7 @@ Non-goals: no links in the terminal table; no linking of the spec/fix name colum
 
 ## 3. Implementation Plan
 
-- [ ] **Step 1: Reproduce with a failing test**
+- [x] **Step 1: Reproduce with a failing test**
   - In `skills/woostack-status/scripts/tests/test-html-board.sh`, extend the
     multi-PR `gh` stub (the `#11/#10/#9` case) to emit a `url` field per PR, and
     change the three chip assertions to expect the anchor form, e.g.
@@ -67,13 +67,13 @@ Non-goals: no links in the terminal table; no linking of the spec/fix name colum
     still renders the plain `<span class="chip ...">` (no `<a`), so the degradation
     path is pinned.
   - Confirm these fail against the current `chip()` (`<span>` only).
-- [ ] **Step 2: Apply the minimal fix**
+- [x] **Step 2: Apply the minimal fix**
   - `status.sh`: add `url` to both `gh pr list --json` field lists; append
     `(.url // "")` to both jq `@tsv` outputs; read the trailing `url` in both
     loops; give `chip()` the 4th `url` arg with the anchor (new-tab) / span branch and
     an `html_escape`d href.
   - `board-template.html`: add the `a.chip` / `a.chip:hover` CSS rules.
-- [ ] **Step 3: Verification**
+- [x] **Step 3: Verification**
   - Run `bash skills/woostack-status/scripts/tests/run-tests.sh` — both
     `test-html-board.sh` and `test-status.sh` green (terminal assertions unchanged,
     HTML chip assertions now expect links).

--- a/skills/woostack-status/scripts/board-template.html
+++ b/skills/woostack-status/scripts/board-template.html
@@ -38,6 +38,8 @@
   .bar > div { background: var(--bar-fg); border-radius: 3px; height: 6px; }
   .chip { display: inline-block; padding: 0 .4rem; border-radius: 4px; font-size: .75rem;
           margin-right: .25rem; white-space: nowrap; }
+  a.chip { text-decoration: none; color: inherit; cursor: pointer; }
+  a.chip:hover { text-decoration: underline; }
   .c-open { background: var(--chip-open); } .c-merged { background: var(--chip-merged); }
   .c-closed { background: var(--chip-closed); } .c-partial { background: var(--warn-bg); }
   .flags { background: var(--warn-bg); color: var(--warn-fg); border-radius: 6px;

--- a/skills/woostack-status/scripts/status.sh
+++ b/skills/woostack-status/scripts/status.sh
@@ -150,7 +150,7 @@ prs_for_spec() {
     suffix="specs/$base"
   fi
   json="$(gh_json pr list --state all --search "$base" \
-          --json number,state,headRefName,author,updatedAt,body --limit 50)"
+          --json number,state,headRefName,author,updatedAt,body,url --limit 50)"
   [ -n "$json" ] || return 0
   # gh --search is fuzzy (tokenizes the path), so it cross-matches look-alike PRs. Narrow
   # with the search, then exact-match a Spec: trailer value in each PR body. The needle
@@ -161,17 +161,17 @@ prs_for_spec() {
             test("^[[:space:]]*Spec:[[:space:]]")
             and (sub("^[[:space:]]*Spec:[[:space:]]*"; "") | gsub("[[:space:]]+$"; "") | endswith($needle))
           ))
-        | [.number, .state, .headRefName, (.author.login // ""), .updatedAt] | @tsv' 2>/dev/null
+        | [.number, .state, .headRefName, (.author.login // ""), .updatedAt, (.url // "")] | @tsv' 2>/dev/null
 }
 
 prs_for_branch() {
   local branch="$1" json
   [ -n "$branch" ] || return 0
   json="$(gh_json pr list --state all --head "$branch" \
-          --json number,state,headRefName,author,updatedAt --limit 20)"
+          --json number,state,headRefName,author,updatedAt,url --limit 20)"
   [ -n "$json" ] || return 0
   printf '%s' "$json" | jq -r \
-    '.[] | [.number, .state, .headRefName, (.author.login // ""), .updatedAt] | @tsv' 2>/dev/null
+    '.[] | [.number, .state, .headRefName, (.author.login // ""), .updatedAt, (.url // "")] | @tsv' 2>/dev/null
 }
 
 resolve_phase() {
@@ -269,7 +269,15 @@ html_escape() {
   printf '%s' "$s"
 }
 
-chip() { printf '<span class="chip c-%s">#%s %s</span>' "$1" "$2" "$3"; }
+chip() {
+  local mark="$1" num="$2" label="$3" url="${4:-}"
+  if [ -n "$url" ]; then
+    printf '<a class="chip c-%s" href="%s" target="_blank" rel="noopener noreferrer">#%s %s</a>' \
+      "$mark" "$(html_escape "$url")" "$num" "$label"
+  else
+    printf '<span class="chip c-%s">#%s %s</span>' "$mark" "$num" "$label"
+  fi
+}
 
 render_html() {
   local tpl="$HERE/board-template.html" out="$WOO_DIR/visuals/status-board.html"
@@ -366,23 +374,23 @@ for f in "${specs[@]}"; do
   fi
   open=0; merged=0; prcount=0; inc_cell="-"; inc_parts=""; inc_html=""
   last_author=""; last_upd_date=""
-  while IFS=$'\t' read -r num state head author upd; do
+  while IFS=$'\t' read -r num state head author upd url; do
     [ -z "$num" ] && continue
     prcount=$((prcount+1))
     case "$state" in OPEN) open=$((open+1)) ;; MERGED) merged=$((merged+1)) ;; esac
     mark="."; case "$state" in MERGED) mark="merged" ;; OPEN) mark="open" ;; CLOSED) mark="closed" ;; esac
     inc_parts="${inc_parts:+$inc_parts . }#$num $mark"
-    inc_html="${inc_html}$(chip "$mark" "$num" "$mark")"
+    inc_html="${inc_html}$(chip "$mark" "$num" "$mark" "$url")"
     last_author="$author"; last_upd_date="${upd:0:10}"
   done < <(prs_for_spec "$specpath")
 
   if [ "$prcount" -eq 0 ] && [ -n "$br" ] && [ "$br" != unknown ]; then
-    while IFS=$'\t' read -r num state head author upd; do
+    while IFS=$'\t' read -r num state head author upd url; do
       [ -z "$num" ] && continue
       prcount=$((prcount+1))
       case "$state" in OPEN) open=$((open+1)) ;; MERGED) merged=$((merged+1)) ;; esac
       inc_cell="#$num (partial)"
-      inc_html="$(chip partial "$num" "(partial)")"
+      inc_html="$(chip partial "$num" "(partial)" "$url")"
       last_author="$author"; last_upd_date="${upd:0:10}"
     done < <(prs_for_branch "$br")
   fi

--- a/skills/woostack-status/scripts/tests/test-html-board.sh
+++ b/skills/woostack-status/scripts/tests/test-html-board.sh
@@ -159,9 +159,9 @@ cat > "$ghstub/gh" <<'GHEOF'
 #!/usr/bin/env bash
 if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
   cat <<'JSON'
-[{"number":11,"state":"OPEN","headRefName":"feature/multi-2","author":{"login":"a"},"updatedAt":"2026-06-02T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-multi.md"},
- {"number":10,"state":"MERGED","headRefName":"feature/multi-1","author":{"login":"a"},"updatedAt":"2026-06-01T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-multi.md"},
- {"number":9,"state":"CLOSED","headRefName":"feature/multi-0","author":{"login":"a"},"updatedAt":"2026-05-30T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-multi.md"}]
+[{"number":11,"state":"OPEN","headRefName":"feature/multi-2","author":{"login":"a"},"updatedAt":"2026-06-02T00:00:00Z","url":"https://github.com/o/r/pull/11","body":"Spec: .woostack/specs/2026-06-01-multi.md"},
+ {"number":10,"state":"MERGED","headRefName":"feature/multi-1","author":{"login":"a"},"updatedAt":"2026-06-01T00:00:00Z","url":"https://github.com/o/r/pull/10","body":"Spec: .woostack/specs/2026-06-01-multi.md"},
+ {"number":9,"state":"CLOSED","headRefName":"feature/multi-0","author":{"login":"a"},"updatedAt":"2026-05-30T00:00:00Z","url":"https://github.com/o/r/pull/9","body":"Spec: .woostack/specs/2026-06-01-multi.md"}]
 JSON
 else
   echo "[]"
@@ -172,9 +172,9 @@ set +e
 WOO_DIR="$r5" WOO_STATUS_NO_OPEN=1 WOOSTACK_GH="$ghstub/gh" bash "$ST" >/dev/null 2>&1
 set -e
 HTML5="$(cat "$r5/visuals/status-board.html")"
-assert_contains "$HTML5" '<span class="chip c-open">#11 open</span>' "AC1: open PR chip rendered"
-assert_contains "$HTML5" '<span class="chip c-merged">#10 merged</span>' "AC1: merged PR chip rendered"
-assert_contains "$HTML5" '<span class="chip c-closed">#9 closed</span>' "AC1: closed PR chip rendered"
+assert_contains "$HTML5" '<a class="chip c-open" href="https://github.com/o/r/pull/11" target="_blank" rel="noopener noreferrer">#11 open</a>' "AC1: open PR chip is a GitHub link"
+assert_contains "$HTML5" '<a class="chip c-merged" href="https://github.com/o/r/pull/10" target="_blank" rel="noopener noreferrer">#10 merged</a>' "AC1: merged PR chip is a GitHub link"
+assert_contains "$HTML5" '<a class="chip c-closed" href="https://github.com/o/r/pull/9" target="_blank" rel="noopener noreferrer">#9 closed</a>' "AC1: closed PR chip is a GitHub link"
 
 # --- AC1: branch-only PR lookup renders the partial chip in HTML ---
 r8="$(mktemp -d)/.woostack"
@@ -187,7 +187,7 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
   case "$*" in
     *"--head feature/fallback"*)
       cat <<'JSON'
-[{"number":77,"state":"OPEN","headRefName":"feature/fallback","author":{"login":"a"},"updatedAt":"2026-06-03T00:00:00Z","body":"no spec trailer"}]
+[{"number":77,"state":"OPEN","headRefName":"feature/fallback","author":{"login":"a"},"updatedAt":"2026-06-03T00:00:00Z","url":"https://github.com/o/r/pull/77","body":"no spec trailer"}]
 JSON
       ;;
     *) echo "[]" ;;
@@ -201,7 +201,29 @@ set +e
 WOO_DIR="$r8" WOO_STATUS_NO_OPEN=1 WOOSTACK_GH="$ghstub2/gh" bash "$ST" >/dev/null 2>&1
 set -e
 HTML8="$(cat "$r8/visuals/status-board.html")"
-assert_contains "$HTML8" '<span class="chip c-partial">#77 (partial)</span>' "AC1: partial PR chip rendered"
+assert_contains "$HTML8" '<a class="chip c-partial" href="https://github.com/o/r/pull/77" target="_blank" rel="noopener noreferrer">#77 (partial)</a>' "AC1: partial PR chip is a GitHub link"
+
+# --- AC1: a PR with no url degrades to a plain (unlinked) chip ---
+r9="$(mktemp -d)/.woostack"
+mkspec "$r9" nourl in-review feature/nourl
+ghstub3="$(mktemp -d)"
+cat > "$ghstub3/gh" <<'GHEOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
+  cat <<'JSON'
+[{"number":42,"state":"OPEN","headRefName":"feature/nourl","author":{"login":"a"},"updatedAt":"2026-06-02T00:00:00Z","body":"Spec: .woostack/specs/2026-06-01-nourl.md"}]
+JSON
+else
+  echo "[]"
+fi
+GHEOF
+chmod +x "$ghstub3/gh"
+set +e
+WOO_DIR="$r9" WOO_STATUS_NO_OPEN=1 WOOSTACK_GH="$ghstub3/gh" bash "$ST" >/dev/null 2>&1
+set -e
+HTML9="$(cat "$r9/visuals/status-board.html")"
+assert_contains "$HTML9" '<span class="chip c-open">#42 open</span>' "AC1: url-less PR falls back to an unlinked chip"
+assert_not_contains "$HTML9" '<a class="chip' "AC1: no anchor chip when url absent"
 
 # --- AC4 edge: openers present but failing -> "no opener found" note, HTML still written ---
 r7="$(mktemp -d)/.woostack"


### PR DESCRIPTION
## Goal
Turn the /woostack-status board's PR references into clickable GitHub links.

## Summary
- `status.sh`: fetch the PR `url` (`gh pr list --json ...,url`) and thread it through `prs_for_spec` / `prs_for_branch` as a trailing TSV field.
- `chip()`: render `<a class="chip …" href=… target="_blank" rel="noopener noreferrer">#N state</a>` when a URL is present; fall back to the current `<span>` when it is absent (gh missing / no url). The href is HTML-escaped.
- `board-template.html`: add `a.chip` / `a.chip:hover` styling so a linked chip still reads as a chip and opens the PR in a new tab.
- Terminal table is unchanged (byte-identical).

## Test plan
- Automated: `bash skills/woostack-status/scripts/tests/run-tests.sh` — test-html-board 57/0 (anchor-chip assertions + a url-less fallback-span assertion), test-status 101/0 (terminal output unchanged).
- Manual: rendered the real board in this repo — 108 PR chips render as `<a href>` to `https://github.com/howarewoo/woostack/pull/N`, 0 unlinked spans.

Spec: .woostack/fixes/2026-07-13-status-board-github-links.md