### PR TITLE
fix: harden Linear artifact readback

### DIFF
--- a/.woostack/fixes/2026-07-16-linear-artifact-migration-normalization.md
+++ b/.woostack/fixes/2026-07-16-linear-artifact-migration-normalization.md
@@ -1,0 +1,47 @@
+---
+type: fix
+status: executing
+branch: fix/linear-artifact-migration-hardening
+---
+
+# Fix: Harden Linear artifact migration against normalization and partial writes
+
+## 1. Root Cause
+The Linear adapter validates remote write success by comparing local source bytes against fresh remote reads (e.g., `cmp -s` for spec/doc and direct content equality for plan/read-back), so writes that are normalized by Linear are treated as unverified failures even when their IDs/state are correct. This is reproducible in `feature-create`, `spec-write`, and `plan-reconcile` with identical content except for provider-induced list-marker normalization.
+
+`command_issue_transition` updates managed increment metadata and target state in one `issueUpdate` call, but then immediately validates through `normalized_increments`; when managed metadata has a PR URL that Linear rewrites to Markdown-autolink form (`[url](<url>)`), `require_repository_pr_url` rejects it and the command marks the transition as pending. At the same time, state has already been written remotely, so retries can become non-convergent.
+
+`issue-list.graphql` does not request native attachment references, yet attachment-based PR metadata can still be present and merged; `raw_managed_increments` currently derives `pullRequest` only from managed metadata. As a result, `status-reconcile` cannot terminalize an increment when managed metadata is null or rewritten.
+
+Across all paths, receipts do not distinguish `attempted-without-verification` from `written-with-provider-normalized` and thus cannot encode a resumable safe state transition.
+
+## 2. Proposed Fix
+Implement shared, provider-aware normalization and lifecycle classification at the adapter boundaries:
+
+- Add a canonical comparison function that compares submitted vs. observed Linear Markdown via Linear-aware equivalence (newline/border metadata and markdown marker normalization) so semantically equal canonicalized documents verify as equivalent while preserving strict semantic mismatch detection.
+- Normalize PR URLs in managed metadata before validation (only accept explicit same-repository `https://.../pull/<n>` and transform supported Linear autolink forms back to canonical URL) so metadata remains contract-safe regardless of Linear rewrite.
+- Extend issue normalization to include native GitHub PR attachment evidence, merging attachment-derived PR URLs into increment state when managed metadata is absent and rejecting conflicts/ambiguities.
+- Tighten `issue-transition` and related receipt logic to be evidence-first: capture observed remote state/evidence after each mutation, classify outcomes (`attempted`, `attemptedWithUnknown`, `writtenButNormalized`, `verified`), and avoid claiming verified success when only one part verifies.
+
+The shared root for all required changes is `skills/woostack-init/scripts/artifacts` (scripts + GraphQL fixtures + tests).
+
+## 3. Implementation Plan
+- [x] **Step 1: Reproduce with a failing test**
+  - Add/update fixture-based tests for `linear-metadata` and `linear-resources` proving: provider marker normalization, URL autolink normalization, attachment-derived pullRequest handling, and non-retry behavior after partial outcomes.
+  - Ensure failure reproduction is explicit for:
+    - `feature-create`, `spec-write`, and `plan-reconcile` content verification.
+    - `issue-transition --target inReview` with managed autolink PR value.
+    - `status-reconcile` using merged native PR attachment.
+
+- [x] **Step 2: Apply the minimal fix**
+  - Implement one provider-aware content comparison helper in `skills/woostack-init/scripts/artifacts/linear-metadata.py` and apply it in `skills/woostack-init/scripts/artifacts/linear.sh` document and plan read-back points.
+  - Implement managed URL normalization in metadata parsing and require exact repository PR URL shape after normalization.
+  - Extend GraphQL issue listing to retrieve native PR references and fold attachment-derived PRs into `raw_managed_increments`.
+  - Update `command_issue_transition` and plan/reconciliation receipt composition to distinguish attempts, observed outcomes, and full verification.
+
+- [x] **Step 3: Verification**
+  - Run focused adapter test suites:
+    - `skills/woostack-init/scripts/tests/test-linear-metadata.sh`
+    - `skills/woostack-init/scripts/tests/test-linear-resources.sh`
+  - Confirm no byte-only exact-match assertions remain where semantically equivalent provider output should be accepted.
+  - Confirm issue transition now emits a resumable, deterministic receipt when only evidence/read-back normalization is delayed by provider rewrites.

--- a/.woostack/fixes/2026-07-16-linear-artifact-migration-normalization.md
+++ b/.woostack/fixes/2026-07-16-linear-artifact-migration-normalization.md
@@ -1,6 +1,6 @@
 ---
 type: fix
-status: executing
+status: in-review
 branch: fix/linear-artifact-migration-hardening
 ---
 

--- a/skills/woostack-init/scripts/artifacts/graphql/issue-list.graphql
+++ b/skills/woostack-init/scripts/artifacts/graphql/issue-list.graphql
@@ -27,6 +27,10 @@ query WoostackIssueList($projectId: ID!, $after: String) {
         }
         pageInfo { hasNextPage endCursor }
       }
+      attachments(first: 50) {
+        nodes { url }
+        pageInfo { hasNextPage }
+      }
     }
     pageInfo { hasNextPage endCursor }
   }

--- a/skills/woostack-init/scripts/artifacts/linear-metadata.py
+++ b/skills/woostack-init/scripts/artifacts/linear-metadata.py
@@ -165,7 +165,36 @@ def normalize_pull_request(value: Any, repository: str) -> str:
 
 def normalize_content(text: str) -> str:
     normalized = text.replace("\r\n", "\n").replace("\r", "\n")
-    return re.sub(r"^([ \t]*)[+*](?=[ \t]+)", r"\1-", normalized, flags=re.MULTILINE)
+    result: list[str] = []
+    fence_character: str | None = None
+    fence_length = 0
+    for line in normalized.splitlines(keepends=True):
+        content = line.removesuffix("\n")
+        fence = re.match(r"^ {0,3}(?P<marker>`{3,}|~{3,})(?P<rest>.*)$", content)
+        if fence_character is not None:
+            if (
+                fence is not None
+                and fence.group("marker")[0] == fence_character
+                and len(fence.group("marker")) >= fence_length
+                and not fence.group("rest").strip()
+            ):
+                fence_character = None
+                fence_length = 0
+            result.append(line)
+            continue
+        if fence is not None:
+            marker = fence.group("marker")
+            rest = fence.group("rest")
+            if marker[0] == "~" or "`" not in rest:
+                fence_character = marker[0]
+                fence_length = len(marker)
+                result.append(line)
+                continue
+        if re.fullmatch(r" {0,3}\*(?:[ \t]*\*){2,}[ \t]*", content):
+            result.append(line)
+            continue
+        result.append(re.sub(r"^( {0,3})[+*](?=[ \t]+)", r"\1-", line))
+    return "".join(result)
 
 
 def normalize_content_fields(value: Any) -> Any:

--- a/skills/woostack-init/scripts/artifacts/linear-metadata.py
+++ b/skills/woostack-init/scripts/artifacts/linear-metadata.py
@@ -17,6 +17,9 @@ HEADER_RE = re.compile(rf"^{re.escape(HEADER)}(?:\r?\n|$)", re.MULTILINE)
 CLOSER_RE = re.compile(r"^\+\+\+(?:\r?\n|$)", re.MULTILINE)
 SCHEMA = 1
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+PR_URL_RE = re.compile(
+    r"^https://github\.com/(?P<repository>[^/\s]+/[^/\s]+)/pull/(?P<number>[1-9][0-9]*)$"
+)
 GIT_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 UUID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-"
@@ -129,6 +132,55 @@ def canonical_json(value: Any) -> str:
         raise MetadataError("JSON value cannot be canonicalized") from error
 
 
+def normalize_pull_request(value: Any, repository: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise MetadataError("pull request evidence is invalid")
+
+    urls: list[str]
+    canonical = PR_URL_RE.fullmatch(value)
+    if canonical is not None:
+        urls = [value]
+    else:
+        linked = re.fullmatch(
+            r"\[(?P<label>https://github\.com/[^\s<>]+)\]\("
+            r"(?P<target><https://github\.com/[^\s<>]+>|https://github\.com/[^\s<>]+)\)",
+            value,
+        )
+        angle = re.fullmatch(r"<(?P<url>https://github\.com/[^\s<>]+)>", value)
+        if linked is not None:
+            target = linked.group("target")
+            urls = [linked.group("label"), target[1:-1] if target.startswith("<") else target]
+        elif angle is not None:
+            urls = [angle.group("url")]
+        else:
+            raise MetadataError("pull request evidence is foreign or invalid")
+
+    if len(set(urls)) != 1:
+        raise MetadataError("pull request evidence is foreign or invalid")
+    match = PR_URL_RE.fullmatch(urls[0])
+    if match is None or match.group("repository") != repository:
+        raise MetadataError("pull request evidence is foreign or invalid")
+    return urls[0]
+
+
+def normalize_content(text: str) -> str:
+    normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+    return re.sub(r"^([ \t]*)[+*](?=[ \t]+)", r"\1-", normalized, flags=re.MULTILINE)
+
+
+def normalize_content_fields(value: Any) -> Any:
+    pending = [value]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, dict):
+            if isinstance(current.get("content"), str):
+                current["content"] = normalize_content(current["content"])
+            pending.extend(current.values())
+        elif isinstance(current, list):
+            pending.extend(current)
+    return value
+
+
 def require_nonempty_string(value: Any, message: str) -> str:
     if not isinstance(value, str) or not value:
         raise MetadataError(message)
