### PR TITLE
Add deterministic skill package validation

### DIFF
--- a/.woostack/plans/2026-07-15-skill-evaluation-optimization.md
+++ b/.woostack/plans/2026-07-15-skill-evaluation-optimization.md
@@ -52,7 +52,7 @@ Every implementation branch follows Red → Green → Refactor. Run only the nam
 - Create: `skills/woostack-eval/scripts/tests/test-shared-parser.sh`
 - Test: `site/scripts/gen-skills.test.mjs`
 
-- [ ] **Step 1 — Red: write contract fixtures and assertions**
+- [x] **Step 1 — Red: write contract fixtures and assertions**
 
 Use temporary package directories from the shell tests; do not commit synthetic skill packages. Pin these cases:
 
@@ -70,7 +70,7 @@ invalid: symlink, FIFO/special file, `.git`, `.env*`, or secret-looking package 
 
 The parser test imports one exported `parseFrontmatter(raw, file)` function and asserts `{fm, body}` compatibility with the site generator. The package validator test expects a non-zero exit plus an exact field/path for each invalid fixture.
 
-- [ ] **Step 2 — Verify Red**
+- [x] **Step 2 — Verify Red**
 
 Run:
 
@@ -86,7 +86,7 @@ Expected: both fail because `validate.mjs` does not exist.
 **Files:**
 - Create: `skills/woostack-eval/scripts/validate.mjs`
 
-- [ ] **Step 1 — Green: implement the smallest exported API**
+- [x] **Step 1 — Green: implement the smallest exported API**
 
 Export and document:
 
@@ -117,7 +117,7 @@ Required behavior:
 - Never call a model, network, package manager, or provider.
 - Guard the CLI entrypoint with an `import.meta.url` check so site generation and `prepare.mjs` can import the module without executing argument parsing or writing output.
 
-- [ ] **Step 2 — Run Green tests**
+- [x] **Step 2 — Run Green tests**
 
 ```bash
 bash skills/woostack-eval/scripts/tests/run-tests.sh
@@ -131,15 +131,15 @@ Expected: parser, package, corpus, path-safety, placeholder, and YAML-hazard cas
 - Modify: `site/scripts/gen-skills.mjs:1-55`
 - Modify: `site/scripts/gen-skills.test.mjs:1-35`
 
-- [ ] **Step 1 — Red: change the test import authority**
+- [x] **Step 1 — Red: change the test import authority**
 
 Import `parseFrontmatter` directly from `../../skills/woostack-eval/scripts/validate.mjs` in the test and add the safe-placeholder/colon-space pair. Expected failure: the generator still owns a second parser.
 
-- [ ] **Step 2 — Green: delete the duplicate parser**
+- [x] **Step 2 — Green: delete the duplicate parser**
 
 Import and re-export `parseFrontmatter` from the canonical validator in `gen-skills.mjs` so existing generator consumers retain their API. Keep rendering functions in the site script.
 
-- [ ] **Step 3 — Verify shared production behavior**
+- [x] **Step 3 — Verify shared production behavior**
 
 ```bash
 node --test site/scripts/gen-skills.test.mjs

--- a/.woostack/plans/2026-07-15-skill-evaluation-optimization.md
+++ b/.woostack/plans/2026-07-15-skill-evaluation-optimization.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-15-skill-evaluation-optimization.md
-status: ready
+status: executing
 branch: feature/skill-evaluation-optimization
 ---
 

--- a/site/scripts/gen-skills.mjs
+++ b/site/scripts/gen-skills.mjs
@@ -2,6 +2,9 @@ import { readdir, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseFrontmatter } from '../../skills/woostack-eval/scripts/validate.mjs';
+
+export { parseFrontmatter };
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..'); // site/scripts -> repo root
@@ -36,24 +39,6 @@ export const INTERNAL_ORDER = ['woostack-harden', 'woostack-ideate'];
 
 const ORDER = [...PUBLIC_ORDER, ...SUPPORTING_ORDER, ...INTERNAL_ORDER];
 const INTERNAL = new Set(INTERNAL_ORDER);
