### PR TITLE
Prepare isolated skill evaluation runs

### DIFF
--- a/.woostack/plans/2026-07-15-skill-evaluation-optimization.md
+++ b/.woostack/plans/2026-07-15-skill-evaluation-optimization.md
@@ -22,8 +22,10 @@ Create one Graphite stack above the existing spec+plan base branch. Each increme
 | Increment | Branch | Git parent | Acceptance coverage |
 | --- | --- | --- | --- |
 | 1 | `feature/skill-eval-validation` | `feature/skill-evaluation-optimization` | AC3, AC11 prerequisite, AC18 |
-| 2 | `feature/skill-eval-runtime` | increment 1 | AC4–AC9 engine proof |
-| 3 | `feature/skill-eval-command` | increment 2 | AC1, AC2, AC4–AC10, AC19 |
+| 2a | `feature/skill-eval-runtime-preparation` | increment 1 | AC4, AC5 preparation |
+| 2b | `feature/skill-eval-runtime-aggregate` | increment 2a | AC5–AC8 aggregation |
+| 2c | `feature/skill-eval-runtime-report` | increment 2b | AC9 and complete engine proof |
+| 3 | `feature/skill-eval-command` | increment 2c | AC1, AC2, AC4–AC10, AC19 |
 | 4 | `feature/skill-review-package-context` | increment 3 | AC3, AC11, AC12 |
 | 5 | `feature/skill-review-rubric` | increment 4 | AC13 |
 | 6 | `feature/skill-trigger-core` | increment 5 | AC14, cluster 1 |
@@ -162,13 +164,13 @@ pnpm -C site build
 
 Commit with `/woostack-commit --no-pr-update`, review this PR, and leave no registration deferral: there is no `SKILL.md` or public command yet.
 
-## Increment 2: Isolated evaluator runtime, receipts, aggregation, and reports
+## Increment 2a: Isolated evaluator preparation
 
-> **Branch:** `feature/skill-eval-runtime`  
+> **Branch:** `feature/skill-eval-runtime-preparation`  
 > **Depends on:** Increment 1  
 > **Git parent:** `feature/skill-eval-validation`
 
-> Independently shippable internal evaluator engine. It is deterministic and fully testable with synthetic worker evidence; it still exposes no public command.
+> Independently shippable preparation tooling: safe baseline resolution, private workspaces, frozen definitions and package identities, and deterministic dispatch manifests.
 
 ### Task 1: Pin workspace and baseline preparation
 
@@ -176,7 +178,7 @@ Commit with `/woostack-commit --no-pr-update`, review this PR, and leave no regi
 - Create: `skills/woostack-eval/references/runner.md`
 - Create: `skills/woostack-eval/scripts/tests/test-prepare.sh`
 
-- [ ] **Step 1 — Red**
+- [x] **Step 1 — Red**
 
 Cover explicit baseline-ref precedence, explicit baseline-path precedence, mutual exclusion, merge-base resolution through `skills/woostack-init/scripts/resolve-base.sh`, no-skill baseline only for proven absence/non-Git target, dirty candidate preservation, invalid Git lookup fail-closed, atomic run IDs, concurrent runs, ignored `.woostack/tmp` selection, `${TMPDIR:-/tmp}` fallback, traversal/symlink rejection, candidate/baseline separation, fixture copying, canonical trigger catalogs, and original-package pre-dispatch hash.
 
@@ -192,6 +194,8 @@ Expected manifest shape:
   "baseline": {"kind": "git-ref", "identity": "0123456789abcdef0123456789abcdef01234567"},
   "runConfiguration": {"host": null, "runner": null, "model": null, "sessionIdentity": null, "tier": null, "effort": null},
   "originalPackageHash": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "packageHashes": {"candidate": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "baseline": "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"},
+  "gradingPlan": [{"caseId": "markdown-handoff", "repetition": 1, "assertionId": "clear-handoff", "graderId": null}],
   "expected": [{"caseId": "markdown-handoff", "variant": "candidate", "repetition": 1, "kind": "behavior"}],
   "pairs": [{"caseId": "markdown-handoff", "repetition": 1, "candidate": "cases/markdown-handoff/1/candidate", "baseline": "cases/markdown-handoff/1/baseline"}]
 }
@@ -217,11 +221,19 @@ Implementation requirements:
 - Read baseline Git objects without checking out over the user's worktree: enumerate with `git ls-tree -r -z <sha> -- <relative-package>`, reject non-regular modes, and materialize each accepted blob with `git show <sha>:<path>` into the private temporary tree. An explicit absolute baseline path establishes a read-only allowed root.
 - Allocate the run directory atomically with mode `0700`; never reuse an existing ID.
 - Use `.woostack/tmp/skill-evals` only after canonical-root resolution and `git check-ignore` proof; otherwise use an atomic system-temporary directory and report that fallback.
-- Copy only allowed package/fixture files. Build one isolated workspace per case/variant/repetition, plus append-only `evidence/` paths outside the case's capability root. Evidence names are deterministic and collision-free: `action.<kind>.<case-id>.<variant>.<repetition>.json` and `grade.<case-id>.<repetition>.<grader-id>.json`; writers use create-new semantics.
+- Copy only allowed package/fixture files. Build one isolated workspace per case/variant/repetition, plus append-only `evidence/` paths outside the case's capability root. Evidence names are deterministic and collision-free: `action.<kind>.<case-id>.<variant>.<repetition>.json` and `grade.<case-id>.<variant>.<repetition>.<grader-id>.json`; writers use create-new semantics.
 - Produce candidate and baseline trigger catalogs from the same canonical public name/description list rooted at the explicit `--catalog-root` supplied by the skill; default only to the installed collection root derived from `import.meta.url`. Change only the target variant. Add an external target to the candidate catalog when absent; a no-skill baseline omits it.
 - Group candidate/baseline workers into inseparable pairs; do not decide host concurrency in the script.
 
 Run `test-prepare.sh`; expected pass.
+
+## Increment 2b: Receipt aggregation and grading
+
+> **Branch:** `feature/skill-eval-runtime-aggregate`  
+> **Depends on:** Increment 2a  
+> **Git parent:** `feature/skill-eval-runtime-preparation`
+
+> Independently shippable aggregation authority: immutable evidence snapshots, exact receipts, objective assertions, blinded qualitative grades, and honest complete/blocked/degraded metrics.
 
 ### Task 3: Pin receipt, assertion, grade, and aggregate behavior
 
@@ -243,6 +255,7 @@ Red cases:
 
 **Files:**
 - Create: `skills/woostack-eval/scripts/aggregate.mjs`
+- Create: `skills/woostack-eval/scripts/aggregate/*.mjs`
 
 CLI:
 
@@ -253,6 +266,14 @@ node aggregate.mjs --manifest <manifest.json> --evidence <dir> --out <aggregate.
 Accept append-only action receipts with the spec-required identity, timing, output, completion, and error fields. Validate exactly the manifest's expected set before grading. Run deterministic assertions against copied workspaces/captured outputs, accept only explicit qualitative grades with completed grader receipts, compute per-case/overall rates and variance, and emit `executionStatus` exactly `complete | blocked | degraded`. Assertion failures may coexist with `complete`; missing execution proof may not. Do not emit a universal merge verdict.
 
 Run `test-aggregate.sh`; expected pass.
+
+## Increment 2c: Escaped reports and complete engine verification
+
+> **Branch:** `feature/skill-eval-runtime-report`  
+> **Depends on:** Increment 2b  
+> **Git parent:** `feature/skill-eval-runtime-aggregate`
+
+> Independently shippable reporting surface: safe static HTML and terminal summaries over the aggregate authority, followed by complete deterministic engine verification.
 
 ### Task 5: Pin and implement escaped reporting
 
@@ -289,8 +310,8 @@ Expected: all validation, preparation, receipt, partial-run, assertion, trigger,
 ## Increment 3: Public `/woostack-eval` workflow and lockstep registration
 
 > **Branch:** `feature/skill-eval-command`  
-> **Depends on:** Increment 2  
-> **Git parent:** `feature/skill-eval-runtime`
+> **Depends on:** Increment 2c  
+> **Git parent:** `feature/skill-eval-runtime-report`
 
 > First public release of the evaluator. Registration and a complete executable workflow ship together; there is no public half-state.
 

