### PR TITLE
Specify and plan the /woostack-change workflow

### DIFF
--- a/.woostack/plans/2026-07-15-woostack-change.md
+++ b/.woostack/plans/2026-07-15-woostack-change.md
@@ -1,0 +1,200 @@
+---
+type: plan
+source: .woostack/specs/2026-07-15-woostack-change.md
+status: ready
+branch: feature/woostack-change
+---
+
+**Source:** [[specs/2026-07-15-woostack-change]]
+
+# `/woostack-change` Implementation Plan
+
+**Goal:** Ship `/woostack-change <goal>` as the 22nd registered public/adoption skill: a gate-free, isolated, one-PR path for bounded non-bug enhancements and refactors.
+
+**Architecture:** One implementation increment updates the entire public command contract atomically. The new skill owns classification, a `change/<slug>` worktree, direct implementation, verification and inline review receipts, `woostack-commit` delegation, and verified teardown; existing worktree, TDD, commit, and least-code authorities remain linked. A structural shell test pins the multi-reader command surface and safety barriers, while the Fumadocs build proves generated skill discovery and authored framing pages remain valid.
+
+**Tech Stack:** Markdown skill contracts, Bash structural verification, Graphite/Git worktrees, existing `woostack-tdd` and `woostack-commit` skills, Fumadocs/Next.js docs build.
+
+**Dependency and Git-parent shape:** One independently shippable increment. Its implementation branch stacks directly on the spec+plan base PR branch `feature/woostack-change`; no sibling or dependent increment exists.
+
+## Increment 1: Public `/woostack-change` command
+
+> One independently shippable PR containing the skill, its focused structural test, commit/worktree integration, all registered-command bookkeeping, and affected authored docs. Keeping these sites together satisfies the public-surface lockstep contract; splitting them would leave either an undiscoverable skill or broken routing.
+
+### Task 1: Pin the command contract with a failing structural test
+
+**Files:**
+- Create: `skills/woostack-change/scripts/tests/test-command-surface.sh`
+
+- [ ] **Step 1: Write the executable structural test**
+  ```bash
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+  skill="$ROOT/skills/woostack-change/SKILL.md"
+
+  require_file() {
+    [ -f "$ROOT/$1" ] || { printf 'missing file: %s\n' "$1" >&2; exit 1; }
+  }
+
+  require_text() {
+    local file="$1" text="$2"
+    grep -Fq -- "$text" "$ROOT/$file" || {
+      printf 'missing contract in %s: %s\n' "$file" "$text" >&2
+      exit 1
+    }
+  }
+
+  require_file "skills/woostack-change/SKILL.md"
+  require_text "skills/woostack-change/SKILL.md" "name: woostack-change"
+  require_text "skills/woostack-change/SKILL.md" '/woostack-change <goal>'
+  require_text "skills/woostack-change/SKILL.md" 'change/<slug>'
+  require_text "skills/woostack-change/SKILL.md" '.woostack/worktrees/change-<slug>'
+  require_text "skills/woostack-change/SKILL.md" 'PASS'
+  require_text "skills/woostack-change/SKILL.md" 'BLOCKED'
+  require_text "skills/woostack-change/SKILL.md" 'No approval gate'
+  require_text "skills/woostack-change/SKILL.md" 'Never merge'
+
+  require_text "skills/using-woostack/SKILL.md" '/woostack-change <goal>'
+  require_text "skills/woostack-commit/SKILL.md" 'change/*'
+  require_text "skills/woostack-init/references/worktrees.md" 'change/<slug>'
+  require_text "AGENTS.md" 'twenty-two skills'
+  require_text "CONTRIBUTING.md" 'twenty-second registered public/adoption skill'
+  require_text "skills/woostack-bootstrap/references/development.md" 'woostack-change'
+  require_text "site/content/docs/getting-started.mdx" 'woostack-change'
+  require_text "site/content/docs/concepts/worktrees.mdx" 'woostack-change'
+  require_text "site/content/docs/concepts/least-code.mdx" 'woostack-change'
+
+  if [ -e "$ROOT/.woostack/changes" ]; then
+    printf 'unexpected persistent change-artifact directory\n' >&2
+    exit 1
+  fi
+
+  printf 'woostack-change command surface: PASS\n'
+  ```
+
+- [ ] **Step 2: Confirm the test is syntactically valid**
+  Run: `bash -n skills/woostack-change/scripts/tests/test-command-surface.sh`
+  Expected: exit `0`, no output.
+
+- [ ] **Step 3: Run the test before implementation and confirm red**
+  Run: `bash skills/woostack-change/scripts/tests/test-command-surface.sh`
+  Expected: FAIL with `missing file: skills/woostack-change/SKILL.md`.
+
+### Task 2: Author the gate-free change skill
+
+**Files:**
+- Create: `skills/woostack-change/SKILL.md`
+- Test: `skills/woostack-change/scripts/tests/test-command-surface.sh`
+
+- [ ] **Step 1: Add concise discovery frontmatter and command boundary**
+  The file must begin with:
+  ```markdown
+  ---
+  name: woostack-change
+  description: Use for a bounded non-bug enhancement or refactor that can ship as one reviewable PR without the full build or fix loop. Classifies scope before writing, isolates work on change/<slug>, implements with TDD or concrete verification, records an inline review receipt, commits through woostack-commit, and tears down only after a verified PR. Routes bugs to woostack-fix, greenfield work to woostack-bootstrap, and multi-PR work to woostack-build. Never merges. Invoke via /woostack-change <goal>.
+  ---
+
+  # woostack-change
+  ```
+
+- [ ] **Step 2: Define the complete qualifying and routing contract**
+  Add sections `## Commands`, `## Scope preflight`, and `## Procedure` that require:
+  - an explicit goal; one focused question when the target or outcome is ambiguous;
+  - repository/context inspection before any write;
+  - bugs, regressions, incidents, and root-cause work route to `woostack-fix`;
+  - greenfield project creation routes to `woostack-bootstrap`;
+  - work that cannot remain one reviewable PR routes to `woostack-build`;
+  - qualifying non-bug behavior/API changes and refactors may proceed even when user-visible, provided the full safe change remains one PR;
+  - classification happens before creating the worktree, and routing is not an approval gate.
+
+- [ ] **Step 3: Define worktree creation and direct implementation**
+  Link `../woostack-init/references/worktrees.md` as the authority. Require resolving the primary root and base, creating `change/<slug>` at `$WOOSTACK_ROOT/.woostack/worktrees/change-<slug>`, and running `gt track --parent "$base"` from that worktree. All writes and downstream skill calls use that cwd. State a concise intent, then implement without waiting. Link the TDD kernel and `patterns.md §10`; require red→green→refactor for new observable behavior and exact concrete verification for docs/config/no-runner work.
+
+- [ ] **Step 4: Define verification, review receipt, and closeout**
+  Require the narrow relevant checks plus a smoke test of the changed path. Review the current diff inline through two explicit lenses: specification/intent compliance and code/skill quality. Emit a receipt of exactly `PASS` or `BLOCKED` naming the reviewed diff state; a missing receipt is blocked. On `PASS`, invoke `woostack-commit` from the same `change/*` worktree, require successful push/submission and PR read-back, then remove only the worktree. Return branch, commit, PR URL, verification evidence, and review receipt. Never merge.
+
+- [ ] **Step 5: Add a prominent failure barrier and matching hard constraints**
+  Include a visible `<HARD-STOP>` block plus `## Hard constraints` restatement covering: no approval gate; no spec/plan/change artifact; no writes before classification; no silent workflow fallback; no verification/review downgrade; one branch/one PR; preserve worktree on expanded scope or any verification/review/commit/submit failure; verified PR before teardown; never merge. Expanded scope after writes must stop and report the exact worktree path rather than auto-stack or delete work.
+
+- [ ] **Step 6: Verify the skill-specific structural contract**
+  Run: `bash skills/woostack-change/scripts/tests/test-command-surface.sh`
+  Expected at this intermediate point: FAIL at the first not-yet-updated external command-surface site, proving the skill checks now pass and bookkeeping remains red.
+
+### Task 3: Integrate `change/*` with commit and worktree authorities
+
+**Files:**
+- Modify: `skills/woostack-commit/SKILL.md`
+- Modify: `skills/woostack-init/references/worktrees.md`
+- Test: `skills/woostack-change/scripts/tests/test-command-surface.sh`
+
+- [ ] **Step 1: Extend the commit branch-shape guard**
+  Update every relevant `woostack-commit` branch-shape and caller-created-worktree sentence so `change/*` is accepted alongside `feature/*` and `fix/*`, and so a driving `woostack-change` caller reuses its existing worktree instead of creating a second branch. Do not weaken protected-branch checks or Linear attribution behavior. A Markdown change PR with no spec/fix continues to omit the `Spec:` trailer under the existing rule.
+
+- [ ] **Step 2: Extend the canonical worktree consumer contract**
+  Add `woostack-change` to the authority's consumer list, create/operate examples, stack-base description, and parallel-run descriptions where build/fix are currently exhaustive. Document `change/<slug>` → `.woostack/worktrees/change-<slug>` and one standalone PR targeting the resolved base. Cross-link the new skill; do not duplicate its classification or review workflow.
+
+- [ ] **Step 3: Verify the integration clauses**
+  Run: `grep -F 'change/*' skills/woostack-commit/SKILL.md && grep -F 'change/<slug>' skills/woostack-init/references/worktrees.md`
+  Expected: both commands print matching contract lines and exit `0`.
+
+### Task 4: Register the 22nd public command in lockstep
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `skills/using-woostack/SKILL.md`
+- Modify: `skills/woostack-bootstrap/references/development.md`
+- Test: `skills/woostack-change/scripts/tests/test-command-surface.sh`
+
+- [ ] **Step 1: Update repository authority and contribution map**
+  In `AGENTS.md`, change the public count from twenty-one to twenty-two, insert `woostack-change` after `woostack-fix`, add it to Mode B routing and the Quick file map, and change the protected `SKILL.md` total from twenty-four to twenty-five while preserving the two internal plus one unregistered accounting. In `CONTRIBUTING.md`, add the skill to the complete public surface, identify it as the twenty-second registered public/adoption skill, and add its change-location table row.
+
+- [ ] **Step 2: Update adoption and command routing**
+  Add `/woostack-change <goal>` to `skills/using-woostack/SKILL.md` with the exact bounded non-bug one-PR boundary. Update `README.md` installation examples and authoring-flow section so bootstrap, build, fix, and change are the four supported code-writing routes; describe fix as bugs/root-cause work and change as gate-free bounded non-bug work. Update `skills/woostack-bootstrap/references/development.md` with the new command row.
+
+- [ ] **Step 3: Preserve cross-skill boundaries**
+  Ensure no existing `/woostack-fix` claim still presents generic non-bug refactors/enhancements as its preferred entry point where the new routing boundary applies. Do not rewrite fix's internal ability to handle an enhancement when explicitly invoked; routing and public-facing recommendations should prefer change for qualifying non-bug work.
+
+- [ ] **Step 4: Re-run the structural test**
+  Run: `bash skills/woostack-change/scripts/tests/test-command-surface.sh`
+  Expected at this intermediate point: FAIL at the first not-yet-updated authored site page, proving repository routing/bookkeeping now passes.
+
+### Task 5: Synchronize authored docs and prove consumer discovery
+
+**Files:**
+- Modify: `site/content/docs/getting-started.mdx`
+- Modify: `site/content/docs/concepts/worktrees.mdx`
+- Modify: `site/content/docs/concepts/least-code.mdx`
+- Generated, not committed: `site/content/docs/skills/woostack-change.mdx`
+- Test: `skills/woostack-change/scripts/tests/test-command-surface.sh`
+
+- [ ] **Step 1: Update authored workflow framing**
+  Add `woostack-change` to getting-started with its non-bug, one-PR, no-gate boundary and distinguish `woostack-fix` as the diagnosed bug path. Add its branch/path row and parallel-run wording to the worktree page. Add it to the authoring skills that carry least-code guidance. Do not manually create or edit the generated per-skill MDX page.
+
+- [ ] **Step 2: Run focused structural verification**
+  Run: `bash -n skills/woostack-change/scripts/tests/test-command-surface.sh && bash skills/woostack-change/scripts/tests/test-command-surface.sh`
+  Expected: `woostack-change command surface: PASS` and exit `0`.
+
+- [ ] **Step 3: Build the documentation site**
+  Run: `pnpm -C site build`
+  Expected: exit `0`; prebuild generates a valid `/docs/skills/woostack-change` reference page and the Next.js production build completes.
+
+- [ ] **Step 4: Smoke-test generated command discovery**
+  Run: `test -f site/content/docs/skills/woostack-change.mdx && grep -Fq 'name: woostack-change' skills/woostack-change/SKILL.md && grep -Fq '/woostack-change <goal>' skills/using-woostack/SKILL.md`
+  Expected: exit `0`. Generated files remain gitignored and unstaged.
+
+- [ ] **Step 5: Perform the increment review receipt**
+  Review the complete implementation diff against spec AC1–AC5 and the skill-authoring/least-code constraints. Record `PASS` only when the new skill, branch guard, worktree authority, public counts, routing, authored docs, and structural verification agree; otherwise record `BLOCKED` with exact findings and fix them before commit.
+
+## Plan Checks
+
+- **Spec coverage:** Tasks 1–5 cover classification/routing, gate-free isolated execution, verification/review receipts, one-PR closeout, failure preservation, and every public-surface reader named in the spec.
+- **AC coverage:** AC1 maps to Tasks 1, 2, and 4; AC2 to Tasks 1–3; AC3 to Tasks 1, 2, and 5; AC4 to Tasks 1–3; AC5 to Tasks 1, 4, and 5. Every happy/error/edge branch has either a structural assertion or explicit skill procedure/hard-stop clause.
+- **No placeholders:** All files, commands, expected outcomes, routing destinations, branch/worktree shapes, counts, and lifecycle outcomes are concrete.
+- **Architecture:** One increment is necessary for atomic public registration and independently shippable as the complete new command. No abstraction, dependency, artifact schema, status lifecycle, or second PR is introduced.
+- **Types/API/database/security/observability:** No application type, database, runtime API, credential, or telemetry surface changes. The agent command contract treats ambiguous input and failed receipts as explicit stopped outcomes and never swallows or downgrades failures.
+- **Dependencies:** No new package or external service dependency. Site generation and build use the existing `site/` toolchain.
+- **Git validity:** One root increment stacks directly on `feature/woostack-change`; no cycles, deferrals, sibling tracks, or unrepresentable ancestry.