-
-export function parseFrontmatter(raw, file = '<input>') {
-  const m = /^---\n([\s\S]*?)\n---\n?/.exec(raw);
-  if (!m) throw new Error(`${file}: missing frontmatter`);
-  const fm = {};
-  for (const line of m[1].split('\n')) {
-    const mm = /^(\w+):\s*(.*)$/.exec(line);
-    if (!mm) continue;
-    let v = mm[2].trim();
-    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
-      v = v.slice(1, -1).replace(/\\"/g, '"'); // some descriptions are YAML-quoted in source
-    }
-    fm[mm[1]] = v;
-  }
-  if (!fm.name) throw new Error(`${file}: frontmatter missing 'name'`);
-  if (!fm.description) throw new Error(`${file}: frontmatter missing 'description'`);
-  return { fm, body: raw.slice(m[0].length) };
-}
 
 export function stripTitleHeading(body, name) {
   const lines = body.split('\n');

--- a/site/scripts/gen-skills.test.mjs
+++ b/site/scripts/gen-skills.test.mjs
@@ -2,17 +2,22 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { parseFrontmatter } from '../../skills/woostack-eval/scripts/validate.mjs';
 import {
   INTERNAL_ORDER,
   PUBLIC_ORDER,
   SUPPORTING_ORDER,
-  parseFrontmatter,
+  parseFrontmatter as generatorParseFrontmatter,
   stripTitleHeading,
   rewriteLinks,
   neutralizeTags,
   renderPage,
   navOrder,
 } from './gen-skills.mjs';
+
+test('generator re-exports the canonical frontmatter parser', () => {
+  assert.equal(generatorParseFrontmatter, parseFrontmatter);
+});
 
 test('parseFrontmatter extracts name + description and returns the body', () => {
   const raw = '---\nname: woostack-build\ndescription: Use when building a feature.\n---\n\n# woostack-build\n\nbody';
@@ -30,6 +35,27 @@ test('parseFrontmatter strips surrounding YAML quotes (some descriptions are quo
   const raw = '---\nname: woostack-tdd\ndescription: "TDD home: red→green. Quoted in source."\n---\nb';
   const { fm } = parseFrontmatter(raw, 'woostack-tdd');
   assert.equal(fm.description, 'TDD home: red→green. Quoted in source.'); // no leading/trailing "
+});
+
+test('parseFrontmatter accepts safe placeholders in plain descriptions', () => {
+  const raw = '---\nname: woostack-plan\ndescription: Write the approved spec to <plan-path>.\n---\nbody';
+  const { fm } = parseFrontmatter(raw, 'woostack-plan');
+  assert.equal(fm.description, 'Write the approved spec to <plan-path>.');
+});
+
+test('parseFrontmatter accepts quoted colon-space descriptions with safe placeholders', () => {
+  const raw = '---\nname: woostack-plan\ndescription: "Plan output: write <plan-path> safely."\n---\nbody';
+  const { fm } = parseFrontmatter(raw, 'woostack-plan');
+  assert.equal(fm.description, 'Plan output: write <plan-path> safely.');
+});
+
+test('parseFrontmatter rejects colon-space in a plain description deterministically', () => {
+  const raw = '---\nname: woostack-plan\ndescription: Plan output: write safely.\n---\nbody';
+  assert.throws(
+    () => parseFrontmatter(raw, 'woostack-plan'),
+    (error) => error.code === 'frontmatter-plain-colon-space' &&
+      error.message === 'woostack-plan: description contains colon-space in a plain scalar; quote the value',
+  );
 });
 
 test('stripTitleHeading removes only the first exact "# <name>" H1', () => {

--- a/skills/woostack-eval/references/schemas.md
+++ b/skills/woostack-eval/references/schemas.md
@@ -1,0 +1,246 @@
+# Skill evaluation schemas
+
+All schemas in this document use `schemaVersion: 1`. Producers must reject unknown
+versions, unknown fields, wrong JSON types, and duplicate identities. Paths are POSIX-style,
+relative paths even when the host is Windows. They must be normalized before use, must stay
+inside the stated root, and must resolve only through regular, non-symlink files.
+
+## Corpus files
+
+Both corpus files have this envelope:
+
+```json
+{"schemaVersion":1,"skill":"woostack-example","cases":[]}
+```
+
+`skill` must exactly equal the package frontmatter `name`. A case `id` is a stable,
+unique, lower-case kebab-case identifier. Published IDs are never repurposed for a different
+scenario. Assertion IDs are likewise stable and unique within their case.
+
+### Behavior corpus
+
+`evals/evals.json` contains behavior cases:
+
+```json
+{
+  "schemaVersion": 1,
+  "skill": "woostack-example",
+  "cases": [{
+    "id": "preserves-approval-gate",
+    "prompt": "Carry out the approved plan.",
+    "fixtures": ["approved-plan.md"],
+    "capabilities": ["read-workspace"],
+    "expected": "The worker stops at the required approval gate.",
+    "assertions": [{
+      "id": "mentions-approval",
+      "kind": "final-contains",
+      "substring": "approval",
+      "critical": true
+    }]
+  }]
+}
+```
+
+Required case fields are `id`, non-empty `prompt`, non-empty `expected`, and non-empty
+`assertions`. `fixtures` is optional and contains unique paths relative to the owning
+`evals/fixtures/` directory. A fixture may not be absolute, contain a `..` segment, escape
+that directory, or resolve through a symlink or non-regular file.
+
+`capabilities` is optional and defaults to `["read-workspace"]`. Its only allowed values are:
+
+- `read-workspace`
+- `write-workspace`
+- `shell-workspace`
+
+Corpus data can never grant network, credential, provider, environment-inspection, or
+out-of-workspace access.
+
+### Trigger corpus
+
+`evals/trigger-evals.json` contains trigger cases:
+
+```json
+{
+  "schemaVersion": 1,
+  "skill": "woostack-example",
+  "cases": [{
+    "id": "runs-example-command",
+    "query": "Evaluate this example skill.",
+    "shouldTrigger": true,
+    "expectedSkill": "woostack-example",
+    "conflictsWith": ["woostack-review"]
+  }]
+}
+```
+
+Required fields are `id`, non-empty `query`, boolean `shouldTrigger`, and
+`expectedSkill`. `expectedSkill` is a canonical skill name or the literal `none`.
+`conflictsWith` is an optional unique array of canonical skill names. Positive and negative
+cases use this same shape.
+
+## Assertions
+
+Every assertion has exactly `id`, `kind`, its kind-specific fields, and optional boolean
+`critical` (default `false`). The eight deterministic kinds and the qualitative kind are:
+
+| `kind` | Required fields | Semantics |
+| --- | --- | --- |
+| `path-exists` | `path` | A regular, non-symlink workspace path exists. |
+| `path-absent` | `path` | No workspace entry exists at the path. |
+| `file-contains` | `file`, `substring` | UTF-8 file includes the literal substring. |
+| `file-excludes` | `file`, `substring` | UTF-8 file excludes the literal substring. |
+| `json-path-equals` | `file`, `pointer`, `expected` | Parsed JSON value at the pointer is deeply equal to the JSON `expected` value. |
+| `final-contains` | `substring` | Captured final output includes the literal substring. |
+| `final-excludes` | `substring` | Captured final output excludes the literal substring. |
+| `receipt-field-equals` | `pointer`, `expected` | Action receipt value at the pointer is deeply equal to `expected`. |
+| `qualitative` | `rubric` | An isolated grader answers the explicit boolean question in `rubric`. |
+
+`path` and `file` are relative to the copied case workspace and never follow symlinks.
+All `substring` checks are case-sensitive, literal UTF-8 substring checks: they are not
+regular expressions, globs, Unicode normalization, or Markdown-aware matching. An empty
+substring is invalid.
+
+`pointer` is an RFC 6901 JSON Pointer. It is either the empty string (the whole document) or
+starts with `/`; `~0` decodes to `~` and `~1` to `/`. No dot-path or URI-fragment syntax is
+accepted. `qualitative.rubric` must be a non-empty question answerable strictly true or false.
+The grader's boolean and rationale are stored in a grade, never inferred from prose.
+
+## Action receipts
+
+One append-only action receipt is written last for every expected
+case/variant/repetition. Its exact shape is:
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "20260715T120000Z-1234",
+  "caseId": "preserves-approval-gate",
+  "repetition": 1,
+  "variant": "candidate",
+  "kind": "behavior",
+  "targetSkill": "woostack-example",
+  "baseline": {"kind":"git-ref","identity":"0123456789abcdef0123456789abcdef01234567"},
+  "packageHash": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "capabilities": ["read-workspace"],
+  "host": "omp",
+  "runner": "worker",
+  "model": "model-name",
+  "sessionIdentity": null,
+  "tier": null,
+  "effort": null,
+  "startedAt": "2026-07-15T12:00:00.000Z",
+  "durationMs": 1234,
+  "output": {"path":"outputs/final.txt","sha256":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","bytes":42},
+  "transcript": "unavailable",
+  "tokenUsage": "unavailable",
+  "selectedSkill": null,
+  "completionStatus": "complete",
+  "error": null
+}
+```
+
+`repetition` is one-based. `variant` is exactly `candidate` or `baseline`; `kind` is exactly
+`behavior` or `trigger`. `baseline.kind` is `git-ref`, `path`, or `none`, with a reproducible
+`identity`. Exactly one of non-empty `model` and non-empty `sessionIdentity` supplies the
+completion identity. `tier` and `effort` are strings when exposed and otherwise `null`.
+`startedAt` is RFC 3339 UTC, `durationMs` is a non-negative finite integer, and `output`
+identifies a regular evidence file by relative path, SHA-256, and byte length.
+
+`transcript` is either an output identity with the same `{path,sha256,bytes}` shape or the
+literal `unavailable`. `tokenUsage` is either `unavailable` or
+`{"input":<non-negative integer>,"output":<non-negative integer>,"total":<non-negative integer>}`.
+It is never zero-filled when telemetry is absent. A trigger receipt sets `selectedSkill` to a
+canonical skill name or `none`; a behavior receipt sets it to `null`.
+
+`completionStatus` is exactly `complete`, `failed`, or `timed-out`. A complete receipt has
+`error: null`; another status has exactly
+`{"code":"<stable-kebab-case>","message":"<non-empty sanitized text>"}`. A receipt is not
+proof until it is the unique receipt for a manifest identity and all identity/configuration
+fields match its paired run.
+
+## Qualitative grades
+
+A grade is append-only and has this exact shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "20260715T120000Z-1234",
+  "caseId": "preserves-approval-gate",
+  "repetition": 1,
+  "graderId": "clarity-grader",
+  "assertionId": "clear-handoff",
+  "anonymizedOutputId": "output-7f3a",
+  "completionStatus": "complete",
+  "pass": true,
+  "rationale": "The handoff names the required next action.",
+  "error": null,
+  "receipt": {"path":"evidence/action.grader.preserve-approval-gate.1.clarity-grader.json","sha256":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}
+}
+```
+
+The grade contains no candidate/baseline label. `graderId`, `assertionId`, and
+`anonymizedOutputId` are stable kebab-case identities. `completionStatus` uses the action
+receipt enum. On `complete`, `pass` is boolean, `rationale` is non-empty, and `error` is null.
+Otherwise `pass` and `rationale` are null and `error` has the receipt error shape. The
+aggregate restores the variant only through the manifest and completed grader receipt.
+
+## Aggregate
+
+The aggregate is versioned and has these top-level fields:
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "20260715T120000Z-1234",
+  "targetSkill": "woostack-example",
+  "executionStatus": "complete",
+  "baseline": {"kind":"git-ref","identity":"0123456789abcdef0123456789abcdef01234567"},
+  "runs": 3,
+  "cases": [],
+  "overall": {
+    "objectivePassRate": {"candidate":1,"baseline":0.67,"delta":0.33},
+    "criticalFailures": [],
+    "triggerPrecision": "unavailable",
+    "triggerRecall": "unavailable",
+    "durationMs": {"candidate":{"mean":1234,"variance":12},"baseline":{"mean":1400,"variance":18}},
+    "tokenUsage": "unavailable"
+  },
+  "evidenceErrors": []
+}
+```
+
+`executionStatus` is exactly `complete`, `blocked`, or `degraded`. Assertion failures may
+coexist with `complete`. Missing, duplicate, malformed, failed, timed-out, unknown, or
+identity-mismatched required evidence makes the aggregate `blocked`. Explicitly accepted
+candidate-only smoke evidence is `degraded` and emits no comparison or trigger metric.
+
+Each case entry identifies `caseId`, `kind`, and separate `candidate` and `baseline`
+repetition results; each assertion result identifies `assertionId`, `critical`, `pass`, and
+its observed evidence identity. Qualitative results additionally preserve `rationale` and
+the grade/receipt identities. Rates are numbers from zero through one. Variance is the
+literal `unavailable` for one repetition; unavailable duration or token metrics are never
+coerced to zero. The aggregate accepts exactly the manifest's expected identities, reports
+per-case and overall variance, preserves objective failures separately from execution
+failure, and contains no merge verdict.
+
+`criticalFailures` contains `{caseId,assertionId,repetitions}` entries. `evidenceErrors` uses
+exactly `{code,field,path,message}`: `code` is stable kebab-case, `field` is an RFC 6901
+pointer (or the empty pointer), `path` is a run-root-relative evidence path, and `message` is
+non-empty sanitized text.
+
+## Validator result and errors
+
+`node validate.mjs ... --json` emits one JSON object with exactly `schemaVersion`, `valid`,
+`package`, `files`, `corpora`, `packageHash`, and `errors`. `valid` is `errors.length === 0`.
+`package` contains normalized `name`, `description`, and package-root-relative `path`;
+`files` contains sorted `{path,type,bytes,sha256}` entries where `type` is `skill`,
+`reference`, `script`, `asset`, or `eval`; `corpora` contains behavior/trigger presence and
+case counts; `packageHash` is a `sha256:` identity or `null` when safe hashing cannot finish.
+
+Every validator error has exactly `{code,field,path,message}`. `field` is an RFC 6901
+pointer into the source document (the empty pointer for a whole-file/path failure), `path` is
+package-relative, and `message` is non-empty. Errors are sorted by `path`, then `field`, then
+`code`. The CLI exits non-zero exactly when `errors` is non-empty. It reports only the
+fatal deterministic contracts; root/reference size, TOC, unlinked auxiliary files, degrees
+of freedom, and prose quality are not validator errors.

--- a/skills/woostack-eval/scripts/tests/run-tests.sh
+++ b/skills/woostack-eval/scripts/tests/run-tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$SCRIPT_DIR"
+
+status=0
+for test_file in test-*.sh; do
+  [ -f "$test_file" ] || continue
+  printf '== %s ==\n' "$test_file"
+  if ! bash "$test_file"; then
+    status=1
+  fi
+done
+exit "$status"

--- a/skills/woostack-eval/scripts/tests/test-shared-parser.sh
+++ b/skills/woostack-eval/scripts/tests/test-shared-parser.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../../../.." && pwd)
+VALIDATOR="$SCRIPT_DIR/../validate.mjs"
+GENERATOR="$REPO_ROOT/site/scripts/gen-skills.mjs"
+NODE=${NODE:-node}
+
+"$NODE" --input-type=module - "$VALIDATOR" "$GENERATOR" <<'NODE'
+import assert from 'node:assert/strict';
+import { pathToFileURL } from 'node:url';
+
+const [validatorPath, generatorPath] = process.argv.slice(2);
+const { parseFrontmatter } = await import(pathToFileURL(validatorPath).href);
+const { parseFrontmatter: siteParseFrontmatter } = await import(pathToFileURL(generatorPath).href);
+
+assert.equal(typeof parseFrontmatter, 'function', 'validator exports parseFrontmatter(raw, file)');
+
+const quoted = `---
+name: parser-contract
+description: "Use when the source contains status: approved."
+plugin: preserved-for-the-site
+---
+# Parser contract
+
+Body remains byte-for-byte compatible.
+`;
+const placeholder = `---
+name: parser-contract
+description: Execute the approved plan at <plan-path>.
+---
+Body with no title.
+`;
+
+for (const [label, raw] of [['quoted colon-space', quoted], ['plain placeholder', placeholder]]) {
+  const canonical = parseFrontmatter(raw, `${label}.md`);
+  const site = siteParseFrontmatter(raw, `${label}.md`);
+  assert.deepEqual(
+    canonical,
+    site,
+    `${label}: canonical parser returns the site-compatible {fm, body} shape`,
+  );
+  assert.deepEqual(Object.keys(canonical).sort(), ['body', 'fm']);
+  assert.equal(typeof canonical.fm, 'object');
+  assert.equal(typeof canonical.body, 'string');
+}
+
+const plainColonHazard = `---
+name: parser-contract
+description: Use when status: approved is present.
+---
+Body.
+`;
+assert.throws(
+  () => parseFrontmatter(plainColonHazard, 'plain-colon.md'),
+  /description|colon|plain scalar/i,
+  'canonical parser rejects colon-space in an unquoted description',
+);
+
+const fenced = `\`\`\`yaml
+---
+name: parser-contract
+description: This is fenced, not frontmatter.
+---
+\`\`\`
+`;
+assert.throws(
+  () => parseFrontmatter(fenced, 'fenced.md'),
+  /missing frontmatter/i,
+  'canonical parser accepts only an opening unfenced frontmatter block',
+);
+
+console.log('PASS: shared frontmatter parser contract');
+NODE

--- a/skills/woostack-eval/scripts/tests/test-validate.sh
+++ b/skills/woostack-eval/scripts/tests/test-validate.sh
@@ -1,0 +1,562 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+VALIDATOR="$SCRIPT_DIR/../validate.mjs"
+NODE=${NODE:-node}
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/woostack-eval-validate.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+RESULT="$TMP_ROOT/result.json"
+ERRORS="$TMP_ROOT/stderr.txt"
+TIMEOUT_MARKER="$TMP_ROOT/timeout.txt"
+PACKAGE=
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+make_package() {
+  name=$1
+  description_line=$2
+  PACKAGE="$TMP_ROOT/$name"
+  mkdir -p "$PACKAGE/references"
+  cat >"$PACKAGE/SKILL.md" <<EOF
+---
+name: $name
+$description_line
+---
+# $name
+
+[Guide](references/guide.md)
+
+\`\`\`md
+[Ignored missing link](references/not-created.md)
+\`\`\`
+EOF
+  printf '# Guide\n' >"$PACKAGE/references/guide.md"
+}
+
+run_validator() {
+  rm -f "$TIMEOUT_MARKER"
+  set +e
+  validator_args=(--package "$PACKAGE" --repository-root "${REPOSITORY_ROOT:-$TMP_ROOT}" --json)
+  if [ "${TRACKED_ONLY:-0}" -eq 1 ]; then
+    validator_args+=(--tracked-only)
+  fi
+  "$NODE" "$VALIDATOR" "${validator_args[@]}" >"$RESULT" 2>"$ERRORS" &
+  validator_pid=$!
+  (
+    sleep 5
+    if kill -0 "$validator_pid" 2>/dev/null; then
+      printf 'validator exceeded 5 seconds\n' >"$TIMEOUT_MARKER"
+      kill -TERM "$validator_pid" 2>/dev/null || :
+      sleep 1
+      kill -KILL "$validator_pid" 2>/dev/null || :
+    fi
+  ) &
+  watchdog_pid=$!
+  wait "$validator_pid"
+  STATUS=$?
+  kill "$watchdog_pid" 2>/dev/null || :
+  wait "$watchdog_pid" 2>/dev/null || :
+  set -e
+  if [ -f "$TIMEOUT_MARKER" ]; then
+    fail "$(cat "$TIMEOUT_MARKER"): $PACKAGE"
+  fi
+}
+
+expect_valid() {
+  label=$1
+  expected_name=$2
+  expected_description=$3
+  expected_inventory=${4:-SKILL.md:skill,references/guide.md:reference}
+  expected_behavior_count=${5:-0}
+  expected_trigger_count=${6:-0}
+  run_validator
+  if [ "$STATUS" -ne 0 ]; then
+    printf 'FAIL: %s should be valid (exit %s)\n' "$label" "$STATUS" >&2
+    cat "$ERRORS" >&2
+    exit 1
+  fi
+  "$NODE" - "$RESULT" "$expected_name" "$expected_description" "$expected_inventory" \
+    "$expected_behavior_count" "$expected_trigger_count" <<'NODE'
+const fs = require('node:fs');
+const [file, expectedName, expectedDescription, inventoryText, behaviorText, triggerText] =
+  process.argv.slice(2);
+const result = JSON.parse(fs.readFileSync(file, 'utf8'));
+const exactKeys = ['corpora', 'errors', 'files', 'package', 'packageHash', 'schemaVersion', 'valid'];
+const same = (actual, expected) => JSON.stringify(actual) === JSON.stringify(expected);
+if (!same(Object.keys(result).sort(), exactKeys)) {
+  throw new Error(`unexpected result keys: ${Object.keys(result).sort().join(',')}`);
+}
+if (result.schemaVersion !== 1 || result.valid !== true || !same(result.errors, [])) {
+  throw new Error(`expected a valid schemaVersion 1 result: ${JSON.stringify(result)}`);
+}
+if (!same(Object.keys(result.package).sort(), ['description', 'name', 'path'])) {
+  throw new Error(`unexpected package shape: ${JSON.stringify(result.package)}`);
+}
+if (
+  result.package.name !== expectedName ||
+  result.package.description !== expectedDescription ||
+  result.package.path !== expectedName
+) {
+  throw new Error(`unexpected normalized metadata: ${JSON.stringify(result.package)}`);
+}
+if (!same(Object.keys(result.corpora).sort(), ['behavior', 'triggers'])) {
+  throw new Error(`unexpected corpora shape: ${JSON.stringify(result.corpora)}`);
+}
+for (const key of ['behavior', 'triggers']) {
+  if (!same(Object.keys(result.corpora[key]).sort(), ['caseCount', 'present'])) {
+    throw new Error(`unexpected ${key} summary shape: ${JSON.stringify(result.corpora[key])}`);
+  }
+}
+const behaviorCount = Number(behaviorText);
+const triggerCount = Number(triggerText);
+const expectedCorpora = {
+  behavior: { present: behaviorCount > 0, caseCount: behaviorCount },
+  triggers: { present: triggerCount > 0, caseCount: triggerCount },
+};
+if (!same(result.corpora, expectedCorpora)) {
+  throw new Error(`unexpected corpus summaries: ${JSON.stringify(result.corpora)}`);
+}
+const inventory = inventoryText.split(',').filter(Boolean);
+const actualInventory = result.files.map((entry) => `${entry.path}:${entry.type}`);
+if (!same(actualInventory, inventory)) {
+  throw new Error(`unexpected sorted inventory: ${JSON.stringify(actualInventory)}`);
+}
+for (const entry of result.files) {
+  if (!same(Object.keys(entry).sort(), ['bytes', 'path', 'sha256', 'type'])) {
+    throw new Error(`unexpected file entry shape: ${JSON.stringify(entry)}`);
+  }
+  if (
+    !['skill', 'reference', 'script', 'asset', 'eval'].includes(entry.type) ||
+    !Number.isSafeInteger(entry.bytes) ||
+    entry.bytes < 0 ||
+    !/^sha256:[0-9a-f]{64}$/.test(entry.sha256)
+  ) {
+    throw new Error(`invalid file entry: ${JSON.stringify(entry)}`);
+  }
+}
+if (!/^sha256:[0-9a-f]{64}$/.test(result.packageHash)) {
+  throw new Error(`invalid package hash: ${result.packageHash}`);
+}
+NODE
+}
+
+expect_invalid() {
+  label=$1
+  expected_code=$2
+  expected_path=$3
+  expected_field=$4
+  run_validator
+  [ "$STATUS" -ne 0 ] || fail "$label should exit non-zero"
+  "$NODE" - "$RESULT" "$expected_code" "$expected_path" "$expected_field" <<'NODE'
+const fs = require('node:fs');
+const [file, code, path, field] = process.argv.slice(2);
+const result = JSON.parse(fs.readFileSync(file, 'utf8'));
+const same = (actual, expected) => JSON.stringify(actual) === JSON.stringify(expected);
+const exactKeys = ['corpora', 'errors', 'files', 'package', 'packageHash', 'schemaVersion', 'valid'];
+if (!same(Object.keys(result).sort(), exactKeys)) {
+  throw new Error(`unexpected result keys: ${Object.keys(result).sort().join(',')}`);
+}
+if (result.schemaVersion !== 1 || result.valid !== false || !Array.isArray(result.errors)) {
+  throw new Error(`expected an invalid schemaVersion 1 result: ${JSON.stringify(result)}`);
+}
+if (!same(Object.keys(result.package).sort(), ['description', 'name', 'path'])) {
+  throw new Error(`unexpected package shape: ${JSON.stringify(result.package)}`);
+}
+if (
+  ![null, 'string'].includes(result.package.name === null ? null : typeof result.package.name) ||
+  ![null, 'string'].includes(result.package.description === null ? null : typeof result.package.description) ||
+  typeof result.package.path !== 'string'
+) {
+  throw new Error(`invalid package metadata types: ${JSON.stringify(result.package)}`);
+}
+if (!same(Object.keys(result.corpora).sort(), ['behavior', 'triggers'])) {
+  throw new Error(`unexpected corpora shape: ${JSON.stringify(result.corpora)}`);
+}
+for (const key of ['behavior', 'triggers']) {
+  const summary = result.corpora[key];
+  if (
+    !same(Object.keys(summary).sort(), ['caseCount', 'present']) ||
+    typeof summary.present !== 'boolean' ||
+    !Number.isSafeInteger(summary.caseCount) ||
+    summary.caseCount < 0
+  ) {
+    throw new Error(`invalid ${key} summary: ${JSON.stringify(summary)}`);
+  }
+}
+if (!Array.isArray(result.files)) throw new Error('files must be an array');
+let previousFile = '';
+for (const entry of result.files) {
+  if (!same(Object.keys(entry).sort(), ['bytes', 'path', 'sha256', 'type'])) {
+    throw new Error(`unexpected file entry shape: ${JSON.stringify(entry)}`);
+  }
+  if (
+    entry.path < previousFile ||
+    !['skill', 'reference', 'script', 'asset', 'eval'].includes(entry.type) ||
+    !Number.isSafeInteger(entry.bytes) ||
+    entry.bytes < 0 ||
+    !/^sha256:[0-9a-f]{64}$/.test(entry.sha256)
+  ) {
+    throw new Error(`invalid or unsorted file entry: ${JSON.stringify(entry)}`);
+  }
+  previousFile = entry.path;
+}
+if (result.packageHash !== null && !/^sha256:[0-9a-f]{64}$/.test(result.packageHash)) {
+  throw new Error(`invalid package hash: ${result.packageHash}`);
+}
+const identities = new Set();
+let previousErrorKey = '';
+for (const error of result.errors) {
+  if (!same(Object.keys(error).sort(), ['code', 'field', 'message', 'path'])) {
+    throw new Error(`unexpected error shape: ${JSON.stringify(error)}`);
+  }
+  if (
+    !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(error.code) ||
+    typeof error.path !== 'string' ||
+    error.path.startsWith('/') ||
+    error.path.split('/').includes('..') ||
+    typeof error.field !== 'string' ||
+    (error.field !== '' && !/^\/(?:[^~\/]|~[01])*(?:\/(?:[^~\/]|~[01])*)*$/.test(error.field)) ||
+    typeof error.message !== 'string' ||
+    error.message.trim().length === 0 ||
+    /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(error.message)
+  ) {
+    throw new Error(`invalid error contract: ${JSON.stringify(error)}`);
+  }
+  const identity = `${error.code}\u0000${error.path}\u0000${error.field}`;
+  if (identities.has(identity)) throw new Error(`duplicate error: ${JSON.stringify(error)}`);
+  identities.add(identity);
+  const sortKey = `${error.path}\u0000${error.field}\u0000${error.code}`;
+  if (sortKey < previousErrorKey) {
+    throw new Error(`errors are not path/field/code sorted: ${JSON.stringify(result.errors)}`);
+  }
+  previousErrorKey = sortKey;
+}
+const error = result.errors.find((entry) =>
+  entry.code === code && entry.path === path && entry.field === field
+);
+if (!error) {
+  throw new Error(`missing ${code} at ${path}${field}: ${JSON.stringify(result.errors)}`);
+}
+NODE
+}
+
+expect_exact_errors() {
+  label=$1
+  expected_json=$2
+  run_validator
+  [ "$STATUS" -ne 0 ] || fail "$label should exit non-zero"
+  "$NODE" - "$RESULT" "$expected_json" <<'NODE'
+const fs = require('node:fs');
+const [file, expectedText] = process.argv.slice(2);
+const result = JSON.parse(fs.readFileSync(file, 'utf8'));
+const actual = result.errors.map(({ code, path, field }) => ({ code, path, field }));
+const expected = JSON.parse(expectedText);
+if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+  throw new Error(`unexpected exact errors: ${JSON.stringify(actual)}`);
+}
+NODE
+}
+
+# Supported YAML scalars: quoted colon-space and a plain single-token placeholder.
+make_package quoted-description 'description: "Use when the input has status: approved and preserve it."'
+expect_valid 'quoted colon-space description' quoted-description \
+  'Use when the input has status: approved and preserve it.'
+
+make_package plain-placeholder 'description: Execute the plan at <plan-path> after approval.'
+expect_valid 'plain angle-bracket placeholder' plain-placeholder \
+  'Execute the plan at <plan-path> after approval.'
+
+# Real YAML plain-scalar hazards and XML-like markup remain fatal.
+make_package plain-colon-hazard 'description: Use when the plan has status: approved.'
+expect_invalid 'plain colon-space description' frontmatter-plain-colon-space SKILL.md /description
+
+make_package implicit-boolean-description 'description: true'
+expect_invalid 'implicit boolean description' frontmatter-non-string-scalar SKILL.md /description
+
+make_package implicit-null-description 'description: null'
+expect_invalid 'implicit null description' frontmatter-non-string-scalar SKILL.md /description
+
+make_package implicit-number-description 'description: 42'
+expect_invalid 'implicit number description' frontmatter-non-string-scalar SKILL.md /description
+
+make_package malformed-quoted-description 'description: "unterminated'
+expect_invalid 'malformed quoted description' frontmatter-invalid-scalar SKILL.md /description
+
+make_package invalid-quoted-escape 'description: "invalid \q escape"'
+expect_invalid 'invalid quoted description escape' frontmatter-invalid-scalar SKILL.md /description
+
+make_package script-tag 'description: Use <script> only after approval.'
+expect_invalid 'script tag description' frontmatter-xml-markup SKILL.md /description
+
+make_package paired-tags 'description: Use <strong>care</strong> for approvals.'
+expect_invalid 'paired markup description' frontmatter-xml-markup SKILL.md /description
+
+# Frontmatter identity and bounds.
+make_package directory-name 'description: Valid package description.'
+# Keep the directory name but change the declared identity.
+printf '%s\n' '---' 'name: other-name' 'description: Valid package description.' '---' '# other-name' \
+  >"$PACKAGE/SKILL.md"
+expect_invalid 'directory/name mismatch' frontmatter-name-directory-mismatch SKILL.md /name
+
+make_package empty-description 'description: ""'
+expect_invalid 'empty description' frontmatter-description-empty SKILL.md /description
+
+LONG_DESCRIPTION=$("$NODE" -e "process.stdout.write('x'.repeat(1025))")
+make_package oversized-description "description: $LONG_DESCRIPTION"
+expect_invalid 'over-1024 description' frontmatter-description-too-long SKILL.md /description
+
+PACKAGE="$TMP_ROOT/missing-frontmatter"
+mkdir -p "$PACKAGE"
+printf '# missing-frontmatter\n' >"$PACKAGE/SKILL.md"
+expect_invalid 'missing frontmatter' frontmatter-missing SKILL.md ''
+
+PACKAGE="$TMP_ROOT/fenced-frontmatter"
+mkdir -p "$PACKAGE"
+cat >"$PACKAGE/SKILL.md" <<'EOF'
+```yaml
+---
+name: fenced-frontmatter
+description: This block is documentation, not frontmatter.
+---
+```
+EOF
+expect_invalid 'fenced frontmatter' frontmatter-missing SKILL.md ''
+
+# Local links outside fences must exist and remain contained. Fenced links above are ignored.
+make_package missing-link 'description: Package with a missing link.'
+printf '\n[Missing](references/missing.md)\n' >>"$PACKAGE/SKILL.md"
+expect_invalid 'missing local Markdown link' link-target-missing SKILL.md /links/1
+
+make_package escaping-link 'description: Package with an escaping link.'
+printf '\n[Outside](../../outside.md)\n' >>"$PACKAGE/SKILL.md"
+expect_invalid 'escaping local Markdown link' link-target-outside SKILL.md /links/1
+
+make_package balanced-link 'description: Package with balanced and escaped link destinations.'
+printf '# Parenthesized guide\n' >"$PACKAGE/references/guide(1).md"
+printf '\n[Balanced](references/guide(1).md)\n[Escaped](references/guide\\(1\\).md)\n' >>"$PACKAGE/SKILL.md"
+expect_valid 'balanced and escaped Markdown destinations' balanced-link \
+  'Package with balanced and escaped link destinations.' \
+  'SKILL.md:skill,references/guide(1).md:reference,references/guide.md:reference'
+
+make_package reference-link 'description: Package with a reference-style link.'
+printf '\n[Reference][guide-reference]\n\n[guide-reference]: references/guide.md\n' >>"$PACKAGE/SKILL.md"
+expect_valid 'reference-style Markdown link' reference-link 'Package with a reference-style link.'
+
+make_package missing-reference-link 'description: Package with a missing reference target.'
+printf '\n[Missing][missing-reference]\n\n[missing-reference]: references/missing(1).md\n' >>"$PACKAGE/SKILL.md"
+expect_invalid 'missing reference-style link target' link-target-missing SKILL.md /links/1
+
+make_package titled-followed-link 'description: Package with adjacent titled and missing links.'
+printf '\n[Good](references/guide.md "title") [Missing](references/missing.md)\n' >>"$PACKAGE/SKILL.md"
+expect_invalid 'titled link does not swallow following link' link-target-missing SKILL.md /links/2
+
+make_package mixed-fence-markers 'description: Package with strict Markdown fences.'
+cat >>"$PACKAGE/SKILL.md" <<'EOF'
+
+````md
+~~~
+[Ignored after different marker](references/missing-one.md)
+```
+[Ignored after short marker](references/missing-two.md)
+```` trailing
+[Ignored after suffixed marker](references/missing-three.md)
+````
+EOF
+expect_valid 'strict Markdown fence closing' mixed-fence-markers 'Package with strict Markdown fences.'
+
+# A valid behavior corpus pins every supported assertion and capability.
+make_package valid-corpus 'description: Package with a complete behavior corpus.'
+mkdir -p "$PACKAGE/evals/fixtures"
+printf 'fixture\n' >"$PACKAGE/evals/fixtures/input.txt"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{
+  "schemaVersion": 1,
+  "skill": "valid-corpus",
+  "cases": [{
+    "id": "all-assertions",
+    "prompt": "Exercise each deterministic assertion.",
+    "fixtures": ["input.txt"],
+    "capabilities": ["read-workspace", "write-workspace", "shell-workspace"],
+    "expected": "Each assertion is evaluated according to its documented semantics.",
+    "assertions": [
+      {"id":"exists","kind":"path-exists","path":"result.txt"},
+      {"id":"absent","kind":"path-absent","path":"forbidden.txt"},
+      {"id":"contains","kind":"file-contains","file":"result.txt","substring":"literal .* text"},
+      {"id":"excludes","kind":"file-excludes","file":"result.txt","substring":"secret"},
+      {"id":"json","kind":"json-path-equals","file":"result.json","pointer":"/a~1b/~0key","expected":{"ok":true}},
+      {"id":"final-has","kind":"final-contains","substring":"done"},
+      {"id":"final-lacks","kind":"final-excludes","substring":"failed"},
+      {"id":"receipt","kind":"receipt-field-equals","pointer":"/completionStatus","expected":"complete"},
+      {"id":"quality","kind":"qualitative","rubric":"Does the answer explain the approval boundary?","critical":true}
+    ]
+  }]
+}
+EOF
+cat >"$PACKAGE/evals/trigger-evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"valid-corpus","cases":[
+  {"id":"positive","query":"Use the valid corpus skill.","shouldTrigger":true,"expectedSkill":"valid-corpus"},
+  {"id":"near-miss","query":"Review this instead.","shouldTrigger":false,"expectedSkill":"woostack-review","conflictsWith":["woostack-review"]}
+]}
+EOF
+expect_valid 'complete supported corpora' valid-corpus 'Package with a complete behavior corpus.' \
+  'SKILL.md:skill,evals/evals.json:eval,evals/fixtures/input.txt:eval,evals/trigger-evals.json:eval,references/guide.md:reference' \
+  1 2
+
+make_package duplicate-case-ids 'description: Corpus with duplicate case identifiers.'
+mkdir -p "$PACKAGE/evals"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"duplicate-case-ids","cases":[
+  {"id":"same-case","prompt":"One","expected":"One","assertions":[{"id":"one","kind":"final-contains","substring":"one"}]},
+  {"id":"same-case","prompt":"Two","expected":"Two","assertions":[{"id":"two","kind":"final-contains","substring":"two"}]}
+]}
+EOF
+expect_invalid 'duplicate corpus IDs' corpus-duplicate-id evals/evals.json /cases/1/id
+
+make_package unsupported-capability 'description: Corpus with an unsupported capability.'
+mkdir -p "$PACKAGE/evals"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"unsupported-capability","cases":[
+  {"id":"network-case","prompt":"Do work","capabilities":["network"],"expected":"No network","assertions":[{"id":"done","kind":"final-contains","substring":"done"}]}
+]}
+EOF
+expect_invalid 'unsupported capability' corpus-unsupported-capability evals/evals.json /cases/0/capabilities/0
+
+make_package unsupported-assertion 'description: Corpus with an unsupported assertion.'
+mkdir -p "$PACKAGE/evals"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"unsupported-assertion","cases":[
+  {"id":"regex-case","prompt":"Do work","expected":"Literal checks","assertions":[{"id":"regex","kind":"final-matches","pattern":"done.*"}]}
+]}
+EOF
+expect_invalid 'unsupported assertion' corpus-unsupported-assertion evals/evals.json /cases/0/assertions/0/kind
+
+make_package missing-fixture 'description: Corpus with a missing fixture.'
+mkdir -p "$PACKAGE/evals"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"missing-fixture","cases":[
+  {"id":"missing-input","prompt":"Read input","fixtures":["missing.txt"],"expected":"Read it","assertions":[{"id":"done","kind":"final-contains","substring":"done"}]}
+]}
+EOF
+expect_invalid 'missing fixture' corpus-fixture-missing evals/evals.json /cases/0/fixtures/0
+
+make_package traversing-fixture 'description: Corpus with a traversing fixture.'
+mkdir -p "$PACKAGE/evals/fixtures"
+printf 'outside\n' >"$PACKAGE/evals/outside.txt"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"traversing-fixture","cases":[
+  {"id":"outside-input","prompt":"Read input","fixtures":["../outside.txt"],"expected":"Reject traversal","assertions":[{"id":"done","kind":"final-contains","substring":"done"}]}
+]}
+EOF
+expect_invalid 'traversing fixture' corpus-fixture-outside evals/evals.json /cases/0/fixtures/0
+
+make_package aliased-fixture 'description: Corpus with a non-normalized fixture alias.'
+mkdir -p "$PACKAGE/evals/fixtures"
+printf 'input\n' >"$PACKAGE/evals/fixtures/input.txt"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"aliased-fixture","cases":[
+  {"id":"aliased-input","prompt":"Read input","fixtures":["input.txt","./input.txt"],"expected":"Reject aliases","assertions":[{"id":"done","kind":"final-contains","substring":"done"}]}
+]}
+EOF
+expect_invalid 'dot-segment fixture alias' corpus-fixture-outside evals/evals.json /cases/0/fixtures/1
+
+make_package aliased-assertion-path 'description: Corpus with a non-normalized assertion path.'
+mkdir -p "$PACKAGE/evals"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"aliased-assertion-path","cases":[
+  {"id":"aliased-output","prompt":"Write output","expected":"Reject aliases","assertions":[{"id":"done","kind":"path-exists","path":"dir/./result.txt"}]}
+]}
+EOF
+expect_invalid 'dot-segment assertion alias' corpus-invalid-path evals/evals.json /cases/0/assertions/0/path
+
+# Package inventory rejects links, non-regular entries, metadata, env, and secret-looking paths.
+make_package symlink-package 'description: Package containing a symlink.'
+ln -s references/guide.md "$PACKAGE/linked-guide.md"
+expect_invalid 'symlink package file' package-symlink linked-guide.md ''
+
+make_package fifo-package 'description: Package containing a FIFO.'
+mkfifo "$PACKAGE/events.pipe"
+expect_invalid 'FIFO package file' package-special-file events.pipe ''
+
+make_package git-metadata 'description: Package containing Git metadata.'
+mkdir -p "$PACKAGE/.git"
+printf 'metadata\n' >"$PACKAGE/.git/config"
+expect_invalid '.git package path' package-forbidden-path .git ''
+
+make_package env-file 'description: Package containing an environment file.'
+printf 'TOKEN=not-a-real-secret\n' >"$PACKAGE/.env.local"
+expect_invalid '.env package path' package-forbidden-path .env.local ''
+
+make_package secret-path 'description: Package containing a secret-looking path.'
+mkdir -p "$PACKAGE/secrets"
+printf 'not-a-real-key\n' >"$PACKAGE/secrets/api-key.txt"
+expect_invalid 'secret-looking package path' package-secret-path secrets/api-key.txt ''
+
+# Tracked-only validation ignores untracked corpora and rejects referenced untracked resources.
+TRACKED_ROOT="$TMP_ROOT/tracked-root"
+mkdir -p "$TRACKED_ROOT"
+git init -q "$TRACKED_ROOT"
+REPOSITORY_ROOT=$TRACKED_ROOT
+TRACKED_ONLY=1
+
+PACKAGE="$TRACKED_ROOT/untracked-corpus"
+mkdir -p "$PACKAGE/evals"
+printf '%s\n' '---' 'name: untracked-corpus' 'description: Ignore an untracked corpus.' '---' '# untracked-corpus' \
+  >"$PACKAGE/SKILL.md"
+git -C "$TRACKED_ROOT" add -- untracked-corpus/SKILL.md
+printf '%s\n' '{"schemaVersion":1,"skill":"untracked-corpus","cases":[]}' >"$PACKAGE/evals/evals.json"
+run_validator
+[ "$STATUS" -eq 0 ] || fail 'untracked corpus should be ignored in tracked-only mode'
+"$NODE" - "$RESULT" <<'NODE'
+const fs = require('node:fs');
+const result = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (
+  result.corpora.behavior.present ||
+  result.files.some(({ path }) => path === 'evals/evals.json')
+) {
+  throw new Error(`untracked corpus leaked into result: ${JSON.stringify(result)}`);
+}
+NODE
+
+PACKAGE="$TRACKED_ROOT/untracked-fixture"
+mkdir -p "$PACKAGE/evals/fixtures"
+printf '%s\n' '---' 'name: untracked-fixture' 'description: Reject an untracked fixture.' '---' '# untracked-fixture' \
+  >"$PACKAGE/SKILL.md"
+cat >"$PACKAGE/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"untracked-fixture","cases":[
+  {"id":"untracked-input","prompt":"Read input","fixtures":["input.txt"],"expected":"Reject it","assertions":[{"id":"done","kind":"final-contains","substring":"done"}]}
+]}
+EOF
+git -C "$TRACKED_ROOT" add -- untracked-fixture/SKILL.md untracked-fixture/evals/evals.json
+printf 'input\n' >"$PACKAGE/evals/fixtures/input.txt"
+expect_invalid 'untracked fixture reference' corpus-fixture-untracked evals/evals.json /cases/0/fixtures/0
+
+PACKAGE="$TRACKED_ROOT/untracked-link"
+mkdir -p "$PACKAGE/references"
+cat >"$PACKAGE/SKILL.md" <<'EOF'
+---
+name: untracked-link
+description: Reject an untracked link target.
+---
+# untracked-link
+
+[Guide](references/guide.md)
+EOF
+git -C "$TRACKED_ROOT" add -- untracked-link/SKILL.md
+printf '# Guide\n' >"$PACKAGE/references/guide.md"
+expect_invalid 'untracked local link target' link-target-untracked SKILL.md /links/0
+
+unset REPOSITORY_ROOT TRACKED_ONLY
+
+# Multiple independent errors pin complete error invariants and path/field/code ordering.
+make_package multiple-errors 'description: Package with two deterministic errors.'
+printf 'TOKEN=not-a-real-secret\n' >"$PACKAGE/.env.local"
+printf '\n[Missing](references/missing.md)\n' >>"$PACKAGE/SKILL.md"
+expect_invalid 'multiple-error invariants' package-forbidden-path .env.local ''
+expect_exact_errors 'multiple sorted errors' \
+  '[{"code":"package-forbidden-path","path":".env.local","field":""},{"code":"link-target-missing","path":"SKILL.md","field":"/links/1"}]'
+
+printf 'PASS: validator package and corpus contracts\n'