@@ -208,15 +260,15 @@ def validate_metadata(value: Any) -> dict[str, Any]:
             or len(dependencies) != len(set(dependencies))
         ):
             raise MetadataError("increment metadata is invalid")
-        git_parent = require_nonempty_string(
-            value.get("gitParent"), "increment metadata is invalid"
-        )
+        require_nonempty_string(value.get("gitParent"), "increment metadata is invalid")
         for key in ("branch", "pullRequest"):
             if key in value and not optional_string(value[key]):
                 raise MetadataError("increment metadata is invalid")
+        if value.get("pullRequest") is not None:
+            value["pullRequest"] = normalize_pull_request(
+                value["pullRequest"], value["repository"]
+            )
     return value
-
-
 def managed_section(text: str) -> tuple[int, int, str, dict[str, Any]]:
     headers = list(HEADER_RE.finditer(text))
     if not headers:
@@ -246,9 +298,10 @@ def managed_section(text: str) -> tuple[int, int, str, dict[str, Any]]:
     if "\n" in json_text or "\r" in json_text or not json_text:
         raise MetadataError("managed metadata block is malformed")
 
-    value = validate_metadata(load_json(json_text, "managed metadata JSON is malformed"))
-    if json_text != canonical_json(value):
+    raw_value = load_json(json_text, "managed metadata JSON is malformed")
+    if json_text != canonical_json(raw_value):
         raise MetadataError("managed metadata JSON is not canonical")
+    value = validate_metadata(raw_value)
     return header.end(), closer.start(), newline, value
 
 
@@ -309,6 +362,49 @@ def command_body(args: argparse.Namespace) -> None:
     if before.endswith(("\r\n", "\n")) and after.startswith(("\r\n", "\n")):
         after = after[2:] if after.startswith("\r\n") else after[1:]
     sys.stdout.write(before + after)
