### PR TITLE
docs: least-code-tenet spec + plan

### DIFF
--- a/.woostack/plans/2026-07-14-least-code-tenet.md
+++ b/.woostack/plans/2026-07-14-least-code-tenet.md
@@ -1,0 +1,411 @@
+---
+type: plan
+source: .woostack/specs/2026-07-14-least-code-tenet.md
+status: ready
+branch: feature/least-code-tenet
+---
+
+**Source:** [[specs/2026-07-14-least-code-tenet]]
+
+# Least code, still safe — Implementation Plan
+
+**Goal:** Codify "Least code, still safe" as woostack's one canonical engineering tenet — a tight
+statement in `AGENTS.md`, the full generated-code doctrine in `patterns.md §10`, cross-linked (never
+restated) from the authoring skills (`woostack-execute`, `woostack-ideate`, `woostack-fix`), and
+surfaced to consumers by a new docs-site concepts page.
+
+**Architecture:** Two canonical homes, wired by cross-link. `AGENTS.md` holds the tight tenet and
+points to `patterns.md §10`, which holds the full ladder + deltas A–E. Three authoring skills carry
+a one-line pointer to §10 (no prose copied). A sixth artifact — `concepts/least-code.mdx` plus its
+two nav wirings — frames the tenet for docs readers and links the skills. No test runner exists, so
+every "test" is a concrete `grep`/link-resolution/`git diff`/`pnpm build` command with exact
+expected output (per the `woostack-tdd` no-runner substitution).
+
+**Tech Stack:** Markdown/MDX, JSON, `grep`, `git`, Fumadocs (`pnpm -C site build`).
+
+## Increment 1: Canonical doctrine (AGENTS.md tenet + patterns.md §10)
+
+> One PR: the two canonical homes. `AGENTS.md`'s tenet links `patterns.md §10`; §10 links the
+> `simplify` angle. Both link targets already exist, so the isolated diff has no dangling reference.
+
+### Task 1: AGENTS.md canonical tenet (AC1, AC6)
+
+**Files:**
+- Modify: `AGENTS.md` (`## Hard constraints`, after the heading at line 81) — real file; `.claude/CLAUDE.md` is a symlink to it.
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -c "Least code, still safe" AGENTS.md`
+  Expected: FAIL — prints `0` (tenet absent).
+
+- [ ] **Step 2: Add the tenet as the first Hard-constraints bullet**
+  Insert immediately after the `## Hard constraints` heading (before `- No fabricated versions.`):
+  ```markdown
+  - **Least code, still safe.** Skills — and the code they generate — write as little code as
+    necessary. Understand first (read the code the change touches, trace the real flow), *then* take
+    the first rung that holds: in-tree reuse → stdlib → native feature → installed dep → one line →
+    minimum that works. Deletion over addition, boring over clever — small because it's necessary,
+    not golfed. Comments are minimal and explain *why* (hidden constraint, workaround, surprising
+    invariant), never *what*. Never shrink code by cutting edge cases or risks — validation, error
+    handling, security, accessibility, and data-loss handling stay; keep deliberate multi-layer
+    safety redundancy; at equal size pick the edge-case-correct option; behavior-changing
+    simplification keeps its regression test; a knowingly-cut corner leaves a `why` comment naming
+    its ceiling and upgrade path. Full standard:
+    [`patterns.md §10`](skills/woostack-bootstrap/references/patterns.md); enforced by the
+    `simplify`/`comments` review angles.
+  ```
+
+- [ ] **Step 3: Confirm the tenet, its link, and the symlink**
+  Run: `grep -c "Least code, still safe" AGENTS.md && grep -c "skills/woostack-bootstrap/references/patterns.md" AGENTS.md && grep -c "Least code, still safe" .claude/CLAUDE.md`
+  Expected: PASS — `1`, `1`, `1` (edit landed in the real file; symlink reflects it).
+
+- [ ] **Step 4: Confirm the link target resolves (AC6)**
+  Run: `test -f skills/woostack-bootstrap/references/patterns.md && echo OK`
+  Expected: PASS — `OK`.
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt create -m "docs: add Least code, still safe tenet to AGENTS.md"
+  ```
+
+### Task 2: patterns.md §10 full doctrine (AC2, AC6)
+
+**Files:**
+- Modify: `skills/woostack-bootstrap/references/patterns.md` (§10, lines 158–163) — rename heading, keep the four existing bullets, prepend the ladder + deltas A–E.
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -c "Read first (delta A)" skills/woostack-bootstrap/references/patterns.md`
+  Expected: FAIL — prints `0` (doctrine absent).
+
+- [ ] **Step 2: Rename §10 and expand it**
+  Replace the `## 10. Code size & comments` heading and its four bullets with:
+  ```markdown
+  ## 10. Least code & comments
+
+  Write as little code as necessary — but never at the cost of correctness or safety. Understand the
+  problem first, then take the first rung that holds.
+
+  - **The ladder.** Before adding code, walk the rungs and stop at the first that works: (1) YAGNI —
+    is it needed at all? (2) in-tree reuse — a helper/util/pattern that already exists here; (3)
+    stdlib; (4) a native platform feature; (5) an already-installed dependency; (6) one line; (7)
+    only then the minimum new code that works. The review
+    [`simplify` angle](../../woostack-review/prompts/angles/simplify.md) states the full ladder
+    verbatim and enforces it — link, don't restate.
+  - **Read first (delta A).** The ladder runs *after* you understand the problem: read the code the
+    change touches and trace the real flow end to end before picking a rung. Lazy about the
+    solution, never about reading — the smallest change in the wrong place is a second bug.
+  - **Equal-size tie-breaker (delta B).** When two approaches are the same size, pick the
+    edge-case-correct one. Lazy means less code, not the flimsier algorithm.
+  - **Never-cut list (delta C).** Never shrink code by dropping validation, error handling,
+    security, accessibility, or data-loss handling. Keep deliberate multi-layer safety redundancy
+    (it is not DRY-removable); prefer scoped parsing over a greedy regex; a behavior-changing
+    simplification keeps its regression test.
+  - **Boring over clever (delta D).** Deletion over addition; boring over clever. Code is small
+    because it's necessary, not because it's golfed.
+  - **Deliberate-corner marker (delta E).** A knowingly-cut corner with a known ceiling (global
+    lock, O(n²) scan, naive heuristic) leaves a `why` comment naming the ceiling and the upgrade
+    path, and is distilled as a memory `gotcha`.
+  - Non-test source files: ≤ 500 lines.
+  - User-facing components + procedures: JSDoc with purpose, inputs, outputs.
+  - Comments explain **why** when non-obvious (hidden constraint, workaround, surprising invariant). Skip the **what** — code names that.
+  - No magic literals. Extract to `UPPER_SNAKE_CASE` constants with descriptive names.
+  ```
+
+- [ ] **Step 3: Confirm rename, deltas, and preserved bullets (AC2)**
+  Run: `grep -c "## 10. Least code & comments" skills/woostack-bootstrap/references/patterns.md && grep -c "## 10. Code size & comments" skills/woostack-bootstrap/references/patterns.md && grep -c "Read first (delta A)" skills/woostack-bootstrap/references/patterns.md && grep -c "No magic literals" skills/woostack-bootstrap/references/patterns.md`
+  Expected: PASS — `1`, `0`, `1`, `1` (renamed; read-first present; existing bullet preserved).
+
+- [ ] **Step 4: Confirm the simplify-angle link resolves (AC6)**
+  Run: `test -f skills/woostack-review/prompts/angles/simplify.md && echo OK`
+  Expected: PASS — `OK` (target of `../../woostack-review/prompts/angles/simplify.md` from §10's dir).
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs: expand patterns.md §10 into full least-code doctrine"
+  ```
+
+## Increment 2: Authoring-skill cross-links (execute, ideate, fix)
+
+> One PR: three authoring skills gain a one-line pointer to §10 (which exists in the stack base from
+> Increment 1). No ladder prose is copied — pointers only.
+
+### Task 1: woostack-execute Implement step + Hard constraint (AC3)
+
+**Files:**
+- Modify: `skills/woostack-execute/SKILL.md` (Implement step 2 at line 107; `## Hard constraints` after line 240).
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -c "least code that satisfies the task" skills/woostack-execute/SKILL.md`
+  Expected: FAIL — prints `0`.
+
+- [ ] **Step 2: Add the Implement-step sentence**
+  Append to the end of step 2 ("**Implement** its tasks…", the line ending "…the `woostack-debug` routing in \"When to stop and ask\"."):
+  ```markdown
+   Write the least code that satisfies the task per [`patterns.md §10`](../woostack-bootstrap/references/patterns.md) (understand-first, smallest existing solution, why-not-what comments) — without dropping the edge-case, error-path, security, or accessibility coverage the TDD classes already require.
+  ```
+
+- [ ] **Step 3: Add the Hard-constraints bullet**
+  Insert after the `- **Distill durable knowledge only.** …` bullet in `## Hard constraints`:
+  ```markdown
+  - **Least code, still safe.** Implement the smallest change that passes per [`patterns.md §10`](../woostack-bootstrap/references/patterns.md); never cut validation, error handling, security, or accessibility to shrink a diff.
+  ```
+
+- [ ] **Step 4: Confirm both references land and the link resolves**
+  Run: `grep -c "least code that satisfies the task" skills/woostack-execute/SKILL.md && grep -c "patterns.md §10" skills/woostack-execute/SKILL.md && test -f skills/woostack-bootstrap/references/patterns.md && echo OK`
+  Expected: PASS — `1`, `2`, `OK`.
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt create -m "docs: cross-link least-code doctrine from woostack-execute"
+  ```
+
+### Task 2: woostack-ideate "Least code wins" guard half (AC3)
+
+**Files:**
+- Modify: `skills/woostack-ideate/SKILL.md` (Key principles, "Least code wins" bullet, lines 117–118).
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -c "YAGNI cuts speculative features" skills/woostack-ideate/SKILL.md`
+  Expected: FAIL — prints `0`.
+
+- [ ] **Step 2: Extend the "Least code wins" bullet with the guard half**
+  Replace the existing bullet:
+  ```markdown
+  - **Least code wins.** Prefer the smallest solution that already exists — stdlib, a native
+    feature, an installed dependency — before proposing a new abstraction or dependency. Understand
+    the problem before choosing the smallest shape; YAGNI cuts speculative features, never
+    validation, error handling, security, accessibility, or safety redundancy.
+  ```
+
+- [ ] **Step 3: Confirm the guard half landed**
+  Run: `grep -c "YAGNI cuts speculative features" skills/woostack-ideate/SKILL.md`
+  Expected: PASS — `1`.
+
+- [ ] **Step 4: Commit**
+  ```bash
+  gt modify -c -m "docs: add safety guard to woostack-ideate Least code wins"
+  ```
+
+### Task 3: woostack-fix Proposed Fix template + Hard constraint, delta F (AC3)
+
+**Files:**
+- Modify: `skills/woostack-fix/SKILL.md` (Proposed Fix template line 134; `## Hard constraints` after line 240).
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -c "one guard at the shared function" skills/woostack-fix/SKILL.md`
+  Expected: FAIL — prints `0`.
+
+- [ ] **Step 2: Sharpen the Proposed Fix template line (delta F)**
+  Replace `*Describe the minimal, targeted code changes to resolve the root cause.*` with:
+  ```markdown
+  *Describe the minimal, targeted code changes to resolve the root cause. Fix the shared root once: grep every caller, and prefer one guard at the shared function over one-per-caller patches — smaller diff and correct. Never drop edge-case or safety coverage to shrink the change (per [`patterns.md §10`](../woostack-bootstrap/references/patterns.md)).*
+  ```
+
+- [ ] **Step 3: Add the Hard-constraints bullet**
+  Insert after `- **No guess-and-check.** …` in `## Hard constraints`:
+  ```markdown
+  - **Least code, still safe.** The fix is the smallest change that resolves the *root* cause per [`patterns.md §10`](../woostack-bootstrap/references/patterns.md) — fix the shared root once, never patch symptoms per-caller, never cut safety coverage.
+  ```
+
+- [ ] **Step 4: Confirm delta F, both §10 links, and the target**
+  Run: `grep -c "one guard at the shared function" skills/woostack-fix/SKILL.md && grep -c "patterns.md §10" skills/woostack-fix/SKILL.md && test -f skills/woostack-bootstrap/references/patterns.md && echo OK`
+  Expected: PASS — `1`, `2`, `OK`.
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs: cross-link least-code doctrine from woostack-fix (delta F)"
+  ```
+
+### Task 4: No prose duplication across authoring skills (AC5, AC6)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm the full paragraph lives in ≤2 shipped files (AC5)**
+  Run: `grep -rl "boring over clever" --include="*.md" AGENTS.md skills site | sort`
+  Expected: PASS — exactly two lines: `AGENTS.md` and `skills/woostack-bootstrap/references/patterns.md` (execute/ideate/fix carry pointers, not the paragraph).
+
+- [ ] **Step 2: Confirm the ladder prose is not copied into the authoring skills (AC5)**
+  Run: `grep -rl "in-tree reuse" --include="*.md" skills | sort`
+  Expected: PASS — exactly one line: `skills/woostack-bootstrap/references/patterns.md`.
+
+- [ ] **Step 3: Confirm every new authoring-skill link resolves (AC6)**
+  Run: `for f in skills/woostack-execute skills/woostack-fix; do (cd "$f" && test -f ../woostack-bootstrap/references/patterns.md && echo "$f OK"); done`
+  Expected: PASS — `skills/woostack-execute OK`, `skills/woostack-fix OK`.
+
+- [ ] **Step 4: No commit**
+  Verification-only task — no files change. The checkbox ticks are committed with this increment's
+  edit tasks (Tasks 1–3). If a check above failed, fix the offending file in its own task and re-run.
+
+## Increment 3: Docs-site concepts page + nav wiring (File 6)
+
+> One PR: a new user-facing concepts page plus its two nav surfaces (`meta.json` + `index.mdx`
+> card), moved in lockstep, then the whole site build. Ends with the cross-cutting AC4/AC5 sweep.
+
+### Task 1: Create the concepts page (AC7)
+
+**Files:**
+- Create: `site/content/docs/concepts/least-code.mdx`
+
+- [ ] **Step 1: Write the failing check**
+  Run: `test -f site/content/docs/concepts/least-code.mdx && echo EXISTS || echo MISSING`
+  Expected: FAIL — `MISSING`.
+
+- [ ] **Step 2: Author the page**
+  ```mdx
+  ---
+  title: Least code, still safe
+  description: woostack's core engineering tenet — write as little code as necessary, without cutting edge cases or risks.
+  ---
+
+  woostack's skills — and the code they generate — write as little code as necessary. Less code is
+  less to read, test, and break. But "least code" is a discipline, not a golf score: it never comes
+  at the cost of correctness or safety.
+
+  ## Understand first, then take the first rung that holds
+
+  Laziness is about the *solution*, never about *reading*. Read the code a change touches and trace
+  the real flow end to end before writing anything — the smallest change in the wrong place is a
+  second bug. Then take the first rung that already solves the problem:
+
+  1. **YAGNI** — is it needed at all?
+  2. **In-tree reuse** — a helper, util, or pattern that already exists here.
+  3. **The standard library.**
+  4. **A native platform feature.**
+  5. **An already-installed dependency.**
+  6. **One line.**
+  7. Only then, the minimum new code that works.
+
+  ## Never shrink code by cutting safety
+
+  Deletion over addition, boring over clever — code is small because it's necessary, not golfed.
+  What never gets cut to shrink a diff: validation, error handling, security, accessibility, and
+  data-loss handling. Deliberate multi-layer safety redundancy stays (it is not DRY-removable). At
+  equal size, pick the edge-case-correct option, and a behavior-changing simplification keeps its
+  regression test. A knowingly-cut corner leaves a `why` comment naming its ceiling and upgrade
+  path.
+
+  ## Comments explain why, not what
+
+  Comments are minimal and explain *why* — a hidden constraint, a workaround, a surprising
+  invariant. The code already says *what*.
+
+  ## Where it lives
+
+  The tenet is enforced across the loop, not just stated:
+
+  - The full generated-code standard lives in the bootstrap [development patterns](/docs/skills/woostack-bootstrap).
+  - Authoring skills carry it: [woostack-execute](/docs/skills/woostack-execute),
+    [woostack-ideate](/docs/skills/woostack-ideate), and [woostack-fix](/docs/skills/woostack-fix).
+  - The [review angles](/docs/concepts/review-angles) `simplify` and `comments` grade every change
+    against it.
+  ```
+
+- [ ] **Step 3: Confirm the page exists with frontmatter**
+  Run: `test -f site/content/docs/concepts/least-code.mdx && grep -c "^title: Least code, still safe" site/content/docs/concepts/least-code.mdx`
+  Expected: PASS — `1`.
+
+- [ ] **Step 4: Commit**
+  ```bash
+  gt create -m "docs(site): add Least code concepts page"
+  ```
+
+### Task 2: Wire the page into both nav surfaces (AC7)
+
+**Files:**
+- Modify: `site/content/docs/concepts/meta.json` (`pages` array)
+- Modify: `site/content/docs/concepts/index.mdx` (`<Cards>` block)
+
+- [ ] **Step 1: Write the failing check**
+  Run: `grep -c '"least-code"' site/content/docs/concepts/meta.json && grep -c "/docs/concepts/least-code" site/content/docs/concepts/index.mdx`
+  Expected: FAIL — `0` and `0` (unwired).
+
+- [ ] **Step 2: Add to the nav order**
+  In `site/content/docs/concepts/meta.json`, insert `"least-code",` into `pages` immediately after `"building-rules",`:
+  ```json
+  {
+    "title": "Core concepts",
+    "pages": [
+      "index",
+      "building-rules",
+      "least-code",
+      "memory",
+      "context-management",
+      "worktrees",
+      "status-tracking",
+      "review-angles",
+      "utilities"
+    ]
+  }
+  ```
+
+- [ ] **Step 3: Add the index card**
+  In `site/content/docs/concepts/index.mdx`, insert this `<Card>` immediately after the "Building rules" card, inside `<Cards>`:
+  ```mdx
+    <Card title="Least code, still safe" href="/docs/concepts/least-code" description="woostack's core engineering tenet: write as little code as necessary, without cutting edge cases or risks." />
+  ```
+
+- [ ] **Step 4: Confirm both nav surfaces reference the page (lockstep)**
+  Run: `grep -c '"least-code"' site/content/docs/concepts/meta.json && grep -c "/docs/concepts/least-code" site/content/docs/concepts/index.mdx`
+  Expected: PASS — `1` and `1`.
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs(site): wire least-code page into concepts nav"
+  ```
+
+### Task 3: Site builds + cross-cutting AC4/AC5/AC6 sweep (AC7, AC4, AC5, AC6)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build the docs site (AC7)**
+  Run: `pnpm -C site install --frozen-lockfile && pnpm -C site build`
+  Expected: PASS — build completes, exit code `0` (the new page compiles and is nav-wired). Run the
+  `install` first only if `site/node_modules` is absent; a warm tree can `pnpm -C site build` directly.
+
+- [ ] **Step 2: Confirm no already-aligned skill was touched (AC4)**
+  Run: `git diff --name-only main -- skills site AGENTS.md .claude | sort`
+  Expected: PASS — every path is in the allowed set and none is a `woostack-tdd`, review-angle, or `woostack-audit` file:
+  ```
+  AGENTS.md
+  site/content/docs/concepts/index.mdx
+  site/content/docs/concepts/least-code.mdx
+  site/content/docs/concepts/meta.json
+  skills/woostack-bootstrap/references/patterns.md
+  skills/woostack-execute/SKILL.md
+  skills/woostack-fix/SKILL.md
+  skills/woostack-ideate/SKILL.md
+  ```
+  (`.claude/CLAUDE.md` does **not** list — it is a symlink whose link blob is unchanged; editing the
+  AGENTS.md target does not re-write the link itself.)
+
+- [ ] **Step 3: Confirm no whole-paragraph duplication feature-wide (AC5)**
+  Run: `grep -rl "boring over clever" --include="*.md" AGENTS.md skills site | sort`
+  Expected: PASS — exactly `AGENTS.md` and `skills/woostack-bootstrap/references/patterns.md`. The
+  `.mdx` docs page is excluded by `--include="*.md"` by design: it paraphrases the tenet in its own
+  words rather than copying the paragraph, so it is not a duplication site.
+
+- [ ] **Step 4: Confirm the docs page uses `/docs/…` routes, not repo-relative paths (AC6 edge)**
+  Run: `grep -c "](/docs/" site/content/docs/concepts/least-code.mdx && grep -c "](../" site/content/docs/concepts/least-code.mdx`
+  Expected: PASS — first `≥1`, second `0`.
+
+- [ ] **Step 5: No commit**
+  Verification-only task — no files change. The checkbox ticks are committed with this increment's
+  page/nav tasks (Tasks 1–2). This is the final increment: on all boxes `[x]`, `woostack-execute`
+  authors the plan's terminal `status: done`.
+
+## Plan Checks
+
+- **Spec coverage** — Files 1–6 each map to a task: File 1 → Inc 1 Task 1; File 2 → Inc 1 Task 2;
+  File 3 → Inc 2 Task 1; File 4 → Inc 2 Task 2; File 5 → Inc 2 Task 3; File 6 → Inc 3 Tasks 1–2.
+- **AC coverage** — AC1 → Inc1 T1; AC2 → Inc1 T2; AC3 → Inc2 T1–T3; AC4 → Inc3 T3 S2; AC5 → Inc2 T4
+  + Inc3 T3 S3; AC6 → Inc1 T1 S4/T2 S4 + Inc2 T4 + Inc3 T3 S4; AC7 → Inc3 T1–T3. Each carries a
+  concrete command with expected output (no-runner substitution).
+- **No placeholders** — every step has exact paths, complete content, exact commands, expected
+  output.
+- **Type consistency** — canonical phrase "Least code, still safe" and link target
+  `patterns.md §10` are used identically across AGENTS.md, execute, and fix.
+- **Angle coverage** — architecture (two homes + cross-links, §5); security/edge/error (the guard
+  clause is the never-cut list, AC1–AC3 assert it, and no threat surface is added); a failing check
+  precedes every edit; deps none; infra = the AC7 `pnpm -C site build` guard. observability / api /
+  database / i18n → N/A for a documentation tenet (spec §9).
+- **Deferral markers** — none needed: Increment 2's link targets (`patterns.md §10`) exist in the
+  stack base from Increment 1, so no isolated diff has a dangling reference.

--- a/.woostack/specs/2026-07-14-least-code-tenet.md
+++ b/.woostack/specs/2026-07-14-least-code-tenet.md
@@ -1,7 +1,7 @@
 ---
 name: least-code-tenet
 type: spec
-status: hardened
+status: approved
 date: 2026-07-14
 branch: feature/least-code-tenet
 links:
@@ -56,6 +56,7 @@ restated) from the authoring skills. Fold in the genuinely additive improvements
 [`DietrichGebert/ponytail`](https://github.com/DietrichGebert/ponytail) (deltas A–F below) that
 sharpen how our skills generate code, while keeping woostack's leaner single-source + cross-link
 architecture.
+A user-facing docs-site concepts page also surfaces the tenet to consumers of the collection.
 
 ## 3. Non-goals
 
@@ -76,8 +77,8 @@ architecture.
 
 ## 4. Approach
 
-A **targeted 5-file** change: one canonical statement, one detailed doctrine home, three
-cross-links. Exact anchors and current text confirmed by read.
+A **targeted 6-artifact** change: one canonical statement, one detailed doctrine home, three skill
+cross-links, and one user-facing docs-site concepts page. Exact anchors confirmed by read.
 
 **File 1 — `.claude/CLAUDE.md` / `AGENTS.md` (symlinked; edit the real file), Hard constraints.**
 Add the canonical tenet as a new hard-constraint bullet — the tight, authoritative statement that
@@ -132,10 +133,15 @@ constraints.** Sharpen "minimal, targeted code changes" to include **delta F**: 
 root once (grep callers; one guard at the shared function beats one-per-caller — smaller diff and
 correct), without dropping edge-case or safety coverage.
 
-**Docs-site sync check.** `AGENTS.md` per-skill reference pages regenerate from `SKILL.md`; the
-authored framing pages under `site/content/docs/` are unaffected by a tenet bullet + reference
-expansion. Confirm with `pnpm -C site build` only if an authored page turns out to state the skill
-surface/count (it does not for this change).
+**File 6 — `site/content/docs/concepts/least-code.mdx` (new) + nav wiring.** Add a user-facing
+"Core concepts" page presenting the tenet to consumers (Fumadocs MDX: `title` + `description`
+frontmatter, `##` sections, links to `/docs/skills/…` and `/docs/concepts/…`). Wire it into the
+nav two ways: append `"least-code"` to `site/content/docs/concepts/meta.json`'s `pages` array, and
+add a `<Card>` for it to `site/content/docs/concepts/index.mdx`. The page frames the tenet for
+readers (what "least code, still safe" means, the ladder, the guard) and links the skills; it does
+not restate the full `patterns.md §10` prose. Per-`SKILL.md` reference pages still regenerate at
+build; only these authored pages are hand-edited. Confirm the whole site builds with
+`pnpm -C site build`.
 
 ## 5. Components & data flow
 
@@ -165,8 +171,8 @@ Failure modes for a docs/skills change and how each is prevented or caught:
   §10 full); the other three files carry pointers only. Verified in §7 AC5.
 - **Broken cross-links** (wrong relative depth from AGENTS.md at repo root vs. skills). Verified in
   §7 AC6 by resolving each new link target on disk.