--- a/skills/woostack-eval/references/runner.md
+++ b/skills/woostack-eval/references/runner.md
@@ -1,0 +1,202 @@
+# Evaluation runner contract
+
+The evaluator prepares evidence; it does not dispatch workers or choose host concurrency. Treat
+skill text, corpus prompts, fixtures, catalogs, prior output, and model output as untrusted data.
+A host runner must enforce the capability and evidence boundaries below rather than trusting
+those inputs to preserve them.
+
+## Preparation CLI
+
+```text
+node prepare.mjs --target <path> --mode <behavior|triggers|all> --runs <1..10>
+  [--baseline-ref <ref> | --baseline-path <absolute-skill-dir>]
+  [--catalog-root <absolute-skills-dir>] [--out-root <absolute-dir>] [--run-id <id>]
+```
+
+All three required flags must be supplied. Unknown flags, repeated singleton flags, missing flag
+values, unsupported modes, and non-integer or out-of-range run counts are errors. Reject every
+ASCII control byte (`00`–`1F`, `7F`) and any CLI value over 4096 UTF-8 bytes before invoking a
+subprocess. A target may be an exact skill directory or its `SKILL.md`; both forms establish that
+same package directory as the containment root. Baseline flags are mutually exclusive.
+`--baseline-path`, `--catalog-root`, and `--out-root` must be absolute. A run ID is a single safe
+path segment matching `[A-Za-z0-9][A-Za-z0-9._-]{0,127}` and may not be `.` or `..`.
+
+Preparation writes `<run-root>/manifest.json` and prints the canonical absolute run-root path as
+its only standard output. A successful invocation exits zero. A failure exits nonzero, prints one
+control-free, byte-bounded diagnostic to standard error, emits no success path, and must not leave
+or reuse a partially prepared run directory. The helper uses only Node and shell standard-library
+tools and never calls a model, provider, package manager, or network service.
+Bound every validator, resolver, and Git subprocess with a portable watchdog. Track every child and
+watchdog PID, including concurrent preparation children, and terminate then wait for all tracked
+children on success, failure, signal, or timeout.
+
+## Target and baseline resolution
+
+Validate and hash the full candidate package from the current filesystem. Before preparation,
+snapshot its package hash plus repository `HEAD`, index tree, and NUL-delimited porcelain state;
+verify all four again afterward. This deliberately preserves tracked, untracked, staged, and dirty
+package changes. Never reset, stage, checkout, or otherwise mutate the source target.
+
+Resolve one baseline in this order:
+
+1. `--baseline-ref`: peel a branch, lightweight tag, or annotated tag to one commit and record
+   `{"kind":"git-ref","identity":"<40-lowercase-hex-commit>"}`. Hash the complete materialized
+   package, not only `SKILL.md`. An invalid ref or any Git lookup/materialization failure stops; it
+   never falls through.
+2. `--baseline-path`: validate the user-named absolute package directory as the read-only allowed
+   root, hash it, and copy the complete validated package to a private snapshot. Require the
+   snapshot hash and a post-preparation source hash to equal that original identity, then record
+   `{"kind":"path","identity":"<sha256-package-hash>"}`. An invalid or changing path stops; it
+   never falls through.
+3. For a target in Git, execute the installed collection's canonical
+   `skills/woostack-init/scripts/resolve-base.sh`, then compute `git merge-base HEAD <resolved>`.
+   Do not duplicate or guess resolver logic. If the resolver is unavailable or either lookup
+   fails, require an explicit baseline and stop.
+4. A package proven absent at that valid merge base is
+   `{"kind":"none","identity":"<lowercase-merge-base-commit>:absent"}`. An exact target outside
+   Git with no explicit baseline records
+   `{"kind":"none","identity":"non-git:<sha256-package-hash>:absent"}`. These are the only
+   implicit no-skill states. A present but incomplete, unreadable, symlinked, or otherwise invalid
+   Git baseline is an error, not absence.
+
+Explicit baselines take precedence without consulting the implicit merge-base resolver. For a Git
+baseline, enumerate only the target package with
+`git ls-tree -r -z <commit> -- <repository-relative-package>`, accept regular blob modes only, and
+read each accepted blob with `git show <commit>:<path>`. Preserve `100644` as `0644` and `100755`
+as `0755`. Materialize into a private temporary tree; never checkout over the worktree. An explicit
+baseline directory is a read-only allowed root and all descendants remain containment-checked.
+
+## Run-root allocation
+
+When `--out-root` is present, use it exactly. Otherwise, use
+`<canonical-git-root>/.woostack/tmp/skill-evals` only when canonical Git-root resolution succeeds
+and `git check-ignore` proves that exact location ignored. Do not infer a common root or alter
+`.woostack/` or ignore rules. If that proof is unavailable or false, atomically allocate beneath
+`${TMPDIR:-/tmp}` and report the fallback on standard error. Reject both the selected output root
+and `TMPDIR` when either resolves inside the candidate or an explicit path baseline.
+
+An explicit run ID is never reused. Without one, use `YYYYMMDDTHHMMSSZ-<pid>`. Reserve the final
+run path atomically as a new directory with mode `0700`; collision means retry for an automatic ID
+and failure for an explicit ID. Never publish by renaming over a path after a separate existence
+check: even an empty directory created between those operations belongs to someone else.
+Concurrent invocations forced onto one ID must produce exactly one successful run. Write the
+manifest last so it marks complete preparation. Every failure after allocation must remove only
+the directory inode reserved by that invocation without touching pre-existing or replacement runs.
+
+Reject absolute corpus paths, `..` traversal, NUL/control bytes, symlinks, sockets, devices,
+FIFOs, and any resolved path outside its allowed root. Never copy `.git`, `.env*`, credential or
+secret files, or ignored evaluator output.
+
+## Isolated workspaces and evidence
+
+For every selected case and one-based repetition, create two separate capability roots:
+
+```text
+cases/<case-id>/<repetition>/candidate/
+cases/<case-id>/<repetition>/baseline/
+```
+
+Each variant root contains `package/` for the selected package and an always-present `fixtures/`
+directory containing only the files listed by that behavior case. A no-skill baseline has no
+`package/`. Preserve fixture-relative paths below `fixtures/`; a case workspace must not receive a
+fixture declared only by another case.
+Copies must be regular, independent files: neither variant may be a symlink, hard link, or shared
+writable directory with the other variant or source package.
+
+Preparation also writes one host-owned canonical snapshot of each selected case definition at
+`definitions/<kind>.<case-id>.json`. The aggregator reads assertions, trigger truth, capabilities,
+and fixture declarations only from these frozen snapshots and requires their IDs to match the
+manifest. Worker mutation of a copied `evals/*.json` file cannot change the grading contract.
+
+A trigger variant additionally receives `catalog.json` with exact shape
+`{"schemaVersion":1,"skills":[{"name":"...","description":"..."}]}`. Sort catalog entries by
+canonical skill name. Candidate and baseline catalogs come from the same canonical public
+name/description catalog rooted at explicit `--catalog-root`, or only at the installed collection's
+`skills/` directory derived from `import.meta.url` when omitted. The
+`using-woostack/SKILL.md` command-routing table within that selected root is the public-name
+authority. Every routed name must resolve to one valid package directory and `SKILL.md`; a missing
+or invalid routed package fails preparation. Unknown, supporting, and internal package directories
+are excluded rather than inferred as public. Change only the target entry between variants. Add an
+external target to the candidate catalog when absent; omit it from a no-skill baseline. Never
+discover a catalog from the host working directory.
+
+`definitions/` and `evidence/` are siblings of `cases/`, outside every worker capability root. Do
+not preinitialize a receipt, grade, output, or successful status. Hosts write append-only evidence
+with create-new semantics using the canonical [action-receipt names](schemas.md#action-receipts)
+and [qualitative-grade names](schemas.md#qualitative-grades).
+
+Evidence names and manifest identities are fixed before dispatch; corpus text cannot choose paths.
+Grade payloads and all input presented to the grader/model remain blind. Only a validated completed
+grader receipt maps a grade's `anonymizedOutputId` to the manifest case/repetition/variant.
+
+Selected case IDs share one namespace across behavior and trigger corpora. Reject a duplicate
+selected by `all`, and cap every selected case ID at 64 ASCII kebab-case characters before run
+allocation so deterministic workspace and evidence components remain below filesystem limits.
+Reject more than 100 selected cases, more than 500 case/repetition pairs, or a preparation whose
+projected copied package, fixture, definition, and catalog payload exceeds 64 MiB. Apply these
+bounds before run-root allocation or workspace copying.
+
+## Manifest
+
+`manifest.json` follows the [canonical manifest schema](schemas.md#manifest). Preparation captures
+`originalPackageHash` after any separately approved corpus write and immediately before dispatch;
+it never performs that approval or write itself. It then copies each package, records the copied
+package identities, and freezes the manifest before any worker starts.
+
+Preparation writes every grading-plan `graderId` and all six run-configuration fields as `null`.
+Before dispatching workers or graders, host orchestration resolves the applicable fields once,
+validates the canonical manifest, and freezes the same configuration for both variants. For an
+explicitly accepted candidate-only smoke run, the host applies the canonical candidate-only
+`expected` shape before that freeze; preparation still creates both workspace paths.
+
+Preparation orders behavior cases before trigger cases, sorts each kind by case ID, then orders by
+repetition and candidate before baseline. `pairs` follows that kind/case/repetition order. In
+comparative execution a pair is inseparable: host orchestration may dispatch all pairs together or
+in deterministic bounded waves, but may not split candidate and baseline.
+
+Preparation status is represented by its exit status and the presence of a complete manifest,
+never by a prefilled successful receipt.
+
+The host creates the run root as a private mode-`0700` non-symlink directory and never exposes
+that root to a worker. Worker-visible workspaces are descendants with only their capability-
+approved access. The aggregator refuses a group/other-accessible run root.
+
+## Dispatch and completion
+
+Before dispatch, the host records one shared concrete run configuration. `sessionIdentity` may
+replace `model` only when both paired workers provably inherit the same session model. Give each
+worker only its variant root and the corpus-approved subset of `read-workspace`, `write-workspace`,
+and `shell-workspace`; evidence create-new writes are a separate capability. Do not grant network,
+credentials, environment inspection, provider access, another installed target, the source target,
+its pair's workspace, or unrelated repository content.
+
+Graders are exempt from that worker `runConfiguration`, but their paired candidate/baseline
+receipts must satisfy the concrete, bias-resistant configuration match in
+[the qualitative-grade schema](schemas.md#qualitative-grades).
+Before dispatching a grader, the host must use the resolved `gradingPlan` entry for its
+deterministic input, grade, and receipt filenames. It may not accept or infer an arbitrary
+grader-provided identity.
+
+After every worker and grader process has exited and host dispatch is permanently closed, the host
+writes `quiescence.json` create-new with exactly:
+
+```json
+{"schemaVersion":1,"runId":"20260715T120000Z-1234","dispatchClosed":true}
+```
+
+Workers and graders cannot write this proof. Aggregation rejects a missing, malformed, mismatched,
+or non-regular proof before enumerating evidence. The host then builds an immutable run snapshot
+before processing. For every regular evidence, definition, input mapping, output/transcript, and
+copied-package file, it binds the run-root-relative path to device, inode, size, mtime, and a
+streamed SHA-256 taken from an opened no-follow handle. It also binds directory identities and
+name sets using opened directory handles where the host supports them. After processing and before
+publication, the aggregator reopens every path no-follow and revalidates all identities, hashes,
+directories, and names. A same-name rewrite, replacement, added/removed file, directory swap, or
+late evidence emits fatal `snapshot-mutation` and refuses publication.
+
+After all workers finish, hash the original target package again. Any delta invalidates comparison,
+preserves the run directory, and reports changed paths without resetting them. Missing or malformed
+evidence, worker/grader failure, timeout, identity/configuration mismatch, or a split pair blocks a
+clean comparison. Missing telemetry is `unavailable`, not zero. The aggregator owns final
+`complete`, `blocked`, or explicitly accepted candidate-only `degraded` status; preparation does
+not decide those statuses or host concurrency.

--- a/skills/woostack-eval/references/schemas.md
+++ b/skills/woostack-eval/references/schemas.md
@@ -105,10 +105,94 @@ starts with `/`; `~0` decodes to `~` and `~1` to `/`. No dot-path or URI-fragmen
 accepted. `qualitative.rubric` must be a non-empty question answerable strictly true or false.
 The grader's boolean and rationale are stored in a grade, never inferred from prose.
 
+## Manifest
+
+`manifest.json` is host-owned and has this exact shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "20260715T120000Z-1234",
+  "targetSkill": "woostack-example",
+  "mode": "all",
+  "runs": 2,
+  "baseline": {"kind":"git-ref","identity":"0123456789abcdef0123456789abcdef01234567"},
+  "runConfiguration": {
+    "host": null,
+    "runner": null,
+    "model": null,
+    "sessionIdentity": null,
+    "tier": null,
+    "effort": null
+  },
+  "originalPackageHash": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "packageHashes": {
+    "candidate": "sha256:123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0",
+    "baseline": "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+  },
+  "gradingPlan": [{
+    "caseId": "preserves-approval-gate",
+    "repetition": 1,
+    "assertionId": "clear-handoff",
+    "graderId": "clarity-grader"
+  }],
+  "expected": [{
+    "caseId": "preserves-approval-gate",
+    "variant": "candidate",
+    "repetition": 1,
+    "kind": "behavior"
+  }, {
+    "caseId": "preserves-approval-gate",
+    "variant": "baseline",
+    "repetition": 1,
+    "kind": "behavior"
+  }],
+  "pairs": [{
+    "caseId": "preserves-approval-gate",
+    "repetition": 1,
+    "candidate": "cases/preserves-approval-gate/1/candidate",
+    "baseline": "cases/preserves-approval-gate/1/baseline"
+  }]
+}
+```
+
+Every object has exactly the keys shown. `runId`, `targetSkill`, `mode`, `runs`, baseline
+identity, and the six run-configuration fields follow the runner contract. Exactly one of
+`model` and `sessionIdentity` is a non-empty string in a resolved manifest; the inactive field is
+exactly `null`, never an empty string or another JSON type. `originalPackageHash` is the source
+candidate identity captured before preparation. `packageHashes` instead binds the actual copied
+package trees: `candidate` is a canonical SHA-256 identity, and `baseline` is a canonical SHA-256
+identity except that it is exactly `null` for a no-skill baseline. Every copied package for one
+variant must hash to its frozen value. For `baseline.kind: path`, `baseline.identity` is exactly
+the same frozen identity as `packageHashes.baseline`; it does not retain a different pre-copy
+source-tree hash. An action receipt uses its variant's frozen hash; a grader receipt uses the
+candidate frozen hash.
+
+`gradingPlan` contains exactly one entry per frozen qualitative assertion and case/repetition pair,
+sorted by case ID, repetition, then assertion ID. `caseId`, `assertionId`, and a resolved
+`graderId` are stable kebab-case; `repetition` is one-based and within `runs`. Preparation writes
+`graderId: null`, and host orchestration must resolve every null to one stable grader ID before
+dispatch or aggregation. Within one case/repetition, each qualitative assertion must resolve to a
+distinct `graderId`, so its deterministic input, grade, and receipt names cannot collide. The plan
+may not omit or add a qualitative assertion, contain duplicate identities, or select a
+case/assertion absent from the frozen definitions.
+
+`expected` is the canonical unique action identity set. Comparative runs contain candidate then
+baseline for every pair; an explicitly accepted candidate-only run may omit baseline expected
+identities but retains both workspace paths in `pairs`. Each pair has exactly one selected
+case/repetition, canonical contained workspace paths, and no concurrency field. `expected`,
+`pairs`, and `gradingPlan` retain their required deterministic order even though JSON object member
+order is insignificant.
+
 ## Action receipts
 
-One append-only action receipt is written last for every expected
-case/variant/repetition. Its exact shape is:
+One append-only action receipt is written last for every expected case/variant/repetition and for
+every grader action. Worker action receipts use the deterministic filename
+`action.<kind>.<case-id>.<variant>.<repetition>.json`, where `kind` is `behavior` or `trigger`.
+Grader action receipts use
+`action.grader.<case-id>.<variant>.<repetition>.<grader-id>.json`, with the exact resolved
+`gradingPlan` grader ID. All are host-owned names written with create-new semantics. Every receipt
+has this exact shape:
 
 ```json
 {
@@ -140,17 +224,26 @@ case/variant/repetition. Its exact shape is:
 ```
 
 `repetition` is one-based. `variant` is exactly `candidate` or `baseline`; `kind` is exactly
-`behavior` or `trigger`. `baseline.kind` is `git-ref`, `path`, or `none`, with a reproducible
-`identity`. Exactly one of non-empty `model` and non-empty `sessionIdentity` supplies the
+`behavior`, `trigger`, or `grader`. `baseline.kind` is `git-ref`, `path`, or `none`, with a
+reproducible `identity`. Exactly one of non-empty `model` and non-empty `sessionIdentity` supplies the
 completion identity. `tier` and `effort` are strings when exposed and otherwise `null`.
-`startedAt` is RFC 3339 UTC, `durationMs` is a non-negative finite integer, and `output`
+`packageHash` is exactly the manifest's frozen hash for the receipt variant. For `kind: grader`,
+it is exactly the frozen candidate hash. A no-skill baseline worker receipt alone uses `null`.
+`startedAt` is component-valid RFC 3339 UTC. `durationMs`, every identity byte length, and every
+token count is a non-negative JSON safe integer. `output`
 identifies a regular evidence file by relative path, SHA-256, and byte length.
 
 `transcript` is either an output identity with the same `{path,sha256,bytes}` shape or the
 literal `unavailable`. `tokenUsage` is either `unavailable` or
 `{"input":<non-negative integer>,"output":<non-negative integer>,"total":<non-negative integer>}`.
+`total` must equal `input + output` without exceeding the JSON safe-integer range.
+Materialized evidence JSON and output files are limited to 1 MiB each; exceeding the limit blocks
+with `evidence-too-large`. Transcript content is hashed and counted through a stream,
+so it is not materialized in aggregate memory.
 It is never zero-filled when telemetry is absent. A trigger receipt sets `selectedSkill` to a
-canonical skill name or `none`; a behavior receipt sets it to `null`.
+canonical skill name or `none`; a behavior or grader receipt sets it to `null`. A completed
+grader receipt is host-owned: its case, repetition, and variant map the linked grade's blind
+`anonymizedOutputId` back to one manifest identity only after the receipt validates.
 
 `completionStatus` is exactly `complete`, `failed`, or `timed-out`. A complete receipt has
 `error: null`; another status has exactly
@@ -175,15 +268,59 @@ A grade is append-only and has this exact shape:
   "pass": true,
   "rationale": "The handoff names the required next action.",
   "error": null,
-  "receipt": {"path":"evidence/action.grader.preserve-approval-gate.1.clarity-grader.json","sha256":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}
+  "input": {"path":"evidence/input.preserves-approval-gate.candidate.1.clarity-grader.json","sha256":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+  "receipt": {"path":"evidence/action.grader.preserves-approval-gate.candidate.1.clarity-grader.json","sha256":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}
 }
 ```
 
-The grade contains no candidate/baseline label. `graderId`, `assertionId`, and
-`anonymizedOutputId` are stable kebab-case identities. `completionStatus` uses the action
-receipt enum. On `complete`, `pass` is boolean, `rationale` is non-empty, and `error` is null.
-Otherwise `pass` and `rationale` are null and `error` has the receipt error shape. The
-aggregate restores the variant only through the manifest and completed grader receipt.
+The grade JSON contains no candidate/baseline label. Its host-owned deterministic filename is
+`grade.<case-id>.<variant>.<repetition>.<grader-id>.json`; the host does not present that filename
+or variant to the grader/model. Its `receipt.path` must be exactly
+`evidence/action.grader.<case-id>.<variant>.<repetition>.<grader-id>.json` for the same resolved
+grading-plan identity. `graderId`, `assertionId`, and `anonymizedOutputId` are stable kebab-case
+identities. `completionStatus` uses the action receipt enum. On `complete`, `pass` is boolean,
+`rationale` is non-empty, and `error` is null. Otherwise `pass` and `rationale` are null and
+`error` has the receipt error shape. The aggregate restores the variant only after validating the
+linked completed grader receipt against the manifest; it never infers the variant from grade
+content.
+
+The host writes the blind input mapping create-new before grader dispatch. Its deterministic
+filename is `input.<case-id>.<variant>.<repetition>.<grader-id>.json`; that filename and its
+variant are not presented to the grader/model. The mapping has exactly:
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "20260715T120000Z-1234",
+  "caseId": "preserves-approval-gate",
+  "repetition": 1,
+  "graderId": "clarity-grader",
+  "assertionId": "clear-handoff",
+  "anonymizedOutputId": "output-7f3a",
+  "source": {"path":"outputs/final.txt","sha256":"sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","bytes":42}
+}
+```
+
+The grade's exact `{path,sha256}` `input` identity must resolve to that mapping. Its source identity
+must exactly equal the validated worker output identity. Before validating any linked grade or
+grader receipt, the aggregator indexes every syntactically valid host-owned input mapping,
+including orphan mappings and mappings whose later proof fails. Every `anonymizedOutputId` is
+globally unique across all cases and repetitions in the run; the candidate and baseline mappings
+in one pair therefore always differ. A swapped mapping, reused anonymized ID, wrong source, orphan
+input, or mismatched valid grader identity blocks both grades in every affected pair before any
+boolean is exposed.
+
+Grader receipts are exempt from the workers' manifest `runConfiguration`. Each linked grader
+receipt still has exactly one concrete completion identity (`model` or `sessionIdentity`). For the
+candidate and baseline grades sharing one case, repetition, and `graderId`, their validated grader
+receipts must match on `host`, `runner`, completion identity, `tier`, and `effort`; a mismatch
+blocks aggregation rather than permitting grading bias.
+
+Qualitative unblinding always requires complete candidate and baseline grade, mapping, and grader-
+receipt proofs for the pair. This remains true for an accepted candidate-only run: the baseline
+worker result is omitted from aggregate cases, but its isolated grading proof is still required to
+unblind the candidate grade. A lone candidate proof remains blind rather than becoming paired by
+degradation alone.
 
 ## Aggregate
 
@@ -203,7 +340,7 @@ The aggregate is versioned and has these top-level fields:
     "criticalFailures": [],
     "triggerPrecision": "unavailable",
     "triggerRecall": "unavailable",
-    "durationMs": {"candidate":{"mean":1234,"variance":12},"baseline":{"mean":1400,"variance":18}},
+    "durationMs": {"candidate":{"mean":1234,"variance":12},"baseline":{"mean":1400,"variance":18},"delta":-166},
     "tokenUsage": "unavailable"
   },
   "evidenceErrors": []
@@ -212,8 +349,10 @@ The aggregate is versioned and has these top-level fields:
 
 `executionStatus` is exactly `complete`, `blocked`, or `degraded`. Assertion failures may
 coexist with `complete`. Missing, duplicate, malformed, failed, timed-out, unknown, or
-identity-mismatched required evidence makes the aggregate `blocked`. Explicitly accepted
-candidate-only smoke evidence is `degraded` and emits no comparison or trigger metric.
+identity-mismatched required evidence makes the aggregate `blocked`; every comparison, duration,
+token, precision, and recall metric is then `unavailable`, while individually proven repetition
+evidence remains in `cases`. Explicitly accepted candidate-only smoke evidence is `degraded` and
+likewise emits no comparison, duration, token, precision, or recall metric.
 
 Each case entry identifies `caseId`, `kind`, and separate `candidate` and `baseline`
 repetition results; each assertion result identifies `assertionId`, `critical`, `pass`, and
@@ -224,10 +363,75 @@ coerced to zero. The aggregate accepts exactly the manifest's expected identitie
 per-case and overall variance, preserves objective failures separately from execution
 failure, and contains no merge verdict.
 
+Aggregate and HTML report publication share one create-new authority at mode `0600`: it writes
+and fsyncs a same-directory temporary file, atomically links that file to the requested absent
+output path, fsyncs the parent directory, and removes the temporary name on success or failure.
+It never overwrites an existing aggregate or report.
+
+`objectivePassRate` uses only deterministic assertion observations from behavior cases. For each
+variant, every assertion/repetition observation has equal weight: the rate is passing deterministic
+observations divided by all deterministic observations. Trigger outcomes and `qualitative`
+assertions, including their pass/fail values, are excluded from both numerator and denominator. A
+zero denominator is `unavailable`; delta is candidate minus baseline only when both rates are
+numeric.
+
+Duration metrics use completed expected worker receipts of kind `behavior` or `trigger` only;
+grader receipt durations are excluded. For each variant and repetition, average all included
+worker `durationMs` values into one repetition observation. Overall mean is the arithmetic mean of
+those repetition observations, and duration delta is candidate overall mean minus baseline overall
+mean when both are numeric. Overall variance is population variance across the repetition
+observations, `sum((observation - mean)²) / runs`; with one repetition it is `unavailable`, not
+zero. Per-case duration applies the same population formula to that case's one receipt per
+repetition.
+
+For trigger metrics, selecting `targetSkill` is the positive prediction; selecting any other
+skill or `none` is negative. A `shouldTrigger: true` case is positive ground truth and
+`shouldTrigger: false` is negative ground truth. Therefore: TP is positive ground truth with the
+target selected; FP is negative ground truth with the target selected; FN is positive ground truth
+without the target; TN is negative ground truth without the target. Precision is
+`TP / (TP + FP)` and recall is `TP / (TP + FN)`. A zero denominator produces `unavailable`, never
+zero. Each metric is computed separately for candidate and baseline from `selectedSkill` receipts,
+never transcript prose. Delta is candidate minus baseline only when both values are numeric;
+otherwise it is `unavailable`.
+
 `criticalFailures` contains `{caseId,assertionId,repetitions}` entries. `evidenceErrors` uses
 exactly `{code,field,path,message}`: `code` is stable kebab-case, `field` is an RFC 6901
 pointer (or the empty pointer), `path` is a run-root-relative evidence path, and `message` is
 non-empty sanitized text.
+
+Aggregate evidence and fatal snapshot errors use these exhaustive canonical codes and fields:
+
+| Code | Emitted field(s) | Condition |
+| --- | --- | --- |
+| `missing-receipt` | empty pointer | An expected action receipt or qualitative grade is absent. |
+| `duplicate-receipt` | empty pointer | More than one file claims one expected action or qualitative identity. |
+| `unknown-receipt` | empty pointer or `/caseId`, `/variant`, `/repetition`, `/kind`, `/assertionId` | A receipt, grade, grader receipt, or input mapping claims no expected identity. |
+| `malformed-receipt` | empty pointer or the malformed payload pointer | JSON cannot be parsed, is not an object, has a noncanonical key set, or has an invalid completion/error payload. |
+| `missing-field` | the missing field pointer | A required action, grade, nested receipt, or input field is absent. |
+| `incomplete-receipt` | `/completionStatus` | A required worker or grader failed or timed out. |
+| `missing-completion-identity` | `/model` | Exactly one concrete model or session identity is not present. |
+| `configuration-mismatch` | `/host`, `/runner`, `/model`, `/sessionIdentity`, `/tier`, or `/effort` | A worker differs from the manifest run configuration. |
+| `grader-configuration-mismatch` | `/host`, `/runner`, `/model`, `/sessionIdentity`, `/tier`, or `/effort` | Paired grader receipts differ on required grading configuration. |
+| `grader-identity-mismatch` | `/graderId` | Candidate and baseline grades in a pair use different grader identities. |
+| `identity-mismatch` | the mismatched identity or payload pointer | An action receipt, grade, linked receipt, or input path disagrees with its host-owned expected identity, including the resolved grader ID in a grader receipt filename. |
+| `missing-grade-receipt` | `/receipt/path` | A grade's deterministic linked `action.grader.<case-id>.<variant>.<repetition>.<grader-id>.json` receipt is absent. |
+| `missing-grade-input` | `/input/path` | A grade's deterministic host-owned input mapping is absent. |
+| `grade-input-hash-mismatch` | `/input/sha256` | A grade's input hash does not match the host-owned mapping bytes. |
+| `grade-input-mismatch` | `/schemaVersion`, `/runId`, `/caseId`, `/repetition`, `/graderId`, `/assertionId`, `/anonymizedOutputId`, or `/source` | A mapping's identity or source provenance differs from its grade and validated worker output. |
+| `anonymized-output-collision` | `/anonymizedOutputId` | An anonymized output identity is reused by another grade/mapping anywhere in the run. |
+| `grade-receipt-hash-mismatch` | `/receipt/sha256` | A grade's receipt hash does not match the linked grader receipt. |
+| `evidence-too-large` | empty pointer, `/output/path`, `/transcript/path`, or `/input/path` | A materialized JSON, output, or input file exceeds the 1 MiB bound. |
+| `output-hash-mismatch` | `/output/sha256` | Worker or grader output bytes do not match the receipt hash. |
+| `output-bytes-mismatch` | `/output/bytes` | Worker or grader output length does not match the receipt byte count. |
+| `transcript-hash-mismatch` | `/transcript/sha256` | Transcript bytes do not match the receipt hash. |
+| `transcript-bytes-mismatch` | `/transcript/bytes` | Transcript length does not match the receipt byte count. |
+| `package-hash-mismatch` | `/packageHash` | A copied package, worker receipt, or grader receipt differs from the applicable frozen manifest package identity. |
+| `unsafe-evidence-path` | `/output/path`, `/transcript/path`, or `/receipt/path` | The referenced path is absolute, escapes the run root, or is otherwise unsafe. |
+| `non-regular-evidence` | `/output/path`, `/transcript/path`, or `/receipt/path` | Referenced evidence is missing, a directory, symlink, special file, or unstable regular file. |
+| `snapshot-mutation` | empty pointer | Fatal: a snapshotted path, directory identity/name set, opened-handle inode/device/size/mtime, or streamed SHA-256 changes; publication is refused. |
+Errors are normalized and sorted by `path`, then `field`, then `code`. A single-fault input emits
+only its canonical error; secondary missing/unknown errors for the same rejected receipt are not
+added.
 
 ## Validator result and errors
 

--- a/skills/woostack-eval/scripts/prepare.mjs
+++ b/skills/woostack-eval/scripts/prepare.mjs
@@ -1,0 +1,1470 @@
+import {
+  chmod as chmodAsync,
+  copyFile as copyFileAsync,
+  lstat as lstatAsync,
+  mkdir as mkdirAsync,
+  mkdtemp as mkdtempAsync,
+  readdir as readdirAsync,
+  readFile as readFileAsync,
+  realpath as realpathAsync,
+  rm as rmAsync,
+  writeFile as writeFileAsync,
+} from 'node:fs/promises';
+import { spawn, spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { hashPackage, parseFrontmatter, validatePackage } from './validate.mjs';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CATALOG_ROOT = path.resolve(SCRIPT_DIR, '..', '..');
+const DEFAULT_BASELINE_RESOLVER = path.resolve(
+  SCRIPT_DIR,
+  '..',
+  '..',
+  'woostack-init',
+  'scripts',
+  'resolve-base.sh',
+);
+
+const RUN_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SAFE_FILE_MODE = 0o700;
+const MAX_CHILD_BYTES = 16 * 1024 * 1024;
+const MAX_ARGUMENT_BYTES = 4096;
+const MAX_CASE_ID_LENGTH = 64;
+const MAX_DIAGNOSTIC_BYTES = 1000;
+const MAX_CHILD_TERMINATION_MS = 2000;
+const MAX_CASE_COUNT = 100;
+const MAX_CASE_REPETITIONS = 500;
+const MAX_PROJECTED_WORKSPACE_BYTES = 64 * 1024 * 1024;
+
+const trackedChildren = new Set();
+const tempRoots = new Set();
+let allocated = null;
+
+function emit(...parts) {
+  process.stderr.write(`${parts.join(' ')}\n`);
+}
+
+function hasControlOrNul(value) {
+  return /[\x00-\x1F\x7F]/.test(value);
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function formatRunId(timestamp = new Date(), pid = process.pid) {
+  const z = (value) => String(value).padStart(2, '0');
+  return `${timestamp.getUTCFullYear()}${z(timestamp.getUTCMonth() + 1)}${z(timestamp.getUTCDate())}T${z(timestamp.getUTCHours())}${z(timestamp.getUTCMinutes())}${z(timestamp.getUTCSeconds())}Z-${pid}`;
+}
+
+function validateControl(value, label) {
+  if (hasControlOrNul(value)) {
+    throw new Error(`invalid ${label}`);
+  }
+}
+
+function validateArgumentSize(value, label) {
+  if (Buffer.byteLength(value, 'utf8') > MAX_ARGUMENT_BYTES) {
+    throw new Error(`${label} exceeds ${MAX_ARGUMENT_BYTES} bytes`);
+  }
+}
+
+function boundedDiagnostic(error) {
+  const raw = error && error.message ? error.message : String(error);
+  let clean = raw.replace(/[\x00-\x1F\x7F]/g, '?');
+  const bytes = Buffer.from(clean, 'utf8');
+  if (bytes.byteLength <= MAX_DIAGNOSTIC_BYTES) return clean;
+  clean = bytes.subarray(0, MAX_DIAGNOSTIC_BYTES - 3).toString('utf8').replace(/\uFFFD+$/g, '');
+  return `${clean}...`;
+}
+
+function isSafeRelativePath(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return false;
+  if (raw.includes('\\')) return false;
+  if (path.isAbsolute(raw)) return false;
+  const parts = raw.split('/').filter(Boolean);
+  if (parts.length === 0) return false;
+  for (const part of parts) {
+    if (part === '.' || part === '..') return false;
+  }
+  return !hasControlOrNul(raw);
+}
+
+function isSafeRunId(value) {
+  return typeof value === 'string' && RUN_ID_RE.test(value);
+}
+
+
+
+function toCanonical(value) {
+  return value.split(path.sep).join('/');
+}
+
+function parseCommandLine(argv) {
+  const options = {
+    target: null,
+    mode: null,
+    runs: null,
+    baselineRef: null,
+    baselinePath: null,
+    catalogRoot: null,
+    outRoot: null,
+    runId: null,
+  };
+  const seen = new Set();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    validateControl(arg, 'argument');
+    validateArgumentSize(arg, 'argument');
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unknown positional argument: ${arg}`);
+    }
+
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${arg} requires a value`);
+      }
+      validateControl(value, arg);
+      validateArgumentSize(value, arg);
+      index += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '--target': {
+        if (seen.has('target')) throw new Error('Repeated flag: --target');
+        options.target = readValue();
+        seen.add('target');
+        break;
+      }
+      case '--mode': {
+        if (seen.has('mode')) throw new Error('Repeated flag: --mode');
+        const value = readValue();
+        if (value !== 'behavior' && value !== 'triggers' && value !== 'all') {
+          throw new Error(`Unsupported mode: ${value}`);
+        }
+        options.mode = value;
+        seen.add('mode');
+        break;
+      }
+      case '--runs': {
+        if (seen.has('runs')) throw new Error('Repeated flag: --runs');
+        const value = readValue();
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed < 1 || parsed > 10 || !/^[0-9]+$/.test(value)) {
+          throw new Error(`Invalid runs: ${value}`);
+        }
+        options.runs = parsed;
+        seen.add('runs');
+        break;
+      }
+      case '--baseline-ref': {
+        if (seen.has('baseline-path')) {
+          throw new Error('Cannot combine --baseline-ref and --baseline-path');
+        }
+        if (seen.has('baseline-ref')) throw new Error('Repeated flag: --baseline-ref');
+        options.baselineRef = readValue();
+        seen.add('baseline-ref');
+        break;
+      }
+      case '--baseline-path': {
+        if (seen.has('baseline-ref')) {
+          throw new Error('Cannot combine --baseline-ref and --baseline-path');
+        }
+        if (seen.has('baseline-path')) throw new Error('Repeated flag: --baseline-path');
+        options.baselinePath = readValue();
+        if (!path.isAbsolute(options.baselinePath)) {
+          throw new Error('--baseline-path must be absolute');
+        }
+        seen.add('baseline-path');
+        break;
+      }
+      case '--catalog-root': {
+        if (seen.has('catalog-root')) throw new Error('Repeated flag: --catalog-root');
+        options.catalogRoot = readValue();
+        if (!path.isAbsolute(options.catalogRoot)) {
+          throw new Error('--catalog-root must be absolute');
+        }
+        seen.add('catalog-root');
+        break;
+      }
+      case '--out-root': {
+        if (seen.has('out-root')) throw new Error('Repeated flag: --out-root');
+        options.outRoot = readValue();
+        if (!path.isAbsolute(options.outRoot)) {
+          throw new Error('--out-root must be absolute');
+        }
+        seen.add('out-root');
+        break;
+      }
+      case '--run-id': {
+        if (seen.has('run-id')) throw new Error('Repeated flag: --run-id');
+        options.runId = readValue();
+        if (!isSafeRunId(options.runId)) {
+          throw new Error(`Invalid run-id: ${options.runId}`);
+        }
+        seen.add('run-id');
+        break;
+      }
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.target || !options.mode || options.runs === null) {
+    throw new Error('Missing required flags: --target, --mode, --runs');
+  }
+  if (options.baselinePath && !path.isAbsolute(options.baselinePath)) {
+    throw new Error('--baseline-path must be absolute');
+  }
+  if (options.runId && !isSafeRunId(options.runId)) {
+    throw new Error(`Invalid run-id: ${options.runId}`);
+  }
+
+  return options;
+}
+
+function parseGitSha(value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!/^[0-9a-f]{40}$/.test(normalized)) return null;
+  return normalized;
+}
+
+function isBlobMode(mode) {
+  return mode === '100644' || mode === '100755';
+}
+
+function terminateChild(child) {
+  if (process.platform === 'win32' && child.pid) {
+    try {
+      spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], {
+        stdio: 'ignore',
+        timeout: MAX_CHILD_TERMINATION_MS,
+        windowsHide: true,
+      });
+    } catch {
+      // Fall back to the direct child when taskkill is unavailable.
+    }
+  }
+  if (process.platform !== 'win32' && child.pid) {
+    try {
+      process.kill(-child.pid, 'SIGKILL');
+      return;
+    } catch {
+      // Fall back to the direct child when its process group is already gone.
+    }
+  }
+  try {
+    child.kill('SIGKILL');
+  } catch {
+    // The child may already have exited.
+  }
+}
+
+async function runCommand(command, args, {
+  cwd = process.cwd(),
+  env = process.env,
+  timeoutMs = 10000,
+  allowCodes = [0],
+  encoding = 'utf8',
+} = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      detached: process.platform !== 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    trackedChildren.add(child);
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let settled = false;
+    let terminationError = null;
+    let terminationTimer = null;
+
+    const finish = (action, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      clearTimeout(terminationTimer);
+      trackedChildren.delete(child);
+      action(value);
+    };
+    const timeoutError = () => {
+      const error = new Error(`command timeout: ${command} ${args.join(' ')}`);
+      error.code = 'ETIMEDOUT';
+      return error;
+    };
+    const terminateWithDeadline = (error) => {
+      if (terminationError) return;
+      terminationError = error;
+      terminateChild(child);
+      terminationTimer = setTimeout(() => finish(reject, error), MAX_CHILD_TERMINATION_MS);
+    };
+
+    const timer = setTimeout(() => {
+      terminateWithDeadline(timeoutError());
+    }, timeoutMs);
+
+    const pushChunk = (chunk, kind) => {
+      if (!chunk?.length || settled) return;
+      const nextSize = (kind === 'stdout' ? stdoutBytes : stderrBytes) + chunk.length;
+      if (nextSize > MAX_CHILD_BYTES) {
+        terminateWithDeadline(new Error(`command output exceeded limit: ${command} ${args.join(' ')}`));
+        return;
+      }
+      if (kind === 'stdout') {
+        stdoutBytes = nextSize;
+        stdoutChunks.push(chunk);
+      } else {
+        stderrBytes = nextSize;
+        stderrChunks.push(chunk);
+      }
+    };
+
+    child.stdout?.on('data', (chunk) => pushChunk(chunk, 'stdout'));
+    child.stderr?.on('data', (chunk) => pushChunk(chunk, 'stderr'));
+
+    child.once('error', (error) => finish(reject, error));
+
+    child.once('close', (code, signal) => {
+      if (settled) return;
+      const stdout = encoding === 'buffer'
+        ? Buffer.concat(stdoutChunks)
+        : Buffer.concat(stdoutChunks).toString(encoding);
+      const stderr = encoding === 'buffer'
+        ? Buffer.concat(stderrChunks)
+        : Buffer.concat(stderrChunks).toString(encoding);
+
+      if (terminationError) {
+        finish(reject, terminationError);
+        return;
+      }
+
+      if (!allowCodes.includes(code)) {
+        const failed = new Error(`command failed (${code ?? signal ?? 'signal'}) : ${command} ${args.join(' ')}`);
+        failed.code = code;
+        failed.stderr = String(stderr);
+        failed.stdout = String(stdout);
+        finish(reject, failed);
+        return;
+      }
+
+      finish(resolve, { code, stdout, stderr });
+    });
+  });
+}
+
+function gitEnvironment(env = {}) {
+  return {
+    ...process.env,
+    ...env,
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'core.fsmonitor',
+    GIT_CONFIG_VALUE_0: 'false',
+  };
+}
+
+async function runGit(cwd, args, opts = {}) {
+  return runCommand('git', ['-c', 'core.fsmonitor=false', ...args], {
+    cwd,
+    ...opts,
+    env: gitEnvironment(opts.env),
+    allowCodes: opts.allowCodes ?? [0],
+  });
+}
+async function readIndexTree(gitRoot) {
+  let failure;
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      return String((await runGit(gitRoot, ['write-tree'])).stdout).trim();
+    } catch (error) {
+      failure = error;
+      await new Promise((resolve) => setTimeout(resolve, (attempt + 1) * 10));
+    }
+  }
+  throw failure;
+}
+
+async function snapshotSource(packageRoot, gitRoot) {
+  const packageHash = await hashPackage(packageRoot, { trackedOnly: false });
+  if (!packageHash) throw new Error('could not snapshot target package');
+  if (!gitRoot) return { packageHash, git: null };
+  const head = String((await runGit(gitRoot, ['rev-parse', 'HEAD'])).stdout).trim();
+  const indexTree = await readIndexTree(gitRoot);
+  const porcelain = (await runGit(
+    gitRoot,
+    ['status', '--porcelain=v1', '-z', '--untracked-files=all'],
+    { encoding: 'buffer' },
+  )).stdout;
+  return { packageHash, git: { head, indexTree, porcelain } };
+}
+
+async function assertSourceUnchanged(before, packageRoot, gitRoot) {
+  const after = await snapshotSource(packageRoot, gitRoot);
+  const sameGit = before.git === null
+    ? after.git === null
+    : after.git !== null
+      && before.git.head === after.git.head
+      && before.git.indexTree === after.git.indexTree
+      && before.git.porcelain.equals(after.git.porcelain);
+  if (before.packageHash !== after.packageHash || !sameGit) {
+    throw new Error('source target changed during preparation');
+  }
+}
+
+
+async function resolveGitRoot(startPath) {
+  const result = await runGit(startPath, ['rev-parse', '--show-toplevel'], { allowCodes: [0, 128] });
+  if (result.code === 0) {
+    const root = String(result.stdout || '').trim();
+    if (!root) throw new Error('Git returned an empty repository root');
+    return path.resolve(root);
+  }
+  if (!/not a git repository/i.test(String(result.stderr || ''))) {
+    throw new Error('Git repository resolution failed');
+  }
+
+  for (let current = path.resolve(startPath); ; current = path.dirname(current)) {
+    try {
+      await lstatAsync(path.join(current, '.git'));
+      throw new Error('Git metadata is present but invalid or unreadable');
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+  }
+}
+
+async function runResolver(gitRoot) {
+  const info = await lstatAsync(DEFAULT_BASELINE_RESOLVER);
+  if (!info.isFile() || info.isSymbolicLink()) {
+    throw new Error('canonical resolver missing');
+  }
+  const result = await runCommand('bash', [DEFAULT_BASELINE_RESOLVER], {
+    cwd: gitRoot,
+    timeoutMs: 15000,
+    env: gitEnvironment(),
+    allowCodes: [0],
+  });
+  const branch = String(result.stdout || '').trim().split('\n')[0];
+  if (!branch) {
+    throw new Error('canonical resolver returned no branch');
+  }
+  return branch;
+}
+
+function safePackageRelative(gitRoot, packageRoot) {
+  const relative = path.relative(gitRoot, packageRoot);
+  if (!relative || relative === '.' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return null;
+  }
+  return toCanonical(relative);
+}
+
+function parseValidation(value, label) {
+  if (!value || !value.valid) {
+    const first = Array.isArray(value?.errors) && value.errors.length > 0
+      ? `${value.errors[0].code} ${value.errors[0].message}`
+      : 'invalid package';
+    throw new Error(`${label} validation failed: ${first}`);
+  }
+}
+
+async function validateTargetPackage(input, defaultRoot) {
+  const result = await validatePackage(input, { repositoryRoot: defaultRoot, trackedOnly: false });
+  parseValidation(result, 'target');
+
+  const packageRoot = await realpathAsync(path.resolve(defaultRoot, result.package.path));
+  const hash = await hashPackage(input, { trackedOnly: false });
+  if (!hash) {
+    throw new Error('could not hash target package');
+  }
+
+  const name = result.package?.name;
+  const description = result.package?.description;
+  if (!name || !description) {
+    throw new Error('target package lacks name or description');
+  }
+
+  return {
+    root: packageRoot,
+    name,
+    description,
+    hash,
+    validation: result,
+  };
+}
+
+async function loadCasesFromCorpus(corpusPath, mode) {
+  let raw;
+  try {
+    raw = await readFileAsync(corpusPath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const entries = Array.isArray(parsed?.cases) ? parsed.cases : [];
+  if (mode === 'behavior') {
+    return entries
+      .map((entry) => {
+        const id = typeof entry?.id === 'string' ? entry.id : '';
+        const fixtureEntries = [];
+        const fixtures = Array.isArray(entry?.fixtures) ? entry.fixtures : [];
+        for (const fixture of fixtures) {
+          if (typeof fixture !== 'string' || !isSafeRelativePath(fixture)) {
+            continue;
+          }
+          if (!fixtureEntries.includes(fixture)) {
+            fixtureEntries.push(fixture);
+          }
+        }
+        return { id, kind: 'behavior', fixtures: fixtureEntries, definition: entry };
+      })
+      .filter((item) => item.id)
+      .sort((left, right) => compareText(left.id, right.id));
+  }
+
+  return entries
+    .map((entry) => ({
+      id: typeof entry?.id === 'string' ? entry.id : '',
+      kind: 'trigger',
+      definition: entry,
+    }))
+    .filter((item) => item.id)
+    .sort((left, right) => compareText(left.id, right.id));
+}
+
+async function loadPublicSkillNames(catalogRoot) {
+  const authorityRoot = path.join(catalogRoot, 'using-woostack');
+  const validation = await validatePackage(authorityRoot, {
+    repositoryRoot: catalogRoot,
+    trackedOnly: false,
+  });
+  parseValidation(validation, 'public command authority');
+
+  const content = await readFileAsync(path.join(authorityRoot, 'SKILL.md'), 'utf8');
+  const names = new Set(['using-woostack']);
+  let inRouting = false;
+  let routeCount = 0;
+  for (const line of content.split(/\r?\n/)) {
+    if (line === '## Command Routing') {
+      inRouting = true;
+      continue;
+    }
+    if (inRouting && line.startsWith('## ')) break;
+    if (!inRouting) continue;
+    const route = line.match(/^\|.*\|\s*`([a-z0-9]+(?:-[a-z0-9]+)*)`\s*\|\s*$/);
+    if (!route) continue;
+    names.add(route[1]);
+    routeCount += 1;
+  }
+  if (routeCount === 0) {
+    throw new Error('public command authority has no routing entries');
+  }
+  return names;
+}
+
+async function loadCatalogSkills(catalogRoot, publicSkillNames) {
+  const root = path.resolve(catalogRoot);
+  const rootStat = await lstatAsync(root);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error('--catalog-root must be a directory');
+  }
+  const skills = [];
+  for (const publicName of [...publicSkillNames].sort(compareText)) {
+    const packageRoot = path.join(root, publicName);
+    let packageState;
+    try {
+      packageState = await lstatAsync(packageRoot);
+    } catch (error) {
+      if (error?.code === 'ENOENT') throw new Error(`catalog entry missing: ${publicName}`);
+      throw error;
+    }
+    if (packageState.isSymbolicLink() || !packageState.isDirectory()) {
+      throw new Error(`invalid catalog entry: ${publicName}`);
+    }
+    const skillPath = path.join(packageRoot, 'SKILL.md');
+    let skillState;
+    try {
+      skillState = await lstatAsync(skillPath);
+    } catch (error) {
+      if (error?.code === 'ENOENT') throw new Error(`catalog entry lacks SKILL.md: ${publicName}`);
+      throw error;
+    }
+    if (skillState.isSymbolicLink() || !skillState.isFile()) {
+      throw new Error(`invalid catalog skill file: ${skillPath}`);
+    }
+    const content = await readFileAsync(skillPath, 'utf8');
+    const parsed = parseFrontmatter(content, path.join(publicName, 'SKILL.md'));
+    const name = parsed.fm.name;
+    const description = parsed.fm.description;
+    if (name !== publicName || !description) {
+      throw new Error(`invalid catalog skill identity: ${publicName}`);
+    }
+    skills.push({ name, description });
+  }
+  return skills;
+}
+
+function catalogForTarget(baseSkills, includeTarget, targetName, targetDescription) {
+  const byName = new Map();
+  for (const skill of baseSkills) {
+    byName.set(skill.name, { name: skill.name, description: skill.description });
+  }
+  byName.delete(targetName);
+  if (includeTarget) {
+    byName.set(targetName, { name: targetName, description: targetDescription });
+  }
+  return {
+    schemaVersion: 1,
+    skills: [...byName.values()].sort((left, right) => compareText(left.name, right.name)),
+  };
+}
+
+async function materializeGitPackage(gitRoot, commit, packageRelative) {
+  const ls = await runGit(gitRoot, ['ls-tree', '-r', '-z', commit, '--', packageRelative], {
+    allowCodes: [0],
+    encoding: 'utf8',
+    timeoutMs: 20000,
+  });
+  const raw = String(ls.stdout || '');
+  const records = raw.split('\0').filter(Boolean);
+  if (records.length === 0) {
+    return {
+      present: false,
+      tempRoot: null,
+      packageRoot: null,
+    };
+  }
+
+  const tempRoot = await mkdtempAsync(path.join(os.tmpdir(), 'woostack-eval-baseline-'));
+  tempRoots.add(tempRoot);
+  const packageRoot = path.join(tempRoot, path.posix.basename(packageRelative));
+  await mkdirAsync(packageRoot, { mode: SAFE_FILE_MODE, recursive: true });
+
+  for (const rawEntry of records) {
+    const split = rawEntry.indexOf('\t');
+    if (split < 0) throw new Error('invalid git ls-tree output');
+    const meta = rawEntry.slice(0, split);
+    const filePath = rawEntry.slice(split + 1);
+    const parts = meta.split(' ');
+    if (parts.length !== 3) throw new Error('invalid git ls-tree metadata');
+    const [mode, kind] = parts;
+    if (kind !== 'blob' || !isBlobMode(mode)) {
+      throw new Error(`invalid git blob mode for ${filePath}`);
+    }
+    if (!isSafeRelativePath(filePath) && filePath !== packageRelative) {
+      throw new Error(`invalid git path in tree: ${filePath}`);
+    }
+    if (!toCanonical(filePath).startsWith(`${toCanonical(packageRelative)}/`)) {
+      throw new Error(`tree path outside package: ${filePath}`);
+    }
+    const relative = toCanonical(filePath).slice(packageRelative.length + 1);
+    if (!isSafeRelativePath(relative)) throw new Error(`invalid relative blob path: ${relative}`);
+    const { stdout } = await runGit(gitRoot, ['show', `${commit}:${filePath}`], {
+      allowCodes: [0],
+      encoding: 'buffer',
+      timeoutMs: 20000,
+    });
+    const destination = path.join(packageRoot, relative);
+    await mkdirAsync(path.dirname(destination), { mode: SAFE_FILE_MODE, recursive: true });
+    await writeFileAsync(destination, stdout);
+    await chmodAsync(destination, mode === '100755' ? 0o755 : 0o644);
+  }
+
+  return {
+    present: true,
+    tempRoot,
+    packageRoot,
+  };
+}
+
+async function copyDirectory(source, destination, prefix = '', { includeFixtures = false } = {}) {
+  const sourceState = await lstatAsync(source);
+  if (!sourceState.isDirectory() || sourceState.isSymbolicLink()) {
+    throw new Error(`invalid source directory: ${source}`);
+  }
+
+  await mkdirAsync(destination, { mode: SAFE_FILE_MODE, recursive: true });
+  const children = await readdirAsync(source, { withFileTypes: true });
+  const sorted = children.sort((left, right) => compareText(left.name, right.name));
+  for (const child of sorted) {
+    if (!isSafeRelativePath(child.name)) throw new Error(`unsafe path: ${child.name}`);
+    const relative = prefix ? `${prefix}/${child.name}` : child.name;
+    if (
+      (!includeFixtures && relative === 'evals/fixtures')
+      || relative === '.woostack/tmp/skill-evals'
+      || relative.startsWith('.woostack/tmp/skill-evals/')
+    ) {
+      continue;
+    }
+    const from = path.join(source, child.name);
+    const to = path.join(destination, child.name);
+    const state = await lstatAsync(from);
+    if (state.isSymbolicLink()) {
+      throw new Error(`symlink not allowed: ${from}`);
+    }
+    if (state.isDirectory()) {
+      await copyDirectory(from, to, relative, { includeFixtures });
+      continue;
+    }
+    if (!state.isFile()) {
+      throw new Error(`special file not allowed: ${from}`);
+    }
+    await mkdirAsync(path.dirname(to), { mode: SAFE_FILE_MODE, recursive: true });
+    await copyFileAsync(from, to);
+  }
+}
+
+async function copyFixture(sourcePackage, relativeFixture, destinationFixtures) {
+  if (!isSafeRelativePath(relativeFixture)) {
+    throw new Error(`invalid fixture path: ${relativeFixture}`);
+  }
+  const source = path.join(sourcePackage, 'evals', 'fixtures', relativeFixture);
+  const state = await lstatAsync(source);
+  if (state.isSymbolicLink()) {
+    throw new Error(`fixture symlink: ${relativeFixture}`);
+  }
+  if (!state.isFile()) {
+    throw new Error(`fixture is not a file: ${relativeFixture}`);
+  }
+  const destination = path.join(destinationFixtures, relativeFixture);
+  await mkdirAsync(path.dirname(destination), { mode: SAFE_FILE_MODE, recursive: true });
+  await copyFileAsync(source, destination);
+}
+
+function buildSelection(mode, behaviorCases, triggerCases, runs) {
+  const selected = [];
+  const selectedIds = new Set();
+  const kinds = [];
+  if (mode === 'behavior' || mode === 'all') kinds.push('behavior');
+  if (mode === 'triggers' || mode === 'all') kinds.push('trigger');
+
+  for (const kind of kinds) {
+    const cases = kind === 'behavior' ? behaviorCases : triggerCases;
+    for (const item of cases) {
+      if (item.id.length > MAX_CASE_ID_LENGTH) {
+        throw new Error(`case id exceeds ${MAX_CASE_ID_LENGTH} characters: ${item.id}`);
+      }
+      if (selectedIds.has(item.id)) {
+        throw new Error(`duplicate selected case id across corpora: ${item.id}`);
+      }
+      selectedIds.add(item.id);
+      if (selectedIds.size > MAX_CASE_COUNT) {
+        throw new Error(`selected case count exceeds ${MAX_CASE_COUNT}`);
+      }
+      if (selected.length + runs > MAX_CASE_REPETITIONS) {
+        throw new Error(`selected case repetitions exceed ${MAX_CASE_REPETITIONS}`);
+      }
+      for (let repetition = 1; repetition <= runs; repetition += 1) {
+        selected.push({
+          caseId: item.id,
+          kind,
+          repetition,
+          fixtures: item.kind === 'behavior' ? item.fixtures : [],
+          definition: item.definition,
+        });
+      }
+    }
+  }
+  return selected;
+}
+function sumPackageBytes(files, includeFixtures) {
+  let total = 0n;
+  for (const file of files) {
+    if (!includeFixtures && file.path.startsWith('evals/fixtures/')) continue;
+    total += BigInt(file.bytes);
+  }
+  return total;
+}
+
+function assertWorkspaceBudget(selected, target, baseline, catalogSkills) {
+  const candidatePackageBytes = sumPackageBytes(target.validation.files, false);
+  const baselinePackageBytes = sumPackageBytes(baseline.files, false);
+  const fixtureBytes = new Map(
+    target.validation.files
+      .filter((file) => file.path.startsWith('evals/fixtures/'))
+      .map((file) => [file.path.slice('evals/fixtures/'.length), BigInt(file.bytes)]),
+  );
+  const candidateCatalogBytes = BigInt(Buffer.byteLength(`${JSON.stringify(catalogForTarget(
+    catalogSkills,
+    true,
+    target.name,
+    target.description,
+  ))}\n`));
+  const baselineCatalogBytes = BigInt(Buffer.byteLength(`${JSON.stringify(catalogForTarget(
+    catalogSkills,
+    baseline.packageRoot !== null,
+    baseline.packageRoot !== null ? baseline.name : target.name,
+    baseline.packageRoot !== null ? baseline.description : target.description,
+  ))}\n`));
+  const frozenDefinitions = new Set();
+  let projectedBytes = 0n;
+
+  for (const item of selected) {
+    projectedBytes += candidatePackageBytes + baselinePackageBytes;
+    if (item.kind === 'behavior') {
+      for (const fixture of item.fixtures) {
+        const bytes = fixtureBytes.get(fixture);
+        if (bytes === undefined) throw new Error(`fixture missing from package inventory: ${fixture}`);
+        projectedBytes += bytes * 2n;
+      }
+    } else {
+      projectedBytes += candidateCatalogBytes + baselineCatalogBytes;
+    }
+    const definitionName = `${item.kind}.${item.caseId}`;
+    if (!frozenDefinitions.has(definitionName)) {
+      frozenDefinitions.add(definitionName);
+      projectedBytes += BigInt(Buffer.byteLength(`${JSON.stringify(item.definition)}\n`));
+    }
+  }
+
+  if (projectedBytes > BigInt(MAX_PROJECTED_WORKSPACE_BYTES)) {
+    throw new Error(
+      `projected workspace exceeds ${MAX_PROJECTED_WORKSPACE_BYTES} bytes: ${projectedBytes}`,
+    );
+  }
+}
+
+
+
+function makeManifest({
+  runId,
+  targetName,
+  mode,
+  runs,
+  baseline,
+  originalPackageHash,
+  packageHashes,
+  gradingPlan,
+  expected,
+  pairs,
+}) {
+  return {
+    schemaVersion: 1,
+    runId,
+    targetSkill: targetName,
+    mode,
+    runs,
+    baseline,
+    runConfiguration: {
+      host: null,
+      runner: null,
+      model: null,
+      sessionIdentity: null,
+      tier: null,
+      effort: null,
+    },
+    originalPackageHash,
+    packageHashes,
+    gradingPlan,
+    expected,
+    pairs,
+  };
+}
+
+async function assertCleanDirectory(candidate, label) {
+  if (!path.isAbsolute(candidate)) {
+    throw new Error(`${label} must be absolute`);
+  }
+
+  const normalized = path.resolve(candidate);
+  const stat = await lstatAsync(normalized);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`${label} must not be a symlink`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`${label} must be a directory`);
+  }
+
+  return candidate;
+}
+async function canonicalizePotentialPath(candidate) {
+  try {
+    return await realpathAsync(candidate);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+    const parent = path.dirname(candidate);
+    if (parent === candidate) throw error;
+    return path.join(await canonicalizePotentialPath(parent), path.basename(candidate));
+  }
+}
+
+function isContained(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+async function assertOutsideSourceRoots(candidate, roots, label) {
+  const canonical = await canonicalizePotentialPath(path.resolve(candidate));
+  for (const root of roots.filter(Boolean)) {
+    if (isContained(root, canonical)) {
+      throw new Error(`${label} must not be inside a source package`);
+    }
+  }
+  return canonical;
+}
+
+async function prepareOutputRoot(candidate, disallowedRoots) {
+  const normalized = path.resolve(candidate);
+  try {
+    const state = await lstatAsync(normalized);
+    if (state.isSymbolicLink()) throw new Error('output root must not be a symlink');
+    if (!state.isDirectory()) throw new Error('output root must be a directory');
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  const canonical = await canonicalizePotentialPath(normalized);
+  for (const root of disallowedRoots.filter(Boolean)) {
+    if (isContained(root, canonical)) {
+      throw new Error('output root must not be inside a source package');
+    }
+  }
+  await mkdirAsync(canonical, { mode: SAFE_FILE_MODE, recursive: true });
+  return canonical;
+}
+
+
+
+function chooseOutRoot(options, gitRoot) {
+  const fallback = path.isAbsolute(process.env.TMPDIR || '/tmp')
+    ? (process.env.TMPDIR || '/tmp')
+    : path.resolve(process.env.TMPDIR);
+  if (options.outRoot) {
+    return options.outRoot;
+  }
+
+  if (!gitRoot) {
+    emit(`fallback output root: ${fallback}`);
+    return fallback;
+  }
+
+  return runGit(gitRoot, ['check-ignore', '-q', '--', '.woostack/tmp/skill-evals/'], { allowCodes: [0, 1] })
+    .then((result) => {
+      if (result.code === 0) {
+        return path.join(gitRoot, '.woostack', 'tmp', 'skill-evals');
+      }
+      emit(`fallback output root: ${fallback}`);
+      return fallback;
+    })
+    .catch(() => {
+      emit(`fallback output root: ${fallback}`);
+      return fallback;
+    });
+}
+
+async function allocateRunRoot(outRoot, requestedRunId) {
+  const reserve = async (runId) => {
+    const finalPath = path.join(outRoot, runId);
+    let created = false;
+    try {
+      await mkdirAsync(finalPath, { mode: SAFE_FILE_MODE });
+      created = true;
+      await chmodAsync(finalPath, SAFE_FILE_MODE);
+      const identity = await lstatAsync(finalPath);
+      return {
+        runId,
+        finalPath,
+        rootPath: finalPath,
+        identity: { dev: identity.dev, ino: identity.ino },
+      };
+    } catch (error) {
+      if (error?.code === 'EEXIST') return null;
+      if (created) {
+        try {
+          await rmAsync(finalPath, { recursive: true, force: true });
+        } catch (cleanupError) {
+          throw new AggregateError(
+            [error, cleanupError],
+            'run-root reservation failed and rollback cleanup failed',
+          );
+        }
+      }
+      throw error;
+    }
+  };
+
+  if (requestedRunId) {
+    if (!isSafeRunId(requestedRunId)) throw new Error(`invalid run-id: ${requestedRunId}`);
+    const allocation = await reserve(requestedRunId);
+    if (!allocation) {
+      throw new Error(`run id already exists: ${requestedRunId}`);
+    }
+    return allocation;
+  }
+
+  while (true) {
+    const allocation = await reserve(formatRunId());
+    if (allocation) return allocation;
+  }
+}
+
+function scheduleExitCleanup() {
+  let stopping = false;
+  const stop = (signal, code) => {
+    if (stopping) return;
+    stopping = true;
+    void (async () => {
+      let diagnostic = `received ${signal}; cleanup complete`;
+      try {
+        await killTrackedChildren();
+        await cleanupRun();
+      } catch (error) {
+        diagnostic = `received ${signal}; cleanup failed: ${boundedDiagnostic(error)}`;
+      } finally {
+        emit('prepare.mjs:', boundedDiagnostic(diagnostic));
+        process.exit(code);
+      }
+    })();
+  };
+  process.once('SIGINT', () => stop('SIGINT', 130));
+  process.once('SIGTERM', () => stop('SIGTERM', 143));
+}
+
+async function killTrackedChildren() {
+  const children = [...trackedChildren];
+  for (const child of children) terminateChild(child);
+  await Promise.all(children.map((child) => new Promise((resolve) => {
+    if (!trackedChildren.has(child)) {
+      resolve();
+      return;
+    }
+    let waitTimer;
+    const finish = () => {
+      clearTimeout(waitTimer);
+      child.off('close', finish);
+      trackedChildren.delete(child);
+      resolve();
+    };
+    child.once('close', finish);
+    waitTimer = setTimeout(finish, MAX_CHILD_TERMINATION_MS);
+  })));
+}
+
+async function cleanupTemporaryRoots(failures) {
+  for (const root of [...tempRoots]) {
+    try {
+      await rmAsync(root, { recursive: true, force: true });
+      tempRoots.delete(root);
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        tempRoots.delete(root);
+      } else {
+        failures.push(error);
+      }
+    }
+  }
+}
+
+function throwCleanupFailures(failures) {
+  if (failures.length === 0) return;
+  throw new Error(
+    `cleanup failed (${failures.length}): ${boundedDiagnostic(failures[0])}`,
+    { cause: new AggregateError(failures, 'evaluator cleanup failures') },
+  );
+}
+
+async function cleanupTemporarySnapshots() {
+  const failures = [];
+  await cleanupTemporaryRoots(failures);
+  throwCleanupFailures(failures);
+}
+
+async function cleanupRun() {
+  const failures = [];
+  if (allocated) {
+    try {
+      const state = await lstatAsync(allocated.rootPath);
+      if (state.dev === allocated.identity.dev && state.ino === allocated.identity.ino) {
+        await rmAsync(allocated.rootPath, { recursive: true, force: true });
+      }
+      allocated = null;
+    } catch (error) {
+      if (error?.code === 'ENOENT') {
+        allocated = null;
+      } else {
+        failures.push(error);
+      }
+    }
+  }
+  await cleanupTemporaryRoots(failures);
+  throwCleanupFailures(failures);
+}
+
+async function chooseBaseline(info, options) {
+  const gitRoot = info.gitRoot;
+  if (options.baselineRef) {
+    if (!gitRoot) {
+      throw new Error('explicit baseline-ref requires target under git');
+    }
+    const resolved = parseGitSha((await runGit(gitRoot, ['rev-parse', `${options.baselineRef}^{commit}`]).then((value) => value.stdout)));
+    if (!resolved) {
+      throw new Error(`invalid baseline ref: ${options.baselineRef}`);
+    }
+    const packageRelative = safePackageRelative(gitRoot, info.packageRoot);
+    if (!packageRelative) {
+      throw new Error('candidate package is outside git root');
+    }
+    const materialized = await materializeGitPackage(gitRoot, resolved, packageRelative);
+    if (!materialized.present) {
+      throw new Error('explicit baseline ref does not point to a package');
+    }
+    const validation = await validatePackage(materialized.packageRoot, {
+      repositoryRoot: materialized.tempRoot,
+      trackedOnly: false,
+    });
+    parseValidation(validation, 'baseline');
+    return {
+      identity: { kind: 'git-ref', identity: resolved },
+      packageRoot: materialized.packageRoot,
+      name: validation.package.name,
+      description: validation.package.description,
+      files: validation.files,
+    };
+  }
+
+  if (options.baselinePath) {
+    const baselineInput = path.resolve(options.baselinePath);
+    const baselineState = await lstatAsync(baselineInput);
+    if (baselineState.isSymbolicLink() || !baselineState.isDirectory()) {
+      throw new Error('--baseline-path must name a non-symlink skill directory');
+    }
+    const candidate = await validateTargetPackage(baselineInput, baselineInput);
+    if (candidate.name !== info.targetName) {
+      throw new Error('--baseline-path must identify the same skill as --target');
+    }
+
+    const tempRoot = await mkdtempAsync(path.join(os.tmpdir(), 'woostack-eval-path-baseline-'));
+    tempRoots.add(tempRoot);
+    await chmodAsync(tempRoot, SAFE_FILE_MODE);
+    const snapshotRoot = path.join(tempRoot, 'package');
+    await copyDirectory(candidate.root, snapshotRoot, '', { includeFixtures: true });
+    const snapshotHash = await hashPackage(snapshotRoot, { trackedOnly: false });
+    if (snapshotHash !== candidate.hash) {
+      throw new Error('explicit baseline changed while creating its private snapshot');
+    }
+    return {
+      identity: { kind: 'path', identity: candidate.hash },
+      packageRoot: snapshotRoot,
+      sourceRoot: candidate.root,
+      sourceHash: candidate.hash,
+      name: candidate.name,
+      description: candidate.description,
+      files: candidate.validation.files,
+    };
+  }
+
+  if (!gitRoot) {
+    return {
+      identity: { kind: 'none', identity: `non-git:${info.targetHash}:absent` },
+      packageRoot: null,
+      name: null,
+      description: null,
+      files: [],
+    };
+  }
+
+  const baseBranch = await runResolver(gitRoot);
+  const mergeBase = parseGitSha(await runGit(gitRoot, ['merge-base', 'HEAD', baseBranch]).then((value) => value.stdout));
+  if (!mergeBase) {
+    throw new Error('could not compute merge-base baseline');
+  }
+  const packageRelative = safePackageRelative(gitRoot, info.packageRoot);
+  if (!packageRelative) {
+    throw new Error('candidate package is outside resolved Git root');
+  }
+  const materialized = await materializeGitPackage(gitRoot, mergeBase, packageRelative);
+  if (!materialized.present) {
+    return {
+      identity: { kind: 'none', identity: `${mergeBase}:absent` },
+      packageRoot: null,
+      name: null,
+      description: null,
+      files: [],
+    };
+  }
+  const validation = await validatePackage(materialized.packageRoot, {
+    repositoryRoot: materialized.tempRoot,
+    trackedOnly: false,
+  });
+  if (!validation.valid) {
+    throw new Error('merge-base baseline materialization is invalid');
+  }
+  return {
+    identity: { kind: 'git-ref', identity: mergeBase },
+    packageRoot: materialized.packageRoot,
+    name: validation.package.name,
+    description: validation.package.description,
+    files: validation.files,
+  };
+}
+
+async function synchronizeBaselineSnapshot() {
+  const readyPath = process.env.WOOSTACK_EVAL_TEST_BASELINE_SNAPSHOT_READY || '';
+  const releasePath = process.env.WOOSTACK_EVAL_TEST_BASELINE_SNAPSHOT_RELEASE || '';
+  if (!readyPath && !releasePath) return;
+  if (process.env.WOOSTACK_EVAL_TEST_MODE !== '1') {
+    throw new Error('baseline snapshot synchronization requires WOOSTACK_EVAL_TEST_MODE=1');
+  }
+  if (!readyPath || !releasePath) {
+    throw new Error('baseline snapshot synchronization paths must be provided together');
+  }
+  for (const [value, label] of [
+    [readyPath, 'WOOSTACK_EVAL_TEST_BASELINE_SNAPSHOT_READY'],
+    [releasePath, 'WOOSTACK_EVAL_TEST_BASELINE_SNAPSHOT_RELEASE'],
+  ]) {
+    validateControl(value, label);
+    validateArgumentSize(value, label);
+    if (!path.isAbsolute(value)) throw new Error(`${label} must be absolute`);
+  }
+  await writeFileAsync(readyPath, 'ready\n', 'utf8');
+  const release = await readFileAsync(releasePath, 'utf8');
+  if (release !== 'release\n') {
+    throw new Error('invalid baseline snapshot synchronization release');
+  }
+}
+
+async function prepare(argv) {
+
+  const options = parseCommandLine(argv);
+  const configuredTmp = process.env.TMPDIR || '/tmp';
+  validateControl(configuredTmp, 'TMPDIR');
+  validateArgumentSize(configuredTmp, 'TMPDIR');
+
+  const candidateInput = path.resolve(options.target);
+  const candidateBoundary = path.basename(candidateInput) === 'SKILL.md'
+    ? path.dirname(candidateInput)
+    : candidateInput;
+  const target = await validateTargetPackage(candidateInput, candidateBoundary);
+  const targetPackageRoot = target.root;
+  const candidateCatalogCases = await loadCasesFromCorpus(path.join(targetPackageRoot, 'evals', 'evals.json'), 'behavior');
+  const candidateTriggerCases = await loadCasesFromCorpus(path.join(targetPackageRoot, 'evals', 'trigger-evals.json'), 'trigger');
+  const selected = buildSelection(options.mode, candidateCatalogCases, candidateTriggerCases, options.runs);
+  if (selected.length === 0) {
+    throw new Error(`no ${options.mode} evaluation cases selected`);
+  }
+
+  const catalogRoot = path.resolve(options.catalogRoot || DEFAULT_CATALOG_ROOT);
+  const safeCatalogRoot = await assertCleanDirectory(catalogRoot, '--catalog-root');
+  const publicSkillNames = await loadPublicSkillNames(safeCatalogRoot);
+  const catalogSkills = await loadCatalogSkills(safeCatalogRoot, publicSkillNames);
+
+  const gitRoot = await resolveGitRoot(targetPackageRoot);
+  const sourceSnapshot = await snapshotSource(targetPackageRoot, gitRoot);
+  if (sourceSnapshot.packageHash !== target.hash) {
+    throw new Error('source target changed during validation');
+  }
+
+  const explicitBaselineRoot = options.baselinePath
+    ? await canonicalizePotentialPath(path.resolve(options.baselinePath))
+    : null;
+  await assertOutsideSourceRoots(configuredTmp, [targetPackageRoot, explicitBaselineRoot], 'TMPDIR');
+
+  const baseline = await chooseBaseline({
+    gitRoot,
+    packageRoot: targetPackageRoot,
+    targetName: target.name,
+    targetHash: target.hash,
+  }, options);
+  assertWorkspaceBudget(selected, target, baseline, catalogSkills);
+
+  await synchronizeBaselineSnapshot();
+  const outputRoot = await chooseOutRoot(options, gitRoot);
+  const resolvedOutRoot = await prepareOutputRoot(outputRoot, [
+    targetPackageRoot,
+    baseline.sourceRoot,
+  ]);
+
+  const allocation = await allocateRunRoot(resolvedOutRoot, options.runId || null);
+  allocated = allocation;
+
+  try {
+    await mkdirAsync(path.join(allocation.rootPath, 'cases'), { mode: SAFE_FILE_MODE, recursive: true });
+    const definitionsRoot = path.join(allocation.rootPath, 'definitions');
+    await mkdirAsync(definitionsRoot, { mode: SAFE_FILE_MODE });
+    const frozenDefinitions = new Set();
+    for (const item of selected) {
+      const definitionName = `${item.kind}.${item.caseId}.json`;
+      if (frozenDefinitions.has(definitionName)) continue;
+      frozenDefinitions.add(definitionName);
+      await writeFileAsync(
+        path.join(definitionsRoot, definitionName),
+        `${JSON.stringify(item.definition)}\n`,
+        { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+      );
+    }
+    const expected = [];
+    const pairs = [];
+    const gradingPlan = selected.flatMap((item) =>
+      (item.definition.assertions ?? [])
+        .filter((assertion) => assertion.kind === 'qualitative')
+        .map((assertion) => ({
+          caseId: item.caseId,
+          repetition: item.repetition,
+          assertionId: assertion.id,
+          graderId: null,
+        }))).sort((left, right) =>
+      compareText(left.caseId, right.caseId)
+      || left.repetition - right.repetition
+      || compareText(left.assertionId, right.assertionId));
+    const packageHashes = { candidate: null, baseline: null };
+
+    for (const item of selected) {
+      const caseDir = path.join(allocation.rootPath, 'cases', item.caseId, String(item.repetition));
+      const candidateVariant = path.join(caseDir, 'candidate');
+      const baselineVariant = path.join(caseDir, 'baseline');
+      await mkdirAsync(candidateVariant, { mode: SAFE_FILE_MODE, recursive: true });
+      await mkdirAsync(baselineVariant, { mode: SAFE_FILE_MODE, recursive: true });
+      await copyDirectory(targetPackageRoot, path.join(candidateVariant, 'package'));
+
+      if (baseline.packageRoot) {
+        await copyDirectory(baseline.packageRoot, path.join(baselineVariant, 'package'));
+      }
+      for (const [variant, packageRoot] of [
+        ['candidate', path.join(candidateVariant, 'package')],
+        ['baseline', baseline.packageRoot ? path.join(baselineVariant, 'package') : null],
+      ]) {
+        if (!packageRoot) continue;
+        const copiedHash = await hashPackage(packageRoot, { trackedOnly: false });
+        if (!copiedHash) throw new Error(`failed to hash copied ${variant} package`);
+        if (packageHashes[variant] === null) {
+          packageHashes[variant] = copiedHash;
+        } else if (packageHashes[variant] !== copiedHash) {
+          throw new Error(`copied ${variant} packages do not share one frozen hash`);
+        }
+      }
+
+      if (item.kind === 'behavior') {
+        await mkdirAsync(path.join(candidateVariant, 'fixtures'), { mode: SAFE_FILE_MODE });
+        await mkdirAsync(path.join(baselineVariant, 'fixtures'), { mode: SAFE_FILE_MODE });
+        for (const fixture of item.fixtures) {
+          await copyFixture(targetPackageRoot, fixture, path.join(candidateVariant, 'fixtures'));
+          if (baseline.packageRoot || baseline.identity.kind === 'none') {
+            await copyFixture(targetPackageRoot, fixture, path.join(baselineVariant, 'fixtures'));
+          }
+        }
+      }
+
+      if (item.kind === 'trigger') {
+        const candidateCatalog = catalogForTarget(
+          catalogSkills,
+          true,
+          target.name,
+          target.description,
+        );
+        const baselineCatalog = catalogForTarget(
+          catalogSkills,
+          baseline.packageRoot !== null,
+          baseline.packageRoot !== null ? baseline.name : target.name,
+          baseline.packageRoot !== null ? baseline.description : target.description,
+        );
+        await writeFileAsync(path.join(candidateVariant, 'catalog.json'), `${JSON.stringify(candidateCatalog)}\n`, 'utf8');
+        await writeFileAsync(path.join(baselineVariant, 'catalog.json'), `${JSON.stringify(baselineCatalog)}\n`, 'utf8');
+      }
+
+      expected.push(
+        {
+          caseId: item.caseId,
+          variant: 'candidate',
+          repetition: item.repetition,
+          kind: item.kind,
+        },
+        {
+          caseId: item.caseId,
+          variant: 'baseline',
+          repetition: item.repetition,
+          kind: item.kind,
+        },
+      );
+      pairs.push({
+        caseId: item.caseId,
+        repetition: item.repetition,
+        candidate: toCanonical(path.join('cases', item.caseId, String(item.repetition), 'candidate')),
+        baseline: toCanonical(path.join('cases', item.caseId, String(item.repetition), 'baseline')),
+      });
+    }
+
+
+    const manifest = makeManifest({
+      runId: allocation.runId,
+      targetName: target.name,
+      mode: options.mode,
+      runs: options.runs,
+      baseline: baseline.identity.kind === 'path'
+        ? { kind: 'path', identity: packageHashes.baseline }
+        : baseline.identity,
+      originalPackageHash: target.hash,
+      packageHashes,
+      gradingPlan,
+      expected,
+      pairs,
+    });
+
+    await mkdirAsync(path.join(allocation.rootPath, 'evidence'), {
+      recursive: true,
+      mode: SAFE_FILE_MODE,
+    });
+    await assertSourceUnchanged(sourceSnapshot, targetPackageRoot, gitRoot);
+    if (baseline.sourceRoot) {
+      const currentBaselineHash = await hashPackage(baseline.sourceRoot, { trackedOnly: false });
+      if (currentBaselineHash !== baseline.sourceHash) {
+        throw new Error('baseline source changed during preparation');
+      }
+    }
+
+    await writeFileAsync(
+      path.join(allocation.rootPath, 'manifest.json'),
+      `${JSON.stringify(manifest)}\n`,
+      { encoding: 'utf8', flag: 'wx' },
+    );
+    await cleanupTemporarySnapshots();
+    allocated = null;
+    process.stdout.write(`${allocation.finalPath}\n`);
+  } finally {
+    await cleanupRun();
+  }
+}
+
+async function main(argv) {
+  scheduleExitCleanup();
+  try {
+    await prepare(argv);
+  } finally {
+    await killTrackedChildren();
+    await cleanupRun();
+  }
+}
+
+function withRealpath(value) {
+  return realpathAsync(value).then(
+    (resolved) => resolved,
+    () => value,
+  );
+}
+
+if (process.argv[1]) {
+  const caller = await withRealpath(path.resolve(process.argv[1]));
+  if ((await withRealpath(fileURLToPath(import.meta.url))) === caller) {
+    main(process.argv.slice(2)).catch((error) => {
+      emit('prepare.mjs:', boundedDiagnostic(error));
+      process.exitCode = 1;
+    });
+  }
+}

--- a/skills/woostack-eval/scripts/tests/test-prepare.sh
+++ b/skills/woostack-eval/scripts/tests/test-prepare.sh
@@ -1,0 +1,1452 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SOURCE_PREPARER="$SCRIPT_DIR/../prepare.mjs"
+SOURCE_VALIDATOR="$SCRIPT_DIR/../validate.mjs"
+NODE=${NODE:-node}
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/woostack-eval-prepare.XXXXXX")
+CANONICAL_TMP_ROOT=$(CDPATH= cd -- "$TMP_ROOT" && pwd -P)
+CHILD_PIDS=()
+
+untrack_pid() {
+  removed=$1
+  for child_index in "${!CHILD_PIDS[@]}"; do
+    if [ "${CHILD_PIDS[$child_index]}" = "$removed" ]; then
+      unset 'CHILD_PIDS[child_index]'
+      return
+    fi
+  done
+}
+
+cleanup() {
+  cleanup_status=$?
+  trap - EXIT HUP INT TERM
+  for tracked in "${CHILD_PIDS[@]-}"; do
+    [ -n "$tracked" ] && kill -TERM "$tracked" 2>/dev/null || :
+  done
+  for tracked in "${CHILD_PIDS[@]-}"; do
+    [ -n "$tracked" ] && wait "$tracked" 2>/dev/null || :
+  done
+  rm -rf "$TMP_ROOT"
+  exit "$cleanup_status"
+}
+trap cleanup EXIT HUP INT TERM
+
+start_timed() {
+  timeout_seconds=$1
+  timed_stdout=$2
+  timed_stderr=$3
+  shift 3
+  TIMED_OUT_MARKER="$timed_stderr.timeout"
+  rm -f "$TIMED_OUT_MARKER"
+  "$@" >"$timed_stdout" 2>"$timed_stderr" &
+  TIMED_PID=$!
+  CHILD_PIDS+=("$TIMED_PID")
+  "$NODE" - "$TIMED_PID" "$timeout_seconds" "$TIMED_OUT_MARKER" <<'NODE' &
+const fs = require('node:fs');
+const [pidText, timeoutText, marker] = process.argv.slice(2);
+const pid = Number(pidText);
+setTimeout(() => {
+  try {
+    process.kill(pid, 0);
+    fs.writeFileSync(marker, `process exceeded ${timeoutText} seconds\n`);
+    process.kill(pid, 'SIGTERM');
+    setTimeout(() => {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {}
+      process.exit(0);
+    }, 1000);
+  } catch {
+    process.exit(0);
+  }
+}, Number(timeoutText) * 1000);
+NODE
+  TIMED_WATCHDOG_PID=$!
+  CHILD_PIDS+=("$TIMED_WATCHDOG_PID")
+}
+
+finish_timed() {
+  timed_pid=$1
+  watchdog_pid=$2
+  timeout_marker=$3
+  if wait "$timed_pid"; then
+    timed_status=0
+  else
+    timed_status=$?
+  fi
+  untrack_pid "$timed_pid"
+  kill "$watchdog_pid" 2>/dev/null || :
+  wait "$watchdog_pid" 2>/dev/null || :
+  untrack_pid "$watchdog_pid"
+  if [ -f "$timeout_marker" ]; then
+    return 124
+  fi
+  return "$timed_status"
+}
+
+run_timed() {
+  timeout_seconds=$1
+  timed_stdout=$2
+  timed_stderr=$3
+  shift 3
+  start_timed "$timeout_seconds" "$timed_stdout" "$timed_stderr" "$@"
+  child_pid=$TIMED_PID
+  watchdog_pid=$TIMED_WATCHDOG_PID
+  timeout_marker=$TIMED_OUT_MARKER
+  finish_timed "$child_pid" "$watchdog_pid" "$timeout_marker"
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  file=$1
+  text=$2
+  label=$3
+  [ -f "$file" ] || fail "$label: missing $file"
+  grep -F -- "$text" "$file" >/dev/null || fail "$label: expected '$text' in $file"
+}
+
+write_skill() {
+  package=$1
+  name=$2
+  description=$3
+  mkdir -p "$package/references"
+  cat >"$package/SKILL.md" <<EOF
+---
+name: $name
+description: $description
+---
+# $name
+
+[Guide](references/guide.md)
+EOF
+  printf '# Guide\n\n%s\n' "$description" >"$package/references/guide.md"
+}
+
+write_public_authority() {
+  package=$1
+  extra_route=${2:-}
+  mkdir -p "$package/references"
+  cat >"$package/SKILL.md" <<'EOF'
+---
+name: using-woostack
+description: Installed public command-routing authority.
+---
+# using-woostack
+
+[Guide](references/guide.md)
+
+## Command Routing
+
+| Request | Load |
+|---|---|
+| `/catalog-peer`, load the synthetic public peer | `catalog-peer` |
+EOF
+  if [ -n "$extra_route" ]; then
+    printf '| `/%s`, load the selected-catalog fixture | `%s` |\n' \
+      "$extra_route" "$extra_route" >>"$package/SKILL.md"
+  fi
+  printf '# Guide\n' >"$package/references/guide.md"
+}
+
+write_corpora() {
+  package=$1
+  name=$2
+  fixture_text=$3
+  mkdir -p "$package/evals/fixtures"
+  printf '%s alpha\n' "$fixture_text" >"$package/evals/fixtures/alpha.txt"
+  printf '%s zeta\n' "$fixture_text" >"$package/evals/fixtures/zeta.txt"
+  cat >"$package/evals/evals.json" <<EOF
+{
+  "schemaVersion": 1,
+  "skill": "$name",
+  "cases": [{
+    "id": "zeta-behavior",
+    "prompt": "Use only the zeta fixture without changing the source package.",
+    "fixtures": ["zeta.txt"],
+    "capabilities": ["read-workspace", "write-workspace"],
+    "expected": "Only the copied zeta fixture is available in this isolated workspace.",
+    "assertions": [{
+      "id": "zeta-fixture-present",
+      "kind": "file-contains",
+      "file": "fixtures/zeta.txt",
+      "substring": "$fixture_text zeta",
+      "critical": true
+    }]
+  }, {
+    "id": "alpha-behavior",
+    "prompt": "Use only the alpha fixture without changing the source package.",
+    "fixtures": ["alpha.txt"],
+    "capabilities": ["read-workspace", "write-workspace"],
+    "expected": "Only the copied alpha fixture is available in this isolated workspace.",
+    "assertions": [{
+      "id": "alpha-fixture-present",
+      "kind": "file-contains",
+      "file": "fixtures/alpha.txt",
+      "substring": "$fixture_text alpha",
+      "critical": true
+    }, {
+      "id": "alpha-quality",
+      "kind": "qualitative",
+      "rubric": "Does the response clearly explain the alpha result?",
+      "critical": false
+    }, {
+      "id": "aardvark-quality",
+      "kind": "qualitative",
+      "rubric": "Does the response state the alpha result directly?",
+      "critical": true
+    }]
+  }]
+}
+EOF
+  cat >"$package/evals/trigger-evals.json" <<EOF
+{
+  "schemaVersion": 1,
+  "skill": "$name",
+  "cases": [{
+    "id": "zeta-trigger",
+    "query": "Do not run the target evaluator workflow.",
+    "shouldTrigger": false,
+    "expectedSkill": "none",
+    "conflictsWith": ["$name"]
+  }, {
+    "id": "alpha-trigger",
+    "query": "Run the target evaluator workflow.",
+    "shouldTrigger": true,
+    "expectedSkill": "$name",
+    "conflictsWith": ["catalog-peer"]
+  }]
+}
+EOF
+}
+
+validate_setup_package() {
+  package=$1
+  result=$2
+  errors="$result.stderr"
+  if ! run_timed 10 "$result" "$errors" "$NODE" "$SOURCE_VALIDATOR" --package "$package" \
+    --repository-root "$(dirname -- "$package")" --json; then
+    cat "$errors" >&2
+    fail "temporary package setup must validate before the Red assertion"
+  fi
+  "$NODE" - "$result" <<'NODE'
+const fs = require('node:fs');
+const result = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (result.schemaVersion !== 1 || result.valid !== true || result.errors.length !== 0) {
+  throw new Error(`invalid temporary package setup: ${JSON.stringify(result)}`);
+}
+NODE
+}
+
+# Prove the synthetic package setup is valid before reporting the intentional Red failure.
+SETUP_PACKAGE="$TMP_ROOT/setup/prepare-target"
+write_skill "$SETUP_PACKAGE" prepare-target 'Candidate package used by the preparation contract.'
+write_corpora "$SETUP_PACKAGE" prepare-target 'fixture payload'
+validate_setup_package "$SETUP_PACKAGE" "$TMP_ROOT/setup-validation.json"
+
+if [ ! -f "$SOURCE_PREPARER" ]; then
+  fail "prepare.mjs is missing (expected Red: temporary package setup validated)"
+fi
+
+# Run against a synthetic installed collection so the default catalog root and canonical
+# resolve-base.sh location are observable rather than inherited from this checkout.
+INSTALL_ROOT="$TMP_ROOT/installed-collection"
+PREPARER="$INSTALL_ROOT/skills/woostack-eval/scripts/prepare.mjs"
+VALIDATOR="$INSTALL_ROOT/skills/woostack-eval/scripts/validate.mjs"
+HASH_HELPER="$TMP_ROOT/hash-package.mjs"
+cat >"$HASH_HELPER" <<'NODE'
+import { pathToFileURL } from 'node:url';
+const [validatorPath, packagePath] = process.argv.slice(2);
+const { hashPackage } = await import(pathToFileURL(validatorPath).href);
+const hash = await hashPackage(packagePath);
+if (!/^sha256:[0-9a-f]{64}$/.test(hash ?? '')) {
+  throw new Error(`cannot inventory-hash copied package: ${packagePath}`);
+}
+process.stdout.write(hash);
+NODE
+RESOLVER="$INSTALL_ROOT/skills/woostack-init/scripts/resolve-base.sh"
+mkdir -p "$(dirname -- "$PREPARER")" "$(dirname -- "$RESOLVER")"
+cp "$SOURCE_PREPARER" "$PREPARER"
+cp "$SOURCE_VALIDATOR" "$VALIDATOR"
+cat >"$RESOLVER" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${RESOLVER_MARKER:?RESOLVER_MARKER is required by the contract test}"
+printf 'invoked\n' >>"$RESOLVER_MARKER"
+if [ -n "${RESOLVER_MUTATE_FILE:-}" ]; then
+  printf '\nmutation during preparation\n' >>"$RESOLVER_MUTATE_FILE"
+  git add -- "$RESOLVER_MUTATE_FILE"
+  git commit -qm 'mutate during preparation'
+fi
+printf '%s\n' "${WOOSTACK_BASE_BRANCH:?WOOSTACK_BASE_BRANCH is required by the contract test}"
+SH
+chmod 0755 "$RESOLVER"
+write_skill "$INSTALL_ROOT/skills/woostack-init" woostack-init 'Installed resolver skill description.'
+write_skill "$INSTALL_ROOT/skills/catalog-peer" catalog-peer 'Installed catalog peer description.'
+write_public_authority "$INSTALL_ROOT/skills/using-woostack"
+
+SYSTEM_TMP="$TMP_ROOT/system-tmp"
+mkdir -p "$SYSTEM_TMP"
+CANONICAL_SYSTEM_TMP=$(CDPATH= cd -- "$SYSTEM_TMP" && pwd -P)
+INVOCATION=0
+STATUS=0
+STDOUT_FILE=
+STDERR_FILE=
+RUN_ROOT=
+
+run_prepare() {
+  INVOCATION=$((INVOCATION + 1))
+  STDOUT_FILE="$TMP_ROOT/stdout.$INVOCATION"
+  STDERR_FILE="$TMP_ROOT/stderr.$INVOCATION"
+  set +e
+  run_timed 10 "$STDOUT_FILE" "$STDERR_FILE" env \
+    TMPDIR="${TEST_TMPDIR:-$SYSTEM_TMP}" \
+    WOOSTACK_BASE_BRANCH="${TEST_BASE_BRANCH:-base}" \
+    RESOLVER_MARKER="$TMP_ROOT/resolver-marker" \
+    "$NODE" "$PREPARER" "$@"
+  STATUS=$?
+  set -e
+  RUN_ROOT=
+  if [ "$STATUS" -eq 0 ]; then
+    RUN_ROOT=$(cat "$STDOUT_FILE")
+  fi
+}
+
+expect_success() {
+  label=$1
+  shift
+  run_prepare "$@"
+  if [ "$STATUS" -ne 0 ]; then
+    printf 'FAIL: %s should succeed (exit %s)\n' "$label" "$STATUS" >&2
+    cat "$STDERR_FILE" >&2
+    exit 1
+  fi
+  [ -n "$RUN_ROOT" ] || fail "$label: missing run-root output"
+  [ "$(printf '%s\n' "$RUN_ROOT" | wc -l | tr -d ' ')" -eq 1 ] || fail "$label: stdout must be one path"
+  [ -d "$RUN_ROOT" ] || fail "$label: reported run root does not exist: $RUN_ROOT"
+  [ -f "$RUN_ROOT/manifest.json" ] || fail "$label: manifest.json is missing"
+}
+
+snapshot_entries() {
+  directory=$1
+  output=$2
+  "$NODE" - "$directory" "$output" <<'NODE'
+const fs = require('node:fs');
+const [directory, output] = process.argv.slice(2);
+let entries = [];
+try {
+  entries = fs.readdirSync(directory).sort();
+} catch (error) {
+  if (error.code !== 'ENOENT' && error.code !== 'ENOTDIR') throw error;
+}
+fs.writeFileSync(output, `${JSON.stringify(entries)}\n`);
+NODE
+}
+
+expect_failure() {
+  label=$1
+  shift
+  failure_out_root=
+  failure_run_id=
+  wanted_value=
+  for argument in "$@"; do
+    if [ -n "$wanted_value" ]; then
+      case "$wanted_value" in
+        out-root) failure_out_root=$argument ;;
+        run-id) failure_run_id=$argument ;;
+      esac
+      wanted_value=
+      continue
+    fi
+    case "$argument" in
+      --out-root) wanted_value=out-root ;;
+      --run-id) wanted_value=run-id ;;
+    esac
+  done
+  residue_before="$TMP_ROOT/residue.$((INVOCATION + 1)).before.json"
+  residue_after="$TMP_ROOT/residue.$((INVOCATION + 1)).after.json"
+  if [ -n "$failure_out_root" ] && [ -n "$failure_run_id" ]; then
+    snapshot_entries "$failure_out_root" "$residue_before"
+  fi
+  run_prepare "$@"
+  [ "$STATUS" -ne 0 ] || fail "$label should fail"
+  [ ! -s "$STDOUT_FILE" ] || fail "$label: failure emitted a success path"
+  [ -s "$STDERR_FILE" ] || fail "$label: failure must explain itself on stderr"
+  if [ -n "$failure_out_root" ] && [ -n "$failure_run_id" ]; then
+    snapshot_entries "$failure_out_root" "$residue_after"
+    cmp -s "$residue_before" "$residue_after" ||
+      fail "$label: failure left a final or staging run-root residue"
+  fi
+}
+
+package_hash() {
+  package=$1
+  output=$2
+  errors="$output.stderr"
+  if ! run_timed 10 "$output" "$errors" "$NODE" "$VALIDATOR" --package "$package" \
+    --repository-root "$(dirname -- "$package")" --json; then
+    cat "$errors" >&2
+    fail "validator failed while hashing $package"
+  fi
+  "$NODE" - "$output" <<'NODE'
+const fs = require('node:fs');
+const result = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (!result.valid || !/^sha256:[0-9a-f]{64}$/.test(result.packageHash)) {
+  throw new Error(`cannot hash package: ${JSON.stringify(result)}`);
+}
+process.stdout.write(result.packageHash);
+NODE
+}
+
+raw_package_hash() {
+  package=$1
+  output=$2
+  errors="$output.stderr"
+  if ! run_timed 10 "$output" "$errors" "$NODE" "$HASH_HELPER" "$VALIDATOR" "$package"; then
+    cat "$errors" >&2
+    fail "hashPackage failed for copied capability package $package"
+  fi
+  cat "$output"
+}
+
+assert_private_run_root() {
+  "$NODE" - "$1" <<'NODE'
+const fs = require('node:fs');
+const root = process.argv[2];
+const mode = fs.statSync(root).mode & 0o777;
+if (mode !== 0o700) throw new Error(`${root} mode is ${mode.toString(8)}, expected 700`);
+NODE
+}
+
+assert_bounded_diagnostic() {
+  "$NODE" - "$1" <<'NODE'
+const fs = require('node:fs');
+const content = fs.readFileSync(process.argv[2]);
+if (content.byteLength > 1100) throw new Error(`diagnostic exceeds bound: ${content.byteLength}`);
+const text = content.toString('utf8');
+if (!text.endsWith('\n') || text.slice(0, -1).includes('\n')) {
+  throw new Error(`diagnostic must occupy exactly one line: ${JSON.stringify(text)}`);
+}
+if (/[\x00-\x1F\x7F]/.test(text.slice(0, -1))) {
+  throw new Error(`diagnostic contains ASCII control bytes: ${JSON.stringify(text)}`);
+}
+NODE
+}
+
+assert_manifest() {
+  manifest=$1
+  expected_run_id=$2
+  expected_target=$3
+  expected_mode=$4
+  expected_runs=$5
+  expected_baseline=$6
+  expected_hash=$7
+  "$NODE" - "$manifest" "$expected_run_id" "$expected_target" "$expected_mode" \
+    "$expected_runs" "$expected_baseline" "$expected_hash" <<'NODE'
+const fs = require('node:fs');
+const assert = require('node:assert/strict');
+const [file, runId, targetSkill, mode, runsText, baselineText, packageHash] = process.argv.slice(2);
+const actual = JSON.parse(fs.readFileSync(file, 'utf8'));
+const runs = Number(runsText);
+const baseline = JSON.parse(baselineText);
+const canonical = (value) => {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonical(value[key])]));
+  }
+  return value;
+};
+const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
+const exactTopKeys = [
+  'baseline', 'expected', 'gradingPlan', 'mode', 'originalPackageHash', 'packageHashes',
+  'pairs', 'runConfiguration', 'runId', 'runs', 'schemaVersion', 'targetSkill',
+];
+if (!same(Object.keys(actual).sort(), exactTopKeys)) {
+  throw new Error(`unexpected manifest keys: ${Object.keys(actual).sort().join(',')}`);
+}
+if (baseline.kind === 'git-ref' && !/^[0-9a-f]{40}$/.test(baseline.identity)) {
+  throw new Error(`git-ref identity is not a resolved lowercase commit: ${baseline.identity}`);
+}
+const selected = [];
+if (mode === 'behavior' || mode === 'all') {
+  selected.push(['alpha-behavior', 'behavior'], ['zeta-behavior', 'behavior']);
+}
+if (mode === 'triggers' || mode === 'all') {
+  selected.push(['alpha-trigger', 'trigger'], ['zeta-trigger', 'trigger']);
+}
+const expected = [];
+const pairs = [];
+for (const [caseId, kind] of selected) {
+  for (let repetition = 1; repetition <= runs; repetition += 1) {
+    expected.push({ caseId, variant: 'candidate', repetition, kind });
+    expected.push({ caseId, variant: 'baseline', repetition, kind });
+    pairs.push({
+      caseId,
+      repetition,
+      candidate: `cases/${caseId}/${repetition}/candidate`,
+      baseline: `cases/${caseId}/${repetition}/baseline`,
+    });
+  }
+}
+assert.deepEqual(Object.keys(actual.packageHashes).sort(), ['baseline', 'candidate']);
+assert.match(actual.packageHashes.candidate, /^sha256:[0-9a-f]{64}$/);
+if (actual.baseline.kind === 'none') {
+  assert.equal(actual.packageHashes.baseline, null);
+} else {
+  assert.match(actual.packageHashes.baseline, /^sha256:[0-9a-f]{64}$/);
+}
+const expectedGradingPlan = [];
+for (const entry of expected) {
+  if (entry.variant === 'candidate'
+      && entry.kind === 'behavior'
+      && entry.caseId === 'alpha-behavior') {
+    for (const assertionId of ['aardvark-quality', 'alpha-quality']) {
+      expectedGradingPlan.push({
+        caseId: entry.caseId,
+        repetition: entry.repetition,
+        assertionId,
+        graderId: null,
+      });
+    }
+  }
+}
+assert.deepEqual(actual.gradingPlan, expectedGradingPlan);
+const wanted = {
+  schemaVersion: 1,
+  runId,
+  targetSkill,
+  mode,
+  runs,
+  baseline,
+  runConfiguration: {
+    host: null,
+    runner: null,
+    model: null,
+    sessionIdentity: null,
+    tier: null,
+    effort: null,
+  },
+  originalPackageHash: packageHash,
+  packageHashes: actual.packageHashes,
+  gradingPlan: expectedGradingPlan,
+  expected,
+  pairs,
+};
+if (!same(actual, wanted)) {
+  throw new Error(`manifest mismatch\nactual=${JSON.stringify(actual)}\nwanted=${JSON.stringify(wanted)}`);
+}
+for (const entry of actual.expected) {
+  if (!same(Object.keys(entry).sort(), ['caseId', 'kind', 'repetition', 'variant'])) {
+    throw new Error(`unexpected expected identity shape: ${JSON.stringify(entry)}`);
+  }
+  if (!['candidate', 'baseline'].includes(entry.variant) || !['behavior', 'trigger'].includes(entry.kind)) {
+    throw new Error(`invalid expected identity status: ${JSON.stringify(entry)}`);
+  }
+}
+for (const pair of actual.pairs) {
+  if (!same(Object.keys(pair).sort(), ['baseline', 'candidate', 'caseId', 'repetition'])) {
+    throw new Error(`pair must not decide waves or concurrency: ${JSON.stringify(pair)}`);
+  }
+}
+NODE
+}
+
+assert_frozen_definitions() {
+  root=$1
+  source_package=$2
+  mode=$3
+  "$NODE" - "$root" "$source_package" "$mode" <<'NODE'
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const [root, sourcePackage, mode] = process.argv.slice(2);
+const expected = new Map();
+for (const [kind, sourceName, enabled] of [
+  ['behavior', 'evals.json', mode === 'behavior' || mode === 'all'],
+  ['trigger', 'trigger-evals.json', mode === 'triggers' || mode === 'all'],
+]) {
+  if (!enabled) continue;
+  const corpus = JSON.parse(
+    fs.readFileSync(path.join(sourcePackage, 'evals', sourceName), 'utf8'),
+  );
+  for (const definition of corpus.cases) {
+    expected.set(`${kind}.${definition.id}.json`, definition);
+  }
+}
+const definitionsRoot = path.join(root, 'definitions');
+const actualNames = fs.readdirSync(definitionsRoot).sort();
+assert.deepEqual(actualNames, [...expected.keys()].sort());
+for (const name of actualNames) {
+  const definitionPath = path.join(definitionsRoot, name);
+  const stats = fs.lstatSync(definitionPath);
+  assert.equal(stats.isFile(), true, `${name} must be a regular file`);
+  assert.equal(stats.isSymbolicLink(), false, `${name} must not be a symlink`);
+  assert.equal(stats.mode & 0o777, 0o600, `${name} must be host-private`);
+  const bytes = fs.readFileSync(definitionPath, 'utf8');
+  assert.equal(bytes.endsWith('\n'), true, `${name} must end with one newline`);
+  assert.deepEqual(JSON.parse(bytes), expected.get(name));
+}
+const pending = [path.join(root, 'cases')];
+while (pending.length > 0) {
+  const directory = pending.pop();
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const child = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      assert.notEqual(entry.name, 'definitions', 'definitions leaked into a worker root');
+      pending.push(child);
+    }
+  }
+}
+NODE
+}
+
+assert_frozen_package_hashes() {
+  manifest=$1
+  candidate_hash=$2
+  baseline_hash=$3
+  "$NODE" - "$manifest" "$candidate_hash" "$baseline_hash" <<'NODE'
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const [manifestPath, candidateHash, baselineHash] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+assert.equal(manifest.packageHashes.candidate, candidateHash);
+assert.equal(
+  manifest.packageHashes.baseline,
+  baselineHash === 'null' ? null : baselineHash,
+);
+NODE
+}
+
+assert_catalog() {
+  catalog=$1
+  expected_json=$2
+  "$NODE" - "$catalog" "$expected_json" <<'NODE'
+const fs = require('node:fs');
+const actual = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const expected = JSON.parse(process.argv[3]);
+const canonical = (value) => {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonical(value[key])]));
+  }
+  return value;
+};
+const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
+if (!same(actual, expected)) {
+  throw new Error(`catalog mismatch: ${JSON.stringify(actual)} != ${JSON.stringify(expected)}`);
+}
+if (!same(Object.keys(actual).sort(), ['schemaVersion', 'skills'])) {
+  throw new Error(`unexpected catalog keys: ${Object.keys(actual)}`);
+}
+for (const skill of actual.skills) {
+  if (!same(Object.keys(skill).sort(), ['description', 'name'])) {
+    throw new Error(`unexpected catalog entry: ${JSON.stringify(skill)}`);
+  }
+}
+NODE
+}
+
+assert_isolated_all_workspace() {
+  root=$1
+  candidate_description=$2
+  baseline_description=$3
+  assert_file_contains "$root/cases/alpha-behavior/1/candidate/package/SKILL.md" "$candidate_description" 'candidate package copy'
+  assert_file_contains "$root/cases/alpha-behavior/1/baseline/package/SKILL.md" "$baseline_description" 'baseline package copy'
+  assert_file_contains "$root/cases/alpha-behavior/1/candidate/fixtures/alpha.txt" 'candidate fixture alpha' 'candidate alpha fixture copy'
+  assert_file_contains "$root/cases/alpha-behavior/1/baseline/fixtures/alpha.txt" 'candidate fixture alpha' 'baseline alpha fixture copy'
+  assert_file_contains "$root/cases/zeta-behavior/1/candidate/fixtures/zeta.txt" 'candidate fixture zeta' 'candidate zeta fixture copy'
+  assert_file_contains "$root/cases/zeta-behavior/1/baseline/fixtures/zeta.txt" 'candidate fixture zeta' 'baseline zeta fixture copy'
+  "$NODE" - "$root" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const root = process.argv[2];
+const files = [
+  'cases/alpha-behavior/1/candidate/package/SKILL.md',
+  'cases/alpha-behavior/1/baseline/package/SKILL.md',
+  'cases/alpha-behavior/1/candidate/fixtures/alpha.txt',
+  'cases/alpha-behavior/1/baseline/fixtures/alpha.txt',
+  'cases/zeta-behavior/1/candidate/fixtures/zeta.txt',
+  'cases/zeta-behavior/1/baseline/fixtures/zeta.txt',
+];
+for (const relative of files) {
+  const full = path.join(root, relative);
+  const stat = fs.lstatSync(full);
+  if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`unsafe copied file: ${relative}`);
+}
+for (const [caseId, own, other] of [
+  ['alpha-behavior', 'alpha.txt', 'zeta.txt'],
+  ['zeta-behavior', 'zeta.txt', 'alpha.txt'],
+]) {
+  for (const variant of ['candidate', 'baseline']) {
+    const fixtureRoot = path.join(root, 'cases', caseId, '1', variant, 'fixtures');
+    if (!fs.existsSync(path.join(fixtureRoot, own))) throw new Error(`${caseId}/${variant} lost ${own}`);
+    if (fs.existsSync(path.join(fixtureRoot, other))) {
+      throw new Error(`${caseId}/${variant} received undeclared fixture ${other}`);
+    }
+  }
+}
+for (const [candidateRelative, baselineRelative, label] of [
+  [files[0], files[1], 'packages'],
+  [files[2], files[3], 'alpha fixtures'],
+  [files[4], files[5], 'zeta fixtures'],
+]) {
+  const left = fs.statSync(path.join(root, candidateRelative));
+  const right = fs.statSync(path.join(root, baselineRelative));
+  if (left.dev === right.dev && left.ino === right.ino) throw new Error(`${label} are hard-linked`);
+}
+const evidence = path.join(root, 'evidence');
+if (!fs.statSync(evidence).isDirectory()) throw new Error('evidence must be a directory');
+if (fs.readdirSync(evidence).length !== 0) throw new Error('preparation must not prefill success evidence');
+for (const caseId of ['alpha-behavior', 'zeta-behavior']) {
+  for (const variant of ['candidate', 'baseline']) {
+    const capabilityRoot = path.join(root, 'cases', caseId, '1', variant);
+    const relative = path.relative(capabilityRoot, evidence);
+    if (relative === '' || (!relative.startsWith('..' + path.sep) && relative !== '..')) {
+      throw new Error('evidence must be outside worker capability roots');
+    }
+  }
+}
+NODE
+}
+
+# Build a repository whose baseline and dirty candidate differ while retaining the same corpora.
+GIT_REPO="$TMP_ROOT/git-repo"
+git init -q -b base "$GIT_REPO"
+CANONICAL_GIT_REPO=$(CDPATH= cd -- "$GIT_REPO" && pwd -P)
+git -C "$GIT_REPO" config user.email evaluator@example.invalid
+git -C "$GIT_REPO" config user.name 'Evaluator Contract'
+TARGET="$GIT_REPO/skills/prepare-target"
+write_skill "$TARGET" prepare-target 'Baseline target description.'
+write_corpora "$TARGET" prepare-target 'candidate fixture'
+printf '#!/usr/bin/env bash\nexit 0\n' >"$TARGET/references/executable.sh"
+chmod 0755 "$TARGET/references/executable.sh"
+write_skill "$GIT_REPO/skills/catalog-peer" catalog-peer 'Repository catalog peer description.'
+write_public_authority "$GIT_REPO/skills/using-woostack"
+printf '.woostack/tmp/skill-evals/\n' >"$GIT_REPO/.gitignore"
+BASELINE_HASH=$(package_hash "$TARGET" "$TMP_ROOT/baseline-validation.json")
+git -C "$GIT_REPO" add .
+git -C "$GIT_REPO" commit -qm 'baseline package'
+BASE_COMMIT=$(git -C "$GIT_REPO" rev-parse HEAD)
+git -C "$GIT_REPO" tag -a baseline-package -m 'annotated baseline package' "$BASE_COMMIT"
+git -C "$GIT_REPO" switch -qc feature
+write_skill "$TARGET" prepare-target 'Dirty candidate target description.'
+printf 'dirty candidate only\n' >"$TARGET/references/dirty-only.txt"
+CANDIDATE_HASH=$(package_hash "$TARGET" "$TMP_ROOT/candidate-validation.json")
+HEAD_BEFORE=$(git -C "$GIT_REPO" rev-parse HEAD)
+INDEX_TREE_BEFORE=$(git -C "$GIT_REPO" write-tree)
+git -C "$GIT_REPO" status --porcelain=v1 -z --untracked-files=all >"$TMP_ROOT/status.before"
+
+# An annotated explicit ref takes precedence and resolves to the peeled lowercase commit even
+# when the implicit resolver points to an invalid branch.
+TEST_BASE_BRANCH=does-not-exist expect_success 'explicit annotated baseline ref precedence' \
+  --target "$TARGET/SKILL.md" --mode all --runs 2 --baseline-ref baseline-package \
+  --catalog-root "$GIT_REPO/skills" --out-root "$TMP_ROOT/runs" --run-id explicit-ref
+[ "$RUN_ROOT" = "$CANONICAL_TMP_ROOT/runs/explicit-ref" ] || fail 'explicit run root path mismatch'
+assert_private_run_root "$RUN_ROOT"
+assert_manifest "$RUN_ROOT/manifest.json" explicit-ref prepare-target all 2 \
+  "{\"kind\":\"git-ref\",\"identity\":\"$BASE_COMMIT\"}" "$CANDIDATE_HASH"
+assert_frozen_definitions "$RUN_ROOT" "$TARGET" all
+assert_isolated_all_workspace "$RUN_ROOT" 'Dirty candidate target description.' 'Baseline target description.'
+[ -f "$RUN_ROOT/cases/alpha-behavior/1/candidate/package/references/dirty-only.txt" ] || fail 'dirty candidate file was not preserved'
+[ ! -e "$RUN_ROOT/cases/alpha-behavior/1/baseline/package/references/dirty-only.txt" ] || fail 'baseline was read from the dirty worktree'
+"$NODE" - "$RUN_ROOT/cases/alpha-behavior/1/baseline/package/references/executable.sh" <<'NODE'
+const fs = require('node:fs');
+const mode = fs.statSync(process.argv[2]).mode & 0o777;
+if (mode !== 0o755) throw new Error(`Git baseline executable mode lost: ${mode.toString(8)}`);
+NODE
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/candidate/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"Repository catalog peer description."},{"name":"prepare-target","description":"Dirty candidate target description."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/baseline/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"Repository catalog peer description."},{"name":"prepare-target","description":"Baseline target description."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+[ ! -e "$TMP_ROOT/resolver-marker" ] || fail 'explicit baseline-ref must not invoke the implicit resolver'
+CANDIDATE_HASH_AFTER=$(package_hash "$TARGET" "$TMP_ROOT/candidate-validation-after.json")
+COPIED_BASELINE_HASH=$(raw_package_hash "$RUN_ROOT/cases/alpha-behavior/1/baseline/package" "$TMP_ROOT/copied-baseline-hash.txt")
+COPIED_CANDIDATE_HASH=$(raw_package_hash "$RUN_ROOT/cases/alpha-behavior/1/candidate/package" "$TMP_ROOT/copied-candidate-hash.txt")
+assert_frozen_package_hashes \
+  "$RUN_ROOT/manifest.json" "$COPIED_CANDIDATE_HASH" "$COPIED_BASELINE_HASH"
+HEAD_AFTER=$(git -C "$GIT_REPO" rev-parse HEAD)
+INDEX_TREE_AFTER=$(git -C "$GIT_REPO" write-tree)
+git -C "$GIT_REPO" status --porcelain=v1 -z --untracked-files=all >"$TMP_ROOT/status.after"
+[ "$CANDIDATE_HASH_AFTER" = "$CANDIDATE_HASH" ] || fail 'preparation changed the full candidate package hash'
+[ "$COPIED_BASELINE_HASH" != "$BASELINE_HASH" ] ||
+  fail 'Git-object capability package unexpectedly retained excluded fixture files'
+[ ! -e "$RUN_ROOT/cases/alpha-behavior/1/candidate/package/evals/fixtures" ] ||
+  fail 'candidate capability package retained evals/fixtures'
+[ ! -e "$RUN_ROOT/cases/alpha-behavior/1/baseline/package/evals/fixtures" ] ||
+  fail 'baseline capability package retained evals/fixtures'
+[ "$HEAD_AFTER" = "$HEAD_BEFORE" ] || fail 'preparation moved HEAD'
+[ "$INDEX_TREE_AFTER" = "$INDEX_TREE_BEFORE" ] || fail 'preparation changed the index tree'
+cmp -s "$TMP_ROOT/status.before" "$TMP_ROOT/status.after" || fail 'preparation changed NUL-safe porcelain state'
+
+# Explicit IDs are create-once and never overwrite an existing manifest.
+MANIFEST_BEFORE=$(shasum -a 256 "$RUN_ROOT/manifest.json" | cut -d ' ' -f 1)
+expect_failure 'duplicate explicit run ID' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --catalog-root "$GIT_REPO/skills" --out-root "$TMP_ROOT/runs" --run-id explicit-ref
+MANIFEST_AFTER=$(shasum -a 256 "$TMP_ROOT/runs/explicit-ref/manifest.json" | cut -d ' ' -f 1)
+[ "$MANIFEST_AFTER" = "$MANIFEST_BEFORE" ] || fail 'duplicate run ID overwrote the first manifest'
+
+# Two concurrent preparers forced onto the same explicit ID produce exactly one complete run.
+for collision_index in 1 2; do
+  start_timed 10 "$TMP_ROOT/collision.$collision_index.out" "$TMP_ROOT/collision.$collision_index.err" env \
+    TMPDIR="$SYSTEM_TMP" WOOSTACK_BASE_BRANCH=base RESOLVER_MARKER="$TMP_ROOT/resolver-marker" \
+    "$NODE" "$PREPARER" --target "$TARGET" --mode behavior --runs 1 \
+      --baseline-ref "$BASE_COMMIT" --catalog-root "$GIT_REPO/skills" \
+      --out-root "$TMP_ROOT/runs" --run-id forced-collision
+  eval "collision_pid_$collision_index=\$TIMED_PID"
+  eval "collision_watchdog_$collision_index=\$TIMED_WATCHDOG_PID"
+  eval "collision_marker_$collision_index=\$TIMED_OUT_MARKER"
+done
+set +e
+finish_timed "$collision_pid_1" "$collision_watchdog_1" "$collision_marker_1"
+collision_status_1=$?
+finish_timed "$collision_pid_2" "$collision_watchdog_2" "$collision_marker_2"
+collision_status_2=$?
+set -e
+case "$collision_status_1:$collision_status_2" in
+  0:1|1:0) ;;
+  *) fail "same-ID collision must yield one success and one collision failure: $collision_status_1/$collision_status_2" ;;
+esac
+if [ "$collision_status_1" -eq 0 ]; then
+  collision_loser=2
+else
+  collision_loser=1
+fi
+[ ! -s "$TMP_ROOT/collision.$collision_loser.out" ] ||
+  fail 'same-ID collision loser emitted a success path'
+assert_file_contains "$TMP_ROOT/collision.$collision_loser.err" 'already exists' \
+  'same-ID collision diagnostic'
+[ -f "$TMP_ROOT/runs/forced-collision/manifest.json" ] ||
+  fail 'same-ID collision did not leave exactly one complete run'
+assert_private_run_root "$TMP_ROOT/runs/forced-collision"
+
+# An explicit absolute package path also bypasses the implicit resolver and is content-identified.
+PATH_BASELINE="$TMP_ROOT/path-baseline/prepare-target"
+write_skill "$PATH_BASELINE" prepare-target 'Explicit path baseline description.'
+write_corpora "$PATH_BASELINE" prepare-target 'path baseline fixture'
+PATH_BASELINE_HASH=$(package_hash "$PATH_BASELINE" "$TMP_ROOT/path-baseline-validation.json")
+rm -f "$TMP_ROOT/resolver-marker"
+TEST_BASE_BRANCH=does-not-exist expect_success 'explicit baseline path precedence' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-path "$PATH_BASELINE" \
+  --catalog-root "$GIT_REPO/skills" --out-root "$TMP_ROOT/runs" --run-id explicit-path
+COPIED_PATH_BASELINE_HASH=$(raw_package_hash "$RUN_ROOT/cases/alpha-behavior/1/baseline/package" "$TMP_ROOT/copied-path-baseline-hash.txt")
+COPIED_PATH_CANDIDATE_HASH=$(raw_package_hash "$RUN_ROOT/cases/alpha-behavior/1/candidate/package" "$TMP_ROOT/copied-path-candidate-hash.txt")
+assert_manifest "$RUN_ROOT/manifest.json" explicit-path prepare-target behavior 1 \
+  "{\"kind\":\"path\",\"identity\":\"$COPIED_PATH_BASELINE_HASH\"}" "$CANDIDATE_HASH"
+assert_frozen_package_hashes \
+  "$RUN_ROOT/manifest.json" "$COPIED_PATH_CANDIDATE_HASH" "$COPIED_PATH_BASELINE_HASH"
+assert_file_contains "$RUN_ROOT/cases/alpha-behavior/1/baseline/package/SKILL.md" \
+  'Explicit path baseline description.' 'explicit path baseline copy'
+[ "$COPIED_PATH_BASELINE_HASH" != "$PATH_BASELINE_HASH" ] ||
+  fail 'path capability package unexpectedly retained excluded fixture files'
+[ ! -e "$TMP_ROOT/resolver-marker" ] || fail 'explicit baseline-path must not invoke the implicit resolver'
+
+expect_failure 'output root inside explicit baseline package' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-path "$PATH_BASELINE" \
+  --out-root "$PATH_BASELINE/evals/output" --run-id baseline-contained-output
+[ ! -e "$PATH_BASELINE/evals/output" ] || fail 'baseline-contained output root was created'
+TEST_TMPDIR="$PATH_BASELINE/evals/tmp" expect_failure 'TMPDIR inside explicit baseline package' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-path "$PATH_BASELINE" \
+  --run-id baseline-contained-tmpdir
+[ ! -e "$PATH_BASELINE/evals/tmp" ] || fail 'baseline-contained TMPDIR was created'
+
+EQUIVALENT_TARGET="$TMP_ROOT/target-equivalence/equivalent-target"
+write_skill "$EQUIVALENT_TARGET" equivalent-target 'Target path-form containment fixture.'
+printf 'outside target root\n' >"$TMP_ROOT/target-equivalence/outside.md"
+printf '\n[Escaped resource](../outside.md)\n' >>"$EQUIVALENT_TARGET/SKILL.md"
+expect_failure 'target directory form enforces package-root containment' \
+  --target "$EQUIVALENT_TARGET" --mode behavior --runs 1 \
+  --baseline-path "$PATH_BASELINE" --out-root "$TMP_ROOT/runs" --run-id target-dir-containment
+assert_file_contains "$STDERR_FILE" 'link-target-outside' 'target directory containment diagnostic'
+expect_failure 'target SKILL.md form enforces package-root containment' \
+  --target "$EQUIVALENT_TARGET/SKILL.md" --mode behavior --runs 1 \
+  --baseline-path "$PATH_BASELINE" --out-root "$TMP_ROOT/runs" --run-id target-file-containment
+assert_file_contains "$STDERR_FILE" 'link-target-outside' 'target SKILL.md containment diagnostic'
+
+# Once the private baseline snapshot is complete, preparation announces that it is frozen and
+# waits for an explicit release. Mutating the caller-owned baseline while preparation is paused
+# must invalidate the run instead of changing prepared variants or identity.
+MUTABLE_BASELINE="$TMP_ROOT/mutable-baseline/prepare-target"
+write_skill "$MUTABLE_BASELINE" prepare-target 'Baseline mutation detection fixture.'
+write_corpora "$MUTABLE_BASELINE" prepare-target 'mutable fixture'
+MUTATION_OUT="$TMP_ROOT/baseline-mutation-runs"
+MUTATION_BARRIER="$TMP_ROOT/baseline-mutation-barrier"
+mkdir -p "$MUTATION_OUT" "$MUTATION_BARRIER"
+mkfifo "$MUTATION_BARRIER/ready" "$MUTATION_BARRIER/release"
+start_timed 20 "$TMP_ROOT/baseline-mutation.out" "$TMP_ROOT/baseline-mutation.err" env \
+  TMPDIR="$SYSTEM_TMP" WOOSTACK_BASE_BRANCH=base RESOLVER_MARKER="$TMP_ROOT/resolver-marker" \
+  WOOSTACK_EVAL_TEST_MODE=1 \
+  WOOSTACK_EVAL_TEST_BASELINE_SNAPSHOT_READY="$MUTATION_BARRIER/ready" \
+  WOOSTACK_EVAL_TEST_BASELINE_SNAPSHOT_RELEASE="$MUTATION_BARRIER/release" \
+  "$NODE" "$PREPARER" --target "$TARGET" --mode all --runs 1 \
+    --baseline-path "$MUTABLE_BASELINE" --catalog-root "$GIT_REPO/skills" \
+    --out-root "$MUTATION_OUT" --run-id baseline-mutated
+baseline_mutation_pid=$TIMED_PID
+baseline_mutation_watchdog=$TIMED_WATCHDOG_PID
+baseline_mutation_marker=$TIMED_OUT_MARKER
+if ! run_timed 10 "$MUTATION_BARRIER/state" "$MUTATION_BARRIER/error" \
+  bash -c 'IFS= read -r state <"$1" && printf "%s\n" "$state"' sh "$MUTATION_BARRIER/ready"; then
+  fail 'baseline mutation test never reached the frozen-snapshot barrier'
+fi
+baseline_barrier_state=$(cat "$MUTATION_BARRIER/state")
+[ "$baseline_barrier_state" = ready ] ||
+  fail "baseline mutation barrier returned unexpected state: $baseline_barrier_state"
+printf '\nmutation after snapshot\n' >>"$MUTABLE_BASELINE/references/guide.md"
+if ! run_timed 10 "$MUTATION_BARRIER/release.out" "$MUTATION_BARRIER/release.error" \
+  bash -c 'printf "release\n" >"$1"' sh "$MUTATION_BARRIER/release"; then
+  fail 'baseline mutation test could not release the frozen-snapshot barrier'
+fi
+set +e
+finish_timed "$baseline_mutation_pid" "$baseline_mutation_watchdog" "$baseline_mutation_marker"
+baseline_mutation_status=$?
+set -e
+[ "$baseline_mutation_status" -eq 1 ] ||
+  fail "baseline mutation should fail preparation, got $baseline_mutation_status"
+[ ! -s "$TMP_ROOT/baseline-mutation.out" ] || fail 'baseline mutation emitted a success path'
+assert_file_contains "$TMP_ROOT/baseline-mutation.err" 'baseline source changed' \
+  'baseline mutation diagnostic'
+[ ! -e "$MUTATION_OUT/baseline-mutated" ] || fail 'baseline mutation left reserved run residue'
+
+CONTAINED_BASELINE="$TMP_ROOT/contained-baseline/prepare-target"
+write_skill "$CONTAINED_BASELINE" prepare-target 'Baseline with an escaping resource link.'
+printf 'outside baseline root\n' >"$TMP_ROOT/contained-baseline/outside.md"
+printf '\n[Escaped resource](../outside.md)\n' >>"$CONTAINED_BASELINE/SKILL.md"
+expect_failure 'baseline path resources stay inside the explicit allowed root' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-path "$CONTAINED_BASELINE" \
+  --out-root "$TMP_ROOT/runs" --run-id baseline-outside-resource
+
+expect_failure 'baseline flag mutual exclusion' \
+  --target "$TARGET" --mode all --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --baseline-path "$PATH_BASELINE" --out-root "$TMP_ROOT/runs" --run-id invalid-both
+[ ! -e "$TMP_ROOT/runs/invalid-both" ] || fail 'mutually exclusive flags left a run directory'
+
+expect_failure 'baseline path must be a directory' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-path "$PATH_BASELINE/SKILL.md" \
+  --out-root "$TMP_ROOT/runs" --run-id baseline-skill-file
+OTHER_BASELINE="$TMP_ROOT/path-baseline/other-target"
+write_skill "$OTHER_BASELINE" other-target 'Different skill baseline description.'
+expect_failure 'baseline path must identify the target skill' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-path "$OTHER_BASELINE" \
+  --out-root "$TMP_ROOT/runs" --run-id baseline-other-skill
+expect_failure 'output root inside target package' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --catalog-root "$GIT_REPO/skills" --out-root "$TARGET/evals/output" --run-id nested-output
+[ ! -e "$TARGET/evals/output" ] || fail 'rejected target-contained output root was created'
+
+# With no explicit baseline, the installed canonical resolver is the only merge-base authority.
+rm -f "$TMP_ROOT/resolver-marker"
+TEST_BASE_BRANCH=base expect_success 'canonical merge-base resolver' \
+  --target "$TARGET" --mode triggers --runs 1 --catalog-root "$GIT_REPO/skills" \
+  --out-root "$TMP_ROOT/runs" --run-id merge-base
+assert_manifest "$RUN_ROOT/manifest.json" merge-base prepare-target triggers 1 \
+  "{\"kind\":\"git-ref\",\"identity\":\"$BASE_COMMIT\"}" "$CANDIDATE_HASH"
+[ "$(wc -l <"$TMP_ROOT/resolver-marker" | tr -d ' ')" -eq 1 ] || fail 'canonical resolver was not invoked exactly once'
+
+# Missing canonical resolution fails closed, while an explicit baseline remains usable.
+mv "$RESOLVER" "$RESOLVER.disabled"
+expect_failure 'missing canonical resolver without explicit baseline' \
+  --target "$TARGET" --mode all --runs 1 --catalog-root "$GIT_REPO/skills" \
+  --out-root "$TMP_ROOT/runs" --run-id missing-resolver
+expect_success 'explicit baseline does not need resolver' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --catalog-root "$GIT_REPO/skills" --out-root "$TMP_ROOT/runs" --run-id no-resolver-explicit
+mv "$RESOLVER.disabled" "$RESOLVER"
+
+# Repository-local Git config must not execute a caller-controlled fsmonitor hook.
+FSMONITOR_MARKER="$TMP_ROOT/fsmonitor-invoked"
+FSMONITOR_HOOK="$TMP_ROOT/fsmonitor-hook.sh"
+cat >"$FSMONITOR_HOOK" <<EOF
+#!/bin/sh
+printf 'invoked\n' >>"$FSMONITOR_MARKER"
+EOF
+chmod +x "$FSMONITOR_HOOK"
+git -C "$GIT_REPO" config core.fsmonitor "$FSMONITOR_HOOK"
+expect_success 'target Git config cannot execute fsmonitor hooks' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --catalog-root "$GIT_REPO/skills" --out-root "$TMP_ROOT/runs" --run-id safe-git-config
+git -C "$GIT_REPO" config --unset core.fsmonitor
+[ ! -e "$FSMONITOR_MARKER" ] || fail 'preparation executed repository-local fsmonitor code'
+
+# Invalid explicit or implicit Git lookups never fall through to another baseline kind.
+expect_failure 'invalid explicit Git ref fails closed' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-ref refs/heads/not-present \
+  --out-root "$TMP_ROOT/runs" --run-id invalid-ref
+TEST_BASE_BRANCH=not-present expect_failure 'invalid merge-base lookup fails closed' \
+  --target "$TARGET" --mode behavior --runs 1 --out-root "$TMP_ROOT/runs" --run-id invalid-merge-base
+
+# A package proven absent at a valid merge base is the Git no-skill baseline.
+NEW_REPO="$TMP_ROOT/new-skill-repo"
+git init -q -b base "$NEW_REPO"
+git -C "$NEW_REPO" config user.email evaluator@example.invalid
+git -C "$NEW_REPO" config user.name 'Evaluator Contract'
+write_skill "$NEW_REPO/skills/catalog-peer" catalog-peer 'New repository peer.'
+write_public_authority "$NEW_REPO/skills/using-woostack"
+git -C "$NEW_REPO" add .
+git -C "$NEW_REPO" commit -qm 'base without target'
+ABSENT_BASE=$(git -C "$NEW_REPO" rev-parse HEAD)
+git -C "$NEW_REPO" switch -qc feature
+NEW_TARGET="$NEW_REPO/skills/new-target"
+write_skill "$NEW_TARGET" new-target 'New target candidate description.'
+write_corpora "$NEW_TARGET" new-target 'new target fixture'
+NEW_HASH=$(package_hash "$NEW_TARGET" "$TMP_ROOT/new-target-validation.json")
+rm -f "$TMP_ROOT/resolver-marker"
+TEST_BASE_BRANCH=base expect_success 'Git target absent at merge base' \
+  --target "$NEW_TARGET" --mode all --runs 1 --catalog-root "$NEW_REPO/skills" \
+  --out-root "$TMP_ROOT/runs" --run-id git-no-skill
+assert_manifest "$RUN_ROOT/manifest.json" git-no-skill new-target all 1 \
+  "{\"kind\":\"none\",\"identity\":\"$ABSENT_BASE:absent\"}" "$NEW_HASH"
+NO_SKILL_COPIED_HASH=$(raw_package_hash \
+  "$RUN_ROOT/cases/alpha-behavior/1/candidate/package" \
+  "$TMP_ROOT/no-skill-copied-candidate-hash.txt")
+assert_frozen_package_hashes "$RUN_ROOT/manifest.json" "$NO_SKILL_COPIED_HASH" null
+[ ! -e "$RUN_ROOT/cases/alpha-behavior/1/baseline/package" ] || fail 'no-skill baseline must omit the package'
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/candidate/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"New repository peer."},{"name":"new-target","description":"New target candidate description."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/baseline/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"New repository peer."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+
+# An exact target outside Git defaults to a deterministic no-skill baseline. Explicit baselines
+# still take precedence. The installed catalog remains the default authority and the fallback run
+# root remains beneath TMPDIR.
+NON_GIT_TARGET="$TMP_ROOT/outside-git/external-target"
+write_skill "$NON_GIT_TARGET" external-target 'External target description.'
+write_corpora "$NON_GIT_TARGET" external-target 'external fixture'
+NON_GIT_HASH=$(package_hash "$NON_GIT_TARGET" "$TMP_ROOT/non-git-validation.json")
+expect_success 'non-Git target defaults to no-skill baseline' \
+  --target "$NON_GIT_TARGET" --mode triggers --runs 1 --run-id non-git-no-baseline
+assert_manifest "$RUN_ROOT/manifest.json" non-git-no-baseline external-target triggers 1 \
+  "{\"kind\":\"none\",\"identity\":\"non-git:$NON_GIT_HASH:absent\"}" "$NON_GIT_HASH"
+[ ! -e "$RUN_ROOT/cases/alpha-trigger/1/baseline/package" ] ||
+  fail 'non-Git no-skill baseline must omit the package'
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/baseline/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"Installed catalog peer description."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+NON_GIT_BASELINE="$TMP_ROOT/outside-git-baseline/external-target"
+write_skill "$NON_GIT_BASELINE" external-target 'External baseline description.'
+expect_success 'non-Git target with explicit baseline' \
+  --target "$NON_GIT_TARGET" --mode triggers --runs 1 \
+  --baseline-path "$NON_GIT_BASELINE" --run-id non-git-target
+NON_GIT_BASELINE_HASH=$(package_hash "$NON_GIT_BASELINE" "$TMP_ROOT/non-git-baseline-validation.json")
+assert_manifest "$RUN_ROOT/manifest.json" non-git-target external-target triggers 1 \
+  "{\"kind\":\"path\",\"identity\":\"$NON_GIT_BASELINE_HASH\"}" "$NON_GIT_HASH"
+case "$RUN_ROOT" in
+  "$CANONICAL_SYSTEM_TMP"/*) ;;
+  *) fail "non-Git fallback escaped TMPDIR: $RUN_ROOT" ;;
+esac
+assert_file_contains "$STDERR_FILE" 'fallback' 'non-Git temporary-root report'
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/candidate/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"Installed catalog peer description."},{"name":"external-target","description":"External target description."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/baseline/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"Installed catalog peer description."},{"name":"external-target","description":"External baseline description."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+
+# Catalogs contain public commands only and reject corrupt public entries.
+
+PUBLIC_CATALOG="$TMP_ROOT/public-catalog"
+write_public_authority "$PUBLIC_CATALOG/using-woostack" unknown-support
+write_skill "$PUBLIC_CATALOG/catalog-peer" catalog-peer 'Public catalog peer.'
+write_skill "$PUBLIC_CATALOG/woostack-ask" woostack-ask 'Supporting read-only utility.'
+write_skill "$PUBLIC_CATALOG/woostack-harden" woostack-harden 'Internal hardening utility.'
+write_skill "$PUBLIC_CATALOG/woostack-ideate" woostack-ideate 'Internal design utility.'
+write_skill "$PUBLIC_CATALOG/unknown-support" unknown-support 'Unknown directory must not become public.'
+expect_success 'selected catalog root owns its public command authority' \
+  --target "$NON_GIT_TARGET" --mode triggers --runs 1 --catalog-root "$PUBLIC_CATALOG" \
+  --baseline-path "$NON_GIT_BASELINE" --out-root "$TMP_ROOT/runs" --run-id public-catalog
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/candidate/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"Public catalog peer."},{"name":"external-target","description":"External target description."},{"name":"unknown-support","description":"Unknown directory must not become public."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+assert_catalog "$RUN_ROOT/cases/alpha-trigger/1/baseline/catalog.json" \
+  '{"schemaVersion":1,"skills":[{"name":"catalog-peer","description":"Public catalog peer."},{"name":"external-target","description":"External baseline description."},{"name":"unknown-support","description":"Unknown directory must not become public."},{"name":"using-woostack","description":"Installed public command-routing authority."}]}'
+
+MISSING_CATALOG="$TMP_ROOT/missing-catalog"
+write_public_authority "$MISSING_CATALOG/using-woostack" broken-entry
+write_skill "$MISSING_CATALOG/catalog-peer" catalog-peer 'Valid peer beside missing route.'
+expect_failure 'missing routed catalog entry fails closed' \
+  --target "$NON_GIT_TARGET" --mode triggers --runs 1 --catalog-root "$MISSING_CATALOG" \
+  --baseline-path "$NON_GIT_BASELINE" --out-root "$TMP_ROOT/runs" --run-id missing-catalog
+assert_file_contains "$STDERR_FILE" 'catalog entry missing: broken-entry' \
+  'missing routed catalog entry diagnostic'
+
+INVALID_CATALOG="$TMP_ROOT/invalid-catalog"
+write_public_authority "$INVALID_CATALOG/using-woostack" broken-entry
+write_skill "$INVALID_CATALOG/catalog-peer" catalog-peer 'Valid peer beside corruption.'
+mkdir -p "$INVALID_CATALOG/broken-entry"
+printf 'not frontmatter\n' >"$INVALID_CATALOG/broken-entry/SKILL.md"
+expect_failure 'invalid public catalog entry fails closed' \
+  --target "$NON_GIT_TARGET" --mode triggers --runs 1 --catalog-root "$INVALID_CATALOG" \
+  --baseline-path "$NON_GIT_BASELINE" --out-root "$TMP_ROOT/runs" --run-id invalid-catalog
+
+# An ignored repository-local evaluator root is preferred; unignored roots fall back to TMPDIR.
+TEST_BASE_BRANCH=base expect_success 'ignored repository-local run root' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-ref "$BASE_COMMIT" --run-id ignored-root
+case "$RUN_ROOT" in
+  "$CANONICAL_GIT_REPO/.woostack/tmp/skill-evals/ignored-root") ;;
+  *) fail "ignored repository root was not selected: $RUN_ROOT" ;;
+esac
+assert_private_run_root "$RUN_ROOT"
+printf '' >"$GIT_REPO/.gitignore"
+expect_success 'unignored repository root fallback' \
+  --target "$TARGET" --mode behavior --runs 1 --baseline-ref "$BASE_COMMIT" --run-id unignored-root
+case "$RUN_ROOT" in
+  "$CANONICAL_SYSTEM_TMP"/*) ;;
+  *) fail "unignored root did not fall back beneath TMPDIR: $RUN_ROOT" ;;
+esac
+assert_file_contains "$STDERR_FILE" 'fallback' 'unignored temporary-root report'
+
+# Auto-generated IDs are safe and concurrent allocation is atomic and unique.
+CONCURRENT_OUT="$TMP_ROOT/concurrent-runs"
+mkdir -p "$CONCURRENT_OUT"
+CONCURRENT_OUT=$(CDPATH= cd -- "$CONCURRENT_OUT" && pwd -P)
+concurrent_pids=()
+concurrent_watchdogs=()
+concurrent_markers=()
+for index in 1 2 3 4 5 6; do
+  start_timed 10 "$TMP_ROOT/concurrent.$index.out" "$TMP_ROOT/concurrent.$index.err" env \
+    TMPDIR="$SYSTEM_TMP" WOOSTACK_BASE_BRANCH=base \
+    RESOLVER_MARKER="$TMP_ROOT/resolver-marker" \
+    "$NODE" "$PREPARER" --target "$TARGET" --mode behavior --runs 1 \
+      --baseline-ref "$BASE_COMMIT" --catalog-root "$GIT_REPO/skills" \
+      --out-root "$CONCURRENT_OUT"
+  concurrent_pids+=("$TIMED_PID")
+  concurrent_watchdogs+=("$TIMED_WATCHDOG_PID")
+  concurrent_markers+=("$TIMED_OUT_MARKER")
+done
+for offset in 0 1 2 3 4 5; do
+  if ! finish_timed "${concurrent_pids[$offset]}" "${concurrent_watchdogs[$offset]}" \
+    "${concurrent_markers[$offset]}"; then
+    cat "$TMP_ROOT/concurrent.$((offset + 1)).err" >&2
+    fail "concurrent preparation process ${concurrent_pids[$offset]} failed or timed out"
+  fi
+done
+"$NODE" - "$CONCURRENT_OUT" "$TMP_ROOT" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const [outRoot, tempRoot] = process.argv.slice(2);
+const reported = [];
+for (let index = 1; index <= 6; index += 1) {
+  const value = fs.readFileSync(path.join(tempRoot, `concurrent.${index}.out`), 'utf8').trim();
+  if (!path.isAbsolute(value) || path.dirname(value) !== outRoot) throw new Error(`invalid reported root: ${value}`);
+  reported.push(value);
+}
+if (new Set(reported).size !== reported.length) throw new Error(`run IDs collided: ${reported.join(',')}`);
+for (const root of reported) {
+  const id = path.basename(root);
+  if (!/^\d{8}T\d{6}Z-[1-9]\d*$/.test(id)) throw new Error(`unsafe automatic run ID: ${id}`);
+  if ((fs.statSync(root).mode & 0o777) !== 0o700) throw new Error(`non-private concurrent run: ${root}`);
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
+  if (manifest.runId !== id) throw new Error(`manifest run ID mismatch: ${root}`);
+}
+NODE
+
+# Safe CLI and path handling fail before a complete run becomes visible.
+expect_failure 'missing target flag' --mode all --runs 1 --out-root "$TMP_ROOT/runs" --run-id missing-target
+expect_failure 'missing mode flag' --target "$TARGET" --runs 1 --out-root "$TMP_ROOT/runs" --run-id missing-mode
+expect_failure 'missing runs flag' --target "$TARGET" --mode all --out-root "$TMP_ROOT/runs" --run-id missing-runs
+expect_failure 'unknown flag' --target "$TARGET" --mode all --runs 1 --unknown value
+expect_failure 'repeated singleton flag' --target "$TARGET" --target "$TARGET" --mode all --runs 1
+expect_failure 'unsupported mode' --target "$TARGET" --mode smoke --runs 1
+expect_failure 'zero runs' --target "$TARGET" --mode all --runs 0
+expect_failure 'too many runs' --target "$TARGET" --mode all --runs 11
+expect_failure 'fractional runs' --target "$TARGET" --mode all --runs 1.5
+
+# Interrupt cleanup kills the entire spawned command group, not only its direct shell.
+PROCESS_GROUP_BIN="$TMP_ROOT/process-group-bin"
+PROCESS_GROUP_READY="$TMP_ROOT/process-group-descendant.ready"
+PROCESS_GROUP_SURVIVED="$TMP_ROOT/process-group-descendant.survived"
+mkdir -p "$PROCESS_GROUP_BIN"
+cat >"$PROCESS_GROUP_BIN/git" <<'EOF'
+#!/bin/sh
+(
+  sleep 1
+  printf 'survived\n' >"$WOOSTACK_EVAL_TEST_DESCENDANT_SURVIVED"
+) &
+printf 'ready\n' >"$WOOSTACK_EVAL_TEST_DESCENDANT_READY"
+wait
+EOF
+chmod +x "$PROCESS_GROUP_BIN/git"
+start_timed 20 "$TMP_ROOT/process-group.out" "$TMP_ROOT/process-group.err" env \
+  PATH="$PROCESS_GROUP_BIN:$PATH" \
+  WOOSTACK_EVAL_TEST_DESCENDANT_READY="$PROCESS_GROUP_READY" \
+  WOOSTACK_EVAL_TEST_DESCENDANT_SURVIVED="$PROCESS_GROUP_SURVIVED" \
+  "$NODE" "$PREPARER" --target "$TARGET" --mode behavior --runs 1 \
+    --baseline-ref "$BASE_COMMIT" --out-root "$TMP_ROOT/runs" --run-id process-group
+process_group_pid=$TIMED_PID
+process_group_watchdog=$TIMED_WATCHDOG_PID
+process_group_timeout_marker=$TIMED_OUT_MARKER
+if ! run_timed 5 "$TMP_ROOT/process-group-ready.out" "$TMP_ROOT/process-group-ready.err" \
+  bash -c 'while [ ! -s "$1" ]; do sleep 0.05; done' sh "$PROCESS_GROUP_READY"; then
+  fail 'spawned descendant did not start'
+fi
+kill -TERM "$process_group_pid"
+set +e
+finish_timed "$process_group_pid" "$process_group_watchdog" "$process_group_timeout_marker"
+process_group_status=$?
+set -e
+sleep 1.2
+[ ! -e "$PROCESS_GROUP_SURVIVED" ] ||
+  fail 'spawned descendant survived preparation interrupt cleanup'
+[ "$process_group_status" -eq 143 ] ||
+  fail "interrupted preparation returned $process_group_status instead of 143"
+assert_file_contains "$TMP_ROOT/process-group.err" 'received SIGTERM' \
+  'signal cleanup diagnostic'
+signal_diagnostic_count=$(grep -Fc -- 'received SIGTERM' "$TMP_ROOT/process-group.err")
+[ "$signal_diagnostic_count" -eq 1 ] ||
+  fail "signal cleanup emitted $signal_diagnostic_count SIGTERM diagnostics instead of one"
+
+# The command's own watchdog must kill a hanging Git descendant and return before the outer guard.
+INTERNAL_TIMEOUT_BIN="$TMP_ROOT/internal-timeout-bin"
+INTERNAL_TIMEOUT_READY="$TMP_ROOT/internal-timeout-descendant.ready"
+INTERNAL_TIMEOUT_SURVIVED="$TMP_ROOT/internal-timeout-descendant.survived"
+mkdir -p "$INTERNAL_TIMEOUT_BIN"
+cat >"$INTERNAL_TIMEOUT_BIN/git" <<'EOF'
+#!/bin/sh
+(
+  sleep 11.5
+  printf 'survived\n' >"$WOOSTACK_EVAL_TEST_DESCENDANT_SURVIVED"
+) &
+printf 'ready\n' >"$WOOSTACK_EVAL_TEST_DESCENDANT_READY"
+wait
+EOF
+chmod +x "$INTERNAL_TIMEOUT_BIN/git"
+set +e
+run_timed 15 "$TMP_ROOT/internal-timeout.out" "$TMP_ROOT/internal-timeout.err" env \
+  PATH="$INTERNAL_TIMEOUT_BIN:$PATH" \
+  WOOSTACK_EVAL_TEST_DESCENDANT_READY="$INTERNAL_TIMEOUT_READY" \
+  WOOSTACK_EVAL_TEST_DESCENDANT_SURVIVED="$INTERNAL_TIMEOUT_SURVIVED" \
+  "$NODE" "$PREPARER" --target "$TARGET" --mode behavior --runs 1 \
+    --baseline-ref "$BASE_COMMIT" --out-root "$TMP_ROOT/runs" --run-id internal-timeout
+internal_timeout_status=$?
+set -e
+[ "$internal_timeout_status" -eq 1 ] ||
+  fail "internal command timeout returned $internal_timeout_status instead of 1"
+sleep 1.7
+[ ! -e "$INTERNAL_TIMEOUT_SURVIVED" ] ||
+  fail 'internal command timeout left a Git descendant running'
+[ ! -e "$TMP_ROOT/runs/internal-timeout" ] ||
+  fail 'internal command timeout left run-root residue'
+assert_file_contains "$TMP_ROOT/internal-timeout.err" 'command timeout: git' \
+  'internal command timeout diagnostic'
+
+
+EMPTY_TARGET="$TMP_ROOT/empty-selection/empty-target"
+EMPTY_BASELINE="$TMP_ROOT/empty-selection-baseline/empty-target"
+write_skill "$EMPTY_TARGET" empty-target 'Package without evaluation cases.'
+write_skill "$EMPTY_BASELINE" empty-target 'Empty-selection baseline.'
+expect_failure 'selected mode requires at least one case' --target "$EMPTY_TARGET" \
+  --mode behavior --runs 1 --baseline-path "$EMPTY_BASELINE" \
+  --out-root "$TMP_ROOT/runs" --run-id empty-selection
+assert_file_contains "$STDERR_FILE" 'no behavior evaluation cases selected' \
+  'empty selection diagnostic'
+FIXTURELESS_TARGET="$TMP_ROOT/fixtureless/fixtureless-target"
+FIXTURELESS_BASELINE="$TMP_ROOT/fixtureless-baseline/fixtureless-target"
+write_skill "$FIXTURELESS_TARGET" fixtureless-target 'Behavior package without declared fixtures.'
+write_skill "$FIXTURELESS_BASELINE" fixtureless-target 'Fixtureless baseline package.'
+mkdir -p "$FIXTURELESS_TARGET/evals"
+cat >"$FIXTURELESS_TARGET/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"fixtureless-target","cases":[{
+  "id":"fixtureless-case",
+  "prompt":"Complete without fixtures.",
+  "expected":"The capability root still contains an empty fixtures directory.",
+  "assertions":[{"id":"done","kind":"final-contains","substring":"done"}]
+}]}
+EOF
+expect_success 'fixtureless behavior creates empty fixture roots' \
+  --target "$FIXTURELESS_TARGET" --mode behavior --runs 1 \
+  --baseline-path "$FIXTURELESS_BASELINE" --out-root "$TMP_ROOT/runs" --run-id fixtureless
+[ -d "$RUN_ROOT/cases/fixtureless-case/1/candidate/fixtures" ] ||
+  fail 'fixtureless candidate workspace omitted fixtures directory'
+[ -d "$RUN_ROOT/cases/fixtureless-case/1/baseline/fixtures" ] ||
+  fail 'fixtureless baseline workspace omitted fixtures directory'
+
+CASE_LIMIT_TARGET="$TMP_ROOT/case-limit/case-limit-target"
+CASE_LIMIT_BASELINE="$TMP_ROOT/case-limit-baseline/case-limit-target"
+write_skill "$CASE_LIMIT_TARGET" case-limit-target 'Package exceeding the preparation case limit.'
+write_skill "$CASE_LIMIT_BASELINE" case-limit-target 'Case-limit baseline package.'
+mkdir -p "$CASE_LIMIT_TARGET/evals"
+"$NODE" - "$CASE_LIMIT_TARGET/evals/evals.json" <<'NODE'
+const fs = require('node:fs');
+const cases = Array.from({ length: 101 }, (_, index) => {
+  const ordinal = String(index + 1).padStart(3, '0');
+  return {
+    id: `case-${ordinal}`,
+    prompt: `Run case ${ordinal}.`,
+    expected: `Complete case ${ordinal}.`,
+    assertions: [{ id: 'done', kind: 'final-contains', substring: 'done' }],
+  };
+});
+fs.writeFileSync(process.argv[2], `${JSON.stringify({
+  schemaVersion: 1,
+  skill: 'case-limit-target',
+  cases,
+})}\n`);
+NODE
+expect_failure 'selected case count is bounded' \
+  --target "$CASE_LIMIT_TARGET" --mode behavior --runs 1 \
+  --baseline-path "$CASE_LIMIT_BASELINE" --out-root "$TMP_ROOT/runs" --run-id case-limit
+assert_file_contains "$STDERR_FILE" 'selected case count exceeds 100' \
+  'selected case count diagnostic'
+[ ! -e "$TMP_ROOT/runs/case-limit" ] || fail 'case-limit rejection allocated a run root'
+
+BUDGET_TARGET="$TMP_ROOT/workspace-budget/budget-target"
+BUDGET_BASELINE="$TMP_ROOT/workspace-budget-baseline/budget-target"
+write_skill "$BUDGET_TARGET" budget-target 'Package exceeding the projected workspace budget.'
+write_skill "$BUDGET_BASELINE" budget-target 'Workspace-budget baseline package.'
+mkdir -p "$BUDGET_TARGET/evals"
+cat >"$BUDGET_TARGET/evals/evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"budget-target","cases":[{
+  "id":"budget-case",
+  "prompt":"Exercise the workspace budget.",
+  "expected":"Preparation rejects the projected copies.",
+  "assertions":[{"id":"done","kind":"final-contains","substring":"done"}]
+}]}
+EOF
+"$NODE" - "$BUDGET_TARGET/payload.bin" <<'NODE'
+const fs = require('node:fs');
+fs.writeFileSync(process.argv[2], Buffer.alloc(7 * 1024 * 1024));
+NODE
+expect_failure 'projected workspace bytes are bounded' \
+  --target "$BUDGET_TARGET" --mode behavior --runs 10 \
+  --baseline-path "$BUDGET_BASELINE" --out-root "$TMP_ROOT/runs" --run-id workspace-budget
+assert_file_contains "$STDERR_FILE" 'projected workspace exceeds 67108864 bytes' \
+  'projected workspace budget diagnostic'
+[ ! -e "$TMP_ROOT/runs/workspace-budget" ] ||
+  fail 'workspace-budget rejection allocated a run root'
+
+
+expect_failure 'relative baseline path' --target "$TARGET" --mode all --runs 1 --baseline-path relative/path
+expect_failure 'relative catalog root' --target "$TARGET" --mode triggers --runs 1 --catalog-root relative/path
+expect_failure 'relative output root' --target "$TARGET" --mode all --runs 1 --out-root relative/path
+expect_failure 'run ID traversal' --target "$TARGET" --mode all --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --out-root "$TMP_ROOT/runs" --run-id ../escaped
+expect_failure 'run ID absolute path' --target "$TARGET" --mode all --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --out-root "$TMP_ROOT/runs" --run-id /absolute
+expect_failure 'run ID dot segment' --target "$TARGET" --mode all --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --out-root "$TMP_ROOT/runs" --run-id ..
+[ ! -e "$TMP_ROOT/escaped" ] || fail 'traversal created a directory outside the output root'
+
+expect_failure 'newline in CLI value' --target "$TARGET" --mode $'all\ninjected' --runs 1
+assert_bounded_diagnostic "$STDERR_FILE"
+expect_failure 'tab in CLI value' --target "$TARGET" --mode $'all\tinjected' --runs 1
+assert_bounded_diagnostic "$STDERR_FILE"
+OVERSIZED_ARGUMENT=$(printf 'a%.0s' {1..5000})
+expect_failure 'oversized CLI value' --target "$TARGET" --mode behavior --runs 1 \
+  --baseline-ref "$OVERSIZED_ARGUMENT"
+assert_bounded_diagnostic "$STDERR_FILE"
+
+# Selected case IDs are bounded before allocation, and behavior/trigger identities share one
+# namespace because both feed deterministic workspace and evidence names.
+CASE_ID_TARGET="$TMP_ROOT/case-ids/case-id-target"
+CASE_ID_BASELINE="$TMP_ROOT/case-id-baseline/case-id-target"
+write_skill "$CASE_ID_TARGET" case-id-target 'Case identifier boundary fixture.'
+write_skill "$CASE_ID_BASELINE" case-id-target 'Case identifier baseline.'
+mkdir -p "$CASE_ID_TARGET/evals"
+write_case_id_behavior() {
+  case_id=$1
+  cat >"$CASE_ID_TARGET/evals/evals.json" <<EOF
+{"schemaVersion":1,"skill":"case-id-target","cases":[{
+  "id":"$case_id",
+  "prompt":"Prepare an isolated workspace.",
+  "expected":"No unexpected path exists.",
+  "assertions":[{"id":"path-stays-absent","kind":"path-absent","path":"unexpected"}]
+}]}
+EOF
+}
+MAX_CASE_ID=$(printf 'a%.0s' {1..64})
+write_case_id_behavior "$MAX_CASE_ID"
+validate_setup_package "$CASE_ID_TARGET" "$TMP_ROOT/case-id-64-validation.json"
+expect_success 'maximum conservative case ID length' --target "$CASE_ID_TARGET" \
+  --mode behavior --runs 1 --baseline-path "$CASE_ID_BASELINE" \
+  --out-root "$TMP_ROOT/runs" --run-id case-id-64
+TOO_LONG_CASE_ID="${MAX_CASE_ID}a"
+write_case_id_behavior "$TOO_LONG_CASE_ID"
+validate_setup_package "$CASE_ID_TARGET" "$TMP_ROOT/case-id-65-validation.json"
+expect_failure 'case ID beyond evidence-safe boundary' --target "$CASE_ID_TARGET" \
+  --mode behavior --runs 1 --baseline-path "$CASE_ID_BASELINE" \
+  --out-root "$TMP_ROOT/runs" --run-id case-id-65
+write_case_id_behavior shared-case
+cat >"$CASE_ID_TARGET/evals/trigger-evals.json" <<'EOF'
+{"schemaVersion":1,"skill":"case-id-target","cases":[{
+  "id":"shared-case",
+  "query":"Select the target skill.",
+  "shouldTrigger":true,
+  "expectedSkill":"case-id-target"
+}]}
+EOF
+validate_setup_package "$CASE_ID_TARGET" "$TMP_ROOT/cross-corpus-validation.json"
+expect_failure 'cross-corpus duplicate selected case ID' --target "$CASE_ID_TARGET" \
+  --mode all --runs 1 --baseline-path "$CASE_ID_BASELINE" \
+  --out-root "$TMP_ROOT/runs" --run-id duplicate-cross-corpus
+
+ln -s "$PATH_BASELINE" "$TMP_ROOT/symlink-baseline"
+expect_failure 'symlink baseline root' --target "$TARGET" --mode all --runs 1 \
+  --baseline-path "$TMP_ROOT/symlink-baseline" --out-root "$TMP_ROOT/runs" --run-id symlink-baseline
+ln -s "$TARGET" "$TMP_ROOT/symlink-target"
+expect_failure 'symlink target root' --target "$TMP_ROOT/symlink-target" --mode all --runs 1 \
+  --baseline-path "$PATH_BASELINE" --out-root "$TMP_ROOT/runs" --run-id symlink-target
+mkdir -p "$TMP_ROOT/real-output"
+ln -s "$TMP_ROOT/real-output" "$TMP_ROOT/symlink-output"
+expect_failure 'symlink output root' --target "$TARGET" --mode all --runs 1 --baseline-ref "$BASE_COMMIT" \
+  --out-root "$TMP_ROOT/symlink-output" --run-id symlink-output
+
+UNSAFE_FIXTURE_TARGET="$TMP_ROOT/unsafe-fixture/unsafe-target"
+write_skill "$UNSAFE_FIXTURE_TARGET" unsafe-target 'Unsafe fixture package.'
+write_corpora "$UNSAFE_FIXTURE_TARGET" unsafe-target 'safe before replacement'
+rm "$UNSAFE_FIXTURE_TARGET/evals/fixtures/alpha.txt"
+printf 'outside fixture\n' >"$TMP_ROOT/outside-fixture.txt"
+ln -s "$TMP_ROOT/outside-fixture.txt" "$UNSAFE_FIXTURE_TARGET/evals/fixtures/alpha.txt"
+expect_failure 'symlink fixture' --target "$UNSAFE_FIXTURE_TARGET" --mode behavior --runs 1 \
+  --baseline-path "$PATH_BASELINE" --out-root "$TMP_ROOT/runs" --run-id symlink-fixture
+
+# Git metadata failures are not silently treated as a non-Git target.
+BROKEN_GIT_ROOT="$TMP_ROOT/broken-git"
+BROKEN_GIT_TARGET="$BROKEN_GIT_ROOT/skills/broken-target"
+mkdir -p "$BROKEN_GIT_ROOT/.git"
+write_skill "$BROKEN_GIT_TARGET" broken-target 'Target beneath malformed Git metadata.'
+write_corpora "$BROKEN_GIT_TARGET" broken-target 'broken git fixture'
+expect_failure 'malformed Git metadata fails closed' \
+  --target "$BROKEN_GIT_TARGET" --mode behavior --runs 1 \
+  --out-root "$TMP_ROOT/runs" --run-id malformed-git
+
+# Resolver-time source mutation changes package, HEAD, and index after the preflight snapshot.
+MUTATION_REPO="$TMP_ROOT/mutation-repo"
+git init -q -b base "$MUTATION_REPO"
+git -C "$MUTATION_REPO" config user.email evaluator@example.invalid
+git -C "$MUTATION_REPO" config user.name 'Evaluator Contract'
+MUTATION_TARGET="$MUTATION_REPO/skills/mutation-target"
+write_skill "$MUTATION_TARGET" mutation-target 'Source snapshot mutation target.'
+write_corpora "$MUTATION_TARGET" mutation-target 'mutation fixture'
+git -C "$MUTATION_REPO" add .
+git -C "$MUTATION_REPO" commit -qm 'mutation baseline'
+git -C "$MUTATION_REPO" switch -qc feature
+rm -f "$TMP_ROOT/resolver-marker"
+RESOLVER_MUTATE_FILE="$MUTATION_TARGET/references/guide.md" TEST_BASE_BRANCH=base \
+  expect_failure 'source mutation after snapshot fails closed' \
+  --target "$MUTATION_TARGET" --mode behavior --runs 1 \
+  --out-root "$TMP_ROOT/runs" --run-id source-mutated
+assert_file_contains "$MUTATION_TARGET/references/guide.md" \
+  'mutation during preparation' 'snapshot mutation hook'
+
+# A target present but invalid in a Git object is corruption, not a no-skill baseline.
+CORRUPT_REPO="$TMP_ROOT/corrupt-baseline-repo"
+git init -q -b base "$CORRUPT_REPO"
+git -C "$CORRUPT_REPO" config user.email evaluator@example.invalid
+git -C "$CORRUPT_REPO" config user.name 'Evaluator Contract'
+mkdir -p "$CORRUPT_REPO/skills/corrupt-target"
+printf 'not a package\n' >"$CORRUPT_REPO/not-a-skill"
+ln -s ../../not-a-skill "$CORRUPT_REPO/skills/corrupt-target/SKILL.md"
+git -C "$CORRUPT_REPO" add .
+git -C "$CORRUPT_REPO" commit -qm 'symlinked baseline target'
+git -C "$CORRUPT_REPO" switch -qc feature
+rm "$CORRUPT_REPO/skills/corrupt-target/SKILL.md"
+write_skill "$CORRUPT_REPO/skills/corrupt-target" corrupt-target 'Valid candidate replacing corrupt baseline.'
+write_corpora "$CORRUPT_REPO/skills/corrupt-target" corrupt-target 'corrupt baseline fixture'
+TEST_BASE_BRANCH=base expect_failure 'present invalid Git baseline fails closed' \
+  --target "$CORRUPT_REPO/skills/corrupt-target" --mode all --runs 1 \
+  --out-root "$TMP_ROOT/runs" --run-id corrupt-baseline
+
+printf 'PASS: prepare contract\n'

--- a/skills/woostack-eval/scripts/validate.mjs
+++ b/skills/woostack-eval/scripts/validate.mjs
@@ -2,8 +2,8 @@ import { createHash } from 'node:crypto';
 import { execFile as execFileCallback } from 'node:child_process';
 import { lstat, readFile, readdir, realpath } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { pathToFileURL } from 'node:url';
 
 const execFile = promisify(execFileCallback);
 const KEBAB_CASE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -1167,7 +1167,11 @@ async function main(argv) {
   process.stdout.write(`${JSON.stringify(result, null, options.json ? 0 : 2)}\n`);
   if (!result.valid) process.exitCode = 1;
 }
-
-if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
-  await main(process.argv.slice(2));
+if (process.argv[1]) {
+  const self = await realpath(fileURLToPath(import.meta.url)).catch(() => path.resolve(fileURLToPath(import.meta.url)));
+  const requested = await realpath(path.resolve(process.argv[1])).catch(() => path.resolve(process.argv[1]));
+  if (self === requested) {
+    await main(process.argv.slice(2));
+  }
 }
+


### PR DESCRIPTION
## Goal

Split the oversized evaluator runtime into reviewable increments by landing only the safe, deterministic preparation layer in this PR. Worker dispatch, aggregation, and reporting remain in later stacked slices.

## Summary

- Add deterministic candidate/baseline preparation with private per-case workspaces, frozen case definitions, package identities, grading plans, and expected dispatch manifests.
- Resolve explicit and merge-base Git baselines from Git objects without mutating the source worktree; allocate private run roots atomically.
- Build canonical candidate and baseline trigger catalogs with contained fixtures and host-owned definitions outside worker capability roots.
- Document the preparation contract and split the runtime plan into preparation, aggregation, and reporting PRs.

## Test plan

### Automated

- [ ] `bash skills/woostack-eval/scripts/tests/test-prepare.sh` — PASS
- [ ] `bash skills/woostack-eval/scripts/tests/run-tests.sh` — PASS before splitting the runtime work into separate PRs

### Manual

**Before merge**

- [ ] Confirm this slice stops after writing a complete manifest and does not dispatch workers, aggregate evidence, or render reports.
- [ ] Inspect baseline resolution and run allocation for fail-closed behavior, source-worktree preservation, private `0700` roots, collision handling, and invocation-owned cleanup.
- [ ] Inspect the prepared manifest/workspaces for frozen hashes and definitions, canonical catalogs, isolated variants, and an initially empty evidence directory.

Spec: .woostack/specs/2026-07-15-skill-evaluation-optimization.md

## Final stack verification

### Automated

- [ ] `bash skills/woostack-eval/scripts/tests/run-tests.sh` — passed all 9 evaluator script suites.
- [ ] `bash skills/woostack-eval/scripts/tests/test-critical-corpora.sh` — validated exactly 15 required packages.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-package.sh` — passed 45/45.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-package-ci.sh` — passed 18/18.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-small-diff.sh` — passed 19/19.
- [ ] `bash skills/woostack-review/scripts/tests/test-skills-angle-rubric.sh` — passed 28/28.
- [ ] `bash skills/woostack-review/scripts/tests/test-progressive-disclosure.sh` — passed 190/190.
- [ ] `bash skills/woostack-commit/tests/test-linear-attribution.sh` — passed.
- [ ] `bash skills/woostack-commit/tests/test-progressive-disclosure.sh` — passed.
- [ ] `bash skills/woostack-build/tests/test-linear-build-contract.sh` — passed.
- [ ] `bash skills/woostack-build/scripts/tests/test-build-spec-commit-ordering.sh` — passed.
- [ ] `bash skills/woostack-build/scripts/tests/test-progressive-disclosure.sh` — passed 63/63.
- [ ] `bash skills/using-woostack/tests/test-artifact-reader-contract.sh` — passed 12/12.
- [ ] `bash skills/woostack-change/scripts/tests/test-command-surface.sh` — passed 12/12.
- [ ] `bash skills/woostack-respond/scripts/tests/test-command-surface.sh` — passed 15/15.
- [ ] `node --test site/scripts/gen-skills.test.mjs` — passed 14/14.
- [ ] `pnpm -C site build` — passed; 147 static pages generated.

### Comparative model evidence

- [ ] No model-backed old-versus-candidate run was dispatched: this host cannot prove the evaluator's required per-worker capability isolation. Therefore no receipt or report path exists, and no model-eval pass is claimed.