+
+
+def read_text_file(path: str, message: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise MetadataError(message) from error
+
+
+def command_compare(args: argparse.Namespace) -> None:
+    expected = normalize_content(read_text_file(args.expected_file, "expected content could not be read"))
+    observed = normalize_content(read_text_file(args.observed_file, "observed content could not be read"))
+    raise SystemExit(0 if expected == observed else 1)
+
+
+def command_normalize_content(args: argparse.Namespace) -> None:
+    _, text = read_stdin()
+    sys.stdout.write(normalize_content(text))
+
+
+def command_normalize_plan(args: argparse.Namespace) -> None:
+    _, text = read_stdin()
+    value = load_json(text, "plan JSON is malformed")
+    if not isinstance(value, list):
+        raise MetadataError("plan JSON must be an array")
+    print(canonical_json(normalize_content_fields(value)))
+
+
+def command_normalize_pr(args: argparse.Namespace) -> None:
+    _, text = read_stdin()
+    print(normalize_pull_request(text.rstrip("\r\n"), args.repository))
+
+
+def command_normalize_prs(args: argparse.Namespace) -> None:
+    _, text = read_stdin()
+    value = load_json(text, "pull request evidence JSON is malformed")
+    if not isinstance(value, list):
+        raise MetadataError("pull request evidence must be an array")
+    for item in value:
+        if not isinstance(item, dict) or "url" not in item:
+            raise MetadataError("pull request evidence is invalid")
+        item["url"] = normalize_pull_request(item["url"], args.repository)
+    print(canonical_json(value))
 
 
 def read_replacement(args: argparse.Namespace) -> dict[str, Any]:
@@ -665,6 +761,25 @@ def build_parser() -> argparse.ArgumentParser:
     body_parser.add_argument("--repository")
     body_parser.add_argument("--project-id")
     body_parser.set_defaults(handler=command_body)
+
+    compare_parser = subparsers.add_parser("compare")
+    compare_parser.add_argument("--expected-file", required=True)
+    compare_parser.add_argument("--observed-file", required=True)
+    compare_parser.set_defaults(handler=command_compare)
+
+    normalize_content_parser = subparsers.add_parser("normalize-content")
+    normalize_content_parser.set_defaults(handler=command_normalize_content)
+
+    normalize_plan_parser = subparsers.add_parser("normalize-plan")
+    normalize_plan_parser.set_defaults(handler=command_normalize_plan)
+
+    normalize_pr_parser = subparsers.add_parser("normalize-pr")
+    normalize_pr_parser.add_argument("--repository", required=True)
+    normalize_pr_parser.set_defaults(handler=command_normalize_pr)
+
+    normalize_prs_parser = subparsers.add_parser("normalize-prs")
+    normalize_prs_parser.add_argument("--repository", required=True)
+    normalize_prs_parser.set_defaults(handler=command_normalize_prs)
 
     replace_parser = subparsers.add_parser("replace")
     replacement = replace_parser.add_mutually_exclusive_group(required=True)

--- a/skills/woostack-init/scripts/artifacts/linear.sh
+++ b/skills/woostack-init/scripts/artifacts/linear.sh
@@ -801,12 +801,12 @@ command_feature_create() {
         fi
       fi
       if ! projects="$(project_list)"; then
-        jq -cn --argjson returned "$returned_project" '{attempted:["projectCreate"],observed:{project:null,document:null},returned:{project:$returned,document:null},verified:false,pending:["project-read-back"]}'
+        jq -cn --argjson returned "$returned_project" '{attempted:["projectCreate"],observed:{project:null,document:null},returned:{project:$returned,document:null},outcome:"attemptedWithUnknown",verified:false,pending:["project-read-back"]}'
         return 1
       fi
       set +e; project="$(resolve_from_list "$projects" "$repository" "$status_map" "$ACTIVE_STATUSES" '')"; resolve_rc=$?; set -e
       if [[ "$resolve_rc" -ne 0 ]]; then
-        jq -cn --argjson returned "$returned_project" '{attempted:["projectCreate"],observed:{project:null,document:null},returned:{project:$returned,document:null},verified:false,pending:["project-discovery"]}'
+        jq -cn --argjson returned "$returned_project" '{attempted:["projectCreate"],observed:{project:null,document:null},returned:{project:$returned,document:null},outcome:"attemptedWithUnknown",verified:false,pending:["project-discovery"]}'
         return 1
       fi
       ;;
@@ -828,7 +828,7 @@ command_feature_create() {
       fi
       if ! documents="$(document_list "$project_id")"; then
         rm -f "$expected_file"
-        jq -cn --arg project "$project_id" --argjson returned "$returned_document" '{attempted:["documentCreate"],observed:{project:$project,document:null},returned:{project:null,document:$returned},verified:false,pending:["document-read-back"]}'
+        jq -cn --arg project "$project_id" --argjson returned "$returned_document" '{attempted:["documentCreate"],observed:{project:$project,document:null},returned:{project:null,document:$returned},outcome:"attemptedWithUnknown",verified:false,pending:["document-read-back"]}'
         return 1
       fi
       set +e; doc="$(find_spec "$project_id" "$repository" "$documents")"; doc_rc=$?; set -e
@@ -914,7 +914,7 @@ command_spec_write() {
   fi
   if ! documents="$(document_list "$project_id")"; then
     rm -f "$expected_file"
-    jq -cn --argjson returned "$returned" '{attempted:["documentUpdate"],observed:{document:null},returned:{document:$returned},verified:false,pending:["document-read-back"]}'
+    jq -cn --argjson returned "$returned" '{attempted:["documentUpdate"],observed:{document:null},returned:{document:$returned},outcome:(if $returned==null then "attemptedWithUnknown" else "attempted" end),verified:false,pending:["document-read-back"]}'
     return 1
   fi
   set +e; readback="$(find_spec "$project_id" "$repository" "$documents")"; readback_rc=$?; set -e

--- a/skills/woostack-init/scripts/artifacts/linear.sh
+++ b/skills/woostack-init/scripts/artifacts/linear.sh
@@ -80,12 +80,32 @@ owned_project() {
   jq -c '.[0]' <<<"$matches"
 }
 
+normalize_repository_pr_url() {
+  local repository="$1" url="$2"
+  python3 "$METADATA" normalize-pr --repository "$repository" <<<"$url" 2>/dev/null ||
+    fail "pull request evidence is foreign or invalid"
+}
+
 require_repository_pr_url() {
-  local repository="$1" url="$2" prefix number
-  prefix="https://github.com/$repository/pull/"
-  [[ "$url" == "$prefix"* ]] || fail "pull request evidence is foreign or invalid"
-  number="${url#"$prefix"}"
-  [[ "$number" =~ ^[1-9][0-9]*$ ]] || fail "pull request evidence is foreign or invalid"
+  normalize_repository_pr_url "$1" "$2" >/dev/null
+}
+
+content_files_equivalent() {
+  python3 "$METADATA" compare --expected-file "$1" --observed-file "$2"
+}
+
+content_json_equivalent() {
+  local expected="$1" observed="$2" expected_file observed_file result
+  expected_file="$(mktemp)"
+  observed_file="$(mktemp)"
+  jq -j '.content' <<<"$expected" >"$expected_file"
+  jq -j '.content' <<<"$observed" >"$observed_file"
+  set +e
+  content_files_equivalent "$expected_file" "$observed_file"
+  result=$?
+  set -e
+  rm -f "$expected_file" "$observed_file"
+  return "$result"
 }
 
 
@@ -281,7 +301,11 @@ issue_list() {
         (.relations.nodes|type=="array") and
         (((.relations.pageInfo.hasNextPage // false))|type=="boolean") and
         (.inverseRelations.nodes|type=="array") and
-        (((.inverseRelations.pageInfo.hasNextPage // false))|type=="boolean")
+        (((.inverseRelations.pageInfo.hasNextPage // false))|type=="boolean") and
+        (.attachments == null or (
+          (.attachments.nodes|type)=="array" and
+          .attachments.pageInfo.hasNextPage==false
+        ))
       )
     ' >/dev/null 2>&1 <<<"$response" || fail "issue list response is invalid"
     page='[]'
@@ -301,7 +325,9 @@ issue_list() {
 }
 
 raw_managed_increments() {
-  local issues="$1" project_id="$2" repository="$3" issue_map="$4" enforce_ordinal_cardinality="${5:-true}" tmp result='[]' node description metadata body native_refs semantic item pr branch
+  local issues="$1" project_id="$2" repository="$3" issue_map="$4" enforce_ordinal_cardinality="${5:-true}"
+  local tmp result='[]' node description metadata body native_refs semantic item pr branch
+  local attachment_url normalized_attachment attachment_prs effective_pr
   tmp="$(mktemp -d)"
   while IFS= read -r node; do
     description="$(jq -r '.description // ""' <<<"$node")"
@@ -311,11 +337,30 @@ raw_managed_increments() {
     [[ "$(jq -r '.artifactType' <<<"$metadata")" == increment ]] || { rm -rf "$tmp"; fail "managed issue metadata has the wrong artifact type"; }
     pr="$(jq -r '.pullRequest // empty' <<<"$metadata")"
     branch="$(jq -r '.branch // empty' <<<"$metadata")"
+    attachment_prs='[]'
+    while IFS= read -r attachment_url; do
+      [[ "$attachment_url" == *github.com/*/pull/* ]] || continue
+      normalized_attachment="$(normalize_repository_pr_url "$repository" "$attachment_url")"
+      attachment_prs="$(jq -cn --argjson urls "$attachment_prs" --arg url "$normalized_attachment" '$urls+[$url]|unique|sort')"
+    done < <(jq -r '.attachments.nodes[]?.url? // empty' <<<"$node")
     if [[ -n "$pr" ]]; then
       [[ -n "$branch" ]] || { rm -rf "$tmp"; fail "pull request metadata requires a branch"; }
-      require_repository_pr_url "$repository" "$pr"
+      if ! jq -e --arg pr "$pr" 'all(.[]; .==$pr)' >/dev/null <<<"$attachment_prs"; then
+        [[ "$(jq 'length' <<<"$attachment_prs")" -eq 0 ]] || { rm -rf "$tmp"; fail "managed issue pull request metadata conflicts with native attachment evidence"; }
+      fi
+      effective_pr="$pr"
+    else
+      case "$(jq 'length' <<<"$attachment_prs")" in
+        0) effective_pr='' ;;
+        1) effective_pr="$(jq -r '.[0]' <<<"$attachment_prs")" ;;
+        *) rm -rf "$tmp"; fail "managed issue has ambiguous native pull request attachment evidence" ;;
+      esac
     fi
-    body="$(python3 "$METADATA" body --repository "$repository" --project-id "$project_id" <"$tmp/description" 2>/dev/null)" || { rm -rf "$tmp"; fail "managed increment content is invalid"; }
+    python3 "$METADATA" body --repository "$repository" --project-id "$project_id" <"$tmp/description" >"$tmp/body" 2>/dev/null ||
+      { rm -rf "$tmp"; fail "managed increment content is invalid"; }
+    body="$(cat "$tmp/body")"
+    printf '%s' "$body" | python3 "$METADATA" normalize-content >"$tmp/body-normalized" ||
+      { rm -rf "$tmp"; fail "managed increment content normalization failed"; }
     native_refs="$(jq -c '
       [
         (.blockedBy.nodes[]?.id),
@@ -331,7 +376,7 @@ raw_managed_increments() {
     ' >/dev/null 2>&1 <<<"$node" || { rm -rf "$tmp"; fail "managed issue has a cross-project relation"; }
     semantic="$(jq -r --arg state "$(jq -r '.state.id' <<<"$node")" 'to_entries | map(select(.value==$state)) | if length==1 then .[0].key else "" end' <<<"$issue_map")"
     [[ -n "$semantic" ]] || { rm -rf "$tmp"; fail "managed issue has an unmapped state"; }
-    item="$(jq -cn --argjson issue "$node" --argjson metadata "$metadata" --argjson native "$native_refs" --arg status "$semantic" --arg content "$body" '
+    item="$(jq -cn --argjson issue "$node" --argjson metadata "$metadata" --argjson native "$native_refs" --arg status "$semantic" --arg content "$body" --rawfile normalizedContent "$tmp/body-normalized" --arg pullRequest "$effective_pr" '
       {
         id:$issue.id,
         identifier:$issue.identifier,
@@ -342,8 +387,9 @@ raw_managed_increments() {
         nativeDependencies:$native,
         gitParent:$metadata.gitParent,
         branch:($metadata.branch // null),
-        pullRequest:($metadata.pullRequest // null),
+        pullRequest:(if $pullRequest=="" then null else $pullRequest end),
         content:$content,
+        contentNormalized:$normalizedContent,
         title:$issue.title,
         url:$issue.url,
         incrementId:$metadata.incrementId
@@ -366,13 +412,13 @@ raw_managed_increments() {
 }
 
 normalized_increments() {
-  local project_id="$1" repository="$2" issue_map="$3" issues raw
+  local project_id="$1" repository="$2" issue_map="$3" include_content="${4:-false}" issues raw
   issues="$(issue_list "$project_id")" || fail "issue discovery failed"
   raw="$(raw_managed_increments "$issues" "$project_id" "$repository" "$issue_map")"
-  jq -ce '
+  jq -ce --argjson includeContent "$include_content" '
     if any(.[]; .dependencies!=.nativeDependencies)
     then error("native blocked-by relations disagree with managed metadata")
-    else map(del(.nativeDependencies,.projectId))
+    else map(del(.nativeDependencies,.projectId) | if $includeContent then . else del(.contentNormalized) end)
     end
   ' <<<"$raw" || fail "native blocked-by relations disagree with managed metadata"
 }
@@ -737,7 +783,7 @@ command_feature_resolve() {
 
 command_feature_create() {
   local repository='' title='' team_id='' status_map='' spec_file='' projects project='' project_attempted=false returned_project=null
-  local documents doc='' document_attempted=false returned_document=null expected_file observed_file variables response attempted observed pending='[]' verified
+  local documents doc='' document_attempted=false returned_document=null expected_file observed_file variables response attempted observed pending='[]' verified normalized=false
   while [[ $# -gt 0 ]]; do case "$1" in
     --repository) repository="$2"; shift 2;; --title) title="$2"; shift 2;; --team-id) team_id="$2"; shift 2;;
     --status-map) status_map="$2"; shift 2;; --spec-file) spec_file="$2"; shift 2;; *) usage;; esac; done
@@ -794,7 +840,10 @@ command_feature_create() {
   observed="$(jq -cn --arg project "$project_id" --arg document "${doc:+$(jq -r '.id' <<<"$doc")}" '{project:$project,document:(if $document=="" then null else $document end)}')"
   if [[ -n "$doc" ]]; then
     observed_file="$(mktemp)"; jq -j '.content' <<<"$doc" >"$observed_file"
-    cmp -s "$expected_file" "$observed_file" || pending="$(jq -c '.+["document-content-verification"]' <<<"$pending")"
+    if ! cmp -s "$expected_file" "$observed_file"; then
+      content_files_equivalent "$expected_file" "$observed_file" && normalized=true ||
+        pending="$(jq -c '.+["document-content-verification"]' <<<"$pending")"
+    fi
     rm -f "$observed_file"
   fi
   rm -f "$expected_file"
@@ -811,7 +860,7 @@ command_feature_create() {
     fi
   fi
   verified=false; [[ "$(jq 'length' <<<"$pending")" -eq 0 ]] && verified=true
-  jq -cn --argjson attempted "$attempted" --argjson observed "$observed" --argjson rp "$returned_project" --argjson rd "$returned_document" --argjson verified "$verified" --argjson pending "$pending" '{attempted:$attempted,observed:$observed,returned:{project:$rp,document:$rd},verified:$verified,pending:$pending}'
+  jq -cn --argjson attempted "$attempted" --argjson observed "$observed" --argjson rp "$returned_project" --argjson rd "$returned_document" --argjson verified "$verified" --argjson normalized "$normalized" --argjson pending "$pending" '{attempted:$attempted,observed:$observed,returned:{project:$rp,document:$rd},outcome:(if $verified and $normalized then "writtenButNormalized" elif $verified then "verified" elif ($attempted|length)>0 then "attemptedWithUnknown" else "attempted" end),verified:$verified,pending:$pending}'
   [[ "$verified" == true ]]
 }
 
@@ -825,7 +874,7 @@ command_spec_read() {
 }
 
 command_spec_write() {
-  local project_id='' repository='' content_file='' expected='' issue_map='' documents doc current expected_file current_file replacement_metadata increments evidence response returned=null readback='' observed_file verified=false pending='[]'
+  local project_id='' repository='' content_file='' expected='' issue_map='' documents doc current expected_file current_file replacement_metadata increments evidence response returned=null readback='' observed_file verified=false normalized=false pending='[]'
   while [[ $# -gt 0 ]]; do case "$1" in --project) project_id="$2"; shift 2;; --repository) repository="$2"; shift 2;;
     --content-file) content_file="$2"; shift 2;; --expected-revision) expected="$2"; shift 2;;
     --issue-state-map) issue_map="$2"; shift 2;; *) usage;; esac; done
@@ -873,15 +922,18 @@ command_spec_write() {
     pending='["document-discovery"]'
   else
     observed_file="$(mktemp)"; jq -j '.content' <<<"$readback" >"$observed_file"
-    cmp -s "$expected_file" "$observed_file" || pending="$(jq -c '.+["document-content-verification"]' <<<"$pending")"
+    if ! cmp -s "$expected_file" "$observed_file"; then
+      content_files_equivalent "$expected_file" "$observed_file" && normalized=true ||
+        pending="$(jq -c '.+["document-content-verification"]' <<<"$pending")"
+    fi
     rm -f "$observed_file"
     [[ "$(jq -r '.id' <<<"$readback")" == "$(jq -r '.id' <<<"$doc")" ]] || pending="$(jq -c '.+["document-identity-verification"]' <<<"$pending")"
     if [[ "$returned" != null && "$(jq -r '.id' <<<"$returned")" != "$(jq -r '.id' <<<"$readback")" ]]; then pending="$(jq -c '.+["document-return-mismatch"]' <<<"$pending")"; fi
   fi
   rm -f "$expected_file"
   [[ "$(jq 'length' <<<"$pending")" -eq 0 ]] && verified=true
-  jq -cn --arg id "${readback:+$(jq -r '.id' <<<"$readback")}" --argjson returned "$returned" --argjson verified "$verified" --argjson pending "$pending" \
-    '{attempted:["documentUpdate"],observed:{document:(if $id=="" then null else $id end)},returned:{document:$returned},verified:$verified,pending:$pending}'
+  jq -cn --arg id "${readback:+$(jq -r '.id' <<<"$readback")}" --argjson returned "$returned" --argjson verified "$verified" --argjson normalized "$normalized" --argjson pending "$pending" \
+    '{attempted:["documentUpdate"],observed:{document:(if $id=="" then null else $id end)},returned:{document:$returned},outcome:(if $verified and $normalized then "writtenButNormalized" elif $verified then "verified" elif $returned==null then "attemptedWithUnknown" else "attempted" end),verified:$verified,pending:$pending}'
   [[ "$verified" == true ]]
 }
 
@@ -1055,7 +1107,9 @@ command_issue_transition() {
   [[ -n "$issue_ref" && -n "$target" ]] || usage
   jq -e --arg target "$target" 'has($target)' >/dev/null 2>&1 <<<"$issue_map" || fail "unknown issue state"
   [[ "$target" != "done" ]] || fail "done requires verified merge attribution through status-reconcile"
-  [[ -z "$pull_request" ]] || require_repository_pr_url "$repository" "$pull_request"
+  if [[ -n "$pull_request" ]]; then
+    pull_request="$(normalize_repository_pr_url "$repository" "$pull_request")"
+  fi
   [[ -z "$pull_request" || -n "$branch" ]] || fail "pull request attribution requires a branch"
   owned_project "$project_id" "$repository" >/dev/null
   issues="$(issue_list "$project_id")" || fail "issue discovery failed"
@@ -1106,12 +1160,12 @@ command_issue_transition() {
   fi
   [[ "$verified" == true ]] || pending='["issue-status-or-evidence-verification"]'
   jq -cn --arg current "$current" --arg target "$target" --arg id "$(jq -r '.id // empty' <<<"$readback")" --argjson returned "$returned" --argjson verified "$verified" --argjson pending "$pending" \
-    '{current:$current,target:$target,attempted:["issueUpdate"],completed:(if $verified then ["issueUpdate"] else [] end),observed:{issue:(if $id=="" then null else $id end)},returned:{issue:$returned},verified:$verified,pending:$pending}'
+    '{current:$current,target:$target,attempted:["issueUpdate"],completed:(if $verified then ["issueUpdate"] else [] end),observed:{issue:(if $id=="" then null else $id end)},returned:{issue:$returned},outcome:(if $verified then "verified" elif $returned==null then "attemptedWithUnknown" else "attempted" end),verified:$verified,pending:$pending}'
   [[ "$verified" == true ]]
 }
 
 command_status_reconcile() {
-  local project_id='' repository='' status_map='' issue_map='' prs_file=''
+  local project_id='' repository='' status_map='' issue_map='' prs_file='' prs_json=''
   local expected_eligible='' expected_project_transition='' expected_snapshot=''
   local increments eligible eligible_ids inc response after projects project project_semantic current_project_semantic
   local observed_snapshot all_done should_project project_verified=false non_target_ok
@@ -1128,6 +1182,8 @@ command_status_reconcile() {
   require_uuid "$project_id" "project id"; require_repository "$repository"
   validate_status_map "$status_map"; validate_issue_state_map "$issue_map"
   [[ -r "$prs_file" ]] || fail "pull request evidence file is unreadable"
+  prs_json="$(python3 "$METADATA" normalize-prs --repository "$repository" <"$prs_file")" ||
+    fail "pull request evidence is invalid or foreign"
   jq -e '
     type=="array" and length==(unique|length) and
     all(.[]; type=="string" and test("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"))
@@ -1153,7 +1209,7 @@ command_status_reconcile() {
       (.url|ltrimstr($prefix)|test("^[1-9][0-9]*$")) and
       (.merged|type=="boolean")
     )
-  ' >/dev/null 2>&1 "$prs_file" || fail "pull request evidence is invalid or foreign"
+  ' >/dev/null 2>&1 <<<"$prs_json" || fail "pull request evidence is invalid or foreign"
 
   project="$(owned_project "$project_id" "$repository")"
   project_semantic="$(jq -r --arg state "$(jq -r '.status.id' <<<"$project")" \
@@ -1185,12 +1241,11 @@ command_status_reconcile() {
         .url==$issue.pullRequest and .merged==true
       )] | length)==1
     )
-  ' >/dev/null 2>&1 "$prs_file" \
+  ' >/dev/null 2>&1 <<<"$prs_json" \
     || fail "pull request attribution pair is missing, duplicate, or foreign; or done evidence is unmerged"
-
-  eligible="$(jq -cn --arg project "$project_id" --argjson increments "$increments" --slurpfile evidence "$prs_file" '
+  eligible="$(jq -cn --arg project "$project_id" --argjson increments "$increments" --argjson evidence "$prs_json" '
     [$increments[] | select(.status=="inReview") | . as $issue |
-      [$evidence[0][] | select(
+      [$evidence[] | select(
         .projectId==$project and .issueIdentifier==$issue.identifier and
         .url==$issue.pullRequest and .merged==true
       )] | select(length==1) | $issue]
@@ -1201,7 +1256,7 @@ command_status_reconcile() {
   all_done=false
   if [[ "$(jq 'length' <<<"$increments")" -gt 0 ]] &&
      jq -e 'all(.[]; .status=="done")' >/dev/null <<<"$increments"; then all_done=true; fi
-  [[ "$project_semantic" != done || "$all_done" == true ]] \
+  [[ "$project_semantic" != "done" || "$all_done" == true ]] \
     || fail "project and managed issue terminal states are inconsistent"
   should_project=false
   if [[ "$project_semantic" == inReview && "$(jq 'length' <<<"$increments")" -gt 0 ]] &&
@@ -1211,7 +1266,7 @@ command_status_reconcile() {
   [[ "$should_project" == "$expected_project_transition" ]] \
     || fail "project transition preview drifted before mutation"
 
-  if [[ "$project_semantic" == done ]]; then
+  if [[ "$project_semantic" == "done" ]]; then
     [[ "$(jq 'length' <<<"$eligible_ids")" -eq 0 && "$expected_project_transition" == false ]] \
       || fail "done project cannot carry pending terminal writes"
     jq -cn --arg id "$project_id" \
@@ -1319,7 +1374,7 @@ compose_increment_description() {
 
 command_plan_reconcile() {
   local project_id='' repository='' team_id='' issue_map='' plan_file='' desired current issues uuid_map observed match removed inc stable id dep_ids parent old metadata description variables response returned response_valid
-  local attempted='[]' completed='[]' pending='[]' mutation_responses='[]' current_relations desired_relations rel key final expected verified=false
+  local attempted='[]' completed='[]' pending='[]' mutation_responses='[]' current_relations desired_relations rel key final expected verified=false normalized=false
   while [[ $# -gt 0 ]]; do case "$1" in
     --project) project_id="$2"; shift 2;; --repository) repository="$2"; shift 2;;
     --team-id) team_id="$2"; shift 2;; --issue-state-map) issue_map="$2"; shift 2;;
@@ -1358,7 +1413,7 @@ command_plan_reconcile() {
     then error("unrepresentable Git ancestry") else . end |
     if any(.[]; . as $item | any($item.dependencies[]; . as $dependency | item($dependency).ordinal >= $item.ordinal))
     then error("dependency must precede dependent ordinal") else . end
-  ' "$plan_file" 2>/dev/null)" || fail "desired increment plan is invalid"
+  ' "$plan_file" 2>/dev/null | python3 "$METADATA" normalize-plan)" || fail "desired increment plan is invalid"
 
   owned_project "$project_id" "$repository" >/dev/null
   issues="$(issue_list "$project_id")" || fail "issue discovery failed"
@@ -1421,7 +1476,7 @@ command_plan_reconcile() {
       old="$(jq -c --arg stable "$stable" '[.[]|select(.incrementId==$stable)] | if length==1 then .[0] else null end' <<<"$current")"
       [[ "$old" != null ]] || continue
       if jq -e --argjson old "$old" --argjson desired "$inc" --argjson dependencies "$dep_ids" --arg parent "$parent" '
-        $old.title==$desired.title and $old.content==$desired.content and
+        $old.title==$desired.title and $old.contentNormalized==$desired.content and
         $old.ordinal==$desired.ordinal and $old.dependencies==$dependencies and
         $old.gitParent==$parent
       ' >/dev/null; then continue; fi
@@ -1470,26 +1525,32 @@ command_plan_reconcile() {
   fi
 
   set +e
-  final="$(normalized_increments "$project_id" "$repository" "$issue_map" 2>/dev/null)"
+  final="$(normalized_increments "$project_id" "$repository" "$issue_map" true 2>/dev/null)"
   final_rc=$?
   set -e
   if [[ "$final_rc" -eq 0 ]]; then
     expected="$(jq -cn --argjson desired "$desired" --argjson ids "$uuid_map" '
       [$desired[] | . as $item | {
-        id:$ids[.incrementId],incrementId,ordinal,title,content,
+        id:$ids[.incrementId],incrementId,ordinal,title,content,contentNormalized:.content,
         dependencies:([.dependencies[] | $ids[.]] | sort),
         gitParent:(if $ids[.gitParent] then $ids[.gitParent] else .gitParent end)
       }] | sort_by(.ordinal,.id)
     ')"
     if jq -e --argjson expected "$expected" '
-      map({id,incrementId,ordinal,title,content,dependencies,gitParent}) == $expected
-    ' >/dev/null <<<"$final"; then verified=true; else pending="$(jq -c '.+["final-plan-verification"]' <<<"$pending")"; fi
+      map({id,incrementId,ordinal,title,contentNormalized,dependencies,gitParent}) ==
+      ($expected | map({id,incrementId,ordinal,title,contentNormalized,dependencies,gitParent}))
+    ' >/dev/null <<<"$final"; then
+      verified=true
+      if jq -e --argjson desired "$desired" '
+        any(.[]; . as $got | any($desired[]; .incrementId==$got.incrementId and .content!=$got.content))
+      ' >/dev/null <<<"$final"; then normalized=true; fi
+    else pending="$(jq -c '.+["final-plan-verification"]' <<<"$pending")"; fi
   else pending="$(jq -c '.+["final-dag-verification"]' <<<"$pending")"; fi
   operation_status="$(jq -cn --argjson mutations "$mutation_responses" --argjson final "${final:-[]}" --argjson desired "$desired" --argjson ids "$uuid_map" '
     def issue_ok($stable):
       ([ $desired[] | select(.incrementId==$stable) ][0]) as $want |
       ([ $final[] | select(.incrementId==$stable) ][0]) as $got |
-      ($got != null and $got.title==$want.title and $got.content==$want.content and
+      ($got != null and $got.title==$want.title and $got.contentNormalized==$want.content and
        $got.ordinal==$want.ordinal and
        $got.dependencies==([$want.dependencies[] | $ids[.]] | sort) and
        $got.gitParent==(if $ids[$want.gitParent] then $ids[$want.gitParent] else $want.gitParent end));
@@ -1510,13 +1571,15 @@ command_plan_reconcile() {
   ')"
   completed="$(jq -c '.completed' <<<"$operation_status")"
   pending="$(jq -cn --argjson existing "$pending" --argjson operations "$(jq -c '.pending' <<<"$operation_status")" '$existing+$operations|unique')"
-  jq -cn --argjson desired "$desired" --argjson uuidMap "$uuid_map" --argjson attempted "$attempted" --argjson completed "$completed" --argjson pending "$pending" --argjson mutations "$mutation_responses" --argjson final "${final:-null}" --argjson relations "${desired_relations:-[]}" --argjson verified "$verified" '
+  jq -cn --argjson desired "$desired" --argjson uuidMap "$uuid_map" --argjson attempted "$attempted" --argjson completed "$completed" --argjson pending "$pending" --argjson mutations "$mutation_responses" --argjson final "${final:-null}" --argjson relations "${desired_relations:-[]}" --argjson verified "$verified" --argjson normalized "$normalized" '
     {
       intended:{operations:$attempted,increments:[$desired[]|{incrementId,ordinal,dependencies,gitParent}]},
       observed:{issueIds:($uuidMap|to_entries|map({incrementId:.key,id:.value})),relations:$relations},
       returned:{mutations:$mutations},
       readBack:{increments:(if ($final|type)=="array" then [$final[]|{id,incrementId,ordinal,dependencies,gitParent,status}] else null end),dagVerified:$verified},
-      attempted:$attempted,completed:$completed,pending:$pending,remainingSubsteps:$pending,verified:$verified
+      attempted:$attempted,completed:$completed,pending:$pending,remainingSubsteps:$pending,
+      outcome:(if $verified and $normalized then "writtenButNormalized" elif $verified then "verified" elif ($attempted|length)>0 then "attemptedWithUnknown" else "attempted" end),
+      verified:$verified
     }'
   [[ "$verified" == true && "$(jq 'length' <<<"$pending")" -eq 0 ]]
 }

--- a/skills/woostack-init/scripts/tests/test-linear-metadata.sh
+++ b/skills/woostack-init/scripts/tests/test-linear-metadata.sh
@@ -42,6 +42,29 @@ assert_eq "$RUN_STDOUT" "$canonical" "Linear-normalized parse emits canonical JS
 printf '%b' '+++ Woostack metadata — managed, do not edit\r\n\r\n{"artifactType":"spec","projectId":"project-123","repository":"acme/widgets","schema":1,"state":"approved"}\r\n\r\n+++\r\n' >"$TMP/linear-normalized-crlf.md"
 run_metadata "$TMP/linear-normalized-crlf.md" parse
 assert_exit 0 "$RUN_RC" "CRLF Linear-normalized managed metadata parses"
+
+autolink='[https://github.com/acme/widgets/pull/11](<https://github.com/acme/widgets/pull/11>)'
+{
+  printf '%s\n\n' '+++ Woostack metadata — managed, do not edit'
+  jq -cnS --arg pr "$autolink" \
+    '{artifactType:"increment",branch:"feature/eng-11",dependencies:[],gitParent:"main",incrementId:"track-a",ordinal:1,projectId:"project-123",pullRequest:$pr,repository:"acme/widgets",schema:1}'
+  printf '\n%s\n' '+++'
+} >"$TMP/autolink.md"
+run_metadata "$TMP/autolink.md" parse --repository acme/widgets --project-id project-123
+assert_exit 0 "$RUN_RC" "Linear PR autolink metadata parses"
+assert_eq "$(jq -r '.pullRequest' <<<"$RUN_STDOUT")" \
+  "https://github.com/acme/widgets/pull/11" \
+  "Linear PR autolink metadata normalizes to the canonical repository URL"
+
+printf '%s\n' '* first' '  + nested' >"$TMP/provider-markers.md"
+printf '%s\n' '- first' '  - nested' >"$TMP/canonical-markers.md"
+run_metadata "$TMP/provider-markers.md" compare \
+  --expected-file "$TMP/canonical-markers.md" --observed-file "$TMP/provider-markers.md"
+assert_exit 0 "$RUN_RC" "provider list-marker normalization compares equivalent"
+printf '%s\n' '- different' >"$TMP/different-markers.md"
+run_metadata "$TMP/provider-markers.md" compare \
+  --expected-file "$TMP/different-markers.md" --observed-file "$TMP/provider-markers.md"
+assert_exit 1 "$RUN_RC" "provider content comparison preserves semantic mismatches"
 for invalid_padding in \
   $'+++ Woostack metadata — managed, do not edit\n\n{"artifactType":"spec","projectId":"project-123","repository":"acme/widgets","schema":1}\n+++\n' \
   $'+++ Woostack metadata — managed, do not edit\n{"artifactType":"spec","projectId":"project-123","repository":"acme/widgets","schema":1}\n\n+++\n' \

--- a/skills/woostack-init/scripts/tests/test-linear-metadata.sh
+++ b/skills/woostack-init/scripts/tests/test-linear-metadata.sh
@@ -65,6 +65,33 @@ printf '%s\n' '- different' >"$TMP/different-markers.md"
 run_metadata "$TMP/provider-markers.md" compare \
   --expected-file "$TMP/different-markers.md" --observed-file "$TMP/provider-markers.md"
 assert_exit 1 "$RUN_RC" "provider content comparison preserves semantic mismatches"
+cat >"$TMP/literal-markers-expected.md" <<'EOF'
+```text
+- fenced
+```
+    - indented
+~~~
+- tilde fenced
+~~~
+EOF
+cat >"$TMP/literal-markers-observed.md" <<'EOF'
+```text
+* fenced
+```
+    * indented
+~~~
+* tilde fenced
+~~~
+EOF
+run_metadata "$TMP/literal-markers-observed.md" compare \
+  --expected-file "$TMP/literal-markers-expected.md" \
+  --observed-file "$TMP/literal-markers-observed.md"
+assert_exit 1 "$RUN_RC" "provider normalization preserves fenced and indented code markers"
+printf '%s\n' '- * *' >"$TMP/list-item-asterisks.md"
+printf '%s\n' '* * *' >"$TMP/thematic-break.md"
+run_metadata "$TMP/thematic-break.md" compare \
+  --expected-file "$TMP/list-item-asterisks.md" --observed-file "$TMP/thematic-break.md"
+assert_exit 1 "$RUN_RC" "provider normalization preserves thematic breaks"
 for invalid_padding in \
   $'+++ Woostack metadata — managed, do not edit\n\n{"artifactType":"spec","projectId":"project-123","repository":"acme/widgets","schema":1}\n+++\n' \
   $'+++ Woostack metadata — managed, do not edit\n{"artifactType":"spec","projectId":"project-123","repository":"acme/widgets","schema":1}\n\n+++\n' \

--- a/skills/woostack-init/scripts/tests/test-linear-resources.sh
+++ b/skills/woostack-init/scripts/tests/test-linear-resources.sh
@@ -222,6 +222,8 @@ assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "false" "failed project read-back 
 assert_eq "$(jq -c '.pending' <<<"$OUTPUT")" '["project-read-back"]' "failed project read-back has a precise pending reason"
 assert_not_contains "$OUTPUT" "Acceptance body." "failed project read-back receipt excludes spec content"
 assert_eq "$(grep -c $'mutation\tproject-create' "$work/calls")" "1" "failed project read-back never retries project create"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attemptedWithUnknown" \
+  "failed project-create read-back classifies an unknown attempted mutation"
 
 reset_fake
 queue project-list project-list-one.json 1
@@ -234,6 +236,18 @@ assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "false" "failed document read-back
 assert_eq "$(jq -c '.pending' <<<"$OUTPUT")" '["document-read-back"]' "failed document read-back has a precise pending reason"
 assert_not_contains "$OUTPUT" "Acceptance body." "failed document read-back receipt excludes spec content"
 assert_eq "$(grep -c $'mutation\tdocument-create' "$work/calls")" "1" "failed document read-back never retries document create"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attemptedWithUnknown" \
+  "failed document-create read-back classifies an unknown attempted mutation"
+reset_fake
+queue project-list project-list-one.json 1
+queue document-list document-list-updated.json 1
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' \
+  --team-id "$team_id" --status-map "$status_map" --spec-file "$work/spec.md"
+assert_exit 1 "$RC" "existing mismatched spec stays unverified without a mutation"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attempted" \
+  "feature create classifies an unverified no-mutation attempt"
+assert_not_contains "$(cat "$work/calls")" $'mutation\t' \
+  "existing mismatched spec performs no mutation"
 
 # Partial completion resumes existing project and document without duplicate mutation.
 reset_fake
@@ -294,6 +308,18 @@ assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "false" "failed spec read-back is 
 assert_eq "$(jq -c '.pending' <<<"$OUTPUT")" '["document-read-back"]' "failed spec read-back has a precise pending reason"
 assert_not_contains "$OUTPUT" "Revised body." "failed spec read-back receipt excludes spec content"
 assert_eq "$(grep -c $'mutation\tdocument-update' "$work/calls")" "1" "failed spec read-back never retries document update"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attemptedWithUnknown" \
+  "failed spec read-back classifies an unknown update outcome"
+reset_fake
+queue document-list document-list-one.json 1
+queue document-update document-update-success.json 1
+queue document-list document-list-updated.json 2
+touch "$work/responses/document-list.2.fail"
+run_capture spec-write --project "$project_id" --repository acme/widgets \
+  --content-file "$work/revised.md" --expected-revision "$revision"
+assert_exit 1 "$RC" "failed spec read-back after a returned update stays unverified"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attempted" \
+  "spec write distinguishes a returned update from an unknown mutation outcome"
 
 reset_fake; queue document-list document-list-updated.json 1
 run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
@@ -990,6 +1016,15 @@ run_capture plan-read --project "$project_id" --repository acme/widgets \
   --issue-state-map "$issue_state_map"
 assert_exit 1 "$RC" "ambiguous native PR evidence fails closed"
 assert_contains "$OUTPUT" "ambiguous" "ambiguous PR evidence has a safe diagnostic"
+jq '.data.issues.nodes[0].attachments.pageInfo.hasNextPage=true' \
+  "$FIXTURES/issue-list-valid.json" >"$work/issue-list-truncated-attachments.json"
+reset_fake
+cp "$work/issue-list-truncated-attachments.json" "$work/responses/issue-list.1.json"
+run_capture plan-read --project "$project_id" --repository acme/widgets \
+  --issue-state-map "$issue_state_map"
+assert_exit 1 "$RC" "truncated native PR attachment evidence fails closed"
+assert_contains "$OUTPUT" "issue discovery failed" \
+  "truncated attachment evidence has a safe diagnostic"
 
 # Metadata/native relation disagreement blocks rather than guessing.
 reset_fake; queue issue-list issue-list-relation-drift.json 1
@@ -1110,6 +1145,18 @@ assert_not_contains "$(cat "$work/calls")" $'mutation\t' \
   "provider-equivalent plan content performs no issue mutation"
 assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "writtenButNormalized" \
   "plan reconciliation classifies provider-normalized readback"
+reset_fake
+queue project-list project-list-one.json 1
+for count in 1 2 3; do
+  cp "$work/issue-list-provider-normalized.json" "$work/responses/issue-list.$count.json"
+done
+touch "$work/responses/issue-list.3.fail"
+run_capture plan-reconcile --project "$project_id" --repository acme/widgets \
+  --team-id "$team_id" --issue-state-map "$issue_state_map" \
+  --plan-file "$work/reconcile-provider-plan.json"
+assert_exit 1 "$RC" "failed final plan read-back stays unverified without a mutation"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attempted" \
+  "plan reconciliation classifies an unverified no-mutation attempt"
 
 # Relation repair can resume from metadata/native drift left by an unknown
 # relation outcome. Initial discovery tolerates only that drift; final readback
@@ -1123,6 +1170,8 @@ assert_exit 1 "$RC" "failed relation repair remains pending after strict readbac
 assert_eq "$(grep -c $'mutation\trelation-create' "$work/calls")" "1" "failed relation repair is attempted once"
 assert_not_contains "$(cat "$work/calls")" $'mutation\tissue-' "failed relation repair does not duplicate converged issue writes"
 assert_contains "$(jq -r '.pending|join(",")' <<<"$OUTPUT")" "final-dag-verification" "relation drift fails strict final DAG verification"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attemptedWithUnknown" \
+  "failed relation repair classifies an attempted unknown outcome"
 reset_fake; queue project-list project-list-one.json 1
 cp "$work/issue-list-relation-drift-resume.json" "$work/responses/issue-list.1.json"
 cp "$work/issue-list-relation-drift-resume.json" "$work/responses/issue-list.2.json"
@@ -1171,6 +1220,29 @@ assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" true \
   "autolink-normalized issue evidence is fully verified"
 assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "verified" \
   "autolink normalization produces a fully verified transition outcome"
+reset_fake
+queue project-list project-list-one.json 1
+queue issue-list issue-list-executing.json 1
+queue issue-update issue-update-success.json 1
+queue issue-list issue-list-executing.json 2
+run_capture issue-transition --project "$project_id" --repository acme/widgets \
+  --issue ENG-11 --issue-state-map "$issue_state_map" --target inReview \
+  --branch feature/eng-11 --pull-request https://github.com/acme/widgets/pull/11
+assert_exit 1 "$RC" "issue transition rejects an unchanged returned update"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attempted" \
+  "issue transition classifies a returned but unverified update"
+reset_fake
+queue project-list project-list-one.json 1
+queue issue-list issue-list-executing.json 1
+queue issue-update issue-update-success.json 1
+touch "$work/responses/issue-update.1.fail"
+queue issue-list issue-list-executing.json 2
+run_capture issue-transition --project "$project_id" --repository acme/widgets \
+  --issue ENG-11 --issue-state-map "$issue_state_map" --target inReview \
+  --branch feature/eng-11 --pull-request https://github.com/acme/widgets/pull/11
+assert_exit 1 "$RC" "issue transition rejects an unchanged unknown update"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "attemptedWithUnknown" \
+  "issue transition classifies an unverified unknown update"
 
 reset_fake; queue project-list project-list-one.json 1; queue issue-list issue-list-executing.json 1
 run_capture issue-transition --project "$project_id" --repository acme/widgets --issue ENG-11 --issue-state-map "$issue_state_map" --target inReview

--- a/skills/woostack-init/scripts/tests/test-linear-resources.sh
+++ b/skills/woostack-init/scripts/tests/test-linear-resources.sh
@@ -170,6 +170,23 @@ assert_eq "$(jq -r '.input.projectId' <<<"$document_create_variables")" "$projec
 assert_contains "$(jq -r '.input.content' <<<"$document_create_variables")" "Acceptance body." "document create sends exact source content"
 assert_contains "$(jq -r '.input.content' <<<"$document_create_variables")" '"repository":"acme/widgets"' "document create appends canonical spec ownership"
 
+# Linear may rewrite Markdown list markers while preserving the document.
+printf '# Feature Alpha\n\n- Provider-normalized item.\n' >"$work/provider-spec.md"
+printf '# Feature Alpha\n\n* Provider-normalized item.\n\n+++ Woostack metadata — managed, do not edit\n{"artifactType":"spec","designState":"draft","projectId":"%s","repository":"acme/widgets","schema":1}\n+++\n' \
+  "$project_id" >"$work/provider-spec-observed.md"
+make_document_list "$work/provider-document-list.json" "$work/provider-spec-observed.md" \
+  '2026-07-12T10:04:00.000Z'
+reset_fake
+queue project-list project-list-one.json 1
+cp "$work/provider-document-list.json" "$work/responses/document-list.1.json"
+run_capture feature-create --repository acme/widgets --title 'Feature Alpha' \
+  --team-id "$team_id" --status-map "$status_map" --spec-file "$work/provider-spec.md"
+assert_exit 0 "$RC" "feature create resumes across provider list-marker normalization"
+assert_not_contains "$(cat "$work/calls")" $'mutation\t' \
+  "provider-normalized existing spec needs no duplicate mutation"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "writtenButNormalized" \
+  "feature create classifies provider-normalized readback"
+
 # Unknown mutation outcome is discovered and resumed without repeating the mutation.
 reset_fake
 queue project-list project-list-none.json 1
@@ -246,6 +263,22 @@ assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "true" "spec update is read-back v
 document_update_variables="$(call_variables document-update 1)"
 assert_eq "$(jq -r '.id' <<<"$document_update_variables")" "dddddddd-dddd-4ddd-8ddd-dddddddddddd" "document update targets the managed spec"
 assert_contains "$(jq -r '.input.content' <<<"$document_update_variables")" "Revised body." "document update sends revised content"
+printf '# Feature Alpha\n\n- Revised item.\n\n+++ Woostack metadata — managed, do not edit\n{"artifactType":"spec","designState":"draft","projectId":"%s","repository":"acme/widgets","schema":1}\n+++\n' \
+  "$project_id" >"$work/revised-list.md"
+sed 's/- Revised item./* Revised item./' "$work/revised-list.md" >"$work/revised-list-observed.md"
+make_document_list "$work/revised-list-document.json" "$work/revised-list-observed.md" \
+  '2026-07-12T10:05:00.000Z'
+reset_fake
+queue document-list document-list-one.json 1
+queue document-update document-update-success.json 1
+cp "$work/revised-list-document.json" "$work/responses/document-list.2.json"
+run_capture spec-write --project "$project_id" --repository acme/widgets \
+  --content-file "$work/revised-list.md" --expected-revision "$revision"
+assert_exit 0 "$RC" "spec write verifies provider-normalized list markers"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" true \
+  "provider-normalized spec write remains fully verified"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "writtenButNormalized" \
+  "spec write classifies provider-normalized readback"
 reset_fake; queue document-list document-list-one.json 1; queue document-update document-update-success.json 1; touch "$work/responses/document-update.1.fail"; queue document-list document-list-updated.json 2
 run_capture spec-write --project "$project_id" --repository acme/widgets --content-file "$work/revised.md" --expected-revision "$revision"
 assert_exit 0 "$RC" "unknown spec update outcome resumes by read-back"
@@ -923,6 +956,41 @@ assert_eq "$(jq -r '[.increments[] | select(.dependencies|length==0)] | length' 
 assert_eq "$(jq -r '.increments[2].dependencies[0]' <<<"$OUTPUT")" "cccccccc-0001-4000-8000-000000000001" "native blocked-by UUID is normalized"
 assert_eq "$(jq -r '.increments[2].gitParent' <<<"$OUTPUT")" "cccccccc-0001-4000-8000-000000000001" "one representable Git parent is retained"
 
+jq '
+  .data.issues.nodes[0].description |= (
+    sub("\"branch\":null"; "\"branch\":\"feature/eng-11\"") |
+    sub("\"pullRequest\":null"; "\"pullRequest\":\"https://github.com/acme/widgets/pull/11\"")
+  ) |
+  .data.issues.nodes[0].attachments={
+    nodes:[{url:"https://github.com/acme/widgets/pull/99"}],
+    pageInfo:{hasNextPage:false}
+  }
+' "$FIXTURES/issue-list-valid.json" >"$work/issue-list-conflicting-pr.json"
+reset_fake
+cp "$work/issue-list-conflicting-pr.json" "$work/responses/issue-list.1.json"
+run_capture plan-read --project "$project_id" --repository acme/widgets \
+  --issue-state-map "$issue_state_map"
+assert_exit 1 "$RC" "conflicting metadata and native PR evidence fails closed"
+assert_contains "$OUTPUT" "conflicts" "conflicting PR evidence has a safe diagnostic"
+
+jq '
+  .data.issues.nodes[0].description |=
+    sub("\"pullRequest\":\"https://github.com/acme/widgets/pull/11\""; "\"pullRequest\":null") |
+  .data.issues.nodes[0].attachments={
+    nodes:[
+      {url:"https://github.com/acme/widgets/pull/11"},
+      {url:"https://github.com/acme/widgets/pull/12"}
+    ],
+    pageInfo:{hasNextPage:false}
+  }
+' "$FIXTURES/issue-list-valid.json" >"$work/issue-list-ambiguous-pr.json"
+reset_fake
+cp "$work/issue-list-ambiguous-pr.json" "$work/responses/issue-list.1.json"
+run_capture plan-read --project "$project_id" --repository acme/widgets \
+  --issue-state-map "$issue_state_map"
+assert_exit 1 "$RC" "ambiguous native PR evidence fails closed"
+assert_contains "$OUTPUT" "ambiguous" "ambiguous PR evidence has a safe diagnostic"
+
 # Metadata/native relation disagreement blocks rather than guessing.
 reset_fake; queue issue-list issue-list-relation-drift.json 1
 run_capture plan-read --project "$project_id" --repository acme/widgets --issue-state-map "$issue_state_map"
@@ -1024,6 +1092,25 @@ assert_eq "$(grep -c $'mutation\tissue-create' "$work/calls")" "1" "create misma
 assert_not_contains "$(cat "$work/calls")" $'mutation\tissue-update' "create mismatch stops before issue update"
 assert_not_contains "$(cat "$work/calls")" $'mutation\trelation-' "create mismatch stops before relation mutation"
 
+# Plan verification uses the same provider-aware Markdown equivalence as specs.
+jq '.increments[0].content="- normalized item"' "$work/reconcile-plan.json" \
+  >"$work/reconcile-provider-plan.json"
+jq '.data.issues.nodes[0].description |= sub("New A\\."; "* normalized item")' \
+  "$FIXTURES/issue-list-reconcile-final.json" >"$work/issue-list-provider-normalized.json"
+reset_fake
+queue project-list project-list-one.json 1
+for count in 1 2 3; do
+  cp "$work/issue-list-provider-normalized.json" "$work/responses/issue-list.$count.json"
+done
+run_capture plan-reconcile --project "$project_id" --repository acme/widgets \
+  --team-id "$team_id" --issue-state-map "$issue_state_map" \
+  --plan-file "$work/reconcile-provider-plan.json"
+assert_exit 0 "$RC" "plan reconciliation verifies provider-normalized list markers"
+assert_not_contains "$(cat "$work/calls")" $'mutation\t' \
+  "provider-equivalent plan content performs no issue mutation"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "writtenButNormalized" \
+  "plan reconciliation classifies provider-normalized readback"
+
 # Relation repair can resume from metadata/native drift left by an unknown
 # relation outcome. Initial discovery tolerates only that drift; final readback
 # remains strict and keeps the failed repair pending.
@@ -1062,7 +1149,28 @@ transition_metadata="$(jq -r '.input.description' <<<"$transition_variables" | p
 assert_eq "$(jq -r '.branch' <<<"$transition_metadata")" "feature/eng-11" "branch is stored in managed issue metadata"
 assert_eq "$(jq -r '.pullRequest' <<<"$transition_metadata")" "https://github.com/acme/widgets/pull/11" "pull request is stored in managed issue metadata"
 assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" "true" "inReview transition receipt is read-back verified"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "verified" \
+  "issue transition reports its fully verified outcome"
 assert_eq "$(cut -f2 "$work/calls" | tr '\n' ',')" "project-list,issue-list,issue-update,issue-list," "issue transition discovers owned project/issue, mutates once, then reads back"
+
+autolink_pr='[https://github.com/acme/widgets/pull/11](<https://github.com/acme/widgets/pull/11>)'
+jq --arg pr "$autolink_pr" '
+  .data.issues.nodes[0].description |=
+    sub("https://github.com/acme/widgets/pull/11"; $pr)
+' "$FIXTURES/issue-list-evidence.json" >"$work/issue-list-evidence-autolink.json"
+reset_fake
+queue project-list project-list-one.json 1
+queue issue-list issue-list-executing.json 1
+queue issue-update issue-update-success.json 1
+cp "$work/issue-list-evidence-autolink.json" "$work/responses/issue-list.2.json"
+run_capture issue-transition --project "$project_id" --repository acme/widgets \
+  --issue ENG-11 --issue-state-map "$issue_state_map" --target inReview \
+  --branch feature/eng-11 --pull-request https://github.com/acme/widgets/pull/11
+assert_exit 0 "$RC" "inReview transition verifies Linear-autolink PR readback"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" true \
+  "autolink-normalized issue evidence is fully verified"
+assert_eq "$(jq -r '.outcome' <<<"$OUTPUT")" "verified" \
+  "autolink normalization produces a fully verified transition outcome"
 
 reset_fake; queue project-list project-list-one.json 1; queue issue-list issue-list-executing.json 1
 run_capture issue-transition --project "$project_id" --repository acme/widgets --issue ENG-11 --issue-state-map "$issue_state_map" --target inReview
@@ -1086,6 +1194,31 @@ executing_snapshot='{"projectStatus":"inReview","issues":[{"id":"cccccccc-0001-4
 review_expect=(--expected-eligible "$review_eligible" --expected-project-transition true --expected-snapshot "$review_snapshot")
 done_expect=(--expected-eligible '[]' --expected-project-transition false --expected-snapshot "$done_snapshot")
 executing_expect=(--expected-eligible '[]' --expected-project-transition false --expected-snapshot "$executing_snapshot")
+jq '
+  .data.issues.nodes[0].description |=
+    sub("\"pullRequest\":\"https://github.com/acme/widgets/pull/11\""; "\"pullRequest\":null") |
+  .data.issues.nodes[0].attachments={nodes:[{url:"https://github.com/acme/widgets/pull/11"}],pageInfo:{hasNextPage:false}}
+' "$FIXTURES/issue-list-evidence.json" >"$work/issue-list-attachment-evidence.json"
+jq '
+  .data.issues.nodes[0].description |=
+    sub("\"pullRequest\":\"https://github.com/acme/widgets/pull/11\""; "\"pullRequest\":null") |
+  .data.issues.nodes[0].attachments={nodes:[{url:"https://github.com/acme/widgets/pull/11"}],pageInfo:{hasNextPage:false}}
+' "$FIXTURES/issue-list-evidence-done.json" >"$work/issue-list-attachment-evidence-done.json"
+reset_fake
+queue project-list project-list-in-review.json 1
+cp "$work/issue-list-attachment-evidence.json" "$work/responses/issue-list.1.json"
+queue issue-update issue-update-success.json 1
+cp "$work/issue-list-attachment-evidence-done.json" "$work/responses/issue-list.2.json"
+queue project-list project-list-in-review.json 2
+queue project-update project-update-done.json 1
+queue project-list project-list-done.json 3
+run_capture status-reconcile --project "$project_id" --repository acme/widgets \
+  --status-map "$status_map" --issue-state-map "$issue_state_map" \
+  --pull-requests-file "$work/merged-prs.json" "${review_expect[@]}"
+assert_exit 0 "$RC" "status reconciliation accepts native PR attachment evidence"
+assert_eq "$(jq -r '.verified' <<<"$OUTPUT")" true \
+  "native attachment terminal reconciliation is fully verified"
+
 reset_fake
 queue project-list project-list-in-review.json 1
 queue issue-list issue-list-evidence.json 1
@@ -1237,8 +1370,8 @@ jq --arg executing "$(jq -r '.executing' <<<"$issue_state_map")" '
     )
   )]
 ' "$FIXTURES/issue-list-evidence.json" >"$work/status-two-before.json"
-jq --arg done "$(jq -r '.done' <<<"$issue_state_map")" --arg blocked "$(jq -r '.blocked' <<<"$issue_state_map")" '
-  .data.issues.nodes[0].state.id=$done |
+jq --arg done_state "$(jq -r '.done' <<<"$issue_state_map")" --arg blocked "$(jq -r '.blocked' <<<"$issue_state_map")" '
+  .data.issues.nodes[0].state.id=$done_state |
   .data.issues.nodes[1].state.id=$blocked
 ' "$work/status-two-before.json" >"$work/status-two-after-drift.json"
 two_snapshot='{"projectStatus":"inReview","issues":[{"id":"cccccccc-0001-4000-8000-000000000001","status":"inReview"},{"id":"cccccccc-0002-4000-8000-000000000002","status":"executing"}]}'


### PR DESCRIPTION
## Goal

Make Linear artifact writes converge when Linear normalizes Markdown or pull-request metadata, without accepting semantic drift or ambiguous evidence.

## Summary

- Normalize provider-rewritten Markdown and same-repository pull-request autolinks before read-back comparison.
- Reconcile managed and native PR attachment evidence while rejecting conflicts, ambiguity, and truncated attachment results.
- Classify mutation receipts from observed read-back state and cover normalized, partial, and terminal reconciliation paths.

## Test plan

### Automated

- [ ] `shellcheck skills/woostack-init/scripts/artifacts/linear.sh skills/woostack-init/scripts/tests/test-linear-metadata.sh skills/woostack-init/scripts/tests/test-linear-resources.sh` (passed)
- [ ] `python3 -m py_compile skills/woostack-init/scripts/artifacts/linear-metadata.py` (passed)
- [ ] `skills/woostack-init/scripts/tests/test-linear-metadata.sh` (157 passed, 0 failed)
- [ ] `skills/woostack-init/scripts/tests/test-linear-resources.sh` (448 passed, 0 failed)

### Manual

**Before merge**

- [ ] Review the accepted normalization set and confirm semantic content mismatches, foreign PR URLs, conflicting evidence, ambiguous attachments, and truncated attachment connections still fail closed.

Spec: .woostack/fixes/2026-07-16-linear-artifact-migration-normalization.md