### PR TITLE
docs: harden premise lens — validate the problem before the solution

### DIFF
--- a/.woostack/plans/2026-07-14-harden-premise-lens.md
+++ b/.woostack/plans/2026-07-14-harden-premise-lens.md
@@ -1,0 +1,247 @@
+---
+type: plan
+source: .woostack/specs/2026-07-14-harden-premise-lens.md
+status: ready
+branch: feature/harden-premise-lens
+---
+
+**Source:** [[specs/2026-07-14-harden-premise-lens]]
+
+# Harden premise lens — validate the problem before the solution — Implementation Plan
+
+**Goal:** Add a non-skippable "premise lens" to `woostack-harden`'s angle pre-flight — plus the matching template evidence fields and SKILL constraints — so a spec/plan/fix is proven *real* (baseline/repro, not assertion) before its solution is hardened.
+
+**Architecture:** Five prose edits across four skill files, single-source-plus-reference: the rule lives once in `angle-preflight.md` (new `## Premise lens` section + a `## Skip rule (YAGNI)` carve-out); the spec and fix templates gain a write-time "Premise / evidence" authoring blockquote; `woostack-harden/SKILL.md` acknowledges the never-skip lens in **both** places it describes the pre-flight (narrative bullet + `## Hard constraints`). No `.html`, no `VALID_ANGLES`, no new rubric, no new gate. This is a docs-only change to a skills collection, so every "failing test" is a concrete `grep`/`bash`/build check with exact expected output (per [plan-template.md](../../skills/woostack-plan/references/plan-template.md)).
+
+**Tech Stack:** Markdown skill files; `grep`/`bash`; Graphite (`gt`) for stacked commits; `pnpm -C site build` for the docs-site sync check.
+
+## Increment 1: Premise lens across pre-flight, templates, and harden SKILL
+
+> One independently shippable PR (~50 LOC of prose, well under the 500 soft target) — its own Graphite branch stacked on the spec+plan base (`feature/harden-premise-lens`, PR #516). The four edits are cross-linked and ship together: splitting them would leave the SKILL referencing a lens that does not yet exist. No deferral markers — nothing is left for a later increment.
+
+All commands run from the repository root (the worktree root: `.woostack/worktrees/feature-harden-premise-lens`).
+
+### Task 1: Premise lens section + Skip rule carve-out (AC1)
+
+**Files:**
+- Modify: `skills/woostack-harden/references/angle-preflight.md` (insert new section before line 19 `## Skip rule (YAGNI)`; amend the Skip rule body, lines 19-23)
+
+- [ ] **Step 1: Write the failing test**
+  Confirm the section does not exist yet and the current Skip rule wording is present (the baseline we will amend):
+  ```bash
+  grep -c '^## Premise lens' skills/woostack-harden/references/angle-preflight.md
+  grep -n 'Do not manufacture questions' skills/woostack-harden/references/angle-preflight.md
+  # Baseline code-angle count (must be identical after the edit — proves the lens bodies are untouched):
+  grep -cE '^- \*\*(security|observability|bugs|tests|api|database|i18n|deps|infra|architecture|types)\*\*' skills/woostack-harden/references/angle-preflight.md
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: (the three commands above)
+  Expected: first prints `0` (no premise-lens section yet); second prints the line `22:...Do not manufacture questions for` (current Skip rule body intact, our edit anchor); third prints `15` (the pre-edit code-angle baseline).
+
+- [ ] **Step 3: Minimal implementation**
+  Insert a new `## Premise lens` section **immediately before** `## Skip rule (YAGNI)` (before line 19), so the never-skip lens leads the file:
+  ```markdown
+  ## Premise lens — is the problem real? (never skips)
+
+  Every change rests on a premise: that the problem is real. Walk this lens first, on every spec,
+  plan, or fix — it is **never** skipped by the YAGNI rule below.
+
+  - **State the problem and the evidence it is real.** If the premise is an *inference about current
+    behavior* ("the tool fails to X", "the rubric misses Y"), **demonstrate it** — a reproduction
+    (bug) or a baseline showing the deficiency (enhancement). **Reject assertion-as-evidence.** Lands
+    in §1 Problem (spec) / §1 Root Cause (fix).
+  - **Evidence bar scales with the claim.** A self-evident premise (a visible bug, an explicit user
+    request) is satisfied by pointing at the repro/request — no ceremony. Only a *derived* premise
+    about current behavior must be demonstrated.
+  - **Harden records, the gate decides.** Harden amends §1 with the evidence *or the disproof* and
+    hands back; a disproven premise is killed at the caller's approve gate, not by harden.
+  - **Premise ≠ priority.** This lens validates that the problem *exists*, not that it is worth
+    solving vs. other work (out of scope — see the caller's gate).
+
+  ```
+  Then replace the Skip rule body (current lines 21-23) so YAGNI scopes only to the lenses below and the premise lens is exempt. The `## Skip rule (YAGNI)` heading stays; its paragraph becomes:
+  ```markdown
+  Walk only the angles **in the lenses below** (the code-derived Spec/Plan lenses) whose surface the
+  artifact actually implicates. A spec with no data layer skips `database`; a CLI-only change skips
+  `api` and `i18n`. Do not manufacture questions for angles the work does not touch. **The premise
+  lens above is exempt — it never skips; every change rests on a premise.**
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  Run:
+  ```bash
+  # New section present, and positioned before the Skip rule (order check):
+  awk '/^## Premise lens/{p=NR} /^## Skip rule/{s=NR} /^## Spec lens/{sp=NR} END{print (p>0 && p<s && s<sp) ? "ORDER_OK" : "ORDER_BAD ("p","s","sp")"}' skills/woostack-harden/references/angle-preflight.md
+  # Skip-rule carve-out present:
+  grep -c 'The premise lens above is exempt' skills/woostack-harden/references/angle-preflight.md
+  # Code-angle lists byte-unchanged: the single-name spec-lens + plan-lens angle bullets still present:
+  grep -cE '^- \*\*(security|observability|bugs|tests|api|database|i18n|deps|infra|architecture|types)\*\*' skills/woostack-harden/references/angle-preflight.md
+  ```
+  Expected: `ORDER_OK`; `1`; and `15` (9 spec-lens single-name bullets + 6 plan-lens single-name bullets — the combined `- **api / database**` plan bullet is intentionally not matched by the single-name pattern; the `## Spec lens` / `## Plan lens` bodies are untouched, so this equals the pre-edit count).
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt create -m "docs(harden): add non-skippable premise lens to angle pre-flight"
+  ```
+
+### Task 2: Template evidence fields — spec + fix (AC2)
+
+**Files:**
+- Modify: `skills/woostack-build/references/spec-template.md` (add authoring blockquote under `## 1. Problem`, after line 18)
+- Modify: `skills/woostack-fix/SKILL.md` (extend the embedded §1 Root Cause guidance, line 131)
+- Verify unchanged: `skills/woostack-build/references/spec-template.html`
+
+- [ ] **Step 1: Write the failing test**
+  ```bash
+  grep -c 'Premise / evidence' skills/woostack-build/references/spec-template.md
+  grep -c 'demonstrate the current behavior is genuinely deficient' skills/woostack-fix/SKILL.md
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: (both commands above)
+  Expected: both print `0` — neither template carries the evidence field yet.
+
+- [ ] **Step 3: Minimal implementation**
+  In `spec-template.md`, insert this authoring blockquote between the `## 1. Problem` heading (line 18) and the `{{PROBLEM}}` placeholder (line 20), mirroring the §7 pre-flight callout pattern (blank line above and below):
+  ```markdown
+  > **Premise / evidence.** State the evidence the problem is real. A derived claim about current behavior must be *demonstrated* (a baseline/repro), not asserted — harden's premise lens will not stamp this spec `hardened` otherwise. A self-evident premise (visible bug, explicit request) just cites the repro/request.
+  ```
+  In `skills/woostack-fix/SKILL.md`, replace the §1 Root Cause guidance line inside the embedded fenced template (current line 131, 3-space indent kept) with:
+  ```markdown
+     *Summarize the findings from woostack-debug. Where does the bad value originate? What is the evidence?* **For an enhancement (no bad value to trace), demonstrate the current behavior is genuinely deficient — a baseline, not an assertion. Harden's premise lens gates this.**
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  ```bash
+  # Both evidence fields present:
+  grep -c 'Premise / evidence' skills/woostack-build/references/spec-template.md
+  grep -c 'demonstrate the current behavior is genuinely deficient' skills/woostack-fix/SKILL.md
+  # spec-template.html UNCHANGED (AC2 edge): no premise content, section structure intact (9 <h2>):
+  grep -ci premise skills/woostack-build/references/spec-template.html
+  grep -c '<h2>' skills/woostack-build/references/spec-template.html
+  git status --short skills/woostack-build/references/spec-template.html
+  ```
+  Expected: `1`; `1`; then `0` (no premise text in the HTML); `9` (all nine section headings still present); and the `git status` line is **empty** (the `.html` file is not modified).
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs(templates): demand premise evidence in spec and fix §1"
+  ```
+
+### Task 3: Harden SKILL — two-location never-skip acknowledgement (AC3)
+
+**Files:**
+- Modify: `skills/woostack-harden/SKILL.md` (narrative bullet, lines 27-30; new `## Hard constraints` bullet after line 71)
+
+- [ ] **Step 1: Write the failing test**
+  ```bash
+  grep -c 'never skips' skills/woostack-harden/SKILL.md
+  grep -c 'Premise before solution' skills/woostack-harden/SKILL.md
+  ```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+  Run: (both commands above)
+  Expected: both print `0` — the SKILL does not yet name the never-skip premise lens in either location.
+
+- [ ] **Step 3: Minimal implementation**
+  (a) Amend the narrative **Angle pre-flight** bullet (lines 27-30) so the premise lens is the stated exception — replace the bullet with:
+  ```markdown
+  - **Angle pre-flight.** When hardening a spec or plan, walk the
+    [spec/plan angle pre-flight](references/angle-preflight.md) and raise a question for any angle
+    the artifact's surface implicates but leaves unaddressed — its skip rule keeps untouched angles
+    silent, **except the premise lens, which never skips: it fires on every spec, plan, or fix, even
+    when no code angle is implicated.** This makes the interview angle-driven, not only
+    decision-tree-driven.
+  ```
+  (b) Add a new bullet to `## Hard constraints` **after** the "Angle pre-flight (spec/plan)" bullet (after line 71, before the "Own no gate" bullet):
+  ```markdown
+  - **Premise before solution (never skips).** Before declaring a spec, plan, or fix `hardened`, walk
+    the premise lens first ([`references/angle-preflight.md`](references/angle-preflight.md)). For a
+    *derived* premise about current behavior, run the baseline/repro yourself (per "explore the
+    codebase to answer before asking") — do not accept assertion. Amend §1 with the evidence or the
+    disproof. This adds no gate: a disproven premise is killed at the caller's approve gate.
+  ```
+
+- [ ] **Step 4: Run the test, confirm it passes**
+  ```bash
+  # Both edits present:
+  grep -c 'never skips' skills/woostack-harden/SKILL.md          # narrative + hard-constraint => 2
+  grep -c 'Premise before solution' skills/woostack-harden/SKILL.md
+  # Hard-constraint bullet sits inside ## Hard constraints, between Angle pre-flight and Own no gate:
+  awk '/^- \*\*Angle pre-flight \(spec\/plan\)/{a=NR} /^- \*\*Premise before solution/{p=NR} /^- \*\*Own no gate/{o=NR} END{print (a<p && p<o) ? "PLACEMENT_OK" : "PLACEMENT_BAD ("a","p","o")"}' skills/woostack-harden/SKILL.md
+  ```
+  Expected: `2` (the phrase "never skips" now appears in both the narrative bullet and the hard-constraint bullet); `1`; `PLACEMENT_OK`.
+
+- [ ] **Step 5: Commit**
+  ```bash
+  gt modify -c -m "docs(harden): name the never-skip premise lens in both SKILL pre-flight sites"
+  ```
+
+### Task 4: Scope guards, cross-link integrity, docs-site & behavioral dogfood (AC4 + §8)
+
+> Verification-only — no file edit, so **no commit**. Pins the negative invariants (AC4) and runs the two §8 checks that are not per-edit greps.
+
+- [ ] **Step 1: Scope guards — premise is NOT a review angle (AC4 edge)**
+  Run:
+  ```bash
+  # VALID_ANGLES must NOT contain "premise":
+  grep -n 'VALID_ANGLES' skills/woostack-review/scripts/load-config.sh | grep -c premise
+  # No premise rubric was added under prompts/angles/:
+  ls skills/woostack-review/prompts/angles/ | grep -c '^premise'
+  # The pre-flight's "Canonical angles — link, do not restate" note is still present and accurate:
+  grep -c 'Canonical angles' skills/woostack-harden/references/angle-preflight.md
+  # AC4 happy: the premise lens itself carves priority/ROI OUT of scope (not a value tribunal):
+  grep -c 'Premise ≠ priority' skills/woostack-harden/references/angle-preflight.md
+  ```
+  Expected: `0` (premise not in `VALID_ANGLES`); `0` (no rubric file); `1` (note intact); `1` (priority explicitly out of scope in the premise lens).
+
+- [ ] **Step 2: Cross-link integrity + no-duplication (AC4 error)**
+  Run:
+  ```bash
+  # Every relative link the new/edited content points at resolves to a real file:
+  test -f skills/woostack-harden/references/angle-preflight.md && echo LINK_OK_preflight
+  # Single source: the rule text lives ONLY in angle-preflight.md across the skills tree
+  # (spec/plan artifacts under .woostack/ are excluded — this checks the four edited skill files):
+  grep -rl 'Evidence bar scales with the claim' skills/
+  grep -rl 'Harden records, the gate decides' skills/
+  ```
+  Expected: `LINK_OK_preflight`; and each `grep -rl` prints exactly one path — `skills/woostack-harden/references/angle-preflight.md` — confirming the templates and SKILL reference the rule (by prose/link) rather than duplicating its full text.
+
+- [ ] **Step 3: Docs-site sync check (§8, CLAUDE.md constraint)**
+  Run:
+  ```bash
+  # No authored docs page restates the pre-flight lens list or harden's constraint set:
+  grep -rl 'premise lens' site/content/docs/ || echo "NO_AUTHORED_PAGE_MENTIONS (expected)"
+  # Site still builds (per-skill reference page regenerates from SKILL.md at build; it is gitignored):
+  pnpm -C site build
+  # No authored docs page changed on disk:
+  git status --short site/content/docs/
+  ```
+  Expected: `NO_AUTHORED_PAGE_MENTIONS (expected)`; `pnpm -C site build` exits `0`; the `git status` line is empty (generated per-skill pages are gitignored, authored pages untouched). If `site` deps are absent, run `pnpm -C site install` first.
+
+- [ ] **Step 4: Behavioral dogfood (§8 — corroborating evidence, not a CI gate)**
+  Construct a throwaway spec whose §1 is a *bare derived assertion* with no baseline, then walk `woostack-harden`'s premise lens against it and confirm the lens fires:
+  ```bash
+  cat > /tmp/premise-dogfood-spec.md <<'EOF'
+  ---
+  name: dogfood
+  type: spec
+  status: draft
+  ---
+  # Dogfood — Design Spec
+  ## 1. Problem
+  Skill X misses case Y. (No baseline, no repro — a bare derived assertion about current behavior.)
+  ## 2. Goal
+  Fix it.
+  EOF
+  ```
+  Then, acting as `woostack-harden` reading `skills/woostack-harden/references/angle-preflight.md`, verify the premise lens (never skips) forces: (1) the §1 claim is a *derived* premise about current behavior with no evidence → harden **raises the premise question** and **runs the baseline itself** ("explore the codebase to answer") rather than stamping `hardened`; (2) had §1 cited a repro/request, the evidence-scales-with-claim rule would pass it without ceremony. Record the outcome in the increment review note. This mirrors the `#512` carve-out and is corroborating evidence only — remove the temp file afterward (`rm /tmp/premise-dogfood-spec.md`).
+
+## Plan Checks
+
+- **Spec coverage** — every §4 edit and §6 error path maps to a task: §4.1 → Task 1; §4.2/§4.3 → Task 2; §4.4 → Task 3; §4.5 (flow, no code) documented, no edit; §6 error paths are the behaviors verified by Task 3 Step 4 (placement) and Task 4 Step 4 (dogfood: assertion-as-evidence raises a question; disproven premise records, no self-kill).
+- **AC coverage** — AC1 → Task 1 (section present, before Skip rule, carve-out, code-angle lists unchanged); AC2 → Task 2 (both templates carry the field; `.html` unchanged, 9 `<h2>` intact); AC3 → Task 3 (hard-constraint bullet + narrative "never skips", placement) and Task 4 Step 4 (dogfood behavior); AC4 → Task 4 Steps 1-2 (happy: priority/ROI carved out of the premise lens; edge: `VALID_ANGLES` clean, no rubric; error: cross-links resolve, no duplication).
+- **No placeholders** — every step carries the exact insertion content and exact command with expected output; no TBD/TODO.
+- **Type consistency** — N/A (prose skill files, no code types); heading/anchor names (`## Premise lens`, "never skips", "Premise before solution", `{{PROBLEM}}`) are used identically across tasks and verification greps.
+- **Angle coverage** — plan lens walked: architecture = single-source-plus-reference (rule once in `angle-preflight.md`, referenced elsewhere), lockstep-aware (spec-template `.md`/`.html` pair pinned unchanged in Task 2; harden's two pre-flight sites moved together in Task 3 per the `autonomy-needs-structural-proof` barrier+hard-constraint law); a verification step per AC; security/observability/api/database/i18n/deps skip (prose-only, no code surface — YAGNI).

--- a/.woostack/specs/2026-07-14-harden-premise-lens.md
+++ b/.woostack/specs/2026-07-14-harden-premise-lens.md
@@ -1,0 +1,247 @@
+---
+name: harden-premise-lens
+type: spec
+status: hardened
+date: 2026-07-14
+branch: feature/harden-premise-lens
+links:
+---
+
+# Harden premise lens — validate the problem before the solution — Design Spec
+
+> Visualize on demand: render this file with [spec-template.html](../../skills/woostack-build/references/spec-template.html) for a rich view. Markdown is the source of truth; the HTML is a presentation target only.
+
+> `status:` is the build-loop phase enum: `draft → hardened → approved → planning → ready → executing → in-review → done` (plus the terminal `abandoned`). The build loop authors each transition and `/woostack-status` reads it; the enum and join contracts are defined once in [conventions.md](../../skills/woostack-status/references/conventions.md).
+
+> **Plan:** [[plans/2026-07-14-harden-premise-lens]]
+
+## 1. Problem
+
+`woostack-harden`'s angle pre-flight interrogates the **solution** and never the **premise**. Every lens entry in
+[`angle-preflight.md`](../../skills/woostack-harden/references/angle-preflight.md) — the whole `## Spec lens`
+(security, observability, bugs, tests, api, database, i18n, deps, infra) and the whole `## Plan lens`
+(architecture, tests, types, security, observability, api/database, deps) — asks "is the design sound?" Not one
+asks "is the problem real?" So harden can stamp an artifact `hardened` while its §1 root cause / problem is an
+**unproven inference about current behavior**. The premise rides through as a fixed assumption; only the solution
+gets grilled.
+
+> **Premise / evidence (this spec).** The premise here is a *derived claim about current behavior* — "the
+> pre-flight has no premise lens" — so it must be **demonstrated**, not asserted:
+>
+> - **Structural evidence (baseline read).** `angle-preflight.md` was read in full. Its lenses are
+>   `## Spec lens` (`angle-preflight.md:25-38`) and `## Plan lens` (`angle-preflight.md:40-49`); every entry
+>   translates a `woostack-review` *code* angle into an authoring check. There is no premise/evidence entry in
+>   either lens, and the `## Skip rule (YAGNI)` (`angle-preflight.md:19-23`) would let any premise question be
+>   skipped as "not implicated" even if one existed.
+> - **Cost evidence (a real failure).** Fix `#511`→PR `#512` (`feat: flag regression-blind (fixture-neutral)
+>   assertions in the tests review angle`) was authored, hardened, committed, and opened as a PR — then
+>   **self-closed as won't-fix** once its premise was finally measured at *execution* and found false (the
+>   `tests` rubric already caught the case at a capable model tier). The fix-plan harden pass at
+>   `woostack-fix` step 3 grilled §2/§3 (bullet placement, severity, over-flag risk) and waved §1 (root cause)
+>   straight through, because the checklist told it to interrogate the design and said nothing about the
+>   premise. Harden did its job correctly against an incomplete checklist. The wasted branch + commit + PR is
+>   the measured cost of the missing lens.
+
+## 2. Goal
+
+Add a **non-skippable premise lens** to harden's angle pre-flight so premise validation happens at the earliest
+artifact — spec-harden (`woostack-build` step 3) and fix-plan harden (`woostack-fix` step 3) — before any plan or
+code effort. Harden **surfaces and records** whether the premise holds, using its existing "explore the codebase
+to answer before asking the user" disposition to *measure the baseline itself* rather than accept assertion. The
+**kill decision stays at the caller's existing approve gate** — harden adds no gate. A disproven premise is
+rejected one full phase earlier than execution (as with `#512`, before the branch/commit/PR ever exist), at
+essentially zero cost.
+
+## 3. Non-goals
+
+- **No priority / ROI / "worth building vs. other work" judgment.** That has no artifact anchor, is not
+  codebase-answerable, and would turn harden's interview into speculation — it violates harden's
+  explore-to-answer disposition. It stays a human call at the caller's gate, informed by `woostack-ideate`. The
+  lens validates *premise* (is the problem real?), not *value* (is it the best use of effort?).
+- **No new gate in harden.** Harden keeps "hand back at no-new-questions; own no gate" (`woostack-harden`
+  SKILL.md:72). It records the evidence or the disproof into §1 and hands back; the caller's existing
+  approve-to-execute gate decides the kill. This preserves `woostack-build`'s "inherit gates, add none."
+- **Not a `woostack-review` angle.** The premise lens is **authoring-only**. It is *not* added to
+  `VALID_ANGLES` in [`load-config.sh`](../../skills/woostack-review/scripts/load-config.sh) and gets no rubric
+  under `woostack-review/prompts/angles/`. A premise is not reviewable from a diff (review sees code, not the
+  claim that motivated it), so unlike the other pre-flight entries this lens does **not** translate a review
+  angle forward — it is a new authoring precondition. `angle-preflight.md`'s "Canonical angles — link, do not
+  restate" note stays accurate: it still covers only the review-derived lenses.
+- **No new machinery.** Reuse the existing pre-flight checklist + harden's explore-to-answer rule. No new
+  script, config key, or status enum value.
+- **No over-demanding ceremony on self-evident premises.** A visible bug or an explicit user request is
+  satisfied by pointing at the repro/request; only a *derived* premise about current behavior must be
+  demonstrated (see §4).
+
+## 4. Approach
+
+Four surgical, cross-linked edits. No duplication — the rule is stated once in the pre-flight and referenced
+elsewhere.
+
+### 4.1 Premise lens in the pre-flight (`skills/woostack-harden/references/angle-preflight.md`)
+
+Add a new section, positioned **before** `## Skip rule (YAGNI)` (so the never-skip lens leads the file and the
+skip rule visibly scopes only to the lenses below it), and amend the Skip rule to carve it out:
+
+- New `## Premise lens — is the problem real? (never skips)` section. Content:
+  - State the problem and the evidence it is real. If the premise is an **inference about current behavior**
+    ("the tool fails to X", "the rubric misses Y"), **demonstrate it** — a reproduction (bug) or a baseline
+    showing the deficiency (enhancement). **Reject assertion-as-evidence.** Lands in §1 Problem (spec) / §1
+    Root Cause (fix).
+  - **Evidence bar scales with the claim.** A self-evident premise (a visible bug, an explicit user request)
+    is satisfied by pointing at the repro/request — no ceremony. Only a derived premise about current behavior
+    must be demonstrated.
+  - **Harden records, the gate decides.** Harden amends §1 with the evidence *or the disproof* and hands back;
+    a disproven premise is killed at the caller's approve gate, not by harden.
+  - **Premise ≠ priority.** This lens validates that the problem exists, not that it is worth solving vs. other
+    work (that is out of scope — see the caller's gate).
+- Amend `## Skip rule (YAGNI)` (`angle-preflight.md:19-23`) so it scopes YAGNI to **the lenses below it** (the
+  code-derived Spec/Plan lenses), with an explicit exemption: **the premise lens never skips** — every change
+  rests on a premise.
+
+### 4.2 Spec template evidence field (`skills/woostack-build/references/spec-template.md`)
+
+Under `## 1. Problem`, add an authoring-guidance blockquote mirroring the existing §7 pre-flight callout
+pattern (`spec-template.md:46`):
+
+> **Premise / evidence.** State the evidence the problem is real. A derived claim about current behavior must be
+> *demonstrated* (a baseline/repro), not asserted — harden's premise lens will not stamp this spec `hardened`
+> otherwise. A self-evident premise (visible bug, explicit request) just cites the repro/request.
+
+This is `.md`-only authoring guidance consumed at write time — like the §7 callout, it does not appear in a
+filled spec. The `spec-template.html` mirror renders content via the `{{PROBLEM}}` placeholder
+(`spec-template.html:26`) and is **unaffected**; md/html structural parity holds with **no HTML edit**.
+
+### 4.3 Fix template evidence field (`skills/woostack-fix/SKILL.md`, embedded §1 Root Cause block)
+
+Extend the §1 Root Cause guidance in the embedded fix-file template (`woostack-fix/SKILL.md:130-131`) so it
+covers **enhancements**, not just bug root causes:
+
+> `## 1. Root Cause` guidance becomes: *Summarize the findings from woostack-debug. Where does the bad value
+> originate? What is the evidence?* **For an enhancement (no bad value to trace), demonstrate the current
+> behavior is genuinely deficient — a baseline, not an assertion. Harden's premise lens gates this.**
+
+The fix file is the combined spec+plan; harden runs on it at `woostack-fix` step 3, so the premise lens fires
+against this §1 exactly as it does against a spec's §1.
+
+### 4.4 Harden SKILL edits — two locations (`skills/woostack-harden/SKILL.md`)
+
+Harden's SKILL describes the pre-flight in **two** places; both must acknowledge the never-skip premise lens or
+the SKILL contradicts itself.
+
+1. **Narrative bullet (`woostack-harden/SKILL.md:27-30`).** It currently says "its skip rule keeps untouched
+   angles silent." Amend it so the premise lens is the stated exception — it always fires, even when no
+   code-angle is implicated.
+2. **Hard constraint (`## Hard constraints`, adjacent to the "Angle pre-flight (spec/plan)" line at
+   `woostack-harden/SKILL.md:69-71`).** Add one bullet:
+
+> **Premise before solution (never skips).** Before declaring a spec, plan, or fix `hardened`, walk the premise
+> lens first (`references/angle-preflight.md`). For a *derived* premise about current behavior, run the
+> baseline/repro yourself (per "explore the codebase to answer before asking") — do not accept assertion. Amend
+> §1 with the evidence or the disproof. This adds no gate: a disproven premise is killed at the caller's
+> approve gate.
+
+### 4.5 Where it runs (no code, documentation of flow)
+
+- `woostack-build` step 3 (spec harden) — earliest artifact, before plan/code.
+- `woostack-build` step 6 (plan harden) — premise already settled at step 3; re-confirmed present in §1.
+- `woostack-fix` step 3 (fix-plan harden) — the fix file's §1 Root Cause.
+- `woostack-plan`'s self-review already reads the pre-flight (`angle-preflight.md:6`), so it inherits the lens
+  with no extra wiring.
+- **`plan-template.md` intentionally untouched.** The premise is validated once — at the spec (build) or in the
+  combined fix file (fix). The plan decomposes an already-premise-validated spec, so its template gains no
+  evidence field; plan harden only re-confirms §1 still carries the evidence.
+
+## 5. Components & data flow
+
+```
+author writes §1 (problem/root-cause + evidence blockquote from template)
+        │
+        ▼
+woostack-harden  ── premise lens (never skips) ──► derived premise?
+        │                                              │ yes
+        │ self-evident (cite repro/request)            ▼
+        │                                    explore-to-answer: run baseline/repro
+        ▼                                              │
+   amend §1 with evidence ◄──────────── holds ─────────┤
+        │                                              │ disproven
+        │                                              ▼
+        │                                   amend §1 with the disproof
+        ▼                                              │
+  hand back "no new questions" ◄────────────────────────┘
+        │
+        ▼
+  caller's approve-to-execute GATE  ──► kill (disproven) | proceed (holds)
+```
+
+- **Input:** §1 of a spec / fix file (problem or root cause + the template's evidence blockquote).
+- **Owner:** `woostack-harden` (spec-harden, plan-harden, fix-plan harden) + `woostack-plan` self-review.
+- **Output:** §1 amended in place with proof or disproof. No new file, no gate, no status value.
+
+## 6. Error handling
+
+- **Assertion-as-evidence on a derived premise** → harden raises a premise question, runs the baseline itself,
+  and blocks `hardened` until §1 carries real evidence. (This is the `#511` case.)
+- **Premise disproven by the baseline** → harden amends §1 with the disproof and hands back; it does **not**
+  self-kill. The caller's gate rejects it. (Preserves "own no gate".)
+- **Self-evident premise over-demanded** → guarded by the evidence-scales-with-claim rule: a visible bug or
+  explicit request cites the repro/request and passes without a manufactured baseline. Prevents the lens from
+  becoming ceremony on obvious work.
+- **Priority creep** ("is this worth it vs. other work") → out of scope by §3; harden does not ask it. Keeps the
+  interview artifact-grounded.
+
+## 7. Acceptance criteria
+
+Each AC is a testable behavior → ≥1 plan task.
+
+> **Angle pre-flight.** Spec lens walked: no data layer, api surface, or UI copy — `database`, `api`, `i18n`
+> skip (YAGNI). `security`/`observability` N/A (prose-only skill edits). `tests` → §8. **premise lens: proven
+> in §1** (structural read + `#512` cost). Implicated: `bugs`/edge (below), `deps`/`infra` N/A.
+
+- **AC1 — Non-skippable premise lens exists in the pre-flight.**
+  - happy: `angle-preflight.md` contains a `## Premise lens` section, placed before `## Skip rule (YAGNI)`, stating the
+    evidence-scales-with-claim rule and the record-not-kill boundary.
+  - edge: the `## Skip rule (YAGNI)` section explicitly exempts the premise lens ("never skips").
+  - error: no code-angle entry is removed or reordered; the Spec/Plan lens lists are byte-unchanged except the
+    new section above them.
+- **AC2 — Templates demand premise evidence.**
+  - happy: `spec-template.md` §1 carries a "Premise / evidence" authoring blockquote; `woostack-fix/SKILL.md`
+    §1 Root Cause guidance demands a baseline for an enhancement.
+  - edge: `spec-template.html` is **unchanged** and still mirrors `spec-template.md`'s section structure (the
+    §1 guidance is write-time-only, rendered via `{{PROBLEM}}`).
+- **AC3 — Harden enforces premise-before-solution.**
+  - happy: `woostack-harden/SKILL.md` gains a premise-lens hard-constraint bullet requiring evidence (not
+    assertion) for a derived premise before `hardened`, **and** the narrative pre-flight bullet (SKILL.md:27-30)
+    names the premise lens as the never-skip exception.
+  - behavior: on a spec whose §1 is a bare derived assertion, harden raises a premise question and runs the
+    baseline itself before proceeding (dogfood check, §8).
+  - edge: the bullet states harden records evidence/disproof and adds **no** gate.
+- **AC4 — Scope guards hold.**
+  - happy: priority/ROI is named out of scope (spec §3 + no harden question asks it).
+  - edge: the premise lens is **not** added to `VALID_ANGLES` in `load-config.sh` and gets no
+    `prompts/angles/` rubric; the pre-flight's "Canonical angles — link, do not restate" note stays accurate.
+  - error: every new cross-link resolves (no dangling relative paths); no fact is duplicated across the four
+    edited files (single source in the pre-flight, referenced elsewhere).
+
+## 8. Testing
+
+> Strategy only — per-behavior cases live in §7.
+
+- **Mechanical (grep/read, deterministic).** AC1–AC4 content assertions: the premise-lens section + skip-rule
+  carve-out are present; the two templates carry the evidence field; `spec-template.html` is unchanged; the
+  harden hard-constraint bullet is present; `load-config.sh` `VALID_ANGLES` is unchanged. Cross-link resolution
+  and no-duplication verified by read.
+- **Behavioral dogfood (no runtime LLM in CI — same carve-out `#512` used).** Run `woostack-harden` against a
+  throwaway spec whose §1 is a bare derived assertion ("skill X misses Y") with no baseline; confirm harden
+  raises the premise question and runs the measurement itself rather than stamping `hardened`. This is
+  corroborating evidence, not a CI gate.
+- **Docs-site sync (CLAUDE.md constraint).** Verify no authored `site/content/docs/` page restates the
+  pre-flight lens list or harden's constraint set; the per-skill reference page regenerates from
+  `woostack-harden/SKILL.md` at build. Run `pnpm -C site build` to confirm the site still builds. No authored
+  page is expected to change (no skill-count, gate, or getting-started change — harden adds no gate).
+
+## 9. Open questions
+
+None. The four edits, their placement, the scope boundary (premise not priority; record not kill; authoring not
+review), and the md/html-mirror no-op were all resolved during ideate/harden and are grounded in the files above.
+This spec's own premise is demonstrated in §1, so it survives its own premise lens.

--- a/.woostack/specs/2026-07-14-harden-premise-lens.md
+++ b/.woostack/specs/2026-07-14-harden-premise-lens.md
@@ -1,7 +1,7 @@
 ---
 name: harden-premise-lens
 type: spec
-status: hardened
+status: approved
 date: 2026-07-14
 branch: feature/harden-premise-lens
 links:


### PR DESCRIPTION
## Goal

Add a non-skippable **premise lens** to `woostack-harden` so hardening validates that the problem is *real* before it grills the solution — closing the gap that let fix #511 / PR #512 be built on a premise (a review-comment claim) that was never validated. The board-visible artifact is the spec+plan; execution ships the ~50-line prose change across four skill files.

## Summary

**This is the docs-only base PR of the stack (spec + plan). It carries no code and is never merged by build; execution increments stack on top.**

- **Spec** (`.woostack/specs/2026-07-14-harden-premise-lens.md`, `status: approved`) — designs a `## Premise lens — is the problem real? (never skips)` section for `angle-preflight.md`, a `## Skip rule (YAGNI)` carve-out scoping YAGNI to the code-derived lenses only, a write-time "Premise / evidence" authoring blockquote in the spec + fix §1 templates, and a two-location `woostack-harden/SKILL.md` acknowledgement (narrative bullet + `## Hard constraints`). Non-goals: no new review angle (`VALID_ANGLES` untouched), no rubric, no gate, no `.html` change, no priority/ROI judgment.
- **Plan** (`.woostack/plans/2026-07-14-harden-premise-lens.md`, `status: ready`) — one PR-sized increment, four TDD tasks (three edit+commit, one verification-only). The four edits are cross-linked (rule stated once in `angle-preflight.md`, referenced elsewhere), so they ship as one increment to avoid broken intermediate states.

## Test plan

_Automated (run by the execution increment; every command has a fixed expected value proven against the current tree during plan-harden):_
- Premise-lens section present and ordered before `## Skip rule` (awk `ORDER_OK`); skip-rule carve-out present (`grep -c 'The premise lens above is exempt'` → `1`).
- Code-angle lists byte-unchanged: `grep -cE '^- \*\*(security|…|types)\*\*'` → `15` (pre-edit baseline == post-edit).
- Both templates carry the evidence field; `spec-template.html` unchanged (`grep -ci premise` → `0`, `grep -c '<h2>'` → `9`, `git status` empty).
- `woostack-harden/SKILL.md` names the never-skip lens in both sites (`grep -c 'never skips'` → `2`).
- Scope guards (AC4): `premise` not in `VALID_ANGLES` → `0`; no `prompts/angles/premise*` rubric → `0`; priority carved out of the premise lens (`grep -c 'Premise ≠ priority'` → `1`); cross-links resolve; rule text not duplicated (`grep -rl` → single path).
- Docs-site build (`pnpm -C site build`) succeeds with no authored-page changes.

_Manual:_
- Behavioral dogfood: run `woostack-harden` against a throwaway spec whose §1 is a bare derived assertion → the premise lens raises a premise question and demands a baseline (corroborating evidence, not a CI gate).

Spec: .woostack/specs/2026-07-14-harden-premise-lens.md
