### PR TITLE
docs(harden): enforce premise-before-solution via non-skippable premise lens

### DIFF
--- a/.woostack/plans/2026-07-14-harden-premise-lens.md
+++ b/.woostack/plans/2026-07-14-harden-premise-lens.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-14-harden-premise-lens.md
-status: ready
+status: done
 branch: feature/harden-premise-lens
 ---
 
@@ -26,7 +26,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
 **Files:**
 - Modify: `skills/woostack-harden/references/angle-preflight.md` (insert new section before line 19 `## Skip rule (YAGNI)`; amend the Skip rule body, lines 19-23)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   Confirm the section does not exist yet and the current Skip rule wording is present (the baseline we will amend):
   ```bash
   grep -c '^## Premise lens' skills/woostack-harden/references/angle-preflight.md
@@ -35,11 +35,11 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
   grep -cE '^- \*\*(security|observability|bugs|tests|api|database|i18n|deps|infra|architecture|types)\*\*' skills/woostack-harden/references/angle-preflight.md
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: (the three commands above)
   Expected: first prints `0` (no premise-lens section yet); second prints the line `22:...Do not manufacture questions for` (current Skip rule body intact, our edit anchor); third prints `15` (the pre-edit code-angle baseline).
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   Insert a new `## Premise lens` section **immediately before** `## Skip rule (YAGNI)` (before line 19), so the never-skip lens leads the file:
   ```markdown
   ## Premise lens — is the problem real? (never skips)
@@ -68,7 +68,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
   lens above is exempt — it never skips; every change rests on a premise.**
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   Run:
   ```bash
   # New section present, and positioned before the Skip rule (order check):
@@ -80,7 +80,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
   ```
   Expected: `ORDER_OK`; `1`; and `15` (9 spec-lens single-name bullets + 6 plan-lens single-name bullets — the combined `- **api / database**` plan bullet is intentionally not matched by the single-name pattern; the `## Spec lens` / `## Plan lens` bodies are untouched, so this equals the pre-edit count).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt create -m "docs(harden): add non-skippable premise lens to angle pre-flight"
   ```
@@ -92,17 +92,17 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
 - Modify: `skills/woostack-fix/SKILL.md` (extend the embedded §1 Root Cause guidance, line 131)
 - Verify unchanged: `skills/woostack-build/references/spec-template.html`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   grep -c 'Premise / evidence' skills/woostack-build/references/spec-template.md
   grep -c 'demonstrate the current behavior is genuinely deficient' skills/woostack-fix/SKILL.md
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: (both commands above)
   Expected: both print `0` — neither template carries the evidence field yet.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   In `spec-template.md`, insert this authoring blockquote between the `## 1. Problem` heading (line 18) and the `{{PROBLEM}}` placeholder (line 20), mirroring the §7 pre-flight callout pattern (blank line above and below):
   ```markdown
   > **Premise / evidence.** State the evidence the problem is real. A derived claim about current behavior must be *demonstrated* (a baseline/repro), not asserted — harden's premise lens will not stamp this spec `hardened` otherwise. A self-evident premise (visible bug, explicit request) just cites the repro/request.
@@ -112,7 +112,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
      *Summarize the findings from woostack-debug. Where does the bad value originate? What is the evidence?* **For an enhancement (no bad value to trace), demonstrate the current behavior is genuinely deficient — a baseline, not an assertion. Harden's premise lens gates this.**
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   ```bash
   # Both evidence fields present:
   grep -c 'Premise / evidence' skills/woostack-build/references/spec-template.md
@@ -124,7 +124,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
   ```
   Expected: `1`; `1`; then `0` (no premise text in the HTML); `9` (all nine section headings still present); and the `git status` line is **empty** (the `.html` file is not modified).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "docs(templates): demand premise evidence in spec and fix §1"
   ```
@@ -134,17 +134,17 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
 **Files:**
 - Modify: `skills/woostack-harden/SKILL.md` (narrative bullet, lines 27-30; new `## Hard constraints` bullet after line 71)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
   ```bash
   grep -c 'never skips' skills/woostack-harden/SKILL.md
   grep -c 'Premise before solution' skills/woostack-harden/SKILL.md
   ```
 
-- [ ] **Step 2: Run the test, confirm it fails**
+- [x] **Step 2: Run the test, confirm it fails**
   Run: (both commands above)
   Expected: both print `0` — the SKILL does not yet name the never-skip premise lens in either location.
 