--- a/.woostack/specs/2026-07-15-woostack-change.md
+++ b/.woostack/specs/2026-07-15-woostack-change.md
@@ -1,7 +1,7 @@
 ---
 name: woostack-change
 type: spec
-status: hardened
+status: approved
 date: 2026-07-15
 branch: feature/woostack-change
 links:
@@ -55,7 +55,7 @@ If scope grows beyond one PR after work starts, or verification/review/commit/su
 
 - **`skills/woostack-change/SKILL.md`** owns classification, worktree lifecycle, direct implementation, verification, inline review, commit delegation, and closeout.
 - **`skills/using-woostack/SKILL.md`** routes explicit and intent-equivalent quick non-bug one-PR requests to the new skill.
-- **Existing authorities** remain single-source and are linked rather than copied: update the consumer list and lifecycle examples in `skills/woostack-init/references/worktrees.md`, then link its worktree/base mechanics; link TDD in `skills/woostack-tdd/SKILL.md`, commit/PR mechanics in `skills/woostack-commit/SKILL.md`, and least-code guidance in bootstrap `patterns.md §10`.
+- **Existing authorities** remain single-source and are linked rather than copied: update the consumer list and lifecycle examples in `skills/woostack-init/references/worktrees.md`; update `skills/woostack-commit/SKILL.md` so its branch-shape guard accepts the caller-created `change/*` worktree without creating another branch; then link worktree/base mechanics, TDD in `skills/woostack-tdd/SKILL.md`, commit/PR mechanics, and least-code guidance in bootstrap `patterns.md §10`.
 - **Public-surface bookkeeping** updates every known reader identified by the repository's `lockstep-edit-sites` wisdom: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `skills/using-woostack/SKILL.md`, and `skills/woostack-bootstrap/references/development.md`.
 - **Authored docs-site framing** updates the getting-started workflow and worktree pages whose current claims exclude the new path. The per-skill reference page remains generated from `SKILL.md`.
 - **Verification** structurally checks that the new skill exists, routing and public counts agree, required safety barriers are present, and the docs site builds.