--- a/skills/woostack-eval/scripts/tests/test-validate.sh
+++ b/skills/woostack-eval/scripts/tests/test-validate.sh
@@ -331,6 +331,15 @@ make_package missing-link 'description: Package with a missing link.'
 printf '\n[Missing](references/missing.md)\n' >>"$PACKAGE/SKILL.md"
 expect_invalid 'missing local Markdown link' link-target-missing SKILL.md /links/1
 
+make_package code-shaped-link 'description: Package with link-shaped code examples.'
+cat >>"$PACKAGE/SKILL.md" <<'EOF'
+
+`[Inline code](references/missing-inline.md)`
+
+    [Indented code](references/missing-indented.md)
+EOF
+expect_valid 'link-shaped Markdown code is ignored' code-shaped-link 'Package with link-shaped code examples.'
+
 make_package escaping-link 'description: Package with an escaping link.'
 printf '\n[Outside](../../outside.md)\n' >>"$PACKAGE/SKILL.md"
 expect_invalid 'escaping local Markdown link' link-target-outside SKILL.md /links/1

--- a/skills/woostack-eval/scripts/validate.mjs
+++ b/skills/woostack-eval/scripts/validate.mjs
@@ -815,6 +815,39 @@ function normalizeReferenceLabel(value) {
   return markdownUnescape(value).trim().replace(/\s+/g, ' ').toLowerCase();
 }
 