-- [ ] **Step 3: Minimal implementation**
+- [x] **Step 3: Minimal implementation**
   (a) Amend the narrative **Angle pre-flight** bullet (lines 27-30) so the premise lens is the stated exception — replace the bullet with:
   ```markdown
   - **Angle pre-flight.** When hardening a spec or plan, walk the
@@ -163,7 +163,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
     disproof. This adds no gate: a disproven premise is killed at the caller's approve gate.
   ```
 
-- [ ] **Step 4: Run the test, confirm it passes**
+- [x] **Step 4: Run the test, confirm it passes**
   ```bash
   # Both edits present:
   grep -c 'never skips' skills/woostack-harden/SKILL.md          # narrative + hard-constraint => 2
@@ -173,7 +173,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
   ```
   Expected: `2` (the phrase "never skips" now appears in both the narrative bullet and the hard-constraint bullet); `1`; `PLACEMENT_OK`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
   ```bash
   gt modify -c -m "docs(harden): name the never-skip premise lens in both SKILL pre-flight sites"
   ```
@@ -182,7 +182,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
 
 > Verification-only — no file edit, so **no commit**. Pins the negative invariants (AC4) and runs the two §8 checks that are not per-edit greps.
 
-- [ ] **Step 1: Scope guards — premise is NOT a review angle (AC4 edge)**
+- [x] **Step 1: Scope guards — premise is NOT a review angle (AC4 edge)**
   Run:
   ```bash
   # VALID_ANGLES must NOT contain "premise":
@@ -196,7 +196,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
   ```
   Expected: `0` (premise not in `VALID_ANGLES`); `0` (no rubric file); `1` (note intact); `1` (priority explicitly out of scope in the premise lens).
 
-- [ ] **Step 2: Cross-link integrity + no-duplication (AC4 error)**
+- [x] **Step 2: Cross-link integrity + no-duplication (AC4 error)**
   Run:
   ```bash
   # Every relative link the new/edited content points at resolves to a real file:
@@ -208,7 +208,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
   ```
   Expected: `LINK_OK_preflight`; and each `grep -rl` prints exactly one path — `skills/woostack-harden/references/angle-preflight.md` — confirming the templates and SKILL reference the rule (by prose/link) rather than duplicating its full text.
 
-- [ ] **Step 3: Docs-site sync check (§8, CLAUDE.md constraint)**
+- [x] **Step 3: Docs-site sync check (§8, CLAUDE.md constraint)**
   Run:
   ```bash
   # No authored docs page restates the pre-flight lens list or harden's constraint set:
@@ -220,7 +220,7 @@ All commands run from the repository root (the worktree root: `.woostack/worktre
   ```
   Expected: `NO_AUTHORED_PAGE_MENTIONS (expected)`; `pnpm -C site build` exits `0`; the `git status` line is empty (generated per-skill pages are gitignored, authored pages untouched). If `site` deps are absent, run `pnpm -C site install` first.
 
-- [ ] **Step 4: Behavioral dogfood (§8 — corroborating evidence, not a CI gate)**
+- [x] **Step 4: Behavioral dogfood (§8 — corroborating evidence, not a CI gate)**
   Construct a throwaway spec whose §1 is a *bare derived assertion* with no baseline, then walk `woostack-harden`'s premise lens against it and confirm the lens fires:
   ```bash
   cat > /tmp/premise-dogfood-spec.md <<'EOF'