-- **Docs-site drift.** Authored pages unaffected; if any authored page states the skill
-  surface/count, `pnpm -C site build` must still pass. Verified in §7 AC7.
+- **Docs-site drift.** File 6 adds one authored page plus two nav wirings; no existing authored
+  page is rewritten. `pnpm -C site build` must pass and the new page must be nav-wired. Verified in §7 AC7.
 - **Over-editing** (touching already-aligned skills). Prevention: non-goals list them explicitly;
   AC scans confirm they are unchanged.
 - **Angle pre-flight (spec lens).** security → the tenet *protects* security/validation checks
@@ -199,8 +205,8 @@ each "test" is a concrete **verification command** with exact expected output (p
   - error: a reference that restates the ladder instead of linking fails (duplication).
   - edge: each link uses the correct relative path from its file's location.
 - **AC4 — Already-aligned skills untouched.**
-  - happy: `git diff --name-only` against base lists only the 5 target files (+ the spec/plan under
-    `.woostack/`).
+  - happy: `git diff --name-only` against base lists only the 6 target files plus the two docs-site
+    nav wirings (`concepts/meta.json`, `concepts/index.mdx`) and the spec/plan under `.woostack/`.
   - error: any diff to `woostack-tdd`, the review angles, or `woostack-audit` is out of scope.
   - edge: N/A.
 - **AC5 — No prose duplication.**
@@ -212,16 +218,17 @@ each "test" is a concrete **verification command** with exact expected output (p
   - happy: every new link target path exists on disk (checked from the linking file's directory).
   - error: a 404 relative path.
   - edge: links from repo-root AGENTS.md vs. from `skills/*/SKILL.md` use different depths.
-- **AC7 — Docs site still builds (guard).**
-  - happy: authored `site/content/docs/` pages need no change (skill surface/count unchanged); if
-    touched, `pnpm -C site build` passes.
-  - error: an authored page contradicting the new tenet.
-  - edge: `N/A` if no authored page references code-brevity doctrine.
+- **AC7 — Docs-site concepts page added and builds.**
+  - happy: `site/content/docs/concepts/least-code.mdx` exists with `title`/`description`
+    frontmatter; `"least-code"` is in `concepts/meta.json` `pages`; `concepts/index.mdx` has its
+    `<Card>`; `pnpm -C site build` exits 0.
+  - error: page present but unwired in `meta.json` (missing from nav) → fails.
+  - edge: the page links `/docs/skills/…` and `/docs/concepts/…`, not repo-relative paths.
 
 ## 8. Testing
 
-Strategy: no test runner in this repo — verification is by `grep`/link-resolution/`git diff`
-scans and a conditional `pnpm -C site build`. Per-behavior checks live in §7. The plan will make
+Strategy: no test runner in this repo — verification is by `grep`/link-resolution/`git diff` scans
+plus a required `pnpm -C site build` (File 6 adds an authored page). Per-behavior checks live in §7. The plan will make
 each AC a checkbox with its exact command and expected output. Manual read-through of each anchor
 confirms wording matches the approved design.
 
@@ -232,11 +239,11 @@ confirms wording matches the approved design.
   §10 is the de-facto cross-skill code standard; a new shared reference would violate least-code.
 - **§10 heading broadens** "Code size & comments" → "Least code & comments" to match the expanded
   content (folded into §4 File 2).
-- **No docs-site page edit in this change** — scanned `site/content/docs/`: `index.mdx` "Minimal
-  dependencies" is skill-architecture (not code brevity) and `concepts/review-angles.mdx` already
-  describes the `simplify` angle (enforcement, accurate). No authored page states a code-brevity
-  *authoring* stance to update; AC7 keeps the build green. Whether to add a user-facing "Least
-  code, still safe" concepts page is a scope call surfaced at the spec-approval gate, not assumed.
+- **Docs-site concepts page ADDED** — at the spec-approval gate the user chose to add a user-facing
+  "Least code, still safe" page (File 6). It joins the existing concept pages
+  (`concepts/meta.json` + an `index.mdx` card) and links the skills; it does not restate
+  `patterns.md §10`. The scan still holds: no *existing* authored page contradicted the tenet, so
+  none is rewritten — only the new page and its two nav wirings are added.
 - **Angle pre-flight (spec lens) walks clean:** security (tenet protects checks; no new threat
   surface), bugs/edge-error (guard clause = the ACs), tests (AC1–7 each carry a verification
   command), deps (none — non-goal), infra (only the AC7 `pnpm -C site build` guard).

--- a/.woostack/specs/2026-07-14-least-code-tenet.md
+++ b/.woostack/specs/2026-07-14-least-code-tenet.md
@@ -1,0 +1,243 @@
+---
+name: least-code-tenet
+type: spec
+status: hardened
+date: 2026-07-14
+branch: feature/least-code-tenet
+links:
+---
+
+# Least code, still safe — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../../skills/woostack-status/references/conventions.md).
+
+> **Plan:** [[plans/2026-07-14-least-code-tenet]]
+
+## 1. Problem
+
+The repo has no single, canonical statement that skills — and the code they generate — should
+write as little code as necessary while still covering edge cases and risks. The principle is
+real and already lived, but it is **scattered and one-sided**:
+
+- **Design phase** carries it: `woostack-ideate` has `YAGNI ruthlessly` + `Least code wins`.
+- **Generated-code size** carries part of it: `patterns.md §10` ("Code size & comments") covers
+  ≤500-line files, why-not-what comments, no magic literals — but not the YAGNI/reuse ladder, the
+  read-first discipline, or the safety guard.
+- **Enforcement** carries it best: the review `simplify` angle states the full 7-rung ladder and
+  the "lazy, not negligent" guard verbatim; the `comments` angle polices comment rot.
+
+The gap: **no canonical tenet**, and the *authoring* skills that actually write code
+(`woostack-execute`, `woostack-fix`) don't carry the principle at all — only the reviewer that
+grades them afterward does.
+
+**Evidence (three independent past-session corpora, unanimous Strong Support):**
+
+| Corpus | Sessions | FOR | COUNTER |
+|---|---|---|---|
+| Codex | 873 | 137 | 210 |
+| omp | 77 (13,041 msgs) | 48 | 56 |
+| Claude | 174 + 897 subagent | strong | strong |
+
+FOR: repeated requests to shrink `AGENTS.md`, keep skills thin, cross-link not duplicate, inline
+single-use vars, delete dead logic, reject a complex regex for a substring. COUNTER (why the guard
+clause is load-bearing): every corpus recorded a simplify impulse that **removed a real safety
+mechanism** and had to be reverted — concurrency guard, gitignore fallback, diff-anchor scoping,
+base-aware branch gate, PII scrub, YAML-injection validation, config failover. The recurring
+nuance across all three: minimal comments means **why-not-what**, and **deliberate multi-layer
+safety redundancy is not DRY-removable**.
+
+## 2. Goal
+
+Codify **one** canonical engineering tenet — "Least code, still safe" — as the repo's named
+source of truth, with the full generated-code doctrine in `patterns.md §10`, cross-linked (never
+restated) from the authoring skills. Fold in the genuinely additive improvements from
+[`DietrichGebert/ponytail`](https://github.com/DietrichGebert/ponytail) (deltas A–F below) that
+sharpen how our skills generate code, while keeping woostack's leaner single-source + cross-link
+architecture.
+
+## 3. Non-goals
+
+- **No always-on hook/plugin injection system.** ponytail injects its ruleset every turn via
+  Node lifecycle hooks; we rely on skills reading their own instructions. Out of scope.
+- **No multi-agent rule-copy files or a sync checker.** ponytail ships N per-agent copies kept in
+  step by `scripts/check-rule-copies.js`. Our "cross-link, do not duplicate" hard constraint is
+  deliberately leaner (one source + links); we do not adopt copies.
+- **No new commands.** No `/…-debt` ledger or `/…-gain` scoreboard; our memory `gotcha` store
+  already captures deferred corners.
+- **No weakening of `woostack-tdd`.** ponytail's "one runnable check behind" is weaker than our
+  full TDD kernel; we keep ours.
+- **No edits to skills that already carry the tenet** (`woostack-tdd`, the `simplify`/`comments`
+  review angles, `woostack-audit`) or to the ~18 skills that write no code. Editing them would
+  restate the doctrine and violate the very tenet being codified.
+- **No blanket rewrite of all 24 skills.** "Update all skills *as necessary*" = only where the
+  authoring / generated-code tenet actually lands.
+
+## 4. Approach
+
+A **targeted 5-file** change: one canonical statement, one detailed doctrine home, three
+cross-links. Exact anchors and current text confirmed by read.
+
+**File 1 — `.claude/CLAUDE.md` / `AGENTS.md` (symlinked; edit the real file), Hard constraints.**
+Add the canonical tenet as a new hard-constraint bullet — the tight, authoritative statement that
+points to `patterns.md §10` for the full ladder and to the `simplify`/`comments` angles for
+enforcement. Governs this repo's own authoring + scripts. Draft:
+
+> **Least code, still safe.** Skills — and the code they generate — write as little code as
+> necessary. Understand first (read the code the change touches, trace the real flow), *then* take
+> the first rung that holds: in-tree reuse → stdlib → native feature → installed dep → one line →
+> minimum that works. Deletion over addition, boring over clever — small because it's necessary,
+> not golfed. Comments are minimal and explain *why* (hidden constraint, workaround, surprising
+> invariant), never *what*. Lazy about the solution, never about reading: the smallest change in
+> the wrong place is a second bug. Never shrink code by cutting edge cases or risks — validation,
+> error handling, security, accessibility, and data-loss handling stay; keep deliberate
+> multi-layer safety redundancy; at equal size pick the edge-case-correct option; behavior-changing
+> simplification keeps its regression test; a knowingly-cut corner leaves a `why` comment naming
+> its ceiling and upgrade path. Full standard:
+> [`patterns.md §10`](skills/woostack-bootstrap/references/patterns.md); enforced by the
+> `simplify`/`comments` review angles.
+
+**File 2 — `skills/woostack-bootstrap/references/patterns.md §10` (lines 158–163).** Rename the
+§10 heading "Code size & comments" → "Least code & comments" and expand it into the full
+generated-code doctrine (the detailed home the tenet points to). Keep the existing four bullets; add:
+- **The ladder** (rungs 1–7: YAGNI → in-tree reuse → stdlib → native → installed dep → one line →
+  minimum that works), cross-linking the `simplify` angle as the enforcement side rather than
+  restating its prose.
+- **Delta A — read first.** The ladder runs *after* understanding the problem: read the code the
+  change touches and trace the real flow end to end before picking a rung. "Lazy about the
+  solution, never about reading; the smallest change in the wrong place is a second bug."
+- **Delta B — equal-size tie-breaker.** When two approaches are the same size, pick the
+  edge-case-correct one; lazy means less code, not the flimsier algorithm.
+- **Delta C — never-cut list** widened to validation, error handling, security, **accessibility**,
+  **data-loss handling**; deliberate multi-layer safety redundancy stays; scoped parsing over
+  greedy regex; behavior-changing simplification keeps its regression test.
+- **Delta D — boring over clever.** Deletion over addition; small because necessary, not golfed.
+- **Delta E — deliberate-corner marker.** A knowingly-cut corner with a known ceiling (global
+  lock, O(n²) scan, naive heuristic) leaves a `why` comment naming the ceiling + upgrade path, and
+  is distilled as a memory `gotcha`.
+
+**File 3 — `skills/woostack-execute/SKILL.md`.** In the **Implement** step (step 2, ~line 103–107)
+add one sentence: implement the least code that satisfies the task per `patterns.md §10`
+(understand-first, smallest existing solution, why-not-what comments) without dropping edge-case,
+error-path, security, or accessibility coverage — the TDD coverage classes already require them.
+Add one **Hard constraints** bullet (~after line 240) naming the tenet and cross-linking §10.
+
+**File 4 — `skills/woostack-ideate/SKILL.md`, "Least code wins" (line 117–118).** Extend with the
+guard half: YAGNI cuts speculative features, not validation, error handling, security,
+accessibility, or safety redundancy; understand the problem before choosing the smallest shape.
+
+**File 5 — `skills/woostack-fix/SKILL.md`, "Proposed Fix" template (line 134) + step 2/Hard
+constraints.** Sharpen "minimal, targeted code changes" to include **delta F**: fix the shared
+root once (grep callers; one guard at the shared function beats one-per-caller — smaller diff and
+correct), without dropping edge-case or safety coverage.
+
+**Docs-site sync check.** `AGENTS.md` per-skill reference pages regenerate from `SKILL.md`; the
+authored framing pages under `site/content/docs/` are unaffected by a tenet bullet + reference
+expansion. Confirm with `pnpm -C site build` only if an authored page turns out to state the skill
+surface/count (it does not for this change).
+
+## 5. Components & data flow
+
+Two audiences, one doctrine, wired by cross-link:
+
+```
+AGENTS.md  "Least code, still safe"  (canonical, tight)   ← repo authors + the collection's scripts
+    │  points to
+    ▼
+patterns.md §10  (full ladder + read-first + tie-breaker + never-cut + marker + anti-golf)   ← generated code
+    ▲  cross-linked by (authoring side)              │  cross-links (enforcement side)
+    │                                                ▼
+woostack-execute (Implement)                   review angles: simplify + comments
+woostack-ideate ("Least code wins")            woostack-audit (already aligned — untouched)
+woostack-fix    (Proposed Fix)                 woostack-tdd (already aligned — untouched)
+```
+
+The canonical statement lives **once** (AGENTS.md); the detailed standard lives **once**
+(patterns.md §10); every other touchpoint is a one-line pointer. No prose is duplicated.
+
+## 6. Error handling
+
+Failure modes for a docs/skills change and how each is prevented or caught:
+
+- **Restating instead of linking** (would violate the tenet + the "cross-link, do not duplicate"
+  hard constraint). Prevention: canonical text appears in exactly two homes (AGENTS.md tight +
+  §10 full); the other three files carry pointers only. Verified in §7 AC5.
+- **Broken cross-links** (wrong relative depth from AGENTS.md at repo root vs. skills). Verified in
+  §7 AC6 by resolving each new link target on disk.
+- **Docs-site drift.** Authored pages unaffected; if any authored page states the skill
+  surface/count, `pnpm -C site build` must still pass. Verified in §7 AC7.
+- **Over-editing** (touching already-aligned skills). Prevention: non-goals list them explicitly;
+  AC scans confirm they are unchanged.
+- **Angle pre-flight (spec lens).** security → the tenet *protects* security/validation checks
+  (the guard is the point); edge/error → the guard clause is entirely about edge/error coverage,
+  captured as ACs; observability / api / database → N/A for a documentation tenet.
+
+## 7. Acceptance criteria
+
+Each AC is a testable behavior → ≥1 plan task. This is a docs/skills repo with no test runner, so
+each "test" is a concrete **verification command** with exact expected output (per the
+`woostack-tdd` no-runner substitution).
+
+- **AC1 — Canonical tenet exists in AGENTS.md.**
+  - happy: `grep -c "Least code, still safe" AGENTS.md` → `≥1`; the bullet names the never-cut
+    list (validation, error handling, security, accessibility, data-loss) and links `patterns.md §10`.
+  - error: the bullet without the `patterns.md §10` link fails review (no canonical→detail path).
+  - edge: `.claude/CLAUDE.md` resolves to the same content (symlink) — edit the real file, not a copy.
+- **AC2 — patterns.md §10 carries the full doctrine.**
+  - happy: §10 contains the 7-rung ladder, the read-first discipline (delta A), the equal-size
+    tie-breaker (delta B), the widened never-cut list (delta C), boring-over-clever/anti-golf
+    (delta D), and the deliberate-corner marker (delta E), and cross-links the `simplify` angle.
+  - error: a rung list that omits "understand first" (delta A) is incomplete — read-first is the
+    load-bearing anti-regression piece.
+  - edge: existing four bullets (≤500 lines, JSDoc, why-not-what, no magic literals) preserved, not
+    replaced.
+- **AC3 — Authoring skills cross-link the doctrine.**
+  - happy: `woostack-execute` Implement step + a Hard-constraints bullet reference `patterns.md §10`;
+    `woostack-ideate` "Least code wins" carries the guard half; `woostack-fix` Proposed Fix carries
+    delta F (shared-root fix).
+  - error: a reference that restates the ladder instead of linking fails (duplication).
+  - edge: each link uses the correct relative path from its file's location.
+- **AC4 — Already-aligned skills untouched.**
+  - happy: `git diff --name-only` against base lists only the 5 target files (+ the spec/plan under
+    `.woostack/`).
+  - error: any diff to `woostack-tdd`, the review angles, or `woostack-audit` is out of scope.
+  - edge: N/A.
+- **AC5 — No prose duplication.**
+  - happy: the full tenet paragraph appears in ≤2 files (AGENTS.md tight, §10 full); the ladder
+    prose is not copied into execute/ideate/fix.
+  - error: the same multi-sentence block in ≥3 files.
+  - edge: short shared phrases (e.g. "least code") recurring is fine; whole-paragraph copies are not.
+- **AC6 — All new cross-links resolve.**
+  - happy: every new link target path exists on disk (checked from the linking file's directory).
+  - error: a 404 relative path.
+  - edge: links from repo-root AGENTS.md vs. from `skills/*/SKILL.md` use different depths.
+- **AC7 — Docs site still builds (guard).**
+  - happy: authored `site/content/docs/` pages need no change (skill surface/count unchanged); if
+    touched, `pnpm -C site build` passes.
+  - error: an authored page contradicting the new tenet.
+  - edge: `N/A` if no authored page references code-brevity doctrine.
+
+## 8. Testing
+
+Strategy: no test runner in this repo — verification is by `grep`/link-resolution/`git diff`
+scans and a conditional `pnpm -C site build`. Per-behavior checks live in §7. The plan will make
+each AC a checkbox with its exact command and expected output. Manual read-through of each anchor
+confirms wording matches the approved design.
+
+## 9. Resolved decisions (harden)
+
+- **patterns.md §10 is the generated-code home** — confirmed. `woostack-tdd` already cross-links
+  `patterns.md §7` from outside bootstrap and its description codifies "link, don't restate," so
+  §10 is the de-facto cross-skill code standard; a new shared reference would violate least-code.
+- **§10 heading broadens** "Code size & comments" → "Least code & comments" to match the expanded
+  content (folded into §4 File 2).
+- **No docs-site page edit in this change** — scanned `site/content/docs/`: `index.mdx` "Minimal
+  dependencies" is skill-architecture (not code brevity) and `concepts/review-angles.mdx` already
+  describes the `simplify` angle (enforcement, accurate). No authored page states a code-brevity
+  *authoring* stance to update; AC7 keeps the build green. Whether to add a user-facing "Least
+  code, still safe" concepts page is a scope call surfaced at the spec-approval gate, not assumed.
+- **Angle pre-flight (spec lens) walks clean:** security (tenet protects checks; no new threat
+  surface), bugs/edge-error (guard clause = the ACs), tests (AC1–7 each carry a verification
+  command), deps (none — non-goal), infra (only the AC7 `pnpm -C site build` guard).
+  observability, api, database, i18n → N/A for a documentation tenet.


### PR DESCRIPTION
## Goal

Codify "Least code, still safe" as woostack's one canonical engineering tenet — a tight statement in `AGENTS.md`, the full generated-code doctrine in `patterns.md §10`, cross-linked (never restated) from the authoring skills, and surfaced to consumers via a new docs-site concepts page.

## Summary

This is the **spec+plan base PR** (docs-only; never merged by build — it is the base of the execution stack).

- **Spec:** `.woostack/specs/2026-07-14-least-code-tenet.md` (`status: approved`)
- **Plan:** `.woostack/plans/2026-07-14-least-code-tenet.md` (`status: ready`)

Scope — 6 artifacts, targeted (no blanket rewrite of all skills):
1. `AGENTS.md` — canonical "Least code, still safe" hard-constraint bullet.
2. `patterns.md §10` — renamed "Least code & comments"; full ladder + deltas A–E (read-first, tie-breaker, widened never-cut list, boring-over-clever, deliberate-corner marker).
3. `woostack-execute` — Implement-step sentence + Hard-constraints bullet cross-linking §10.
4. `woostack-ideate` — "Least code wins" gains the safety guard half.
5. `woostack-fix` — Proposed Fix template + Hard-constraints bullet (delta F: fix the shared root once).
6. `site/content/docs/concepts/least-code.mdx` (new) + nav wiring (`meta.json` + `index.mdx` card).

Plan = 3 linear increments (canonical doctrine → authoring cross-links → docs page), each independently shippable, `spec:plan:PRs = 1:1:3`.

## Test plan

No test runner in this repo — verification is concrete `grep`/link-resolution/`git diff`/`pnpm build` commands (per the woostack-tdd no-runner substitution), one per AC.

### Automated
- [ ] AC1: `grep -c "Least code, still safe" AGENTS.md` → `1`
- [ ] AC2: §10 renamed + carries deltas A–E; existing bullets preserved
- [ ] AC3: execute/ideate/fix carry pointers to `patterns.md §10` (no ladder prose copied)
- [ ] AC4: `git diff --name-only main -- skills site AGENTS.md` lists only the target files
- [ ] AC5: full tenet paragraph in ≤2 shipped `.md` files
- [ ] AC6: every new relative cross-link resolves on disk
- [ ] AC7: `pnpm -C site build` exits 0 with the new page nav-wired

### Manual
- [ ] Read-through confirms wording matches the approved design and no already-aligned skill (`woostack-tdd`, review angles, `woostack-audit`) is touched.