--- a/.woostack/specs/2026-07-15-woostack-change.md
+++ b/.woostack/specs/2026-07-15-woostack-change.md
@@ -1,0 +1,109 @@
+---
+name: woostack-change
+type: spec
+status: hardened
+date: 2026-07-15
+branch: feature/woostack-change
+links:
+---
+
+# `/woostack-change` — Design Spec
+
+> Artifact: `.woostack/specs/2026-07-15-woostack-change.md`. This Markdown file is the source of truth. Render with the build skill's `spec-template.html` only as a presentation target.
+
+> `status:` follows the owning-artifact contract in [`skills/woostack-status/references/conventions.md`](../../skills/woostack-status/references/conventions.md).
+
+> **Plan:** [[plans/2026-07-15-woostack-change]]
+
+## 1. Problem
+
+The user explicitly requested a public skill for quick, small changes that are not fixes and should not require the full build loop. The current routing surface offers `/woostack-build` for features and `/woostack-fix` for bugs, hotfixes, refactors, and enhancements. `/woostack-fix` requires diagnosis and a persisted fix plan even when there is no fault to diagnose; `/woostack-build` requires design, separate spec and plan artifacts, three gates, and a stacked PR shape. Neither is a good semantic or procedural fit for a bounded non-bug change that can ship as one reviewable PR.
+
+The repository's own command documentation confirms this gap: `README.md` currently permits code changes only through bootstrap, build, or fix, while the routing table has no direct, gate-free one-PR authoring command for non-bug enhancements.
+
+## 2. Goal
+
+Add `/woostack-change <goal>` as a public skill for non-bug enhancements and refactors that can be understood, implemented, verified, reviewed, and shipped in one reviewable PR without a persisted spec or plan and without an approval gate.
+
+The command must remain safe despite being quick: isolate writes in a dedicated worktree, state intent before editing, follow the canonical TDD or concrete-verification rule, smoke-test the changed path, perform task-scoped inline compliance and quality review, submit one PR, and tear down only after verified closeout.
+
+## 3. Non-goals
+
+- Replacing `/woostack-fix` for bugs, regressions, production faults, or work requiring root-cause diagnosis.
+- Replacing `/woostack-bootstrap` for greenfield project creation.
+- Replacing `/woostack-build` for work that needs multiple independently reviewable PRs.
+- Creating `.woostack/changes/`, spec, plan, lifecycle, resume, or status-board artifacts.
+- Adding an approval gate, a full review swarm, overnight execution, stacked increments, or merge behavior.
+- Weakening validation, security, accessibility, error handling, or data-loss safeguards merely to keep the diff small.
+
+## 4. Approach
+
+Create `skills/woostack-change/SKILL.md` as a standalone public command with this fixed flow:
+
+1. Inspect repository context and classify the request before any write.
+2. Route bugs to `/woostack-fix`, greenfield work to `/woostack-bootstrap`, and work that cannot remain one reviewable PR to `/woostack-build`.
+3. For qualifying work, resolve the base branch and create `change/<slug>` at `.woostack/worktrees/change-<slug>`, tracked in Graphite against the resolved base.
+4. State a concise execution intent in the conversation; this is informative, not an approval stop.
+5. Implement the bounded change in the worktree. New observable behavior follows the canonical [`woostack-tdd`](../../skills/woostack-tdd/SKILL.md) kernel; documentation, configuration, and no-runner work uses an exact concrete verification.
+6. Smoke-test the changed path, then run task-scoped inline specification-compliance and code-quality checks against the current diff. Emit an explicit `PASS` or `BLOCKED` review receipt naming the reviewed diff state; resolve every blocking finding before closeout.
+7. Invoke [`woostack-commit`](../../skills/woostack-commit/SKILL.md) to commit, push, and open or update the one PR.
+8. Confirm the PR exists, then remove the worktree. Never merge.
+
+If scope grows beyond one PR after work starts, or verification/review/commit/submit fails, stop truthfully and preserve the worktree. Report the blocker and exact worktree path; never silently downgrade checks or delete recoverable work.
+
+## 5. Components & data flow
+
+- **`skills/woostack-change/SKILL.md`** owns classification, worktree lifecycle, direct implementation, verification, inline review, commit delegation, and closeout.
+- **`skills/using-woostack/SKILL.md`** routes explicit and intent-equivalent quick non-bug one-PR requests to the new skill.
+- **Existing authorities** remain single-source and are linked rather than copied: update the consumer list and lifecycle examples in `skills/woostack-init/references/worktrees.md`, then link its worktree/base mechanics; link TDD in `skills/woostack-tdd/SKILL.md`, commit/PR mechanics in `skills/woostack-commit/SKILL.md`, and least-code guidance in bootstrap `patterns.md §10`.
+- **Public-surface bookkeeping** updates every known reader identified by the repository's `lockstep-edit-sites` wisdom: `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `skills/using-woostack/SKILL.md`, and `skills/woostack-bootstrap/references/development.md`.
+- **Authored docs-site framing** updates the getting-started workflow and worktree pages whose current claims exclude the new path. The per-skill reference page remains generated from `SKILL.md`.
+- **Verification** structurally checks that the new skill exists, routing and public counts agree, required safety barriers are present, and the docs site builds.
+
+Request data flows only through the conversation and Git worktree. No new persistent woostack artifact schema or status lifecycle is introduced.
+
+## 6. Error handling
+
+- Missing or ambiguous goal: ask one focused question before classification; do not guess the target.
+- Bug/regression/incident evidence: stop this command before writes and route to `/woostack-fix`.
+- Greenfield request: route to `/woostack-bootstrap`.
+- Multi-PR scope identified before writes: route to `/woostack-build`.
+- Scope expansion after writes: stop; preserve and report the worktree rather than forcing an oversized PR or silently splitting into unmanaged branches.
+- Existing branch/worktree collision, dirty or unexpected worktree state, or base-resolution failure: stop before editing and report the conflict.
+- Missing test runner: use a concrete command with an exact expected result; never claim TDD ran.
+- Failed smoke test, verification, missing review receipt, or `BLOCKED` inline-review finding: do not submit or tear down; report evidence and the worktree path.
+- Failed or unverified commit, push, or PR creation: preserve the worktree and report the failure. PR existence is required before teardown.
+- No failure path may fall back to `/woostack-build` or `/woostack-fix` after implementation automatically; routing after writes requires an explicit handoff with preserved work.
+
+## 7. Acceptance criteria
+
+- **AC1 — Public command discovery and routing**
+  - happy: installation/adoption docs and `using-woostack` expose `/woostack-change <goal>` and route intent-equivalent bounded non-bug one-PR work to it.
+  - error: bug, greenfield, and multi-PR requests are explicitly rejected by this skill and routed to fix, bootstrap, and build respectively before writes.
+  - edge: a request with ambiguous scope asks one focused question rather than selecting a workflow by assumption.
+- **AC2 — Gate-free isolated execution**
+  - happy: a qualifying change creates and uses `change/<slug>` in `.woostack/worktrees/change-<slug>`, states intent, and proceeds without an approval gate or persistent spec/plan/change artifact.
+  - error: base, branch, worktree, or Graphite tracking failure stops before edits and preserves any recoverable state.
+  - edge: scope that expands after editing stops with the worktree preserved and does not auto-create a stack.
+- **AC3 — Verification and review safety**
+  - happy: new behavior uses the TDD kernel; no-runner work names and executes a concrete verification; every run smoke-tests the changed path and records a task-scoped inline compliance and quality review receipt for the current diff.
+  - error: failing verification or blocking review prevents submission and teardown and is reported with evidence.
+  - edge: purely documentary/configuration work does not fabricate a test runner or meaningless failing test.
+- **AC4 — One-PR closeout**
+  - happy: `woostack-commit` commits and submits exactly one `change/<slug>` PR; verified PR existence permits worktree teardown; the handback includes PR URL and verification evidence.
+  - error: commit, push, submission, or PR read-back failure leaves the worktree intact and reports its path.
+  - edge: the skill never merges and never creates a second PR or lifecycle-only closeout commit.
+- **AC5 — Public-surface lockstep**
+  - happy: every public count/list/routing/adoption site and affected authored docs page includes the new command consistently.
+  - error: a structural verification fails when the skill directory exists but a required public-surface site is missing or the count disagrees.
+  - edge: internal `woostack-ideate`, `woostack-harden`, and unregistered `woostack-ask` remain outside the registered public count.
+
+## 8. Testing
+
+This repository has no application test runner. Use committed structural shell verification consistent with existing skill tests to pin the command's required routing, scope barriers, no-gate/no-artifact contract, one-PR closeout, worktree path, and public-surface count/list sites. Run `bash -n` on any added or changed shell test, execute that focused test, and run `pnpm -C site build` because authored documentation and generated per-skill references change.
+
+Smoke-test command discovery by reading the installed skill metadata/routing surface exactly as a consumer would and confirming `/woostack-change` resolves to the new skill.
+
+## 9. Open questions
+
+None. The approved design fixed the command name, scope, no-gate policy, worktree and one-PR lifecycle, verification standard, inline review depth, failure preservation, and routing boundaries.


### PR DESCRIPTION
## Goal

Approve the hardened `/woostack-change` design and add a ready, single-increment implementation plan for a future 22nd registered public skill, without claiming the skill itself has been implemented.

## Summary

- Advances the specification lifecycle to `approved` and records the required `change/*` integration with `woostack-commit`.
- Adds a ready plan covering the skill contract, structural verification, worktree authority, public command registration, authored docs, and consumer discovery.
- Organizes implementation as one independently shippable increment with 21 concrete checklist steps and AC1–AC5 coverage.

## Test plan

### Automated

- [ ] `WOOSTACK_GH=false bash skills/woostack-status/scripts/status.sh --no-open` — passed.
- [ ] Status read-back recognized `woostack-change` as `ready` with `0/21` tasks complete.

### Manual

**Before merge**

- [ ] Inspect the spec and plan together: the spec is `approved`, the plan is `ready`, all checklist items describe future implementation, and one increment covers the complete public command surface.

Spec: .woostack/specs/2026-07-15-woostack-change.md