+function stripInlineCodeSpans(line) {
+  let output = '';
+  for (let index = 0; index < line.length;) {
+    if (line[index] === '\\' && index + 1 < line.length) {
+      output += line.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
+    if (line[index] !== '`') {
+      output += line[index];
+      index += 1;
+      continue;
+    }
+
+    let runEnd = index;
+    while (line[runEnd] === '`') runEnd += 1;
+    const marker = line.slice(index, runEnd);
+    let close = runEnd;
+    while ((close = line.indexOf(marker, close)) !== -1) {
+      if (line[close - 1] !== '`' && line[close + marker.length] !== '`') break;
+      close += marker.length;
+    }
+    if (close === -1) {
+      output += marker;
+      index = runEnd;
+      continue;
+    }
+    output += ' '.repeat(close + marker.length - index);
+    index = close + marker.length;
+  }
+  return output;
+}
+
 function extractMarkdownLinks(raw) {
   const lines = markdownContentLines(raw);
   const definitions = new Map();
@@ -831,8 +864,9 @@ function extractMarkdownLinks(raw) {
   });
 
   const links = [];
-  lines.forEach((line, lineIndex) => {
-    if (definitionLines.has(lineIndex)) return;
+  lines.forEach((rawLine, lineIndex) => {
+    if (definitionLines.has(lineIndex) || /^(?: {4}|\t)/.test(rawLine)) return;
+    const line = stripInlineCodeSpans(rawLine);
     for (let index = 0; index < line.length; index += 1) {
       if (line[index] === '\\') {
         index += 1;
@@ -887,6 +921,7 @@ async function validateLinks(packageRoot, repositoryRoot, files, trackedPaths, e
     try {
       raw = await readFile(absolute, 'utf8');
     } catch {
+      addError(errors, 'package-read-error', '', file.path, 'Package file could not be read');
       continue;
     }
     const links = extractMarkdownLinks(raw);

--- a/skills/woostack-eval/scripts/validate.mjs
+++ b/skills/woostack-eval/scripts/validate.mjs
@@ -1,0 +1,1138 @@
+import { createHash } from 'node:crypto';
+import { execFile as execFileCallback } from 'node:child_process';
+import { lstat, readFile, readdir, realpath } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { pathToFileURL } from 'node:url';
+
+const execFile = promisify(execFileCallback);
+const KEBAB_CASE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const CAPABILITIES = new Set(['read-workspace', 'write-workspace', 'shell-workspace']);
+const CORPUS_FILES = new Map([
+  ['evals.json', 'behavior'],
+  ['trigger-evals.json', 'triggers'],
+]);
+const ASSERTION_FIELDS = new Map([
+  ['path-exists', ['path']],
+  ['path-absent', ['path']],
+  ['file-contains', ['file', 'substring']],
+  ['file-excludes', ['file', 'substring']],
+  ['json-path-equals', ['file', 'pointer', 'expected']],
+  ['final-contains', ['substring']],
+  ['final-excludes', ['substring']],
+  ['receipt-field-equals', ['pointer', 'expected']],
+  ['qualitative', ['rubric']],
+]);
+const HTML_TAGS = new Set([
+  'a', 'abbr', 'address', 'article', 'aside', 'audio', 'b', 'blockquote', 'body', 'br',
+  'button', 'canvas', 'caption', 'code', 'col', 'data', 'datalist', 'dd', 'del', 'details',
+  'dialog', 'div', 'dl', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure', 'footer',
+  'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hr', 'html', 'i',
+  'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'legend', 'li', 'link', 'main', 'map',
+  'mark', 'menu', 'meta', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup', 'option',
+  'output', 'p', 'picture', 'pre', 'progress', 'q', 'rp', 'rt', 'ruby', 's', 'samp',
+  'script', 'search', 'section', 'select', 'slot', 'small', 'source', 'span', 'strong',
+  'style', 'sub', 'summary', 'sup', 'svg', 'table', 'tbody', 'td', 'template', 'textarea',
+  'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track', 'u', 'ul', 'var', 'video', 'wbr',
+  'xml',
+]);
+const BEHAVIOR_CASE_FIELDS = new Set([
+  'id', 'prompt', 'fixtures', 'capabilities', 'expected', 'assertions',
+]);
+const TRIGGER_CASE_FIELDS = new Set([
+  'id', 'query', 'shouldTrigger', 'expectedSkill', 'conflictsWith',
+]);
+
+class ValidationFault extends Error {
+  constructor(code, field, message) {
+    super(message);
+    this.code = code;
+    this.field = field;
+  }
+}
+
+function decodeScalar(source, key, file) {
+  const value = source.trim();
+  if (value.startsWith('"')) {
+    if (!value.endsWith('"') || value.length < 2) {
+      throw new ValidationFault('frontmatter-invalid-scalar', `/${key}`, `${file}: unterminated quoted ${key}`);
+    }
+    try {
+      return JSON.parse(value);
+    } catch {
+      throw new ValidationFault('frontmatter-invalid-scalar', `/${key}`, `${file}: invalid quoted ${key}`);
+    }
+  }
+  if (value.startsWith("'")) {
+    if (!value.endsWith("'") || value.length < 2) {
+      throw new ValidationFault('frontmatter-invalid-scalar', `/${key}`, `${file}: unterminated quoted ${key}`);
+    }
+    const inner = value.slice(1, -1);
+    if (inner.replace(/''/g, '').includes("'")) {
+      throw new ValidationFault('frontmatter-invalid-scalar', `/${key}`, `${file}: invalid quoted ${key}`);
+    }
+    return inner.replace(/''/g, "'");
+  }
+  if (key === 'name' || key === 'description') {
+    if (
+      value === '' ||
+      /^[\[{]|^[|>](?:[-+])?$/.test(value) ||
+      /^(?:~|null|true|false|yes|no|on|off)$/i.test(value) ||
+      /^[-+]?(?:(?:0|[1-9][0-9_]*|0o[0-7_]+|0x[0-9a-f_]+|0b[01_]+)|(?:(?:[0-9][0-9_]*)?\.[0-9_]+|[0-9][0-9_]*(?:\.[0-9_]*)?[eE][-+]?[0-9_]+|\.inf|\.nan))$/i.test(value)
+    ) {
+      throw new ValidationFault('frontmatter-non-string-scalar', `/${key}`, `${file}: ${key} must decode as a string`);
+    }
+  }
+  // YAML treats colon followed by whitespace as a mapping token only in a plain scalar.
+  if (key === 'description' && /:\s/.test(value)) {
+    throw new ValidationFault(
+      'frontmatter-plain-colon-space',
+      '/description',
+      `${file}: description contains colon-space in a plain scalar; quote the value`,
+    );
+  }
+  return value;
+}
+
+function containsXmlMarkup(value) {
+  if (/<!--[\s\S]*?-->|<![^>]*>|<\?[^>]*\?>?/.test(value)) return true;
+  if (/<\/[A-Za-z][A-Za-z0-9:-]*\s*>/.test(value)) return true;
+  for (const match of value.matchAll(/<([A-Za-z][A-Za-z0-9:-]*)([^>]*)>/g)) {
+    const [, tag, suffix] = match;
+    if (suffix.trim() || HTML_TAGS.has(tag.toLowerCase())) return true;
+  }
+  return false;
+}
+
+export function parseFrontmatter(raw, file = '<input>') {
+  if (typeof raw !== 'string') throw new TypeError(`${file}: frontmatter source must be a string`);
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(raw);
+  if (!match) throw new ValidationFault('frontmatter-missing', '', `${file}: missing frontmatter`);
+  const fm = {};
+  const seen = new Set();
+  for (const line of match[1].split(/\r?\n/)) {
+    if (!line.trim() || /^\s*#/.test(line) || /^\s+/.test(line)) continue;
+    const field = /^([A-Za-z_][A-Za-z0-9_-]*):(?:[ \t]*(.*))$/.exec(line);
+    if (!field) {
+      throw new ValidationFault('frontmatter-invalid-line', '', `${file}: invalid frontmatter line`);
+    }
+    const [, key, source] = field;
+    if (seen.has(key)) {
+      throw new ValidationFault('frontmatter-duplicate-field', `/${escapePointer(key)}`, `${file}: duplicate frontmatter field ${key}`);
+    }
+    seen.add(key);
+    fm[key] = decodeScalar(source, key, file);
+  }
+  if (!Object.hasOwn(fm, 'name')) {
+    throw new ValidationFault('frontmatter-name-missing', '/name', `${file}: frontmatter missing 'name'`);
+  }
+  if (!Object.hasOwn(fm, 'description')) {
+    throw new ValidationFault('frontmatter-description-missing', '/description', `${file}: frontmatter missing 'description'`);
+  }
+  if (typeof fm.name !== 'string') {
+    throw new ValidationFault('frontmatter-name-non-scalar', '/name', `${file}: name must be a scalar string`);
+  }
+  if (typeof fm.description !== 'string') {
+    throw new ValidationFault('frontmatter-description-non-scalar', '/description', `${file}: description must be a scalar string`);
+  }
+  if (containsXmlMarkup(fm.description)) {
+    throw new ValidationFault(
+      'frontmatter-xml-markup',
+      '/description',
+      `${file}: description contains XML-like markup`,
+    );
+  }
+  return { fm, body: raw.slice(match[0].length) };
+}
+
+function escapePointer(value) {
+  return String(value).replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+function pointer(...parts) {
+  return parts.length ? `/${parts.map(escapePointer).join('/')}` : '';
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+function isContained(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function normalizedRelative(root, candidate) {
+  const relative = path.relative(root, candidate);
+  if (!isContained(root, candidate)) return '';
+  return relative ? toPosix(relative) : '.';
+}
+
+function makeError(code, field, sourcePath, message) {
+  const cleanMessage = String(message)
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, ' ')
+    .trim() || 'Validation failed';
+  return { code, field, path: sourcePath, message: cleanMessage };
+}
+
+function addError(errors, code, field, sourcePath, message) {
+  if (!errors.some((entry) => entry.code === code && entry.field === field && entry.path === sourcePath)) {
+    errors.push(makeError(code, field, sourcePath, message));
+  }
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sortErrors(errors) {
+  errors.sort((left, right) =>
+    compareText(left.path, right.path) ||
+    compareText(left.field, right.field) ||
+    compareText(left.code, right.code));
+  return errors;
+}
+
+async function safeLstat(root, candidate) {
+  if (!isContained(root, candidate)) return { kind: 'outside' };
+  const relative = path.relative(root, candidate);
+  let current = root;
+  if (relative) {
+    for (const part of relative.split(path.sep)) {
+      current = path.join(current, part);
+      let info;
+      try {
+        info = await lstat(current);
+      } catch (error) {
+        if (error?.code === 'ENOENT') return { kind: 'missing' };
+        return { kind: 'unreadable', error };
+      }
+      if (info.isSymbolicLink()) return { kind: 'symlink' };
+    }
+  }
+  try {
+    const info = await lstat(candidate);
+    const resolvedRoot = await realpath(root);
+    const resolvedCandidate = await realpath(candidate);
+    if (!isContained(resolvedRoot, resolvedCandidate)) return { kind: 'outside' };
+    return { kind: info.isFile() ? 'file' : info.isDirectory() ? 'directory' : 'special', info };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { kind: 'missing' };
+    return { kind: 'unreadable', error };
+  }
+}
+
+function isForbiddenPath(relative) {
+  return relative.split('/').some((part) => part === '.git' || /^\.env/.test(part));
+}
+
+function isSecretPath(relative) {
+  return relative.split('/').some((part) => {
+    const normalized = part.toLowerCase().replace(/\.[^.]*$/, '');
+    return /^(?:secrets?|credentials?|private-keys?|api-keys?|access-tokens?|auth-tokens?)$/.test(normalized) ||
+      /(?:^|[-_.])(?:secret|credential|private[-_]?key|api[-_]?key|access[-_]?token|auth[-_]?token)(?:$|[-_.])/.test(normalized);
+  });
+}
+
+function classifyFile(relative) {
+  if (relative === 'SKILL.md') return 'skill';
+  if (relative.startsWith('references/')) return 'reference';
+  if (relative.startsWith('scripts/')) return 'script';
+  if (relative.startsWith('evals/')) return 'eval';
+  return 'asset';
+}
+
+function hashBuffer(buffer) {
+  return `sha256:${createHash('sha256').update(buffer).digest('hex')}`;
+}
+
+function hashManifest(files) {
+  const hash = createHash('sha256');
+  for (const file of files) {
+    const record = Buffer.from(JSON.stringify([file.path, file.type, file.bytes, file.sha256]), 'utf8');
+    hash.update(String(record.length));
+    hash.update(':');
+    hash.update(record);
+    hash.update('\n');
+  }
+  return `sha256:${hash.digest('hex')}`;
+}
+
+async function gitTrackedEntries(repositoryRoot, packageRoot) {
+  const packageRelative = toPosix(path.relative(repositoryRoot, packageRoot));
+  if (!packageRelative || packageRelative === '.' || packageRelative.startsWith('../')) {
+    throw new Error('package must be a repository subdirectory in tracked-only mode');
+  }
+  const { stdout } = await execFile(
+    'git',
+    ['-C', repositoryRoot, 'ls-files', '--stage', '-z', '--', packageRelative],
+    { encoding: 'buffer', maxBuffer: 16 * 1024 * 1024 },
+  );
+  const entries = [];
+  const trackedPaths = new Set();
+  for (const record of stdout.toString('utf8').split('\0')) {
+    if (!record) continue;
+    const tab = record.indexOf('\t');
+    if (tab < 0) throw new Error('Git returned an invalid tracked-file record');
+    const metadata = record.slice(0, tab).split(' ');
+    const repositoryPath = record.slice(tab + 1);
+    if (
+      metadata.length !== 3 ||
+      metadata[2] !== '0' ||
+      !/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/.test(metadata[1]) ||
+      !isContained(packageRelative, repositoryPath) ||
+      trackedPaths.has(repositoryPath)
+    ) {
+      throw new Error('Git returned an unsafe tracked-file record');
+    }
+    trackedPaths.add(repositoryPath);
+    const relative = path.posix.relative(packageRelative, repositoryPath);
+    if (!relative || relative.startsWith('../')) continue;
+    entries.push({ mode: metadata[0], relative });
+  }
+  entries.sort((left, right) => compareText(left.relative, right.relative));
+  return entries;
+}
+
+async function untrackedEntries(packageRoot, errors) {
+  const entries = [];
+  async function visit(directory, prefix) {
+    let children;
+    try {
+      children = await readdir(directory, { withFileTypes: true });
+    } catch {
+      addError(errors, 'package-read-error', '', prefix || '.', 'Package directory could not be read');
+      return;
+    }
+    children.sort((left, right) => compareText(left.name, right.name));
+    for (const child of children) {
+      const relative = prefix ? `${prefix}/${child.name}` : child.name;
+      if (isForbiddenPath(relative)) {
+        addError(errors, 'package-forbidden-path', '', relative, 'Package contains a forbidden metadata or environment path');
+        continue;
+      }
+      if (child.isSymbolicLink()) {
+        addError(errors, 'package-symlink', '', relative, 'Package entries must not be symbolic links');
+        continue;
+      }
+      if (child.isDirectory()) {
+        await visit(path.join(directory, child.name), relative);
+      } else if (isSecretPath(relative)) {
+        addError(errors, 'package-secret-path', '', relative, 'Package contains a secret-looking path');
+      } else if (child.isFile()) {
+        entries.push({ mode: '100644', relative });
+      } else {
+        addError(errors, 'package-special-file', '', relative, 'Package entries must be regular files or directories');
+      }
+    }
+  }
+  await visit(packageRoot, '');
+  return entries;
+}
+
+async function inventoryPackage(packageRoot, repositoryRoot, trackedOnly, errors) {
+  let entries;
+  let safe = true;
+  if (trackedOnly) {
+    try {
+      entries = await gitTrackedEntries(repositoryRoot, packageRoot);
+    } catch {
+      addError(errors, 'package-git-enumeration-failed', '', '', 'Tracked package files could not be enumerated safely');
+      return { files: [], safe: false, trackedPaths: new Set() };
+    }
+    if (!entries.some((entry) => entry.relative === 'SKILL.md')) {
+      addError(errors, 'package-skill-untracked', '', 'SKILL.md', 'Owning SKILL.md is not tracked by Git');
+      safe = false;
+    }
+  } else {
+    const before = errors.length;
+    entries = await untrackedEntries(packageRoot, errors);
+    if (errors.length !== before) safe = false;
+  }
+
+  const files = [];
+  for (const entry of entries) {
+    const relative = entry.relative;
+    if (isForbiddenPath(relative)) {
+      addError(errors, 'package-forbidden-path', '', relative, 'Package contains a forbidden metadata or environment path');
+      safe = false;
+      continue;
+    }
+    if (isSecretPath(relative)) {
+      addError(errors, 'package-secret-path', '', relative, 'Package contains a secret-looking path');
+      safe = false;
+      continue;
+    }
+    if (entry.mode === '120000') {
+      addError(errors, 'package-symlink', '', relative, 'Package entries must not be symbolic links');
+      safe = false;
+      continue;
+    }
+    if (entry.mode !== '100644' && entry.mode !== '100755') {
+      addError(errors, 'package-special-file', '', relative, 'Tracked package entry is not a regular file');
+      safe = false;
+      continue;
+    }
+    const absolute = path.join(packageRoot, ...relative.split('/'));
+    const state = await safeLstat(packageRoot, absolute);
+    if (state.kind !== 'file') {
+      const code = state.kind === 'symlink' ? 'package-symlink' :
+        state.kind === 'special' ? 'package-special-file' : 'package-file-unavailable';
+      addError(errors, code, '', relative, 'Package file must exist as a regular non-symlink file');
+      safe = false;
+      continue;
+    }
+    try {
+      const content = await readFile(absolute);
+      files.push({
+        path: relative,
+        type: classifyFile(relative),
+        bytes: content.byteLength,
+        sha256: hashBuffer(content),
+      });
+    } catch {
+      addError(errors, 'package-read-error', '', relative, 'Package file could not be read');
+      safe = false;
+    }
+  }
+  files.sort((left, right) => compareText(left.path, right.path));
+  return { files, safe, trackedPaths: trackedOnly ? new Set(files.map((file) => file.path)) : null };
+}
+
+function hasOnlyFields(value, allowed, baseField, sourcePath, errors) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      addError(errors, 'corpus-unknown-field', pointer(...baseField, key), sourcePath, `Unknown corpus field ${key}`);
+    }
+  }
+}
+
+function requireString(value, key, baseField, sourcePath, errors, { nonempty = true } = {}) {
+  const field = pointer(...baseField, key);
+  if (!Object.hasOwn(value, key) || typeof value[key] !== 'string') {
+    addError(errors, 'corpus-invalid-type', field, sourcePath, `${key} must be a string`);
+    return null;
+  }
+  if (nonempty && value[key].trim().length === 0) {
+    addError(errors, 'corpus-empty-string', field, sourcePath, `${key} must be non-empty`);
+    return null;
+  }
+  return value[key];
+}
+
+function validateIdentity(value, key, baseField, sourcePath, errors) {
+  const identity = requireString(value, key, baseField, sourcePath, errors);
+  if (identity !== null && !KEBAB_CASE.test(identity)) {
+    addError(errors, 'corpus-invalid-id', pointer(...baseField, key), sourcePath, `${key} must be lower-case kebab-case`);
+  }
+  return identity;
+}
+
+function validateRelativePath(value, field, sourcePath, errors, code = 'corpus-invalid-path') {
+  if (typeof value !== 'string' || !value || value.includes('\\') || path.posix.isAbsolute(value)) {
+    addError(errors, code, field, sourcePath, 'Path must be a non-empty relative POSIX path');
+    return false;
+  }
+  const segments = value.split('/');
+  if (
+    segments.includes('..') ||
+    segments.includes('.') ||
+    segments.includes('') ||
+    value.includes('\0') ||
+    path.posix.normalize(value) !== value
+  ) {
+    addError(errors, code, field, sourcePath, 'Path must be normalized and remain inside its declared root');
+    return false;
+  }
+  return true;
+}
+
+function isJsonPointer(value) {
+  return typeof value === 'string' &&
+    (value === '' || (value.startsWith('/') && !/(?:^|[^~])~(?:[^01]|$)/.test(value)));
+}
+
+function validateUniqueStringArray(value, key, baseField, sourcePath, errors, validateItem) {
+  const field = pointer(...baseField, key);
+  if (!Array.isArray(value)) {
+    addError(errors, 'corpus-invalid-type', field, sourcePath, `${key} must be an array`);
+    return;
+  }
+  const seen = new Set();
+  value.forEach((item, index) => {
+    const itemField = pointer(...baseField, key, index);
+    if (typeof item !== 'string') {
+      addError(errors, 'corpus-invalid-type', itemField, sourcePath, `${key} entries must be strings`);
+      return;
+    }
+    if (seen.has(item)) {
+      addError(errors, 'corpus-duplicate-value', itemField, sourcePath, `${key} entries must be unique`);
+    }
+    seen.add(item);
+    validateItem?.(item, itemField);
+  });
+}
+
+async function validateFixture(fixture, corpusPath, packageRoot, trackedPaths, field, sourcePath, errors) {
+  if (!validateRelativePath(fixture, field, sourcePath, errors, 'corpus-fixture-outside')) return;
+  const fixtureRoot = path.join(path.dirname(corpusPath), 'fixtures');
+  const candidate = path.resolve(fixtureRoot, ...fixture.split('/'));
+  // Check lexical containment before any filesystem lookup, then reject symlinks in every path component.
+  if (!isContained(fixtureRoot, candidate)) {
+    addError(errors, 'corpus-fixture-outside', field, sourcePath, 'Fixture path escapes evals/fixtures');
+    return;
+  }
+  const packageRelative = toPosix(path.relative(packageRoot, candidate));
+  if (trackedPaths && !trackedPaths.has(packageRelative)) {
+    addError(errors, 'corpus-fixture-untracked', field, sourcePath, 'Fixture must be tracked with its owning package');
+    return;
+  }
+  const state = await safeLstat(packageRoot, candidate);
+  if (state.kind === 'outside') {
+    addError(errors, 'corpus-fixture-outside', field, sourcePath, 'Fixture path escapes the package');
+  } else if (state.kind === 'missing') {
+    addError(errors, 'corpus-fixture-missing', field, sourcePath, 'Fixture file does not exist');
+  } else if (state.kind === 'symlink') {
+    addError(errors, 'corpus-fixture-symlink', field, sourcePath, 'Fixture path must not resolve through a symlink');
+  } else if (state.kind !== 'file') {
+    addError(errors, 'corpus-fixture-special-file', field, sourcePath, 'Fixture must be a regular file');
+  }
+}
+
+function validateAssertion(assertion, caseIndex, assertionIndex, sourcePath, errors) {
+  const base = ['cases', caseIndex, 'assertions', assertionIndex];
+  if (!assertion || typeof assertion !== 'object' || Array.isArray(assertion)) {
+    addError(errors, 'corpus-invalid-type', pointer(...base), sourcePath, 'Assertion must be an object');
+    return null;
+  }
+  const id = validateIdentity(assertion, 'id', base, sourcePath, errors);
+  const kind = requireString(assertion, 'kind', base, sourcePath, errors);
+  if (!ASSERTION_FIELDS.has(kind)) {
+    if (kind !== null) {
+      addError(errors, 'corpus-unsupported-assertion', pointer(...base, 'kind'), sourcePath, `Unsupported assertion kind ${kind}`);
+    }
+    return id;
+  }
+  const required = ASSERTION_FIELDS.get(kind);
+  const allowed = new Set(['id', 'kind', 'critical', ...required]);
+  hasOnlyFields(assertion, allowed, base, sourcePath, errors);
+  for (const key of required) {
+    if (!Object.hasOwn(assertion, key)) {
+      addError(errors, 'corpus-missing-field', pointer(...base, key), sourcePath, `Assertion requires ${key}`);
+    }
+  }
+  if (Object.hasOwn(assertion, 'critical') && typeof assertion.critical !== 'boolean') {
+    addError(errors, 'corpus-invalid-critical', pointer(...base, 'critical'), sourcePath, 'critical must be boolean');
+  }
+  for (const key of ['path', 'file']) {
+    if (required.includes(key) && Object.hasOwn(assertion, key)) {
+      validateRelativePath(assertion[key], pointer(...base, key), sourcePath, errors);
+    }
+  }
+  if (required.includes('substring') &&
+      (typeof assertion.substring !== 'string' || assertion.substring.length === 0)) {
+    addError(errors, 'corpus-invalid-substring', pointer(...base, 'substring'), sourcePath, 'substring must be a non-empty string');
+  }
+  if (required.includes('pointer') && !isJsonPointer(assertion.pointer)) {
+    addError(errors, 'corpus-invalid-pointer', pointer(...base, 'pointer'), sourcePath, 'pointer must be an RFC 6901 JSON Pointer');
+  }
+  if (kind === 'qualitative' &&
+      (typeof assertion.rubric !== 'string' || !assertion.rubric.trim() || !assertion.rubric.trim().endsWith('?'))) {
+    addError(errors, 'corpus-invalid-rubric', pointer(...base, 'rubric'), sourcePath, 'rubric must be a non-empty boolean question');
+  }
+  return id;
+}
+
+async function validateBehaviorCase(value, index, corpusPath, packageRoot, trackedPaths, sourcePath, errors) {
+  const base = ['cases', index];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    addError(errors, 'corpus-invalid-type', pointer(...base), sourcePath, 'Behavior case must be an object');
+    return null;
+  }
+  hasOnlyFields(value, BEHAVIOR_CASE_FIELDS, base, sourcePath, errors);
+  const id = validateIdentity(value, 'id', base, sourcePath, errors);
+  requireString(value, 'prompt', base, sourcePath, errors);
+  requireString(value, 'expected', base, sourcePath, errors);
+  if (Object.hasOwn(value, 'capabilities')) {
+    validateUniqueStringArray(value.capabilities, 'capabilities', base, sourcePath, errors, (capability, field) => {
+      if (!CAPABILITIES.has(capability)) {
+        addError(errors, 'corpus-unsupported-capability', field, sourcePath, `Unsupported capability ${capability}`);
+      }
+    });
+  }
+  if (Object.hasOwn(value, 'fixtures')) {
+    if (!Array.isArray(value.fixtures)) {
+      addError(errors, 'corpus-invalid-type', pointer(...base, 'fixtures'), sourcePath, 'fixtures must be an array');
+    } else {
+      const seenFixtures = new Set();
+      for (let fixtureIndex = 0; fixtureIndex < value.fixtures.length; fixtureIndex += 1) {
+        const fixture = value.fixtures[fixtureIndex];
+        const field = pointer(...base, 'fixtures', fixtureIndex);
+        if (typeof fixture !== 'string') {
+          addError(errors, 'corpus-invalid-type', field, sourcePath, 'Fixture paths must be strings');
+          continue;
+        }
+        if (seenFixtures.has(fixture)) {
+          addError(errors, 'corpus-duplicate-value', field, sourcePath, 'Fixture paths must be unique');
+        }
+        seenFixtures.add(fixture);
+        await validateFixture(fixture, corpusPath, packageRoot, trackedPaths, field, sourcePath, errors);
+      }
+    }
+  }
+  if (!Array.isArray(value.assertions)) {
+    addError(errors, 'corpus-invalid-type', pointer(...base, 'assertions'), sourcePath, 'assertions must be a non-empty array');
+  } else if (value.assertions.length === 0) {
+    addError(errors, 'corpus-empty-assertions', pointer(...base, 'assertions'), sourcePath, 'assertions must be non-empty');
+  } else {
+    const assertionIds = new Set();
+    value.assertions.forEach((assertion, assertionIndex) => {
+      const assertionId = validateAssertion(assertion, index, assertionIndex, sourcePath, errors);
+      if (assertionId !== null && assertionIds.has(assertionId)) {
+        addError(
+          errors,
+          'corpus-duplicate-assertion-id',
+          pointer(...base, 'assertions', assertionIndex, 'id'),
+          sourcePath,
+          `Duplicate assertion id ${assertionId}`,
+        );
+      }
+      if (assertionId !== null) assertionIds.add(assertionId);
+    });
+  }
+  return id;
+}
+
+function validateTriggerCase(value, index, sourcePath, errors) {
+  const base = ['cases', index];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    addError(errors, 'corpus-invalid-type', pointer(...base), sourcePath, 'Trigger case must be an object');
+    return null;
+  }
+  hasOnlyFields(value, TRIGGER_CASE_FIELDS, base, sourcePath, errors);
+  const id = validateIdentity(value, 'id', base, sourcePath, errors);
+  requireString(value, 'query', base, sourcePath, errors);
+  if (!Object.hasOwn(value, 'shouldTrigger') || typeof value.shouldTrigger !== 'boolean') {
+    addError(errors, 'corpus-invalid-type', pointer(...base, 'shouldTrigger'), sourcePath, 'shouldTrigger must be boolean');
+  }
+  const expectedSkill = requireString(value, 'expectedSkill', base, sourcePath, errors);
+  if (expectedSkill !== null && expectedSkill !== 'none' && !KEBAB_CASE.test(expectedSkill)) {
+    addError(errors, 'corpus-invalid-skill', pointer(...base, 'expectedSkill'), sourcePath, 'expectedSkill must be a canonical skill name or none');
+  }
+  if (Object.hasOwn(value, 'conflictsWith')) {
+    validateUniqueStringArray(value.conflictsWith, 'conflictsWith', base, sourcePath, errors, (skill, field) => {
+      if (!KEBAB_CASE.test(skill)) {
+        addError(errors, 'corpus-invalid-skill', field, sourcePath, 'conflictsWith entries must be canonical skill names');
+      }
+    });
+  }
+  return id;
+}
+
+export async function validateCorpus(corpusPath, packageInfo) {
+  const absoluteCorpus = path.resolve(corpusPath);
+  const packageRoot = path.resolve(packageInfo?.root ?? packageInfo?.packageRoot ?? path.dirname(path.dirname(absoluteCorpus)));
+  const packageName = packageInfo?.name ?? packageInfo?.package?.name ?? null;
+  const trackedPaths = packageInfo?.trackedPaths ?? null;
+  const sourcePath = normalizedRelative(packageRoot, absoluteCorpus);
+  const kind = CORPUS_FILES.get(path.basename(absoluteCorpus));
+  const errors = [];
+  const result = { present: true, caseCount: 0, errors };
+  if (!kind) {
+    addError(errors, 'corpus-unknown-file', '', sourcePath, 'Corpus filename is not recognized');
+    return { ...result, errors: sortErrors(errors) };
+  }
+  const state = await safeLstat(packageRoot, absoluteCorpus);
+  if (state.kind !== 'file') {
+    const code = state.kind === 'symlink' ? 'corpus-symlink' :
+      state.kind === 'special' ? 'corpus-special-file' : 'corpus-file-missing';
+    addError(errors, code, '', sourcePath, 'Corpus must be a regular non-symlink file');
+    return { ...result, errors: sortErrors(errors) };
+  }
+  let data;
+  try {
+    data = JSON.parse(await readFile(absoluteCorpus, 'utf8'));
+  } catch {
+    addError(errors, 'corpus-invalid-json', '', sourcePath, 'Corpus must contain valid JSON');
+    return { ...result, errors: sortErrors(errors) };
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    addError(errors, 'corpus-invalid-type', '', sourcePath, 'Corpus root must be an object');
+    return { ...result, errors: sortErrors(errors) };
+  }
+  hasOnlyFields(data, new Set(['schemaVersion', 'skill', 'cases']), [], sourcePath, errors);
+  if (data.schemaVersion !== 1) {
+    addError(errors, 'corpus-schema-version', '/schemaVersion', sourcePath, 'schemaVersion must equal 1');
+  }
+  if (typeof data.skill !== 'string') {
+    addError(errors, 'corpus-invalid-type', '/skill', sourcePath, 'skill must be a string');
+  } else if (data.skill !== packageName) {
+    addError(errors, 'corpus-skill-mismatch', '/skill', sourcePath, 'Corpus skill must exactly match package name');
+  }
+  if (!Array.isArray(data.cases)) {
+    addError(errors, 'corpus-invalid-type', '/cases', sourcePath, 'cases must be an array');
+    return { ...result, errors: sortErrors(errors) };
+  }
+  result.caseCount = data.cases.length;
+  const caseIds = new Set();
+  for (let index = 0; index < data.cases.length; index += 1) {
+    const id = kind === 'behavior'
+      ? await validateBehaviorCase(data.cases[index], index, absoluteCorpus, packageRoot, trackedPaths, sourcePath, errors)
+      : validateTriggerCase(data.cases[index], index, sourcePath, errors);
+    if (id !== null && caseIds.has(id)) {
+      addError(errors, 'corpus-duplicate-id', pointer('cases', index, 'id'), sourcePath, `Duplicate case id ${id}`);
+    }
+    if (id !== null) caseIds.add(id);
+  }
+  return { ...result, errors: sortErrors(errors) };
+}
+
+function markdownContentLines(raw) {
+  const lines = [];
+  let fence = null;
+  for (const line of raw.split(/\r?\n/)) {
+    if (fence) {
+      const closing = /^ {0,3}(`{3,}|~{3,})[ \t]*$/.exec(line);
+      if (
+        closing &&
+        closing[1][0] === fence.marker &&
+        closing[1].length >= fence.length
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+    const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (opening && (opening[1][0] !== '`' || !opening[2].includes('`'))) {
+      fence = { marker: opening[1][0], length: opening[1].length };
+      continue;
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+function markdownUnescape(value) {
+  return value.replace(/\\([!\"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, '$1');
+}
+
+function parseMarkdownBracket(line, start) {
+  if (line[start] !== '[') return null;
+  let depth = 1;
+  let value = '';
+  for (let index = start + 1; index < line.length; index += 1) {
+    const character = line[index];
+    if (character === '\\' && index + 1 < line.length) {
+      value += character + line[index + 1];
+      index += 1;
+    } else if (character === '[') {
+      depth += 1;
+      value += character;
+    } else if (character === ']') {
+      depth -= 1;
+      if (depth === 0) return { value, end: index + 1 };
+      value += character;
+    } else {
+      value += character;
+    }
+  }
+  return null;
+}
+
+function parseBareMarkdownDestination(line, start) {
+  let index = start;
+  while (line[index] === ' ' || line[index] === '\t') index += 1;
+  if (line[index] === '<') {
+    let value = '';
+    for (index += 1; index < line.length; index += 1) {
+      if (line[index] === '\\' && index + 1 < line.length) {
+        value += line[index] + line[index + 1];
+        index += 1;
+      } else if (line[index] === '>') {
+        return { target: markdownUnescape(value), end: index + 1 };
+      } else {
+        value += line[index];
+      }
+    }
+    return null;
+  }
+  let depth = 0;
+  let value = '';
+  for (; index < line.length; index += 1) {
+    const character = line[index];
+    if (character === '\\' && index + 1 < line.length) {
+      value += character + line[index + 1];
+      index += 1;
+    } else if (character === '(') {
+      depth += 1;
+      value += character;
+    } else if (character === ')') {
+      if (depth === 0) break;
+      depth -= 1;
+      value += character;
+    } else if ((character === ' ' || character === '\t') && depth === 0) {
+      break;
+    } else {
+      value += character;
+    }
+  }
+  if (!value || depth !== 0) return null;
+  return { target: markdownUnescape(value), end: index };
+}
+
+function parseInlineMarkdownDestination(line, start) {
+  const destination = parseBareMarkdownDestination(line, start + 1);
+  if (!destination) return null;
+  let index = destination.end;
+  const titleSeparated = line[index] === ' ' || line[index] === '\t';
+  while (line[index] === ' ' || line[index] === '\t') index += 1;
+  if (line[index] === ')') return { target: destination.target, end: index + 1 };
+  if (!titleSeparated || !['"', "'", '('].includes(line[index])) return null;
+
+  const opener = line[index];
+  const closer = opener === '(' ? ')' : opener;
+  let depth = 1;
+  for (index += 1; index < line.length; index += 1) {
+    if (line[index] === '\\' && index + 1 < line.length) {
+      index += 1;
+    } else if (opener === '(' && line[index] === opener) {
+      depth += 1;
+    } else if (line[index] === closer) {
+      depth -= 1;
+      if (depth === 0) {
+        index += 1;
+        break;
+      }
+    }
+  }
+  if (depth !== 0) return null;
+  while (line[index] === ' ' || line[index] === '\t') index += 1;
+  if (line[index] !== ')') return null;
+  return { target: destination.target, end: index + 1 };
+}
+
+function normalizeReferenceLabel(value) {
+  return markdownUnescape(value).trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function extractMarkdownLinks(raw) {
+  const lines = markdownContentLines(raw);
+  const definitions = new Map();
+  const definitionLines = new Set();
+  lines.forEach((line, lineIndex) => {
+    const indent = /^( {0,3})/.exec(line)[1].length;
+    const label = parseMarkdownBracket(line, indent);
+    if (!label || line[label.end] !== ':') return;
+    const destination = parseBareMarkdownDestination(line, label.end + 1);
+    if (!destination) return;
+    const identity = normalizeReferenceLabel(label.value);
+    if (identity && !definitions.has(identity)) definitions.set(identity, destination.target);
+    definitionLines.add(lineIndex);
+  });
+
+  const links = [];
+  lines.forEach((line, lineIndex) => {
+    if (definitionLines.has(lineIndex)) return;
+    for (let index = 0; index < line.length; index += 1) {
+      if (line[index] === '\\') {
+        index += 1;
+        continue;
+      }
+      const bracketStart = line[index] === '!' && line[index + 1] === '[' ? index + 1 : index;
+      if (line[bracketStart] !== '[') continue;
+      const label = parseMarkdownBracket(line, bracketStart);
+      if (!label) continue;
+      if (line[label.end] === '(') {
+        const destination = parseInlineMarkdownDestination(line, label.end);
+        if (destination) {
+          links.push(destination.target);
+          index = destination.end - 1;
+        }
+        continue;
+      }
+      let identity = normalizeReferenceLabel(label.value);
+      let end = label.end;
+      if (line[label.end] === '[') {
+        const reference = parseMarkdownBracket(line, label.end);
+        if (!reference) continue;
+        identity = normalizeReferenceLabel(reference.value || label.value);
+        end = reference.end;
+      }
+      if (definitions.has(identity)) {
+        links.push(definitions.get(identity));
+        index = end - 1;
+      }
+    }
+  });
+  return links;
+}
+
+function localLinkTarget(target) {
+  if (!target || target.startsWith('#') || target.startsWith('//')) return null;
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(target)) return null;
+  const withoutFragment = target.replace(/[?#].*$/, '');
+  if (!withoutFragment) return null;
+  try {
+    return decodeURIComponent(withoutFragment);
+  } catch {
+    return withoutFragment;
+  }
+}
+
+async function validateLinks(packageRoot, repositoryRoot, files, trackedPaths, errors) {
+  for (const file of files) {
+    if (!/\.md$/i.test(file.path)) continue;
+    const absolute = path.join(packageRoot, ...file.path.split('/'));
+    let raw;
+    try {
+      raw = await readFile(absolute, 'utf8');
+    } catch {
+      continue;
+    }
+    const links = extractMarkdownLinks(raw);
+    for (let index = 0; index < links.length; index += 1) {
+      const target = localLinkTarget(links[index]);
+      if (target === null) continue;
+      const field = pointer('links', index);
+      if (target.includes('\0') || target.includes('\\')) {
+        addError(errors, 'link-target-outside', field, file.path, 'Local link target is not a safe POSIX path');
+        continue;
+      }
+      const segments = target.split('/');
+      if (
+        segments.includes('.') ||
+        segments.includes('') ||
+        path.posix.normalize(target) !== target
+      ) {
+        addError(errors, 'link-target-not-normalized', field, file.path, 'Local link target must use a normalized POSIX path');
+        continue;
+      }
+      const candidate = path.resolve(path.dirname(absolute), target);
+      if (!isContained(repositoryRoot, candidate)) {
+        addError(errors, 'link-target-outside', field, file.path, 'Local link target escapes the allowed root');
+        continue;
+      }
+      const state = await safeLstat(repositoryRoot, candidate);
+      if (state.kind === 'missing') {
+        addError(errors, 'link-target-missing', field, file.path, 'Local link target does not exist');
+      } else if (state.kind === 'symlink') {
+        addError(errors, 'link-target-symlink', field, file.path, 'Local link target must not resolve through a symlink');
+      } else if (state.kind !== 'file') {
+        addError(errors, 'link-target-not-regular', field, file.path, 'Local link target must be a regular file');
+      }
+      if (
+        state.kind === 'file' &&
+        trackedPaths &&
+        isContained(packageRoot, candidate) &&
+        !trackedPaths.has(toPosix(path.relative(packageRoot, candidate)))
+      ) {
+        addError(errors, 'link-target-untracked', field, file.path, 'In-package link target must be tracked');
+      }
+    }
+  }
+}
+
+async function resolvePackage(packagePath, repositoryRoot, errors) {
+  const input = path.resolve(packagePath);
+  if (!isContained(repositoryRoot, input)) {
+    addError(errors, 'package-outside-root', '', '', 'Package path must remain inside repository root');
+    return null;
+  }
+  const inputState = await safeLstat(repositoryRoot, input);
+  if (inputState.kind === 'symlink') {
+    addError(errors, 'package-symlink', '', normalizedRelative(repositoryRoot, input), 'Package path must not resolve through a symlink');
+    return null;
+  }
+  if (inputState.kind === 'missing') {
+    addError(errors, 'package-not-found', '', normalizedRelative(repositoryRoot, input), 'Package path does not exist');
+    return null;
+  }
+  if (inputState.kind !== 'directory' && inputState.kind !== 'file') {
+    addError(errors, 'package-special-file', '', normalizedRelative(repositoryRoot, input), 'Package path must be a directory or regular SKILL.md');
+    return null;
+  }
+  let packageRoot;
+  if (inputState.kind === 'file') {
+    if (path.basename(input) !== 'SKILL.md') {
+      addError(errors, 'package-not-skill-file', '', normalizedRelative(repositoryRoot, input), 'Package file must be named SKILL.md');
+      return null;
+    }
+    packageRoot = path.dirname(input);
+  } else {
+    packageRoot = input;
+  }
+  const skillPath = path.join(packageRoot, 'SKILL.md');
+  const skillState = await safeLstat(repositoryRoot, skillPath);
+  if (skillState.kind === 'symlink') {
+    addError(errors, 'package-symlink', '', normalizedRelative(packageRoot, skillPath), 'Owning SKILL.md must not be a symlink');
+    return null;
+  }
+  if (skillState.kind === 'missing') {
+    addError(errors, 'package-skill-missing', '', 'SKILL.md', 'Package must contain one owning SKILL.md');
+    return null;
+  }
+  if (skillState.kind !== 'file') {
+    addError(errors, 'package-skill-not-regular', '', 'SKILL.md', 'Owning SKILL.md must be a regular file');
+    return null;
+  }
+  return { packageRoot, skillPath };
+}
+
+export async function validatePackage(packagePath, { repositoryRoot = process.cwd(), trackedOnly = false } = {}) {
+  const root = path.resolve(repositoryRoot);
+  const input = path.resolve(packagePath);
+  const fallbackRoot = path.basename(input) === 'SKILL.md' ? path.dirname(input) : input;
+  const result = {
+    schemaVersion: 1,
+    valid: false,
+    package: {
+      name: null,
+      description: null,
+      path: normalizedRelative(root, fallbackRoot),
+    },
+    files: [],
+    corpora: {
+      behavior: { present: false, caseCount: 0 },
+      triggers: { present: false, caseCount: 0 },
+    },
+    packageHash: null,
+    errors: [],
+  };
+  const rootState = await safeLstat(root, root);
+  if (rootState.kind !== 'directory') {
+    addError(result.errors, 'repository-root-invalid', '', '', 'Repository root must be a readable non-symlink directory');
+    result.errors = sortErrors(result.errors);
+    return result;
+  }
+  const resolved = await resolvePackage(packagePath, root, result.errors);
+  if (!resolved) {
+    result.errors = sortErrors(result.errors);
+    return result;
+  }
+  const { packageRoot, skillPath } = resolved;
+  result.package.path = normalizedRelative(root, packageRoot);
+  const inventory = await inventoryPackage(packageRoot, root, Boolean(trackedOnly), result.errors);
+  result.files = inventory.files;
+  if (inventory.safe) result.packageHash = hashManifest(result.files);
+
+  let parsed;
+  try {
+    parsed = parseFrontmatter(await readFile(skillPath, 'utf8'), 'SKILL.md');
+    result.package.name = parsed.fm.name;
+    result.package.description = parsed.fm.description;
+  } catch (error) {
+    if (error instanceof ValidationFault) {
+      addError(result.errors, error.code, error.field, 'SKILL.md', error.message);
+    } else {
+      addError(result.errors, 'frontmatter-read-error', '', 'SKILL.md', 'Owning SKILL.md could not be read');
+    }
+  }
+  if (parsed) {
+    const { name, description } = parsed.fm;
+    if (!KEBAB_CASE.test(name)) {
+      addError(result.errors, 'frontmatter-name-invalid', '/name', 'SKILL.md', 'name must be lower-case kebab-case');
+    }
+    if (name !== path.basename(packageRoot)) {
+      addError(
+        result.errors,
+        'frontmatter-name-directory-mismatch',
+        '/name',
+        'SKILL.md',
+        'Frontmatter name must exactly match the package directory',
+      );
+    }
+    if (description.length === 0) {
+      addError(result.errors, 'frontmatter-description-empty', '/description', 'SKILL.md', 'description must be non-empty');
+    } else if ([...description].length > 1024) {
+      addError(
+        result.errors,
+        'frontmatter-description-too-long',
+        '/description',
+        'SKILL.md',
+        'description must not exceed 1024 characters',
+      );
+    }
+  }
+
+  await validateLinks(packageRoot, root, result.files, inventory.trackedPaths, result.errors);
+  for (const [filename, summaryKey] of CORPUS_FILES) {
+    const corpusRelative = `evals/${filename}`;
+    if (inventory.trackedPaths && !inventory.trackedPaths.has(corpusRelative)) continue;
+    const corpusPath = path.join(packageRoot, 'evals', filename);
+    const state = await safeLstat(packageRoot, corpusPath);
+    if (state.kind === 'missing') continue;
+    const corpus = await validateCorpus(corpusPath, {
+      root: packageRoot,
+      name: result.package.name,
+      trackedPaths: inventory.trackedPaths,
+    });
+    result.corpora[summaryKey] = { present: true, caseCount: corpus.caseCount };
+    result.errors.push(...corpus.errors);
+  }
+  result.errors = sortErrors(result.errors);
+  result.valid = result.errors.length === 0;
+  return result;
+}
+
+export async function hashPackage(packagePath, { trackedOnly = false } = {}) {
+  const input = path.resolve(packagePath);
+  const packageRoot = path.basename(input) === 'SKILL.md' ? path.dirname(input) : input;
+  let repositoryRoot = path.dirname(packageRoot);
+  if (trackedOnly) {
+    try {
+      const { stdout } = await execFile(
+        'git',
+        ['-C', packageRoot, 'rev-parse', '--show-toplevel'],
+        { encoding: 'utf8', maxBuffer: 1024 * 1024 },
+      );
+      repositoryRoot = stdout.trim();
+    } catch {
+      return null;
+    }
+  }
+  const errors = [];
+  const resolved = await resolvePackage(input, repositoryRoot, errors);
+  if (!resolved) return null;
+  const inventory = await inventoryPackage(resolved.packageRoot, repositoryRoot, Boolean(trackedOnly), errors);
+  return inventory.safe && errors.length === 0 ? hashManifest(inventory.files) : null;
+}
+
+function parseArguments(argv) {
+  const options = { packagePath: null, repositoryRoot: process.cwd(), trackedOnly: false, json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--package' || argument === '--repository-root') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`);
+      if (argument === '--package') options.packagePath = value;
+      else options.repositoryRoot = value;
+      index += 1;
+    } else if (argument === '--tracked-only') {
+      options.trackedOnly = true;
+    } else if (argument === '--json') {
+      options.json = true;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!options.packagePath) throw new Error('--package is required');
+  return options;
+}
+
+async function main(argv) {
+  let options;
+  try {
+    options = parseArguments(argv);
+  } catch (error) {
+    process.stderr.write(`validate.mjs: ${error.message}\n`);
+    process.exitCode = 2;
+    return;
+  }
+  const result = await validatePackage(options.packagePath, options);
+  process.stdout.write(`${JSON.stringify(result, null, options.json ? 0 : 2)}\n`);
+  if (!result.valid) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await main(process.argv.slice(2));
+}


### PR DESCRIPTION
## Goal

Add one deterministic skill-package validation authority and make the docs generator consume its frontmatter parser.

## Summary

- Adds strict package, corpus, path, fixture, receipt-schema, and tracked-only validation with deterministic JSON errors and hashes.
- Handles YAML scalar hazards, safe angle-bracket placeholders, Markdown fences/references/balanced destinations, symlinks, special files, secret paths, and tracked artifact membership.
- Replaces the docs generator's duplicate frontmatter parser with the canonical evaluator export and adds portable contract tests.

## Test plan

### Automated

- [x] `bash skills/woostack-eval/scripts/tests/run-tests.sh` — passed; shared parser and validator package/corpus contracts.
- [x] `node --check skills/woostack-eval/scripts/validate.mjs` — passed.
- [x] `node --test site/scripts/gen-skills.test.mjs` — passed, 14/14.
- [x] `pnpm -C site build` — passed; 25 generated skill pages and 141 static pages.
- [x] `git diff --check` — passed before commit.

### Manual

- [ ] Inspect the machine-readable schema/error contract in `skills/woostack-eval/references/schemas.md`.
- [ ] Confirm advisory prose/size/TOC guidance remains outside fatal validation.
- [ ] Confirm this PR intentionally exposes internal tooling only; public `/woostack-eval` registration lands after the runtime engine.

Plan: `.woostack/plans/2026-07-15-skill-evaluation-optimization.md` — Increment 1

## Final stack verification

### Automated

- [ ] `bash skills/woostack-eval/scripts/tests/run-tests.sh` — passed all 9 evaluator script suites.
- [ ] `bash skills/woostack-eval/scripts/tests/test-critical-corpora.sh` — validated exactly 15 required packages.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-package.sh` — passed 45/45.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-package-ci.sh` — passed 18/18.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-small-diff.sh` — passed 19/19.
- [ ] `bash skills/woostack-review/scripts/tests/test-skills-angle-rubric.sh` — passed 28/28.
- [ ] `bash skills/woostack-review/scripts/tests/test-progressive-disclosure.sh` — passed 190/190.
- [ ] `bash skills/woostack-commit/tests/test-linear-attribution.sh` — passed.
- [ ] `bash skills/woostack-commit/tests/test-progressive-disclosure.sh` — passed.
- [ ] `bash skills/woostack-build/tests/test-linear-build-contract.sh` — passed.
- [ ] `bash skills/woostack-build/scripts/tests/test-build-spec-commit-ordering.sh` — passed.
- [ ] `bash skills/woostack-build/scripts/tests/test-progressive-disclosure.sh` — passed 63/63.
- [ ] `bash skills/using-woostack/tests/test-artifact-reader-contract.sh` — passed 12/12.
- [ ] `bash skills/woostack-change/scripts/tests/test-command-surface.sh` — passed 12/12.
- [ ] `bash skills/woostack-respond/scripts/tests/test-command-surface.sh` — passed 15/15.
- [ ] `node --test site/scripts/gen-skills.test.mjs` — passed 14/14.
- [ ] `pnpm -C site build` — passed; 147 static pages generated.

### Comparative model evidence

- [ ] No model-backed old-versus-candidate run was dispatched: this host cannot prove the evaluator's required per-worker capability isolation. Therefore no receipt or report path exists, and no model-eval pass is claimed.