--- a/site/content/docs/concepts/review-angles.mdx
+++ b/site/content/docs/concepts/review-angles.mdx
@@ -53,7 +53,7 @@ The exact gating heuristics (file globs and diff-token patterns) live in [`detec
 
 ## Angles also pre-flight authoring
 
-The same angle vocabulary runs **earlier**, too. When [`woostack-harden`](/docs/skills/woostack-harden) hardens a spec or plan (and when [`woostack-plan`](/docs/skills/woostack-plan) self-reviews), they walk a **spec/plan angle pre-flight** that translates each lens into "what to ask before writing," so gaps are caught at authoring instead of surfacing here on the diff. It adds no approval gate; the swarm review described on this page still runs on the code increment PRs.
+The review-angle vocabulary runs **earlier**, too. When [`woostack-harden`](/docs/skills/woostack-harden) hardens a spec or plan (and when [`woostack-plan`](/docs/skills/woostack-plan) self-reviews), it walks a **spec/plan angle pre-flight** that translates each relevant review lens into "what to ask before writing." A separate premise lens leads that pre-flight and never skips: it validates the problem at the earliest problem-bearing artifact (a spec or combined fix), while plan hardening verifies the linked source spec already records the evidence. Neither pre-flight adds an approval gate; the swarm review described on this page still runs on the code increment PRs.
 
 ## Tiers
 

--- a/skills/woostack-build/references/spec-template.md
+++ b/skills/woostack-build/references/spec-template.md
@@ -17,6 +17,8 @@ links:
 
 ## 1. Problem
 
+> **Premise / evidence.** State the evidence the problem is real. A derived claim about current behavior must be *demonstrated* (a baseline/repro), not asserted — harden's premise lens will not stamp this spec `hardened` otherwise. A self-evident premise (visible bug, explicit request) just cites the repro/request.
+
 {{PROBLEM}}
 
 ## 2. Goal

--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -128,7 +128,7 @@ approved execution has actually run.
    # Fix: <Short description of the bug/symptom>
 
    ## 1. Root Cause
-   *Summarize the findings from woostack-debug. Where does the bad value originate? What is the evidence?*
+   *Summarize the findings from woostack-debug. Where does the bad value originate? What is the evidence?* **For an enhancement (no bad value to trace), demonstrate the current behavior is genuinely deficient — a baseline, not an assertion. Harden's premise lens gates this.**
 
    ## 2. Proposed Fix
    *Describe the minimal, targeted code changes to resolve the root cause. Fix the shared root once: grep every caller, and prefer one guard at the shared function over one-per-caller patches — smaller diff and correct. Never drop edge-case or safety coverage to shrink the change (per [`patterns.md §10`](../woostack-bootstrap/references/patterns.md)).*

--- a/skills/woostack-harden/SKILL.md
+++ b/skills/woostack-harden/SKILL.md
@@ -26,10 +26,10 @@ decisions one by one.
   first so downstream questions are well-posed.
 - **Angle pre-flight.** Walk the
   [spec/plan angle pre-flight](references/angle-preflight.md) when hardening a spec or plan, and
-  always walk its premise lens when hardening a fix. Raise a question for any angle the artifact's
-  surface implicates but leaves unaddressed — its skip rule keeps untouched angles silent, except
-  the premise lens, which never skips and applies its artifact-specific evidence rule. This makes
-  the interview angle-driven, not only decision-tree-driven.
+  always walk its premise lens when hardening a design or fix. Raise a question for any angle the
+  artifact's surface implicates but leaves unaddressed — its skip rule keeps untouched angles
+  silent, except the premise lens, which never skips and applies its artifact-specific evidence
+  rule. This makes the interview angle-driven, not only decision-tree-driven.
 
 ## Amend the artifact in place
 
@@ -42,8 +42,9 @@ nothing.
 
 ## Terminal state: hardened, handed back
 
-Stop when a full pass over the decision tree produces **no new questions** and — for a spec or
-plan — every angle the artifact implicates is addressed (the
+Stop when a full pass over the decision tree produces **no new questions**; for a spec or plan,
+every angle the artifact implicates is addressed; and for a spec, plan, design, or fix, the
+premise lens's artifact-specific evidence rule is satisfied (the
 [angle pre-flight](references/angle-preflight.md) walks clean). The artifact is hardened. Then
 hand back to the caller and name the next step:
 
@@ -71,8 +72,8 @@ the caller is what preserves woostack-build's "inherit gates, add none."
 - **Angle pre-flight (spec/plan).** Before declaring a spec or plan hardened, walk the
   [angle pre-flight](references/angle-preflight.md); raise a question for each implicated-but-
   unaddressed angle. No gate; amend in place.
-- **Premise before solution (never skips).** Before declaring a spec, plan, or fix `hardened`, walk
-  the premise lens first and follow its artifact-specific recording rule
+- **Premise before solution (never skips).** Before declaring a spec, plan, design, or fix
+  `hardened`, walk the premise lens first and follow its artifact-specific recording rule
   ([`references/angle-preflight.md`](references/angle-preflight.md)). For a plan, verify the linked
   source spec's §1 rather than amending the plan. This adds no gate: a disproven premise is killed
   at the caller's approve gate.

--- a/skills/woostack-harden/SKILL.md
+++ b/skills/woostack-harden/SKILL.md
@@ -24,10 +24,12 @@ decisions one by one.
   the codebase instead of asking the user.
 - **Resolve dependencies in order.** When one decision gates another, settle the upstream one
   first so downstream questions are well-posed.
-- **Angle pre-flight.** When hardening a spec or plan, walk the
-  [spec/plan angle pre-flight](references/angle-preflight.md) and raise a question for any angle
-  the artifact's surface implicates but leaves unaddressed — its skip rule keeps untouched angles
-  silent. This makes the interview angle-driven, not only decision-tree-driven.
+- **Angle pre-flight.** Walk the
+  [spec/plan angle pre-flight](references/angle-preflight.md) when hardening a spec or plan, and
+  always walk its premise lens when hardening a fix. Raise a question for any angle the artifact's
+  surface implicates but leaves unaddressed — its skip rule keeps untouched angles silent, except
+  the premise lens, which never skips and applies its artifact-specific evidence rule. This makes
+  the interview angle-driven, not only decision-tree-driven.
 
 ## Amend the artifact in place
 
@@ -69,4 +71,9 @@ the caller is what preserves woostack-build's "inherit gates, add none."
 - **Angle pre-flight (spec/plan).** Before declaring a spec or plan hardened, walk the
   [angle pre-flight](references/angle-preflight.md); raise a question for each implicated-but-
   unaddressed angle. No gate; amend in place.
+- **Premise before solution (never skips).** Before declaring a spec, plan, or fix `hardened`, walk
+  the premise lens first and follow its artifact-specific recording rule
+  ([`references/angle-preflight.md`](references/angle-preflight.md)). For a plan, verify the linked
+  source spec's §1 rather than amending the plan. This adds no gate: a disproven premise is killed
+  at the caller's approve gate.
 - **Own no gate.** Hand back at "no new questions"; never solicit final approval or merge.

--- a/skills/woostack-harden/references/angle-preflight.md
+++ b/skills/woostack-harden/references/angle-preflight.md
@@ -16,11 +16,32 @@ The actual swarm review still runs on the execution-increment **code** PRs.
 **translates** the relevant angles from "what they flag in a diff" into "what to ask before
 writing."
 
+## Premise lens — is the problem real? (never skips)
+
+Every change rests on a premise: that the problem is real. Walk this lens first for every spec or
+fix. For a plan, follow its canonical source join and verify the linked spec's §1 already records
+the premise. The lens is **never** skipped by the YAGNI rule below.
+
+- **State the problem and the evidence it is real.** If the premise is an *inference about current
+  behavior* ("the tool fails to X", "the rubric misses Y"), **demonstrate it** — a reproduction
+  (bug) or a baseline showing the deficiency (enhancement). **Reject assertion-as-evidence.** Lands
+  in §1 Problem (spec) / §1 Root Cause (fix).
+- **Evidence bar scales with the claim.** A self-evident premise (a visible bug, an explicit user
+  request) is satisfied by pointing at the repro/request — no ceremony. Only a *derived* premise
+  about current behavior must be demonstrated.
+- **Harden records, plan re-confirms, the gate decides.** Harden amends §1 with the evidence *or
+  the disproof* and hands back. When the target is a plan, verify its linked source spec's §1
+  already carries that record; do not duplicate it in the plan. A disproven premise is killed at
+  the caller's approve gate, not by harden.
+- **Premise ≠ priority.** This lens validates that the problem *exists*, not that it is worth
+  solving vs. other work (out of scope — see the caller's gate).
+
 ## Skip rule (YAGNI)
 
-Walk only the angles whose surface the artifact actually implicates. A spec with no data layer
-skips `database`; a CLI-only change skips `api` and `i18n`. Do not manufacture questions for
-angles the work does not touch.
+Walk only the angles **in the lenses below** (the code-derived Spec/Plan lenses) whose surface the
+artifact actually implicates. A spec with no data layer skips `database`; a CLI-only change skips
+`api` and `i18n`. Do not manufacture questions for angles the work does not touch.
+**The premise lens above is exempt — it never skips; every change rests on a premise.**
 
 ## Spec lens — what to build (lands in §6 Error handling / §7 Acceptance criteria)
 

--- a/skills/woostack-harden/references/angle-preflight.md
+++ b/skills/woostack-harden/references/angle-preflight.md
@@ -18,21 +18,23 @@ writing."
 
 ## Premise lens — is the problem real? (never skips)
 
-Every change rests on a premise: that the problem is real. Walk this lens first for every spec or
-fix. For a plan, follow its canonical source join and verify the linked spec's §1 already records
-the premise. The lens is **never** skipped by the YAGNI rule below.
+Every change rests on a premise: that the problem is real. Walk this lens first for every spec,
+design, or fix. For a plan, follow its canonical source join and verify the linked spec's §1
+already records the premise. The lens is **never** skipped by the YAGNI rule below.
 
 - **State the problem and the evidence it is real.** If the premise is an *inference about current
   behavior* ("the tool fails to X", "the rubric misses Y"), **demonstrate it** — a reproduction
   (bug) or a baseline showing the deficiency (enhancement). **Reject assertion-as-evidence.** Lands
-  in §1 Problem (spec) / §1 Root Cause (fix).
+  in §1 Problem (spec), §1 Root Cause (fix), or the named design's problem/rationale section; with
+  no design file, establish the evidence conversationally and write nothing.
 - **Evidence bar scales with the claim.** A self-evident premise (a visible bug, an explicit user
   request) is satisfied by pointing at the repro/request — no ceremony. Only a *derived* premise
   about current behavior must be demonstrated.
-- **Harden records, plan re-confirms, the gate decides.** Harden amends §1 with the evidence *or
-  the disproof* and hands back. When the target is a plan, verify its linked source spec's §1
-  already carries that record; do not duplicate it in the plan. A disproven premise is killed at
-  the caller's approve gate, not by harden.
+- **Harden records, plan re-confirms, the gate decides.** Harden amends the spec/fix §1 or named
+  design's problem/rationale section with the evidence *or the disproof*; with no design file, it
+  establishes the evidence conversationally and writes nothing. When the target is a plan, verify
+  its linked source spec's §1 already carries that record; do not duplicate it in the plan. A
+  disproven premise is killed at the caller's approve gate, not by harden.
 - **Premise ≠ priority.** This lens validates that the problem *exists*, not that it is worth
   solving vs. other work (out of scope — see the caller's gate).
 


### PR DESCRIPTION
## Goal

`woostack-harden` grilled the *solution* but never validated that the *problem* is real, so a spec/plan/fix could be hardened on a premise that was never proven. This increment adds a non-skippable "premise lens" to the angle pre-flight — plus matching template evidence fields and SKILL constraints — so a change is proven *real* (baseline/repro, not a bare assertion) before its solution is hardened.

## Summary

- `angle-preflight.md`: new `## Premise lens` section placed **before** `## Skip rule (YAGNI)`, stating the evidence-scales-with-claim rule and the record-not-kill boundary; the Skip rule explicitly exempts it ("never skips").
- `spec-template.md` §1: adds a "Premise / evidence" authoring blockquote demanding a *demonstrated* (not asserted) premise. `spec-template.html` left **unchanged** — still mirrors the `.md`.
- `woostack-fix/SKILL.md` §1 Root Cause: demands a baseline for an enhancement (no bad value to trace).
- `woostack-harden/SKILL.md`: names the never-skip premise lens in **both** pre-flight sites (narrative bullet + Hard constraints), single-sourced to the pre-flight — no duplication, no new `VALID_ANGLES` entry, no rubric.

## Test plan

### Automated

- [ ] Docs-site build `pnpm -C site build` → exit `0`, no authored pages changed, generated per-skill pages gitignored.
- [ ] AC4 scope/cross-link greps → premise not in `VALID_ANGLES` (`0`), no rubric (`0`), Canonical-angles note intact (`1`), every cross-link resolves, single-source (`1` path each).
- [ ] AC1/AC3 placement + count guards → `## Premise lens` before `## Skip rule`; `never skips`=`2`; `PLACEMENT_OK`; code-angle bullet count unchanged (`15`→`15`).

### Manual

**Before merge**

- [ ] Read the `angle-preflight.md` diff: the premise lens leads the lenses and the Skip rule carves it out ("never skips").
- [ ] Behavioral dogfood — run `woostack-harden` against a spec whose §1 is a bare derived assertion; confirm the premise lens **fires** (raises the premise question and runs the baseline) rather than stamping `hardened`.

Spec: .woostack/specs/2026-07-14-harden-premise-lens.md
