### PR TITLE
Add skill evaluation receipt aggregation and grading

### DIFF
--- a/.woostack/memory/schema-unions-need-positive-branch-coverage.md
+++ b/.woostack/memory/schema-unions-need-positive-branch-coverage.md
@@ -1,0 +1,19 @@
+---
+name: schema-unions-need-positive-branch-coverage
+type: pattern
+scope: skills/woostack-eval/scripts/aggregate/**,skills/woostack-eval/scripts/tests/test-aggregate.sh
+tags: tests, schema, union, telemetry, identity, regression-coverage
+hook: A schema union is not covered when tests exercise only one successful branch and invalid forms of the other — add a positive contract case for every supported branch.
+updated: 2026-07-17
+source: pr-538
+---
+
+When a persisted contract permits distinct valid representations, rejection tests for the unused
+representation do not prove its success path. Keep at least one complete fixture for every supported
+branch. For the eval aggregator this means both `model` and `sessionIdentity` completion identities,
+and both concrete token telemetry and the `unavailable` sentinel.
+
+Assert the downstream behavior, not only schema acceptance: successful aggregation, preserved
+per-result values, and computed overall metrics or deltas. The same boundary rule applies to safety
+authorities: pair the happy path with focused rejection cases for containment and private-parent
+requirements, including an assertion that rejection leaves no published or temporary file.

--- a/skills/woostack-eval/references/runner.md
+++ b/skills/woostack-eval/references/runner.md
@@ -189,10 +189,13 @@ or non-regular proof before enumerating evidence. The host then builds an immuta
 before processing. For every regular evidence, definition, input mapping, output/transcript, and
 copied-package file, it binds the run-root-relative path to device, inode, size, mtime, and a
 streamed SHA-256 taken from an opened no-follow handle. It also binds directory identities and
-name sets using opened directory handles where the host supports them. After processing and before
-publication, the aggregator reopens every path no-follow and revalidates all identities, hashes,
-directories, and names. A same-name rewrite, replacement, added/removed file, directory swap, or
-late evidence emits fatal `snapshot-mutation` and refuses publication.
+name sets using opened directory handles where the host supports them. Snapshot traversal admits at
+most 4,096 entries including the run root, hashes at most 16 MiB per regular file and 128 MiB
+across the run, and emits
+fatal `snapshot-limit-exceeded` before publication when a bound is crossed. After processing and
+before publication, the aggregator reopens every path no-follow and revalidates all identities,
+hashes, directories, and names. A same-name rewrite, replacement, added/removed file, directory
+swap, or late evidence emits fatal `snapshot-mutation` and refuses publication.
 
 After all workers finish, hash the original target package again. Any delta invalidates comparison,
 preserves the run directory, and reports changed paths without resetting them. Missing or malformed

--- a/skills/woostack-eval/references/schemas.md
+++ b/skills/woostack-eval/references/schemas.md
@@ -365,8 +365,9 @@ failure, and contains no merge verdict.
 
 Aggregate and HTML report publication share one create-new authority at mode `0600`: it writes
 and fsyncs a same-directory temporary file, atomically links that file to the requested absent
-output path, fsyncs the parent directory, and removes the temporary name on success or failure.
-It never overwrites an existing aggregate or report.
+output path, fsyncs the parent directory, and attempts to remove the temporary name on success
+and failure. Cleanup failures are surfaced; an unlink failure can retain the private temporary
+file. Publication never overwrites an existing aggregate or report.
 
 `objectivePassRate` uses only deterministic assertion observations from behavior cases. For each
 variant, every assertion/repetition observation has equal weight: the rate is passing deterministic
@@ -428,7 +429,8 @@ Aggregate evidence and fatal snapshot errors use these exhaustive canonical code
 | `package-hash-mismatch` | `/packageHash` | A copied package, worker receipt, or grader receipt differs from the applicable frozen manifest package identity. |
 | `unsafe-evidence-path` | `/output/path`, `/transcript/path`, or `/receipt/path` | The referenced path is absolute, escapes the run root, or is otherwise unsafe. |
 | `non-regular-evidence` | `/output/path`, `/transcript/path`, or `/receipt/path` | Referenced evidence is missing, a directory, symlink, special file, or unstable regular file. |
-| `snapshot-mutation` | empty pointer | Fatal: a snapshotted path, directory identity/name set, opened-handle inode/device/size/mtime, or streamed SHA-256 changes; publication is refused. |
+| `snapshot-limit-exceeded` | empty pointer | Fatal: a [snapshot bound](runner.md#isolated-workspaces-and-evidence) is crossed; publication is refused. |
+| `snapshot-mutation` | empty pointer | Fatal: a snapshotted path, directory identity/name set, opened-handle inode/device/size/mtime, streamed SHA-256, or consumed file identity differs; publication is refused. |
 Errors are normalized and sorted by `path`, then `field`, then `code`. A single-fault input emits
 only its canonical error; secondary missing/unknown errors for the same rejected receipt are not
 added.

--- a/skills/woostack-eval/scripts/aggregate.mjs
+++ b/skills/woostack-eval/scripts/aggregate.mjs
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  aggregate,
+  runAggregateCli,
+  sanitizeMessage,
+  writeCreateNew,
+} from './aggregate/core.mjs';
+
+const entrypoint = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (entrypoint && fileURLToPath(import.meta.url) === entrypoint) {
+  runAggregateCli(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`aggregate: ${sanitizeMessage(error?.message ?? error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export { aggregate, writeCreateNew };

--- a/skills/woostack-eval/scripts/aggregate/contracts.mjs
+++ b/skills/woostack-eval/scripts/aggregate/contracts.mjs
@@ -1,0 +1,89 @@
+import { isDeepStrictEqual } from 'node:util';
+
+const VARIANTS = ['candidate', 'baseline'];
+const WORKER_KINDS = new Set(['behavior', 'trigger']);
+const CAPABILITIES = new Set(['read-workspace', 'write-workspace', 'shell-workspace']);
+const COMPLETION_STATUSES = new Set(['complete', 'failed', 'timed-out']);
+const SHA256 = /^sha256:[0-9a-f]{64}$/;
+const KEBAB = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const RUN_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const GIT_COMMIT = /^[0-9a-f]{40}$/;
+const ABSENT_BASELINE = /^[0-9a-f]{40}:absent$/;
+const MAX_CASE_ID_BYTES = 64;
+const MAX_RUNS = 10;
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function same(left, right) {
+  return isDeepStrictEqual(left, right);
+}
+
+function exactKeys(value, fields) {
+  return isObject(value) && same(Object.keys(value).sort(), [...fields].sort());
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function optionalString(value) {
+  return value === null || typeof value === 'string';
+}
+
+function caseIdValid(value) {
+  return typeof value === 'string'
+    && Buffer.byteLength(value, 'utf8') <= MAX_CASE_ID_BYTES
+    && KEBAB.test(value);
+}
+
+function baselineIdentityValid(baseline) {
+  if (!exactKeys(baseline, ['kind', 'identity']) || typeof baseline.identity !== 'string') {
+    return false;
+  }
+  if (baseline.kind === 'git-ref') return GIT_COMMIT.test(baseline.identity);
+  if (baseline.kind === 'path') return SHA256.test(baseline.identity);
+  return baseline.kind === 'none' && ABSENT_BASELINE.test(baseline.identity);
+}
+
+function completionIdentityValid(receipt) {
+  return (nonEmptyString(receipt.model) && receipt.sessionIdentity === null)
+    || (nonEmptyString(receipt.sessionIdentity) && receipt.model === null);
+}
+
+function sanitizeMessage(value) {
+  return String(value)
+    .replace(/[\u0000-\u001f\u007f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .slice(0, 240)
+    .trim() || 'Aggregation failed';
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export {
+  ABSENT_BASELINE,
+  CAPABILITIES,
+  COMPLETION_STATUSES,
+  GIT_COMMIT,
+  KEBAB,
+  MAX_CASE_ID_BYTES,
+  MAX_RUNS,
+  RUN_ID,
+  SHA256,
+  VARIANTS,
+  WORKER_KINDS,
+  baselineIdentityValid,
+  caseIdValid,
+  compareText,
+  completionIdentityValid,
+  exactKeys,
+  isObject,
+  nonEmptyString,
+  optionalString,
+  sanitizeMessage,
+  same,
+};

--- a/skills/woostack-eval/scripts/aggregate/core.mjs
+++ b/skills/woostack-eval/scripts/aggregate/core.mjs
@@ -1,0 +1,1195 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+import { hashPackage } from '../validate.mjs';
+import {
+  comparative,
+  durationMetric,
+  metric,
+  tokenComparison,
+  tokenMetric,
+  triggerMetric,
+} from './metrics.mjs';
+import { sanitizeMessage } from './contracts.mjs';
+import {
+  KEBAB,
+  SHA256,
+  VARIANTS,
+  WORKER_KINDS,
+  caseIdValid,
+  compareText,
+  exactKeys,
+  isObject,
+  nonEmptyString,
+  optionalString,
+  requireManifest,
+  same,
+} from './schema.mjs';
+import {
+  capabilitiesValid,
+  completionIdentityValid,
+  completionPayloadError,
+  gradeFilename,
+  inputFilename,
+  pointerValue,
+  qualitativePayloadError,
+} from './grading.mjs';
+import {
+  buildRunSnapshot,
+  indexRunSnapshot,
+  contained,
+  listDirectoryNames,
+  parseFile,
+  regularFile,
+  relativeTo,
+  requireDirectoryChain,
+  requireManifestWorkspaces,
+  requirePrivateRunRoot,
+  requireQuiescenceProof,
+  revalidateRunSnapshot,
+  writeCreateNew,
+} from './safe-access.mjs';
+
+const RECEIPT_FIELDS = [
+  'schemaVersion', 'runId', 'caseId', 'repetition', 'variant', 'kind', 'targetSkill',
+  'baseline', 'packageHash', 'capabilities', 'host', 'runner', 'model',
+  'sessionIdentity', 'tier', 'effort', 'startedAt', 'durationMs', 'output',
+  'transcript', 'tokenUsage', 'selectedSkill', 'completionStatus', 'error',
+];
+const GRADE_FIELDS = [
+  'schemaVersion', 'runId', 'caseId', 'repetition', 'graderId', 'assertionId',
+  'anonymizedOutputId', 'completionStatus', 'pass', 'rationale', 'error', 'input', 'receipt',
+];
+const INPUT_FIELDS = [
+  'schemaVersion', 'runId', 'caseId', 'repetition', 'graderId', 'assertionId',
+  'anonymizedOutputId', 'source',
+];
+const AGGREGATE_ERROR_CODES = new Set([
+  'anonymized-output-collision',
+  'configuration-mismatch',
+  'duplicate-receipt',
+  'evidence-too-large',
+  'grade-input-hash-mismatch',
+  'grade-input-mismatch',
+  'grade-receipt-hash-mismatch',
+  'grader-configuration-mismatch',
+  'grader-identity-mismatch',
+  'identity-mismatch',
+  'incomplete-receipt',
+  'malformed-receipt',
+  'missing-completion-identity',
+  'missing-field',
+  'missing-grade-input',
+  'missing-grade-receipt',
+  'missing-receipt',
+  'non-regular-evidence',
+  'output-bytes-mismatch',
+  'output-hash-mismatch',
+  'package-hash-mismatch',
+  'snapshot-limit-exceeded',
+  'snapshot-mutation',
+  'transcript-bytes-mismatch',
+  'transcript-hash-mismatch',
+  'unknown-receipt',
+  'unsafe-evidence-path',
+]);
+const RFC3339_UTC = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?Z$/;
+const MAX_MATERIALIZED_BYTES = 1024 * 1024;
+const UNAVAILABLE = 'unavailable';
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (!['--manifest', '--evidence', '--out'].includes(flag) || options[flag]) {
+      throw new Error('usage: node aggregate.mjs --manifest <manifest.json> --evidence <dir> --out <aggregate.json>');
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`missing value for ${flag}`);
+    }
+    options[flag] = value;
+    index += 1;
+  }
+  for (const flag of ['--manifest', '--evidence', '--out']) {
+    if (!options[flag]) throw new Error(`missing required option ${flag}`);
+  }
+  return { manifest: options['--manifest'], evidence: options['--evidence'], out: options['--out'] };
+}
+
+
+function validRfc3339Utc(value) {
+  if (typeof value !== 'string') return false;
+  const match = RFC3339_UTC.exec(value);
+  if (!match) return false;
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return false;
+  const date = new Date(timestamp);
+  const components = match.slice(1, 7).map(Number);
+  return date.getUTCFullYear() === components[0]
+    && date.getUTCMonth() + 1 === components[1]
+    && date.getUTCDate() === components[2]
+    && date.getUTCHours() === components[3]
+    && date.getUTCMinutes() === components[4]
+    && date.getUTCSeconds() === components[5];
+}
+
+
+function sha256(bytes) {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+
+
+function errorRecord(code, field, evidencePath, message) {
+  if (!AGGREGATE_ERROR_CODES.has(code)) throw new Error(`undocumented aggregate error code: ${code}`);
+  return { code, field, path: evidencePath, message: sanitizeMessage(message) };
+}
+
+
+function sortErrors(errors) {
+  return errors.sort((left, right) =>
+    compareText(left.path, right.path)
+    || compareText(left.field, right.field)
+    || compareText(left.code, right.code));
+}
+
+function expectedKey(value) {
+  return `${value.kind}\u0000${value.caseId}\u0000${value.variant}\u0000${value.repetition}`;
+}
+
+function expectedReceiptName(value) {
+  return `action.${value.kind}.${value.caseId}.${value.variant}.${value.repetition}.json`;
+}
+
+function gradingPlanKey(value) {
+  return `${value.caseId}\u0000${value.repetition}\u0000${value.assertionId}`;
+}
+
+async function requireResolvedGradingPlan(runRoot, manifest, snapshot) {
+  const expectedKinds = new Map(manifest.expected.map((item) => [item.caseId, item.kind]));
+  const canonicalEntries = [];
+  for (const pair of manifest.pairs) {
+    const kind = expectedKinds.get(pair.caseId);
+    const parsed = await parseFile(runRoot, `definitions/${kind}.${pair.caseId}.json`, snapshot);
+    if (parsed.state.kind !== 'file' || parsed.malformed || parsed.value.id !== pair.caseId) {
+      throw new Error(`frozen ${kind} definition is missing or invalid`);
+    }
+    for (const assertion of (parsed.value.assertions ?? [])
+      .filter((item) => item.kind === 'qualitative')) {
+      canonicalEntries.push({
+        caseId: pair.caseId,
+        repetition: pair.repetition,
+        assertionId: assertion.id,
+      });
+    }
+  }
+  const canonicalKeys = canonicalEntries
+    .sort((left, right) =>
+      compareText(left.caseId, right.caseId)
+      || left.repetition - right.repetition
+      || compareText(left.assertionId, right.assertionId))
+    .map(gradingPlanKey);
+
+  const plan = new Map();
+  const orderedKeys = [];
+  const graderSlots = new Set();
+  for (const entry of manifest.gradingPlan) {
+    if (!exactKeys(entry, ['caseId', 'repetition', 'assertionId', 'graderId'])
+      || !caseIdValid(entry.caseId)
+      || !Number.isSafeInteger(entry.repetition)
+      || entry.repetition < 1
+      || entry.repetition > manifest.runs
+      || !KEBAB.test(entry.assertionId ?? '')
+      || !KEBAB.test(entry.graderId ?? '')) {
+      throw new Error('manifest grading plan is unresolved or invalid');
+    }
+    const key = gradingPlanKey(entry);
+    if (plan.has(key)) throw new Error('manifest grading plan contains duplicate identities');
+    const graderSlot = `${entry.caseId}\u0000${entry.repetition}\u0000${entry.graderId}`;
+    if (graderSlots.has(graderSlot)) {
+      throw new Error('manifest grading plan contains duplicate grader identities');
+    }
+    graderSlots.add(graderSlot);
+    plan.set(key, entry);
+    orderedKeys.push(key);
+  }
+  if (!same(orderedKeys, canonicalKeys)) {
+    throw new Error('manifest grading plan does not match frozen qualitative assertions');
+  }
+  return plan;
+}
+
+
+async function validateIdentityFile(runRoot, identity, field, receiptPath, label, snapshot) {
+  if (!isObject(identity)) {
+    return { error: errorRecord('missing-field', field.slice(0, field.lastIndexOf('/')) || field, receiptPath, `${label} identity is required`) };
+  }
+  if (typeof identity.path !== 'string') {
+    return { error: errorRecord('missing-field', `${field}/path`, receiptPath, `${label} path is required`) };
+  }
+  if (!same(Object.keys(identity).sort(), ['bytes', 'path', 'sha256'])) {
+    return { error: errorRecord('malformed-receipt', '', receiptPath, `${label} identity key set is not canonical`) };
+  }
+  const materialize = label !== 'Transcript';
+  const state = await regularFile(runRoot, identity.path, { materialize, snapshot });
+  if (state.kind === 'unsafe') {
+    return { error: errorRecord('unsafe-evidence-path', `${field}/path`, receiptPath, `${label} path is unsafe`) };
+  }
+  if (state.kind === 'too-large') {
+    return { error: errorRecord('evidence-too-large', `${field}/path`, receiptPath, `${label} exceeds the materialization limit`) };
+  }
+  if (state.kind !== 'file') {
+    return { error: errorRecord('non-regular-evidence', `${field}/path`, receiptPath, `${label} must be a stable regular non-symlink file`) };
+  }
+  if (!SHA256.test(identity.sha256 ?? '') || state.sha256 !== identity.sha256) {
+    const code = label === 'Transcript' ? 'transcript-hash-mismatch' : 'output-hash-mismatch';
+    return { error: errorRecord(code, `${field}/sha256`, receiptPath, `${label} SHA-256 does not match its bytes`) };
+  }
+  if (!Number.isSafeInteger(identity.bytes) || identity.bytes < 0 || state.byteCount !== identity.bytes) {
+    const code = label === 'Transcript' ? 'transcript-bytes-mismatch' : 'output-bytes-mismatch';
+    return { error: errorRecord(code, `${field}/bytes`, receiptPath, `${label} byte count does not match its bytes`) };
+  }
+  return { bytes: state.bytes };
+}
+
+
+function firstMissing(value, fields) {
+  return fields.find((field) => !Object.hasOwn(value, field));
+}
+
+async function validateActionReceipt(receipt, expected, manifest, runRoot, receiptPath, snapshot, isGrader = false) {
+  const missing = firstMissing(receipt, RECEIPT_FIELDS);
+  if (missing) return { error: errorRecord('missing-field', `/${missing}`, receiptPath, `Receipt field ${missing} is required`) };
+  if (!same(Object.keys(receipt).sort(), [...RECEIPT_FIELDS].sort())) {
+    return { error: errorRecord('malformed-receipt', '', receiptPath, 'Receipt key set is not canonical') };
+  }
+
+  for (const [field, wanted] of [
+    ['schemaVersion', 1], ['runId', manifest.runId], ['caseId', expected.caseId],
+    ['repetition', expected.repetition], ['variant', expected.variant], ['kind', expected.kind],
+    ['targetSkill', manifest.targetSkill], ['baseline', manifest.baseline],
+  ]) {
+    if (!same(receipt[field], wanted)) {
+      return { error: errorRecord('identity-mismatch', `/${field}`, receiptPath, `Receipt ${field} does not match its expected identity`) };
+    }
+  }
+
+  for (const field of ['host', 'runner']) {
+    if (!nonEmptyString(receipt[field])) {
+      return { error: errorRecord('identity-mismatch', `/${field}`, receiptPath, `Receipt ${field} must be a non-empty string`) };
+    }
+  }
+  if (!capabilitiesValid(receipt.capabilities)) {
+    return { error: errorRecord('identity-mismatch', '/capabilities', receiptPath, 'Receipt capabilities must be a unique array of documented capabilities') };
+  }
+  if (!completionIdentityValid(receipt)) {
+    return { error: errorRecord('missing-completion-identity', '/model', receiptPath, 'Receipt requires exactly one concrete completion identity') };
+  }
+  for (const field of ['tier', 'effort']) {
+    if (!optionalString(receipt[field])) {
+      return { error: errorRecord('identity-mismatch', `/${field}`, receiptPath, `Receipt ${field} must be a string or null`) };
+    }
+  }
+  if (!isGrader) {
+    for (const field of ['host', 'runner', 'model', 'sessionIdentity', 'tier', 'effort']) {
+      if (!same(receipt[field], manifest.runConfiguration[field])) {
+        return { error: errorRecord('configuration-mismatch', `/${field}`, receiptPath, `Worker ${field} does not match the manifest run configuration`) };
+      }
+    }
+  } else if (!SHA256.test(receipt.packageHash ?? '')
+    || receipt.packageHash !== manifest.packageHashes.candidate) {
+    return {
+      error: errorRecord(
+        'package-hash-mismatch',
+        '/packageHash',
+        receiptPath,
+        'Grader package hash must equal the frozen candidate package identity',
+      ),
+    };
+  }
+  const completionError = completionPayloadError(receipt.completionStatus, receipt.error);
+  if (completionError) {
+    return { error: errorRecord('identity-mismatch', completionError.field, receiptPath, completionError.message) };
+  }
+  if (!validRfc3339Utc(receipt.startedAt)) {
+    return { error: errorRecord('identity-mismatch', '/startedAt', receiptPath, 'Receipt start time must be RFC 3339 UTC') };
+  }
+  if (!Number.isSafeInteger(receipt.durationMs) || receipt.durationMs < 0) {
+    return { error: errorRecord('identity-mismatch', '/durationMs', receiptPath, 'Receipt duration must be a non-negative integer') };
+  }
+  if (receipt.tokenUsage !== UNAVAILABLE) {
+    if (!isObject(receipt.tokenUsage)) {
+      return { error: errorRecord('identity-mismatch', '/tokenUsage', receiptPath, 'Receipt token usage is invalid') };
+    }
+    if (!same(Object.keys(receipt.tokenUsage).sort(), ['input', 'output', 'total'])) {
+      return { error: errorRecord('malformed-receipt', '', receiptPath, 'Token usage key set is not canonical') };
+    }
+    if (!['input', 'output', 'total'].every((field) =>
+      Number.isSafeInteger(receipt.tokenUsage[field]) && receipt.tokenUsage[field] >= 0)
+      || receipt.tokenUsage.total !== receipt.tokenUsage.input + receipt.tokenUsage.output) {
+      return { error: errorRecord('identity-mismatch', '/tokenUsage', receiptPath, 'Receipt token usage is invalid') };
+    }
+  }
+  if (expected.kind === 'trigger') {
+    if (typeof receipt.selectedSkill !== 'string' || (!KEBAB.test(receipt.selectedSkill) && receipt.selectedSkill !== 'none')) {
+      return { error: errorRecord('identity-mismatch', '/selectedSkill', receiptPath, 'Trigger receipt selectedSkill is invalid') };
+    }
+  } else if (receipt.selectedSkill !== null) {
+    return { error: errorRecord('identity-mismatch', '/selectedSkill', receiptPath, 'Non-trigger receipt selectedSkill must be null') };
+  }
+
+  const output = await validateIdentityFile(runRoot, receipt.output, '/output', receiptPath, 'Output', snapshot);
+  if (output.error) return output;
+  let transcriptBytes = null;
+  if (receipt.transcript !== UNAVAILABLE) {
+    const transcript = await validateIdentityFile(runRoot, receipt.transcript, '/transcript', receiptPath, 'Transcript', snapshot);
+    if (transcript.error) return transcript;
+    transcriptBytes = transcript.bytes;
+  }
+  if (receipt.completionStatus !== 'complete') {
+    return { error: errorRecord('incomplete-receipt', '/completionStatus', receiptPath, 'Required action did not complete') };
+  }
+  return { outputBytes: output.bytes, transcriptBytes };
+}
+
+function receiptIdentity(relativePath, bytes) {
+  return { path: relativePath, sha256: sha256(bytes) };
+}
+
+function blockedResult(repetition) {
+  return { repetition, completionStatus: 'blocked', receipt: null, assertions: [] };
+}
+
+
+async function assertionPathState(context, relativePath) {
+  if (context.fileCache.has(relativePath)) return context.fileCache.get(relativePath);
+  const state = await regularFile(context.workspaceRoot, relativePath, {
+    snapshot: context.snapshot,
+    snapshotPath: `${context.workspacePrefix}/${relativePath}`,
+  });
+  context.fileCache.set(relativePath, state);
+  return state;
+}
+
+async function evaluateAssertion(assertion, context) {
+  const base = { assertionId: assertion.id, critical: assertion.critical === true };
+  if (assertion.kind === 'qualitative') {
+    return { ...base, pass: null, rationale: null, anonymizedOutputId: null, grade: null, graderReceipt: null };
+  }
+
+  let pass = false;
+  let observed = null;
+  if (assertion.kind === 'final-contains' || assertion.kind === 'final-excludes') {
+    const contains = context.outputText.includes(assertion.substring);
+    pass = assertion.kind === 'final-contains' ? contains : !contains;
+    observed = context.receipt.output;
+  } else if (assertion.kind === 'receipt-field-equals') {
+    const actual = pointerValue(context.receipt, assertion.pointer);
+    pass = actual.found && same(actual.value, assertion.expected);
+    observed = context.receiptIdentity;
+  } else if (assertion.kind === 'path-exists' || assertion.kind === 'path-absent') {
+    const state = await assertionPathState(context, assertion.path);
+    const exists = state.kind === 'file';
+    pass = assertion.kind === 'path-exists' ? exists : state.kind === 'missing';
+    observed = { path: assertion.path };
+  } else if (['file-contains', 'file-excludes', 'json-path-equals'].includes(assertion.kind)) {
+    const relativePath = assertion.path ?? assertion.file;
+    const state = await assertionPathState(context, relativePath);
+    if (state.kind === 'file') {
+      observed = { path: relativePath, sha256: state.sha256, bytes: state.byteCount };
+      if (assertion.kind === 'file-contains' || assertion.kind === 'file-excludes') {
+        const contains = state.bytes.toString('utf8').includes(assertion.substring);
+        pass = assertion.kind === 'file-contains' ? contains : !contains;
+      } else {
+        try {
+          const value = JSON.parse(state.bytes.toString('utf8'));
+          const actual = pointerValue(value, assertion.pointer);
+          pass = actual.found && same(actual.value, assertion.expected);
+        } catch {
+          pass = false;
+        }
+      }
+    }
+  }
+  return { ...base, pass, observed };
+}
+
+async function loadCaseDefinition(runRoot, pair, expected, snapshot) {
+  const workspacePrefix = pair[expected.variant];
+  const workspaceRoot = path.resolve(runRoot, ...workspacePrefix.split('/'));
+  const definitionPath = `definitions/${expected.kind}.${expected.caseId}.json`;
+  const parsed = await parseFile(runRoot, definitionPath, snapshot);
+  if (parsed.state.kind !== 'file' || parsed.malformed) {
+    throw new Error(`frozen ${expected.kind} definition is missing or invalid`);
+  }
+  if (parsed.value.id !== expected.caseId) {
+    throw new Error('frozen definition identity does not match the manifest');
+  }
+  return { definition: parsed.value, workspaceRoot, workspacePrefix };
+}
+
+async function validateWorkspacePackage(runRoot, pair, expected, receipt, manifest, receiptPath) {
+  const frozenHash = manifest.packageHashes[expected.variant];
+  if (expected.variant === 'baseline' && manifest.baseline.kind === 'none') {
+    return receipt.packageHash === null
+      ? null
+      : errorRecord(
+          'package-hash-mismatch',
+          '/packageHash',
+          receiptPath,
+          'A no-skill baseline must carry the frozen null package identity',
+        );
+  }
+  const packageRoot = path.resolve(runRoot, ...pair[expected.variant].split('/'), 'package');
+  await requireDirectoryChain(runRoot, packageRoot, 'copied package');
+  const currentHash = await hashPackage(packageRoot, { trackedOnly: false });
+  if (!SHA256.test(receipt.packageHash ?? '')
+    || currentHash !== frozenHash
+    || receipt.packageHash !== frozenHash) {
+    return errorRecord(
+      'package-hash-mismatch',
+      '/packageHash',
+      receiptPath,
+      'Copied package hash does not match its frozen manifest identity',
+    );
+  }
+  return null;
+}
+
+
+async function validateGradeInput(runRoot, evidencePrefix, proof, gradePath, snapshot) {
+  const { grade, filenameIdentity, expectedGrade } = proof;
+  if (!exactKeys(grade.input, ['path', 'sha256'])) {
+    return { error: errorRecord('malformed-receipt', '/input', gradePath, 'Grade input identity is not canonical') };
+  }
+  const expectedPath = `${evidencePrefix}/input.${grade.caseId}.${filenameIdentity.variant}.${grade.repetition}.${grade.graderId}.json`;
+  if (grade.input.path !== expectedPath) {
+    return { error: errorRecord('identity-mismatch', '/input/path', gradePath, 'Grade input path is not deterministic') };
+  }
+  const state = await regularFile(runRoot, grade.input.path, { snapshot });
+  if (state.kind === 'too-large') {
+    return { error: errorRecord('evidence-too-large', '/input/path', gradePath, 'Grade input mapping exceeds the materialization limit') };
+  }
+  if (state.kind !== 'file') {
+    return { error: errorRecord('missing-grade-input', '/input/path', gradePath, 'Grade input mapping is absent') };
+  }
+  if (!SHA256.test(grade.input.sha256) || state.sha256 !== grade.input.sha256) {
+    return { error: errorRecord('grade-input-hash-mismatch', '/input/sha256', gradePath, 'Grade input mapping hash does not match') };
+  }
+  let input;
+  try {
+    input = JSON.parse(state.bytes.toString('utf8'));
+  } catch {
+    input = null;
+  }
+  if (!exactKeys(input, INPUT_FIELDS)) {
+    return { error: errorRecord('malformed-receipt', '', grade.input.path, 'Grade input mapping is not canonical') };
+  }
+  for (const [field, wanted] of [
+    ['schemaVersion', 1], ['runId', grade.runId], ['caseId', grade.caseId],
+    ['repetition', grade.repetition], ['graderId', grade.graderId],
+    ['assertionId', grade.assertionId], ['anonymizedOutputId', grade.anonymizedOutputId],
+    ['source', expectedGrade.result.output],
+  ]) {
+    if (!same(input[field], wanted)) {
+      return { error: errorRecord('grade-input-mismatch', `/${field}`, grade.input.path, `Grade input ${field} does not match its source proof`) };
+    }
+  }
+  return { input, bytes: state.bytes };
+}
+
+async function aggregate(options) {
+  const manifestPath = path.resolve(options.manifest);
+  const evidenceRoot = path.resolve(options.evidence);
+  const outPath = path.resolve(options.out);
+  const runRoot = path.dirname(manifestPath);
+  if (!contained(runRoot, evidenceRoot) || evidenceRoot === runRoot) throw new Error('evidence directory must be contained by the run root');
+  if (!contained(runRoot, outPath) || outPath === runRoot) throw new Error('output must be contained by the run root');
+  await requirePrivateRunRoot(runRoot);
+
+  await requireDirectoryChain(runRoot, evidenceRoot, 'evidence directory');
+  await requireDirectoryChain(runRoot, path.dirname(outPath), 'output parent');
+  const manifestRelativePath = relativeTo(runRoot, manifestPath);
+  const runSnapshot = await buildRunSnapshot(runRoot);
+  const snapshot = indexRunSnapshot(runSnapshot);
+  const manifestState = await regularFile(runRoot, manifestRelativePath, { snapshot });
+  if (manifestState.kind !== 'file') throw new Error('manifest must be a stable regular non-symlink file');
+  const manifest = JSON.parse(manifestState.bytes.toString('utf8'));
+  requireManifest(manifest);
+  await requireManifestWorkspaces(runRoot, manifest);
+  await requireQuiescenceProof(runRoot, manifest, snapshot);
+  const gradingPlanByKey = await requireResolvedGradingPlan(runRoot, manifest, snapshot);
+
+  const evidencePrefix = relativeTo(runRoot, evidenceRoot);
+  const names = await listDirectoryNames(runRoot, evidencePrefix, snapshot);
+  const evidencePaths = names.map((name) => `${evidencePrefix}/${name}`);
+  const errors = [];
+  const expectedByKey = new Map(manifest.expected.map((item) => [expectedKey(item), item]));
+  const expectedByPath = new Map(manifest.expected.map((item) => [
+    `${evidencePrefix}/${expectedReceiptName(item)}`, item,
+  ]));
+  const claimed = new Map();
+  const gradePaths = [];
+  const graderActionPaths = new Set();
+  const inputPaths = new Set();
+
+  evidencePaths.sort((left, right) =>
+    Number(expectedByPath.has(right)) - Number(expectedByPath.has(left))
+    || compareText(left, right));
+  for (const evidencePath of evidencePaths) {
+    if (!evidencePath.endsWith('.json')) continue;
+    if (gradeFilename(evidencePath)) {
+      gradePaths.push(evidencePath);
+      continue;
+    }
+    if (inputFilename(evidencePath)) {
+      inputPaths.add(evidencePath);
+      continue;
+    }
+    if (path.basename(evidencePath).startsWith('action.grader.')) {
+      graderActionPaths.add(evidencePath);
+      continue;
+    }
+    const parsed = await parseFile(runRoot, evidencePath, snapshot);
+    const namedExpected = expectedByPath.get(evidencePath);
+    if (parsed.state.kind === 'too-large') {
+      errors.push(errorRecord('evidence-too-large', '', evidencePath, 'Action receipt exceeds the materialization limit'));
+      if (namedExpected) claimed.set(expectedKey(namedExpected), { invalid: true, path: evidencePath });
+      continue;
+    }
+    if (parsed.state.kind !== 'file' || parsed.malformed) {
+      errors.push(errorRecord('malformed-receipt', '', evidencePath, 'Action receipt must be a regular JSON object'));
+      if (namedExpected) claimed.set(expectedKey(namedExpected), { invalid: true, path: evidencePath });
+      continue;
+    }
+    const receipt = parsed.value;
+    const payloadExpected = expectedByKey.get(expectedKey(receipt));
+    if (!namedExpected) {
+      if (payloadExpected) {
+        const key = expectedKey(payloadExpected);
+        if (claimed.has(key)) {
+          errors.push(errorRecord('duplicate-receipt', '', evidencePath, 'More than one receipt claims the same expected identity'));
+        } else {
+          errors.push(errorRecord('unknown-receipt', '', evidencePath, 'Receipt is not at its deterministic expected path'));
+          claimed.set(key, { invalid: true, path: evidencePath });
+        }
+      } else {
+        let field = '';
+        if (!manifest.expected.some((item) => item.caseId === receipt.caseId)) field = '/caseId';
+        else if (!VARIANTS.includes(receipt.variant)) field = '/variant';
+        else if (!Number.isSafeInteger(receipt.repetition) || receipt.repetition < 1 || receipt.repetition > manifest.runs) field = '/repetition';
+        else if (!WORKER_KINDS.has(receipt.kind)) field = '/kind';
+        errors.push(errorRecord('unknown-receipt', field, evidencePath, 'Receipt does not claim a manifest expected identity'));
+      }
+      continue;
+    }
+    const key = expectedKey(namedExpected);
+    if (claimed.has(key)) {
+      errors.push(errorRecord('duplicate-receipt', '', evidencePath, 'More than one receipt claims the same expected identity'));
+      claimed.set(key, { invalid: true, path: evidencePath });
+      continue;
+    }
+    claimed.set(key, {
+      expected: namedExpected,
+      receipt,
+      path: evidencePath,
+      bytes: parsed.state.bytes,
+    });
+  }
+
+  const pairMap = new Map(manifest.pairs.map((pair) => [`${pair.caseId}\u0000${pair.repetition}`, pair]));
+  const definitionCache = new Map();
+  const caseOrder = [];
+  const aggregateCases = new Map();
+  for (const expected of manifest.expected) {
+    if (!aggregateCases.has(expected.caseId)) {
+      aggregateCases.set(expected.caseId, {
+        caseId: expected.caseId,
+        kind: expected.kind,
+        candidate: [],
+        baseline: [],
+        definition: null,
+      });
+      caseOrder.push(expected.caseId);
+    } else if (aggregateCases.get(expected.caseId).kind !== expected.kind) {
+      throw new Error('manifest contains kind drift for one case');
+    }
+  }
+
+  for (const expected of manifest.expected) {
+    const key = expectedKey(expected);
+    const claim = claimed.get(key);
+    const target = aggregateCases.get(expected.caseId)[expected.variant];
+    if (!claim) {
+      const receiptPath = `${evidencePrefix}/${expectedReceiptName(expected)}`;
+      errors.push(errorRecord('missing-receipt', '', receiptPath, 'Expected action receipt is absent'));
+      target.push(blockedResult(expected.repetition));
+      continue;
+    }
+    if (claim.invalid) {
+      target.push(blockedResult(expected.repetition));
+      continue;
+    }
+    const validated = await validateActionReceipt(claim.receipt, expected, manifest, runRoot, claim.path, snapshot);
+    if (validated.error) {
+      errors.push(validated.error);
+      target.push(blockedResult(expected.repetition));
+      continue;
+    }
+
+    const pair = pairMap.get(`${expected.caseId}\u0000${expected.repetition}`);
+    const packageError = await validateWorkspacePackage(
+      runRoot,
+      pair,
+      expected,
+      claim.receipt,
+      manifest,
+      claim.path,
+    );
+    if (packageError) {
+      errors.push(packageError);
+      target.push(blockedResult(expected.repetition));
+      continue;
+    }
+    const definitionKey = `${expected.kind}\u0000${expected.caseId}`;
+    let loaded = definitionCache.get(definitionKey);
+    if (!loaded) {
+      loaded = await loadCaseDefinition(runRoot, pair, expected, snapshot);
+      definitionCache.set(definitionKey, loaded);
+    } else {
+      loaded = {
+        ...loaded,
+        workspaceRoot: path.resolve(runRoot, ...pair[expected.variant].split('/')),
+        workspacePrefix: pair[expected.variant],
+      };
+    }
+    aggregateCases.get(expected.caseId).definition = loaded.definition;
+    const expectedCapabilities = loaded.definition.capabilities ?? ['read-workspace'];
+    if (!same(claim.receipt.capabilities, expectedCapabilities)) {
+      errors.push(errorRecord(
+        'identity-mismatch',
+        '/capabilities',
+        claim.path,
+        'Receipt capabilities do not match the copied case definition',
+      ));
+      target.push(blockedResult(expected.repetition));
+      continue;
+    }
+    const receiptProof = receiptIdentity(claim.path, claim.bytes);
+    const assertions = [];
+    const outputText = validated.outputBytes.toString('utf8');
+    const fileCache = new Map();
+    if (expected.kind === 'behavior') {
+      for (const assertion of loaded.definition.assertions) {
+        assertions.push(await evaluateAssertion(assertion, {
+          workspaceRoot: loaded.workspaceRoot,
+          workspacePrefix: loaded.workspacePrefix,
+          snapshot,
+          receipt: claim.receipt,
+          receiptIdentity: receiptProof,
+          outputText,
+          fileCache,
+        }));
+      }
+    }
+    target.push({
+      repetition: expected.repetition,
+      completionStatus: 'complete',
+      receipt: receiptProof,
+      output: claim.receipt.output,
+      transcript: claim.receipt.transcript,
+      durationMs: claim.receipt.durationMs,
+      tokenUsage: claim.receipt.tokenUsage,
+      selectedSkill: claim.receipt.selectedSkill,
+      assertions,
+    });
+  }
+  const candidateOnly = manifest.expected.every((item) => item.variant === 'candidate');
+
+  const qualitativeExpected = new Map();
+  for (const entry of aggregateCases.values()) {
+    const assertions = entry.definition?.assertions ?? [];
+    for (const assertion of assertions.filter((item) => item.kind === 'qualitative')) {
+      for (const variant of VARIANTS) {
+        for (const result of entry[variant]) {
+          if (result.completionStatus === 'complete') {
+            const plan = gradingPlanByKey.get(gradingPlanKey({
+              caseId: entry.caseId,
+              repetition: result.repetition,
+              assertionId: assertion.id,
+            }));
+            qualitativeExpected.set(`${entry.caseId}\u0000${variant}\u0000${result.repetition}\u0000${assertion.id}`, {
+              entry, variant, result, assertion, graderId: plan.graderId,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  const gradeProofs = [];
+  const referencedGraderReceipts = new Set();
+  for (const expectedGrade of qualitativeExpected.values()) {
+    referencedGraderReceipts.add(
+      `${evidencePrefix}/action.grader.${expectedGrade.entry.caseId}.${expectedGrade.variant}.${expectedGrade.result.repetition}.${expectedGrade.graderId}.json`,
+    );
+  }
+  const qualitativeBySlot = new Map();
+  for (const qualitativeKey of qualitativeExpected.keys()) {
+    const parts = qualitativeKey.split('\u0000');
+    const slot = parts.slice(0, 3).join('\u0000');
+    const keys = qualitativeBySlot.get(slot) ?? [];
+    keys.push(qualitativeKey);
+    qualitativeBySlot.set(slot, keys);
+  }
+  const qualitativeByGraderSlot = new Map();
+  for (const [qualitativeKey, expectedGrade] of qualitativeExpected) {
+    qualitativeByGraderSlot.set(
+      `${expectedGrade.entry.caseId}\u0000${expectedGrade.variant}\u0000${expectedGrade.result.repetition}\u0000${expectedGrade.graderId}`,
+      qualitativeKey,
+    );
+  }
+  const accountedQualitative = new Set();
+  const claimedQualitative = new Map();
+  const anonymizedInputClaims = new Map();
+  for (const inputPath of [...inputPaths].sort(compareText)) {
+    const filenameIdentity = inputFilename(inputPath);
+    const parsed = await parseFile(runRoot, inputPath, snapshot);
+    if (parsed.state.kind !== 'file' || parsed.malformed || !exactKeys(parsed.value, INPUT_FIELDS)) {
+      continue;
+    }
+    const input = parsed.value;
+    if (input.schemaVersion !== 1
+      || input.runId !== manifest.runId
+      || input.caseId !== filenameIdentity.caseId
+      || input.repetition !== filenameIdentity.repetition
+      || input.graderId !== filenameIdentity.graderId
+      || !KEBAB.test(input.assertionId ?? '')
+      || !KEBAB.test(input.anonymizedOutputId ?? '')
+      || !exactKeys(input.source, ['path', 'sha256', 'bytes'])
+      || typeof input.source.path !== 'string'
+      || !SHA256.test(input.source.sha256 ?? '')
+      || !Number.isSafeInteger(input.source.bytes)
+      || input.source.bytes < 0) {
+      continue;
+    }
+    const claims = anonymizedInputClaims.get(input.anonymizedOutputId) ?? [];
+    claims.push({
+      path: inputPath,
+    });
+    anonymizedInputClaims.set(input.anonymizedOutputId, claims);
+  }
+  const collidedAnonymizedOutputs = new Set();
+  for (const [anonymizedOutputId, claims] of anonymizedInputClaims) {
+    if (claims.length < 2) continue;
+    collidedAnonymizedOutputs.add(anonymizedOutputId);
+    for (const claim of claims.slice(1)) {
+      errors.push(errorRecord(
+        'anonymized-output-collision',
+        '/anonymizedOutputId',
+        claim.path,
+        'An anonymized output identity may be used by only one host-owned input mapping in the run',
+      ));
+    }
+  }
+
+  for (const gradePath of gradePaths) {
+    const filenameIdentity = gradeFilename(gradePath);
+    const slot = `${filenameIdentity.caseId}\u0000${filenameIdentity.variant}\u0000${filenameIdentity.repetition}`;
+    const slotQualitative = qualitativeBySlot.get(slot) ?? [];
+    const filenameQualitative = qualitativeByGraderSlot.get(
+      `${slot}\u0000${filenameIdentity.graderId}`,
+    );
+    if (filenameQualitative) accountedQualitative.add(filenameQualitative);
+    inputPaths.delete(
+      `${evidencePrefix}/input.${filenameIdentity.caseId}.${filenameIdentity.variant}.${filenameIdentity.repetition}.${filenameIdentity.graderId}.json`,
+    );
+    referencedGraderReceipts.add(
+      `${evidencePrefix}/action.grader.${filenameIdentity.caseId}.${filenameIdentity.variant}.${filenameIdentity.repetition}.${filenameIdentity.graderId}.json`,
+    );
+    const parsed = await parseFile(runRoot, gradePath, snapshot);
+    if (parsed.state.kind === 'too-large') {
+      if (slotQualitative.length === 1) accountedQualitative.add(slotQualitative[0]);
+      errors.push(errorRecord('evidence-too-large', '', gradePath, 'Grade exceeds the materialization limit'));
+      continue;
+    }
+    if (parsed.state.kind !== 'file' || parsed.malformed) {
+      if (slotQualitative.length === 1) accountedQualitative.add(slotQualitative[0]);
+      errors.push(errorRecord('malformed-receipt', '', gradePath, 'Grade must be a regular JSON object'));
+      continue;
+    }
+    const grade = parsed.value;
+    const directKey = typeof grade.caseId === 'string'
+      && Number.isSafeInteger(grade.repetition)
+      && typeof grade.assertionId === 'string'
+      ? `${grade.caseId}\u0000${filenameIdentity.variant}\u0000${grade.repetition}\u0000${grade.assertionId}`
+      : null;
+    if (directKey && qualitativeExpected.has(directKey)) accountedQualitative.add(directKey);
+    if ((!directKey || !qualitativeExpected.has(directKey)) && slotQualitative.length === 1) {
+      accountedQualitative.add(slotQualitative[0]);
+    }
+    const missing = firstMissing(grade, GRADE_FIELDS);
+    if (missing) {
+      errors.push(errorRecord('missing-field', `/${missing}`, gradePath, `Grade field ${missing} is required`));
+      continue;
+    }
+    if (!same(Object.keys(grade).sort(), [...GRADE_FIELDS].sort())) {
+      errors.push(errorRecord('malformed-receipt', '', gradePath, 'Grade key set is not canonical'));
+      continue;
+    }
+    const invalidStableId = ['graderId', 'assertionId', 'anonymizedOutputId']
+      .find((field) => !KEBAB.test(grade[field] ?? ''));
+    if (invalidStableId) {
+      errors.push(errorRecord('identity-mismatch', `/${invalidStableId}`, gradePath, `Grade ${invalidStableId} must be stable kebab-case`));
+      continue;
+    }
+    let mismatch = null;
+    for (const [field, wanted] of [
+      ['schemaVersion', 1], ['runId', manifest.runId], ['caseId', filenameIdentity.caseId],
+      ['repetition', filenameIdentity.repetition], ['graderId', filenameIdentity.graderId],
+    ]) {
+      if (!same(grade[field], wanted)) { mismatch = field; break; }
+    }
+    if (mismatch) {
+      errors.push(errorRecord('identity-mismatch', `/${mismatch}`, gradePath, `Grade ${mismatch} does not match its host-owned identity`));
+      continue;
+    }
+
+    let expectedGrade = qualitativeExpected.get(directKey);
+    let expose = true;
+    if (!expectedGrade && candidateOnly && filenameIdentity.variant === 'baseline') {
+      const candidateKey = `${grade.caseId}\u0000candidate\u0000${grade.repetition}\u0000${grade.assertionId}`;
+      expectedGrade = qualitativeExpected.get(candidateKey);
+      expose = false;
+    }
+    if (!expectedGrade) {
+      const field = aggregateCases.has(grade.caseId) ? '/assertionId' : '/caseId';
+      errors.push(errorRecord('unknown-receipt', field, gradePath, 'Grade does not match an expected qualitative assertion'));
+      continue;
+    }
+    if (grade.graderId !== expectedGrade.graderId) {
+      errors.push(errorRecord(
+        'identity-mismatch',
+        '/graderId',
+        gradePath,
+        'Grade graderId does not match the resolved host-owned grading plan',
+      ));
+      continue;
+    }
+    if (expose) {
+      if (claimedQualitative.has(directKey)) {
+        errors.push(errorRecord('duplicate-receipt', '', gradePath, 'More than one grade claims one expected qualitative assertion'));
+        continue;
+      }
+      claimedQualitative.set(directKey, gradePath);
+    }
+    const payloadError = qualitativePayloadError(grade);
+    if (payloadError) {
+      errors.push(errorRecord('malformed-receipt', payloadError.field, gradePath, payloadError.message));
+      continue;
+    }
+    if (!isObject(grade.receipt)) {
+      errors.push(errorRecord('missing-grade-receipt', '/receipt/path', gradePath, 'Grade does not identify its grader receipt'));
+      continue;
+    }
+    const missingReceiptField = firstMissing(grade.receipt, ['path', 'sha256']);
+    if (missingReceiptField) {
+      errors.push(errorRecord('missing-field', `/receipt/${missingReceiptField}`, gradePath, `Grade receipt ${missingReceiptField} is required`));
+      continue;
+    }
+    if (!same(Object.keys(grade.receipt).sort(), ['path', 'sha256'])) {
+      errors.push(errorRecord('malformed-receipt', '', gradePath, 'Grade receipt identity key set is not canonical'));
+      continue;
+    }
+    if (typeof grade.receipt.path !== 'string') {
+      errors.push(errorRecord('identity-mismatch', '/receipt/path', gradePath, 'Grade receipt path must be a string'));
+      continue;
+    }
+    if (typeof grade.receipt.sha256 !== 'string') {
+      errors.push(errorRecord('identity-mismatch', '/receipt/sha256', gradePath, 'Grade receipt SHA-256 must be a string'));
+      continue;
+    }
+    const inputProof = await validateGradeInput(
+      runRoot,
+      evidencePrefix,
+      { grade, filenameIdentity, expectedGrade },
+      gradePath,
+      snapshot,
+    );
+    if (inputProof.error) {
+      errors.push(inputProof.error);
+      continue;
+    }
+    inputPaths.delete(grade.input.path);
+    if (grade.completionStatus !== 'complete') {
+      errors.push(errorRecord('incomplete-receipt', '/completionStatus', gradePath, 'Required grade did not complete'));
+      continue;
+    }
+    referencedGraderReceipts.add(grade.receipt.path);
+    const linked = await regularFile(runRoot, grade.receipt.path, { snapshot });
+    if (linked.kind === 'unsafe') {
+      errors.push(errorRecord('unsafe-evidence-path', '/receipt/path', gradePath, 'Grade receipt path is unsafe'));
+      continue;
+    }
+    if (linked.kind !== 'file') {
+      const code = linked.kind === 'missing'
+        && grade.receipt.path === `${evidencePrefix}/action.grader.${grade.caseId}.${filenameIdentity.variant}.${grade.repetition}.${grade.graderId}.json`
+        ? 'missing-grade-receipt'
+        : 'non-regular-evidence';
+      errors.push(errorRecord(code, '/receipt/path', gradePath, 'Linked grader receipt is absent or not a regular file'));
+      continue;
+    }
+    const expectedGraderReceiptPath =
+      `${evidencePrefix}/action.grader.${grade.caseId}.${filenameIdentity.variant}.${grade.repetition}.${grade.graderId}.json`;
+    if (grade.receipt.path !== expectedGraderReceiptPath) {
+      errors.push(errorRecord(
+        'identity-mismatch',
+        '/receipt/path',
+        gradePath,
+        'Grade must link the deterministic expected grader receipt path',
+      ));
+      continue;
+    }
+    if (!SHA256.test(grade.receipt.sha256) || sha256(linked.bytes) !== grade.receipt.sha256) {
+      errors.push(errorRecord('grade-receipt-hash-mismatch', '/receipt/sha256', gradePath, 'Linked grader receipt SHA-256 does not match'));
+      continue;
+    }
+    let graderReceipt;
+    try {
+      graderReceipt = JSON.parse(linked.bytes.toString('utf8'));
+    } catch {
+      graderReceipt = null;
+    }
+    if (!isObject(graderReceipt)) {
+      errors.push(errorRecord('malformed-receipt', '', grade.receipt.path, 'Grader receipt must be a JSON object'));
+      continue;
+    }
+    const expectedReceipt = {
+      caseId: grade.caseId,
+      variant: filenameIdentity.variant,
+      repetition: grade.repetition,
+      kind: 'grader',
+    };
+    const validated = await validateActionReceipt(
+      graderReceipt,
+      expectedReceipt,
+      manifest,
+      runRoot,
+      grade.receipt.path,
+      snapshot,
+      true,
+    );
+    if (validated.error) {
+      errors.push(validated.error);
+      continue;
+    }
+    gradeProofs.push({
+      gradePath,
+      gradeBytes: parsed.state.bytes,
+      grade,
+      filenameIdentity,
+      expectedGrade,
+      input: inputProof.input,
+      inputBytes: inputProof.bytes,
+      expose,
+      graderReceipt,
+      graderReceiptBytes: linked.bytes,
+      graderReceiptPath: grade.receipt.path,
+      valid: !collidedAnonymizedOutputs.has(grade.anonymizedOutputId),
+      pairMatched: false,
+    });
+  }
+  for (const [qualitativeKey, expectedGrade] of qualitativeExpected) {
+    if (accountedQualitative.has(qualitativeKey)) continue;
+    const missingPath = `${evidencePrefix}/grade.${expectedGrade.entry.caseId}.${expectedGrade.variant}.${expectedGrade.result.repetition}.${expectedGrade.graderId}.json`;
+    errors.push(errorRecord('missing-receipt', '', missingPath, 'Expected qualitative grade is absent'));
+  }
+
+
+  const gradeGroups = new Map();
+  for (const proof of gradeProofs) {
+    const key = `${proof.grade.caseId}\u0000${proof.grade.repetition}\u0000${proof.grade.assertionId}`;
+    if (!gradeGroups.has(key)) gradeGroups.set(key, {});
+    const group = gradeGroups.get(key);
+    if (group[proof.filenameIdentity.variant]) {
+      errors.push(errorRecord('duplicate-receipt', '', proof.gradePath, 'More than one grade claims one expected assertion'));
+      proof.valid = false;
+      group[proof.filenameIdentity.variant].valid = false;
+    } else {
+      group[proof.filenameIdentity.variant] = proof;
+    }
+  }
+  for (const group of gradeGroups.values()) {
+    if (!group.candidate || !group.baseline) {
+      const present = group.candidate ?? group.baseline;
+      if (present) present.valid = false;
+      continue;
+    }
+    let matched = group.candidate.valid && group.baseline.valid;
+    if (group.candidate.grade.graderId !== group.baseline.grade.graderId) {
+      errors.push(errorRecord(
+        'grader-identity-mismatch',
+        '/graderId',
+        group.candidate.gradePath,
+        'Paired qualitative grades must use the same grader identity',
+      ));
+      matched = false;
+    }
+    for (const field of matched
+      ? ['host', 'runner', 'model', 'sessionIdentity', 'tier', 'effort']
+      : []) {
+      if (!same(group.candidate.graderReceipt[field], group.baseline.graderReceipt[field])) {
+        errors.push(errorRecord(
+          'grader-configuration-mismatch',
+          `/${field}`,
+          group.candidate.graderReceiptPath,
+          `Paired grader receipt ${field} does not match`,
+        ));
+        matched = false;
+        break;
+      }
+    }
+    group.candidate.valid = group.candidate.valid && matched;
+    group.baseline.valid = group.baseline.valid && matched;
+    group.candidate.pairMatched = matched;
+    group.baseline.pairMatched = matched;
+  }
+
+  for (const proof of gradeProofs.filter((item) =>
+    item.valid && item.pairMatched && item.expose)) {
+    const assertionResult = proof.expectedGrade.result.assertions
+      .find((item) => item.assertionId === proof.grade.assertionId);
+    Object.assign(assertionResult, {
+      pass: proof.grade.pass,
+      rationale: proof.grade.rationale,
+      anonymizedOutputId: proof.grade.anonymizedOutputId,
+      grade: receiptIdentity(proof.gradePath, proof.gradeBytes),
+      graderReceipt: receiptIdentity(proof.graderReceiptPath, proof.graderReceiptBytes),
+      graderInput: receiptIdentity(proof.grade.input.path, proof.inputBytes),
+    });
+  }
+
+  for (const graderPath of graderActionPaths) {
+    if (!referencedGraderReceipts.has(graderPath)) {
+      errors.push(errorRecord('unknown-receipt', '', graderPath, 'Grader receipt is not linked by an expected qualitative grade'));
+    }
+  }
+  for (const inputPath of inputPaths) {
+    errors.push(errorRecord('unknown-receipt', '', inputPath, 'Grader input is not linked by an expected qualitative grade'));
+  }
+
+  await revalidateRunSnapshot(runRoot, runSnapshot);
+
+  const status = errors.length > 0 ? 'blocked' : candidateOnly ? 'degraded' : 'complete';
+  const cases = caseOrder.map((caseId) => aggregateCases.get(caseId));
+  for (const entry of cases) {
+    entry.candidate.sort((a, b) => a.repetition - b.repetition);
+    entry.baseline.sort((a, b) => a.repetition - b.repetition);
+    const candidateDuration = durationMetric(entry.candidate, manifest.runs);
+    const baselineDuration = durationMetric(entry.baseline, manifest.runs);
+    entry.durationMs = status === 'complete'
+      ? { candidate: candidateDuration, baseline: baselineDuration,
+          delta: candidateDuration !== UNAVAILABLE && baselineDuration !== UNAVAILABLE
+            ? candidateDuration.mean - baselineDuration.mean : UNAVAILABLE }
+      : UNAVAILABLE;
+    const candidateObjective = entry.candidate.flatMap((item) => item.assertions ?? [])
+      .filter((item) => typeof item.pass === 'boolean' && item.grade === undefined);
+    const baselineObjective = entry.baseline.flatMap((item) => item.assertions ?? [])
+      .filter((item) => typeof item.pass === 'boolean' && item.grade === undefined);
+    const rate = (items) => items.length === 0 ? UNAVAILABLE : items.filter((item) => item.pass).length / items.length;
+    entry.objectivePassRate = status === 'complete' ? comparative(rate(candidateObjective), rate(baselineObjective)) : UNAVAILABLE;
+  }
+
+  const objective = {};
+  for (const variant of VARIANTS) {
+    const observations = cases.filter((entry) => entry.kind === 'behavior')
+      .flatMap((entry) => entry[variant])
+      .flatMap((result) => result.assertions ?? [])
+      .filter((assertion) => typeof assertion.pass === 'boolean' && assertion.grade === undefined);
+    objective[variant] = observations.length === 0
+      ? UNAVAILABLE
+      : observations.filter((assertion) => assertion.pass).length / observations.length;
+  }
+
+  const criticalFailures = [];
+  for (const entry of cases) {
+    const definitions = entry.definition?.assertions ?? [];
+    for (const definition of definitions.filter((assertion) => assertion.critical === true)) {
+      const repetitions = {};
+      for (const variant of VARIANTS) {
+        repetitions[variant] = entry[variant]
+          .filter((result) => result.assertions?.some((assertion) => assertion.assertionId === definition.id && assertion.pass === false))
+          .map((result) => result.repetition);
+      }
+      if (repetitions.candidate.length > 0 || repetitions.baseline.length > 0) {
+        criticalFailures.push({ caseId: entry.caseId, assertionId: definition.id, repetitions });
+      }
+    }
+  }
+
+  const allResults = Object.fromEntries(VARIANTS.map((variant) => [
+    variant,
+    cases.filter((entry) => WORKER_KINDS.has(entry.kind)).flatMap((entry) => entry[variant]),
+  ]));
+  let overallDuration = UNAVAILABLE;
+  let overallTokens = UNAVAILABLE;
+  let precision = UNAVAILABLE;
+  let recall = UNAVAILABLE;
+  let objectiveRate = UNAVAILABLE;
+  if (status === 'complete') {
+    const candidateDuration = durationMetric(allResults.candidate, manifest.runs);
+    const baselineDuration = durationMetric(allResults.baseline, manifest.runs);
+    overallDuration = {
+      candidate: candidateDuration,
+      baseline: baselineDuration,
+      delta: candidateDuration.mean - baselineDuration.mean,
+    };
+    overallTokens = tokenComparison(
+      tokenMetric(allResults.candidate, manifest.runs),
+      tokenMetric(allResults.baseline, manifest.runs),
+    );
+    const candidatePrecision = triggerMetric(cases, manifest.targetSkill, 'candidate', 'precision');
+    const baselinePrecision = triggerMetric(cases, manifest.targetSkill, 'baseline', 'precision');
+    precision = comparative(candidatePrecision, baselinePrecision);
+    const candidateRecall = triggerMetric(cases, manifest.targetSkill, 'candidate', 'recall');
+    const baselineRecall = triggerMetric(cases, manifest.targetSkill, 'baseline', 'recall');
+    recall = comparative(candidateRecall, baselineRecall);
+    objectiveRate = comparative(objective.candidate, objective.baseline);
+  }
+
+  for (const entry of cases) delete entry.definition;
+  return {
+    schemaVersion: 1,
+    runId: manifest.runId,
+    targetSkill: manifest.targetSkill,
+    executionStatus: status,
+    baseline: manifest.baseline,
+    runs: manifest.runs,
+    cases,
+    overall: {
+      objectivePassRate: objectiveRate,
+      criticalFailures,
+      triggerPrecision: precision,
+      triggerRecall: recall,
+      durationMs: overallDuration,
+      tokenUsage: overallTokens,
+    },
+    evidenceErrors: sortErrors(errors),
+  };
+}
+
+
+async function main(argv) {
+  const options = parseArguments(argv);
+  const result = await aggregate(options);
+  await writeCreateNew(path.resolve(options.out), result);
+}
+
+
+export {
+  aggregate,
+  main as runAggregateCli,
+  sanitizeMessage,
+  writeCreateNew,
+};

--- a/skills/woostack-eval/scripts/aggregate/grading.mjs
+++ b/skills/woostack-eval/scripts/aggregate/grading.mjs
@@ -1,0 +1,117 @@
+import path from 'node:path';
+
+import {
+  CAPABILITIES,
+  COMPLETION_STATUSES,
+  KEBAB,
+  completionIdentityValid,
+  exactKeys,
+  isObject,
+  nonEmptyString,
+  sanitizeMessage,
+} from './contracts.mjs';
+
+
+
+function capabilitiesValid(capabilities) {
+  return Array.isArray(capabilities)
+    && capabilities.every((item) => typeof item === 'string' && CAPABILITIES.has(item))
+    && new Set(capabilities).size === capabilities.length;
+}
+
+function completionPayloadError(completionStatus, error) {
+  if (!COMPLETION_STATUSES.has(completionStatus)) {
+    return {
+      field: '/completionStatus',
+      message: 'Completion status must be complete, failed, or timed-out',
+    };
+  }
+  if (completionStatus === 'complete') {
+    return error === null
+      ? null
+      : { field: '/error', message: 'A completed result must have a null error' };
+  }
+  if (!exactKeys(error, ['code', 'message'])
+    || !KEBAB.test(error.code ?? '')
+    || !nonEmptyString(error.message)
+    || sanitizeMessage(error.message) !== error.message) {
+    return {
+      field: '/error',
+      message: 'A failed or timed-out result requires the canonical error shape',
+    };
+  }
+  return null;
+}
+
+function qualitativePayloadError(grade) {
+  const completionError = completionPayloadError(grade.completionStatus, grade.error);
+  if (completionError) return completionError;
+  if (grade.completionStatus === 'complete') {
+    if (typeof grade.pass !== 'boolean') {
+      return { field: '/pass', message: 'A completed grade requires a boolean pass value' };
+    }
+    if (!nonEmptyString(grade.rationale)) {
+      return { field: '/rationale', message: 'A completed grade requires a non-empty rationale' };
+    }
+  } else {
+    if (grade.pass !== null) {
+      return { field: '/pass', message: 'An incomplete grade must have a null pass value' };
+    }
+    if (grade.rationale !== null) {
+      return { field: '/rationale', message: 'An incomplete grade must have a null rationale' };
+    }
+  }
+  return null;
+}
+
+function parseJsonPointer(pointer) {
+  if (pointer === '') return [];
+  if (typeof pointer !== 'string' || !pointer.startsWith('/')) return null;
+  return pointer.slice(1).split('/').map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~'));
+}
+
+function pointerValue(root, pointer) {
+  const parts = parseJsonPointer(pointer);
+  if (parts === null) return { found: false };
+  let value = root;
+  for (const part of parts) {
+    if (!isObject(value) && !Array.isArray(value)) return { found: false };
+    if (!Object.hasOwn(value, part)) return { found: false };
+    value = value[part];
+  }
+  return { found: true, value };
+}
+
+function gradeFilename(relativePath) {
+  const match = /^grade\.([a-z0-9-]+)\.(candidate|baseline)\.([1-9][0-9]*)\.([a-z0-9-]+)\.json$/
+    .exec(path.basename(relativePath));
+  if (!match) return null;
+  return {
+    caseId: match[1],
+    variant: match[2],
+    repetition: Number(match[3]),
+    graderId: match[4],
+  };
+}
+
+function inputFilename(relativePath) {
+  const match = /^input\.([a-z0-9-]+)\.(candidate|baseline)\.([1-9][0-9]*)\.([a-z0-9-]+)\.json$/
+    .exec(path.basename(relativePath));
+  if (!match) return null;
+  return {
+    caseId: match[1],
+    variant: match[2],
+    repetition: Number(match[3]),
+    graderId: match[4],
+  };
+}
+
+export {
+  capabilitiesValid,
+  completionIdentityValid,
+  completionPayloadError,
+  gradeFilename,
+  inputFilename,
+  pointerValue,
+  qualitativePayloadError,
+};

--- a/skills/woostack-eval/scripts/aggregate/metrics.mjs
+++ b/skills/woostack-eval/scripts/aggregate/metrics.mjs
@@ -1,0 +1,90 @@
+const UNAVAILABLE = 'unavailable';
+
+function mean(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function populationVariance(values, average) {
+  if (values.length < 2) return UNAVAILABLE;
+  return values.reduce((sum, value) => sum + ((value - average) ** 2), 0) / values.length;
+}
+
+function metric(values) {
+  if (values.length === 0) return UNAVAILABLE;
+  const average = mean(values);
+  return { mean: average, variance: populationVariance(values, average) };
+}
+
+function comparative(candidate, baseline) {
+  return {
+    candidate,
+    baseline,
+    delta: typeof candidate === 'number' && typeof baseline === 'number'
+      ? candidate - baseline
+      : UNAVAILABLE,
+  };
+}
+
+function durationMetric(results, runs) {
+  const observations = [];
+  for (let repetition = 1; repetition <= runs; repetition += 1) {
+    const values = results
+      .filter((item) => item.repetition === repetition && item.completionStatus === 'complete')
+      .map((item) => item.durationMs);
+    if (values.length > 0) observations.push(mean(values));
+  }
+  return metric(observations);
+}
+
+function tokenMetric(results, runs) {
+  const fields = ['input', 'output', 'total'];
+  const observations = Object.fromEntries(fields.map((field) => [field, []]));
+  for (let repetition = 1; repetition <= runs; repetition += 1) {
+    const usages = results
+      .filter((item) => item.repetition === repetition && item.completionStatus === 'complete')
+      .map((item) => item.tokenUsage);
+    if (usages.length === 0 || usages.some((usage) => usage === UNAVAILABLE)) return UNAVAILABLE;
+    for (const field of fields) {
+      observations[field].push(usages.reduce((sum, usage) => sum + usage[field], 0));
+    }
+  }
+  return Object.fromEntries(fields.map((field) => [field, metric(observations[field])]));
+}
+
+function tokenComparison(candidate, baseline) {
+  if (candidate === UNAVAILABLE || baseline === UNAVAILABLE) return UNAVAILABLE;
+  return {
+    candidate,
+    baseline,
+    delta: Object.fromEntries(['input', 'output', 'total'].map((field) => [
+      field,
+      candidate[field].mean - baseline[field].mean,
+    ])),
+  };
+}
+
+function triggerMetric(cases, targetSkill, variant, type) {
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  for (const entry of cases.filter((item) => item.kind === 'trigger')) {
+    for (const result of entry[variant]) {
+      const positive = entry.definition.shouldTrigger === true;
+      const predicted = result.selectedSkill === targetSkill;
+      if (positive && predicted) tp += 1;
+      else if (!positive && predicted) fp += 1;
+      else if (positive && !predicted) fn += 1;
+    }
+  }
+  if (type === 'precision') return tp + fp === 0 ? UNAVAILABLE : tp / (tp + fp);
+  return tp + fn === 0 ? UNAVAILABLE : tp / (tp + fn);
+}
+
+export {
+  comparative,
+  durationMetric,
+  metric,
+  tokenComparison,
+  tokenMetric,
+  triggerMetric,
+};

--- a/skills/woostack-eval/scripts/aggregate/safe-access.mjs
+++ b/skills/woostack-eval/scripts/aggregate/safe-access.mjs
@@ -1,0 +1,705 @@
+import { createHash, randomBytes as cryptoRandomBytes } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
+import {
+  link,
+  lstat,
+  open,
+  opendir,
+  readdir,
+  realpath,
+  unlink,
+} from 'node:fs/promises';
+import path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+
+import {
+  VARIANTS,
+  compareText,
+  exactKeys,
+  isObject,
+  same,
+} from './contracts.mjs';
+
+const MAX_MATERIALIZED_BYTES = 1024 * 1024;
+const MAX_SNAPSHOT_FILE_BYTES = 16 * 1024 * 1024;
+const MAX_SNAPSHOT_TOTAL_BYTES = 128 * 1024 * 1024;
+const MAX_SNAPSHOT_ENTRIES = 4096;
+const closeHandle = (handle) => handle.close();
+
+function statIdentity(stats) {
+  return {
+    dev: String(stats.dev),
+    ino: String(stats.ino),
+    size: String(stats.size),
+    mtimeNs: String(stats.mtimeNs),
+  };
+}
+
+function snapshotFailure(evidencePath, message) {
+  const error = new Error(`snapshot-mutation: ${message}`);
+  error.code = 'snapshot-mutation';
+  error.field = '';
+  error.path = evidencePath;
+  return error;
+}
+
+function snapshotLimitFailure(evidencePath, message) {
+  const error = new Error(`snapshot-limit-exceeded: ${message}`);
+  error.code = 'snapshot-limit-exceeded';
+  error.field = '';
+  error.path = evidencePath;
+  return error;
+}
+
+function combinedFailure(primary, secondary, message) {
+  return new AggregateError(
+    [primary, secondary],
+    `${message}: ${primary.message}; ${secondary.message}`,
+    { cause: primary },
+  );
+}
+
+function preservePrimaryFailure(primary, secondary, message) {
+  primary.message = `${primary.message}; ${message}: ${secondary.message}`;
+  primary.cleanupErrors = [...(primary.cleanupErrors ?? []), secondary];
+  return primary;
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+function contained(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === ''
+    || (!relative.startsWith(`..${path.sep}`)
+      && relative !== '..'
+      && !path.isAbsolute(relative));
+}
+
+function relativeTo(root, candidate) {
+  return toPosix(path.relative(root, candidate));
+}
+
+async function requireDirectoryChain(root, candidate, label) {
+  if (!contained(root, candidate)) throw new Error(`${label} escapes the run root`);
+  const relative = path.relative(root, candidate);
+  let cursor = root;
+  for (const part of relative ? relative.split(path.sep) : []) {
+    cursor = path.join(cursor, part);
+    let stats;
+    try {
+      stats = await lstat(cursor);
+    } catch {
+      throw new Error(`${label} must already exist as a directory`);
+    }
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      throw new Error(`${label} must not traverse symlinks or non-directories`);
+    }
+  }
+}
+
+async function openedDirectoryIdentity(absolutePath, {
+  evidencePath = '',
+  closeOpenedHandle = closeHandle,
+} = {}) {
+  let handle;
+  let failure;
+  try {
+    handle = await open(
+      absolutePath,
+      fsConstants.O_RDONLY
+        | (fsConstants.O_DIRECTORY ?? 0)
+        | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+  } catch (error) {
+    if (['ENOENT', 'ENOTDIR', 'ELOOP'].includes(error?.code)) return null;
+    throw error;
+  }
+  try {
+    const stats = await handle.stat({ bigint: true });
+    return stats.isDirectory() ? statIdentity(stats) : null;
+  } catch (error) {
+    failure = error;
+    throw error;
+  } finally {
+    try {
+      await closeOpenedHandle(handle, evidencePath);
+    } catch (error) {
+      if (!failure) throw error;
+      failure = preservePrimaryFailure(failure, error, 'directory-handle cleanup failed');
+    }
+  }
+}
+
+async function openedNodeIdentity(absolutePath, {
+  evidencePath,
+  maxFileBytes,
+  maxTotalBytes,
+  closeOpenedHandle = closeHandle,
+}) {
+  let handle;
+  let failure;
+  try {
+    handle = await open(
+      absolutePath,
+      fsConstants.O_RDONLY
+        | (fsConstants.O_NONBLOCK ?? 0)
+        | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+  } catch (error) {
+    if (['ENOENT', 'ENOTDIR', 'ELOOP'].includes(error?.code)) return null;
+    throw error;
+  }
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (before.isDirectory()) return { kind: 'directory', identity: statIdentity(before) };
+    if (!before.isFile()) return { kind: 'special', identity: statIdentity(before) };
+    if (before.size > BigInt(maxFileBytes)) {
+      throw snapshotLimitFailure(evidencePath, `Run file exceeds the ${maxFileBytes}-byte snapshot limit`);
+    }
+    if (before.size > BigInt(maxTotalBytes)) {
+      throw snapshotLimitFailure(evidencePath, `Run files exceed the ${MAX_SNAPSHOT_TOTAL_BYTES}-byte cumulative snapshot limit`);
+    }
+    const hash = createHash('sha256');
+    let byteCount = 0;
+    for await (const chunk of handle.createReadStream({ autoClose: false })) {
+      byteCount += chunk.length;
+      if (byteCount > maxFileBytes) {
+        throw snapshotLimitFailure(evidencePath, `Run file exceeds the ${maxFileBytes}-byte snapshot limit`);
+      }
+      if (byteCount > maxTotalBytes) {
+        throw snapshotLimitFailure(evidencePath, `Run files exceed the ${MAX_SNAPSHOT_TOTAL_BYTES}-byte cumulative snapshot limit`);
+      }
+      hash.update(chunk);
+    }
+    const after = await handle.stat({ bigint: true });
+    if (!isDeepStrictEqual(statIdentity(before), statIdentity(after))) {
+      throw snapshotFailure(evidencePath, 'A run file changed while its snapshot identity was built');
+    }
+    return {
+      kind: 'file',
+      identity: statIdentity(after),
+      sha256: `sha256:${hash.digest('hex')}`,
+      byteCount,
+    };
+  } catch (error) {
+    failure = error;
+    throw error;
+  } finally {
+    try {
+      await closeOpenedHandle(handle, evidencePath);
+    } catch (error) {
+      if (!failure) throw error;
+      failure = preservePrimaryFailure(failure, error, 'file-handle cleanup failed');
+    }
+  }
+}
+
+function indexRunSnapshot(snapshot) {
+  return {
+    directories: new Map(snapshot.directories),
+    entries: new Map(snapshot.entries),
+  };
+}
+
+function snapshotEntryState(snapshot, relativePath) {
+  const entry = snapshot.entries.get(relativePath);
+  if (entry) return entry.kind === 'file' ? { kind: 'file', entry } : { kind: 'non-regular' };
+  if (snapshot.directories.has(relativePath)) return { kind: 'non-regular' };
+
+  const parts = relativePath.split('/');
+  for (let index = 1; index < parts.length; index += 1) {
+    const ancestor = parts.slice(0, index).join('/');
+    if (snapshot.entries.has(ancestor)) return { kind: 'non-regular' };
+    if (!snapshot.directories.has(ancestor)) return { kind: 'missing' };
+  }
+  return { kind: 'missing' };
+}
+
+async function regularFile(root, relativePath, {
+  materialize = true,
+  maxBytes = MAX_MATERIALIZED_BYTES,
+  snapshot = null,
+  snapshotPath = relativePath,
+} = {}) {
+  if (typeof relativePath !== 'string' || relativePath.length === 0 || path.isAbsolute(relativePath)) {
+    return { kind: 'unsafe' };
+  }
+  const canonical = relativePath.replaceAll('\\', '/');
+  const parts = canonical.split('/');
+  if (canonical !== relativePath || parts.some((part) => part === '' || part === '.' || part === '..')) {
+    return { kind: 'unsafe' };
+  }
+  const absolute = path.resolve(root, ...parts);
+  if (!contained(root, absolute) || absolute === root) return { kind: 'unsafe' };
+  const expected = snapshot ? snapshotEntryState(snapshot, snapshotPath) : null;
+  if (expected && expected.kind !== 'file') return { kind: expected.kind };
+
+  const rootIdentity = await openedDirectoryIdentity(root);
+  if (!rootIdentity) return { kind: 'non-regular' };
+  const directories = [{ path: root, identity: rootIdentity }];
+  let cursor = root;
+  for (const part of parts.slice(0, -1)) {
+    cursor = path.join(cursor, part);
+    const identity = await openedDirectoryIdentity(cursor);
+    if (!identity) return { kind: 'non-regular' };
+    directories.push({ path: cursor, identity });
+  }
+
+  let handle;
+  try {
+    handle = await open(
+      absolute,
+      fsConstants.O_RDONLY
+        | (fsConstants.O_NONBLOCK ?? 0)
+        | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+  } catch (error) {
+    if (['ENOENT', 'ENOTDIR'].includes(error?.code)) return { kind: 'missing' };
+    if (['ELOOP', 'EISDIR'].includes(error?.code)) return { kind: 'non-regular' };
+    throw error;
+  }
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (!before.isFile()) return { kind: 'non-regular' };
+    const hash = createHash('sha256');
+    const chunks = [];
+    let byteCount = 0;
+    let tooLarge = false;
+    for await (const chunk of handle.createReadStream({ autoClose: false })) {
+      byteCount += chunk.length;
+      hash.update(chunk);
+      if (materialize && !tooLarge) {
+        if (byteCount > maxBytes) tooLarge = true;
+        else chunks.push(chunk);
+      }
+    }
+    const after = await handle.stat({ bigint: true });
+    const identity = statIdentity(after);
+    if (!same(statIdentity(before), identity)) return { kind: 'replaced' };
+    for (const directory of directories) {
+      const directoryIdentity = await openedDirectoryIdentity(directory.path);
+      if (!directoryIdentity || !same(directoryIdentity, directory.identity)) return { kind: 'replaced' };
+    }
+    const digest = `sha256:${hash.digest('hex')}`;
+    if (expected && (
+      !same(identity, expected.entry.identity)
+      || byteCount !== expected.entry.byteCount
+      || digest !== expected.entry.sha256
+    )) {
+      throw snapshotFailure(snapshotPath, 'A consumed run file differs from its immutable snapshot');
+    }
+    if (tooLarge) return { kind: 'too-large', byteCount };
+    return {
+      kind: 'file',
+      absolute,
+      bytes: materialize ? Buffer.concat(chunks, byteCount) : null,
+      byteCount,
+      sha256: digest,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function requireManifestWorkspaces(runRoot, manifest) {
+  for (const pair of manifest.pairs) {
+    for (const variant of VARIANTS) {
+      const workspace = path.resolve(runRoot, ...pair[variant].split('/'));
+      await requireDirectoryChain(
+        runRoot,
+        workspace,
+        `manifest ${variant} workspace ${pair.caseId}/${pair.repetition}`,
+      );
+    }
+  }
+}
+
+async function requirePrivateRunRoot(runRoot) {
+  const state = await lstat(runRoot);
+  if (!state.isDirectory() || state.isSymbolicLink() || (state.mode & 0o077) !== 0) {
+    throw new Error('run root must be a private mode-0700 non-symlink directory');
+  }
+}
+
+async function requireQuiescenceProof(runRoot, manifest, snapshot = null) {
+  const state = await regularFile(runRoot, 'quiescence.json', { snapshot });
+  if (state.kind !== 'file') throw new Error('host quiescence proof is missing or unsafe');
+  let proof;
+  try {
+    proof = JSON.parse(state.bytes.toString('utf8'));
+  } catch {
+    throw new Error('host quiescence proof is invalid');
+  }
+  if (!exactKeys(proof, ['schemaVersion', 'runId', 'dispatchClosed'])
+    || proof.schemaVersion !== 1
+    || proof.runId !== manifest.runId
+    || proof.dispatchClosed !== true) {
+    throw new Error('host quiescence proof is invalid');
+  }
+}
+
+async function captureRunSnapshot(runRoot, {
+  closeOpenedHandle = closeHandle,
+  beforeOpenEntry = null,
+} = {}) {
+  const directories = new Map();
+  const entries = new Map();
+  let entryCount = 1;
+  let totalBytes = 0;
+
+  async function readNames(absoluteDirectory, relativeDirectory) {
+    const names = [];
+    for await (const entry of await opendir(absoluteDirectory)) {
+      names.push(entry.name);
+      if (entryCount + names.length > MAX_SNAPSHOT_ENTRIES) {
+        throw snapshotLimitFailure(
+          relativeDirectory,
+          `Run tree exceeds the ${MAX_SNAPSHOT_ENTRIES}-entry snapshot limit`,
+        );
+      }
+    }
+    entryCount += names.length;
+    return names.sort(compareText);
+  }
+
+  async function walk(absoluteDirectory, relativeDirectory, expectedIdentity = null) {
+    const openedDirectory = await openedDirectoryIdentity(absoluteDirectory, {
+      evidencePath: relativeDirectory,
+      closeOpenedHandle,
+    });
+    if (!openedDirectory
+      || (expectedIdentity && !same(openedDirectory, expectedIdentity))) {
+      throw snapshotFailure(relativeDirectory, 'A snapshotted directory is missing, replaced, or unsafe');
+    }
+    const names = await readNames(absoluteDirectory, relativeDirectory);
+    directories.set(relativeDirectory, { identity: openedDirectory, names });
+    for (const name of names) {
+      const absoluteEntry = path.join(absoluteDirectory, name);
+      const relativeEntry = relativeDirectory ? `${relativeDirectory}/${name}` : name;
+      let listed;
+      try {
+        listed = await lstat(absoluteEntry, { bigint: true });
+      } catch (error) {
+        if (['ENOENT', 'ENOTDIR'].includes(error?.code)) {
+          throw snapshotFailure(relativeEntry, 'A run entry changed while the snapshot was built');
+        }
+        throw error;
+      }
+      if (beforeOpenEntry) {
+        await beforeOpenEntry({ absoluteEntry, relativeEntry });
+      }
+      if (listed.isSymbolicLink()) {
+        entries.set(relativeEntry, { kind: 'symlink', identity: statIdentity(listed) });
+        continue;
+      }
+      if (listed.isDirectory()) {
+        await walk(absoluteEntry, relativeEntry, statIdentity(listed));
+        continue;
+      }
+      const opened = await openedNodeIdentity(absoluteEntry, {
+        evidencePath: relativeEntry,
+        maxFileBytes: MAX_SNAPSHOT_FILE_BYTES,
+        maxTotalBytes: MAX_SNAPSHOT_TOTAL_BYTES - totalBytes,
+        closeOpenedHandle,
+      });
+      const expectedKind = listed.isFile() ? 'file' : 'special';
+      if (!opened
+        || opened.kind !== expectedKind
+        || !same(opened.identity, statIdentity(listed))) {
+        throw snapshotFailure(relativeEntry, 'A run entry changed while the snapshot was built');
+      }
+      if (opened.kind === 'file') totalBytes += opened.byteCount;
+      entries.set(relativeEntry, opened);
+    }
+    const revalidatedDirectory = await openedDirectoryIdentity(absoluteDirectory, {
+      evidencePath: relativeDirectory,
+      closeOpenedHandle,
+    });
+    if (!revalidatedDirectory || !same(revalidatedDirectory, openedDirectory)) {
+      throw snapshotFailure(relativeDirectory, 'A run directory changed while the snapshot was built');
+    }
+  }
+
+  await walk(runRoot, '');
+  return { directories: [...directories.entries()], entries: [...entries.entries()] };
+}
+
+async function buildRunSnapshot(runRoot, options) {
+  const snapshot = await captureRunSnapshot(runRoot, options);
+  const confirmation = await captureRunSnapshot(runRoot, options);
+  if (!same(snapshot, confirmation)) {
+    throw snapshotFailure('', 'The run changed while its immutable snapshot was established');
+  }
+  return snapshot;
+}
+
+async function revalidateRunSnapshot(runRoot, snapshot) {
+  const current = await captureRunSnapshot(runRoot);
+  if (!same(snapshot, current)) {
+    throw snapshotFailure('', 'The run changed after its immutable snapshot was established');
+  }
+}
+
+async function listDirectoryNames(runRoot, relativePath, snapshot = null) {
+  const absolutePath = path.resolve(runRoot, ...relativePath.split('/'));
+  if (snapshot) {
+    const expected = snapshot.directories.get(relativePath);
+    const current = await openedDirectoryIdentity(absolutePath);
+    if (!expected || !current || !same(current, expected.identity)) {
+      throw snapshotFailure(relativePath, 'A consumed run directory differs from its immutable snapshot');
+    }
+    return [...expected.names];
+  }
+  const before = await openedDirectoryIdentity(absolutePath);
+  if (!before) {
+    throw snapshotFailure(relativePath, 'Evidence directory is missing, replaced, or unsafe');
+  }
+  const names = (await readdir(absolutePath)).sort(compareText);
+  const after = await openedDirectoryIdentity(absolutePath);
+  if (!after || !same(before, after)) {
+    throw snapshotFailure(relativePath, 'Evidence directory changed while it was enumerated');
+  }
+  return names;
+}
+
+async function parseFile(runRoot, relativePath, snapshot = null) {
+  const state = await regularFile(runRoot, relativePath, { snapshot });
+  if (state.kind !== 'file') return { state };
+  try {
+    const value = JSON.parse(state.bytes.toString('utf8'));
+    if (!isObject(value)) return { state, malformed: true };
+    return { state, value };
+  } catch {
+    return { state, malformed: true };
+  }
+}
+
+function publicationDirectoryIdentity(stats) {
+  return {
+    dev: String(stats.dev),
+    ino: String(stats.ino),
+    uid: String(stats.uid),
+    mode: String(stats.mode),
+  };
+}
+
+async function requirePrivatePublicationParent(parent) {
+  let canonical;
+  try {
+    canonical = await realpath(parent);
+  } catch {
+    throw new Error('publication parent must be an existing private directory');
+  }
+  const listed = await lstat(parent, { bigint: true });
+  const currentUid = typeof process.getuid === 'function' ? BigInt(process.getuid()) : listed.uid;
+  if (!listed.isDirectory()
+    || listed.isSymbolicLink()
+    || (listed.mode & 0o077n) !== 0n
+    || listed.uid !== currentUid) {
+    throw new Error('publication parent must be an owner-private non-symlink directory');
+  }
+  const handle = await open(
+    parent,
+    fsConstants.O_RDONLY
+      | (fsConstants.O_DIRECTORY ?? 0)
+      | (fsConstants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const opened = await handle.stat({ bigint: true });
+    if (!opened.isDirectory()
+      || !same(publicationDirectoryIdentity(opened), publicationDirectoryIdentity(listed))) {
+      throw new Error('publication parent changed while it was opened');
+    }
+    return { handle, identity: publicationDirectoryIdentity(opened), canonical };
+  } catch (error) {
+    try {
+      await handle.close();
+    } catch (closeError) {
+      throw combinedFailure(error, closeError, 'publication parent validation and cleanup failed');
+    }
+    throw error;
+  }
+}
+
+async function revalidatePublicationParent(parent, directory) {
+  if (await realpath(parent) !== directory.canonical) {
+    throw new Error('publication parent changed before commit');
+  }
+  const listed = await lstat(parent, { bigint: true });
+  if (!listed.isDirectory()
+    || listed.isSymbolicLink()
+    || (listed.mode & 0o077n) !== 0n
+    || !same(publicationDirectoryIdentity(listed), directory.identity)) {
+    throw new Error('publication parent changed before commit');
+  }
+}
+
+async function rollbackLinkedOutput(
+  outPath,
+  parent,
+  directory,
+  tempIdentity,
+  syncDirectory,
+  closeOpenedHandle,
+) {
+  let finalHandle;
+  let failure;
+  try {
+    finalHandle = await open(
+      outPath,
+      fsConstants.O_RDONLY
+        | (fsConstants.O_NONBLOCK ?? 0)
+        | (fsConstants.O_NOFOLLOW ?? 0),
+    );
+    const opened = await finalHandle.stat({ bigint: true });
+    const listed = await lstat(outPath, { bigint: true });
+    if (!opened.isFile()
+      || listed.isSymbolicLink()
+      || !same(statIdentity(opened), statIdentity(listed))
+      || opened.dev !== tempIdentity.dev
+      || opened.ino !== tempIdentity.ino) {
+      throw new Error('publication rollback refused an unexpected final file');
+    }
+    await revalidatePublicationParent(parent, directory);
+    // The verified parent is owner-private, and the identity handle remains open across unlink.
+    await unlink(outPath);
+    await syncDirectory(directory.handle);
+  } catch (error) {
+    failure = error;
+    throw error;
+  } finally {
+    if (finalHandle) {
+      try {
+        await closeOpenedHandle(finalHandle, outPath);
+      } catch (error) {
+        if (!failure) throw error;
+        failure = preservePrimaryFailure(
+          failure,
+          error,
+          'rollback final-handle cleanup failed',
+        );
+      }
+    }
+  }
+}
+
+async function publishCreateNew(outPath, contents, {
+  syncDirectory = (directoryHandle) => directoryHandle.sync(),
+  removeTemp = unlink,
+  closeOpenedHandle = closeHandle,
+  randomBytes = cryptoRandomBytes,
+} = {}) {
+  if (typeof contents !== 'string' && !Buffer.isBuffer(contents)) {
+    throw new TypeError('publication contents must be a string or Buffer');
+  }
+  const absoluteOut = path.resolve(outPath);
+  const parent = path.dirname(absoluteOut);
+  const tempPath = path.join(
+    parent,
+    `.${path.basename(absoluteOut)}.${process.pid}.${randomBytes(8).toString('hex')}.tmp`,
+  );
+  const directory = await requirePrivatePublicationParent(parent);
+  let tempHandle;
+  let tempCreated = false;
+  let tempIdentity;
+  let linked = false;
+  let committed = false;
+  let failure = null;
+  try {
+    tempHandle = await open(tempPath, 'wx', 0o600);
+    tempCreated = true;
+    await tempHandle.writeFile(contents);
+    await tempHandle.sync();
+    const stats = await tempHandle.stat({ bigint: true });
+    tempIdentity = { dev: stats.dev, ino: stats.ino };
+    await closeOpenedHandle(tempHandle, tempPath);
+    tempHandle = null;
+
+    await revalidatePublicationParent(parent, directory);
+    await link(tempPath, absoluteOut);
+    linked = true;
+    await removeTemp(tempPath);
+    tempCreated = false;
+    await syncDirectory(directory.handle);
+    committed = true;
+  } catch (error) {
+    failure = error;
+    if (linked && !committed) {
+      try {
+        await rollbackLinkedOutput(
+          absoluteOut,
+          parent,
+          directory,
+          tempIdentity,
+          syncDirectory,
+          closeOpenedHandle,
+        );
+      } catch (rollbackError) {
+        failure = combinedFailure(
+          failure,
+          rollbackError,
+          'publication and rollback failed',
+        );
+      }
+    }
+  }
+
+  if (tempHandle) {
+    try {
+      await closeOpenedHandle(tempHandle, tempPath);
+    } catch (error) {
+      failure = failure
+        ? combinedFailure(failure, error, 'publication and temporary-handle cleanup failed')
+        : error;
+    }
+  }
+  if (tempCreated) {
+    try {
+      await removeTemp(tempPath);
+      tempCreated = false;
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        failure = failure
+          ? combinedFailure(failure, error, 'publication and temporary-file cleanup failed')
+          : error;
+      }
+    }
+  }
+  try {
+    await closeOpenedHandle(directory.handle, parent);
+  } catch (error) {
+    if (!failure && committed) {
+      failure = new Error('publication committed but directory-handle cleanup failed', {
+        cause: error,
+      });
+    } else {
+      failure = failure
+        ? combinedFailure(failure, error, 'publication and directory-handle cleanup failed')
+        : error;
+    }
+  }
+  if (failure) throw failure;
+}
+
+async function writeCreateNew(outPath, value, options) {
+  await publishCreateNew(outPath, `${JSON.stringify(value, null, 2)}\n`, options);
+}
+
+export {
+  buildRunSnapshot,
+  indexRunSnapshot,
+  contained,
+  listDirectoryNames,
+  parseFile,
+  publishCreateNew,
+  regularFile,
+  relativeTo,
+  requireDirectoryChain,
+  requireManifestWorkspaces,
+  requirePrivateRunRoot,
+  requireQuiescenceProof,
+  revalidateRunSnapshot,
+  writeCreateNew,
+};

--- a/skills/woostack-eval/scripts/aggregate/schema.mjs
+++ b/skills/woostack-eval/scripts/aggregate/schema.mjs
@@ -1,0 +1,176 @@
+import {
+  KEBAB,
+  MAX_RUNS,
+  RUN_ID,
+  SHA256,
+  VARIANTS,
+  WORKER_KINDS,
+  baselineIdentityValid,
+  caseIdValid,
+  compareText,
+  completionIdentityValid,
+  isObject,
+  exactKeys,
+  nonEmptyString,
+  optionalString,
+  same,
+} from './contracts.mjs';
+
+function expectedKey(value) {
+  return `${value.kind}\u0000${value.caseId}\u0000${value.variant}\u0000${value.repetition}`;
+}
+
+function requireManifest(manifest) {
+  const manifestFields = [
+    'schemaVersion', 'runId', 'targetSkill', 'mode', 'runs', 'baseline',
+    'runConfiguration', 'originalPackageHash', 'packageHashes', 'gradingPlan',
+    'expected', 'pairs',
+  ];
+  if (!exactKeys(manifest, manifestFields) || manifest.schemaVersion !== 1) {
+    throw new Error('manifest must be a schemaVersion 1 object with the canonical key set');
+  }
+  if (typeof manifest.runId !== 'string' || !RUN_ID.test(manifest.runId)
+    || manifest.runId === '.' || manifest.runId === '..'
+    || typeof manifest.targetSkill !== 'string' || !KEBAB.test(manifest.targetSkill)
+    || typeof manifest.originalPackageHash !== 'string'
+    || !SHA256.test(manifest.originalPackageHash)) {
+    throw new Error('manifest identity is invalid');
+  }
+  if (!['behavior', 'triggers', 'all'].includes(manifest.mode)
+    || !Number.isSafeInteger(manifest.runs) || manifest.runs < 1 || manifest.runs > MAX_RUNS) {
+    throw new Error('manifest run selection is invalid');
+  }
+  if (!baselineIdentityValid(manifest.baseline)) {
+    throw new Error('manifest baseline is invalid');
+  }
+  if (!exactKeys(manifest.packageHashes, ['candidate', 'baseline'])
+    || !SHA256.test(manifest.packageHashes.candidate ?? '')
+    || (manifest.baseline.kind === 'none'
+      ? manifest.packageHashes.baseline !== null
+      : !SHA256.test(manifest.packageHashes.baseline ?? ''))
+    || (manifest.baseline.kind === 'path'
+      && manifest.packageHashes.baseline !== manifest.baseline.identity)) {
+    throw new Error('manifest package hashes are invalid');
+  }
+  const configurationFields = ['host', 'runner', 'model', 'sessionIdentity', 'tier', 'effort'];
+  if (!exactKeys(manifest.runConfiguration, configurationFields)
+    || !nonEmptyString(manifest.runConfiguration.host)
+    || !nonEmptyString(manifest.runConfiguration.runner)
+    || !completionIdentityValid(manifest.runConfiguration)
+    || !optionalString(manifest.runConfiguration.tier)
+    || !optionalString(manifest.runConfiguration.effort)) {
+    throw new Error('manifest run configuration is invalid');
+  }
+  if (!Array.isArray(manifest.expected)
+    || !Array.isArray(manifest.pairs)
+    || !Array.isArray(manifest.gradingPlan)) {
+    throw new Error('manifest expected set is invalid');
+  }
+
+  const identities = new Set();
+  const expectedPairs = new Set();
+  const expectedShapes = new Map();
+  const expectedCases = new Map();
+  for (const item of manifest.expected) {
+    if (!exactKeys(item, ['caseId', 'variant', 'repetition', 'kind'])
+      || !caseIdValid(item.caseId) || !WORKER_KINDS.has(item.kind)
+      || (manifest.mode === 'behavior' && item.kind !== 'behavior')
+      || (manifest.mode === 'triggers' && item.kind !== 'trigger')
+      || !VARIANTS.includes(item.variant) || !Number.isSafeInteger(item.repetition)
+      || item.repetition < 1 || item.repetition > manifest.runs) {
+      throw new Error('manifest contains an invalid expected identity');
+    }
+    const key = expectedKey(item);
+    if (identities.has(key)) throw new Error('manifest contains duplicate expected identities');
+    identities.add(key);
+    const pairKey = `${item.caseId}\u0000${item.repetition}`;
+    expectedPairs.add(pairKey);
+    const shape = expectedShapes.get(pairKey) ?? { kind: item.kind, variants: new Set() };
+    if (shape.kind !== item.kind) throw new Error('manifest contains kind drift within a pair');
+    shape.variants.add(item.variant);
+    expectedShapes.set(pairKey, shape);
+    const expectedCase = expectedCases.get(item.caseId)
+      ?? { kind: item.kind, repetitions: new Set() };
+    if (expectedCase.kind !== item.kind) {
+      throw new Error('manifest contains kind drift for one case');
+    }
+    expectedCase.repetitions.add(item.repetition);
+    expectedCases.set(item.caseId, expectedCase);
+  }
+  if (manifest.expected.length === 0) throw new Error('manifest expected set is empty');
+  const manifestModes = new Set();
+  for (const shape of expectedShapes.values()) {
+    const variants = [...shape.variants].sort().join(',');
+    if (variants !== 'candidate' && variants !== 'baseline,candidate') {
+      throw new Error('manifest expected pairs must include candidate evidence');
+    }
+    manifestModes.add(variants);
+  }
+  if (manifestModes.size !== 1) {
+    throw new Error('manifest expected set must be uniformly paired or candidate-only');
+  }
+
+  const repetitions = Array.from({ length: manifest.runs }, (_, index) => index + 1);
+  for (const expectedCase of expectedCases.values()) {
+    if (!same([...expectedCase.repetitions].sort((left, right) => left - right), repetitions)) {
+      throw new Error('manifest expected set is incomplete for configured runs');
+    }
+  }
+  const orderedCases = [...expectedCases.entries()].sort(([leftId, left], [rightId, right]) =>
+    Number(left.kind === 'trigger') - Number(right.kind === 'trigger')
+    || compareText(leftId, rightId));
+  const expectedVariants = manifestModes.has('candidate') ? ['candidate'] : VARIANTS;
+  const canonicalExpectedKeys = orderedCases.flatMap(([caseId, expectedCase]) =>
+    repetitions.flatMap((repetition) =>
+      expectedVariants.map((variant) => expectedKey({
+        kind: expectedCase.kind,
+        caseId,
+        variant,
+        repetition,
+      }))));
+  if (!same(manifest.expected.map(expectedKey), canonicalExpectedKeys)) {
+    throw new Error('manifest expected identities are not in canonical order');
+  }
+
+  const pairKeys = new Set();
+  const orderedPairKeys = [];
+  for (const pair of manifest.pairs) {
+    const canonicalRoot = caseIdValid(pair?.caseId) && Number.isSafeInteger(pair?.repetition)
+      ? `cases/${pair.caseId}/${pair.repetition}`
+      : null;
+    if (!exactKeys(pair, ['caseId', 'repetition', 'candidate', 'baseline'])
+      || !caseIdValid(pair.caseId) || !Number.isSafeInteger(pair.repetition)
+      || pair.repetition < 1 || pair.repetition > manifest.runs
+      || pair.candidate !== `${canonicalRoot}/candidate`
+      || pair.baseline !== `${canonicalRoot}/baseline`) {
+      throw new Error('manifest contains an invalid workspace pair');
+    }
+    const key = `${pair.caseId}\u0000${pair.repetition}`;
+    if (pairKeys.has(key)) throw new Error('manifest contains duplicate workspace pairs');
+    pairKeys.add(key);
+    orderedPairKeys.push(key);
+  }
+  const canonicalPairKeys = orderedCases.flatMap(([caseId]) =>
+    repetitions.map((repetition) => `${caseId}\u0000${repetition}`));
+  if (!same([...pairKeys].sort(), [...expectedPairs].sort())) {
+    throw new Error('manifest workspace pairs do not exactly match the expected set');
+  }
+  if (!same(orderedPairKeys, canonicalPairKeys)) {
+    throw new Error('manifest workspace pairs are not in canonical order');
+  }
+}
+
+export {
+  KEBAB,
+  SHA256,
+  VARIANTS,
+  WORKER_KINDS,
+  caseIdValid,
+  compareText,
+  exactKeys,
+  isObject,
+  nonEmptyString,
+  optionalString,
+  requireManifest,
+  same,
+};

--- a/skills/woostack-eval/scripts/tests/test-aggregate.sh
+++ b/skills/woostack-eval/scripts/tests/test-aggregate.sh
@@ -1,0 +1,3020 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export LC_ALL=C
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+AGGREGATOR="$SCRIPT_DIR/../aggregate.mjs"
+NODE=${NODE:-node}
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/woostack-eval-aggregate.XXXXXX")
+
+cleanup() {
+  cleanup_status=$?
+  trap - EXIT HUP INT TERM
+  rm -rf "$TMP_ROOT"
+  exit "$cleanup_status"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+# Build every fixture before the intentional missing-implementation check. This keeps Red honest:
+# malformed fixture JSON, a missing evidence file, or an inconsistent expected identity fails here.
+"$NODE" --input-type=module - "$TMP_ROOT" "$SCRIPT_DIR/../validate.mjs" <<'NODE'
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { chmod, cp, link, lstat, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const root = process.argv[2];
+const { hashPackage } = await import(pathToFileURL(process.argv[3]).href);
+const runId = '20260715T120000Z-4242';
+const targetSkill = 'woostack-example';
+let packageHash = null;
+const baseline = { kind: 'git-ref', identity: '0123456789abcdef0123456789abcdef01234567' };
+const materializationLimit = 1024 * 1024;
+const runConfiguration = {
+  host: 'omp',
+  runner: 'worker',
+  model: 'model-a',
+  sessionIdentity: null,
+  tier: 'standard',
+  effort: 'high',
+};
+const cases = [
+  {
+    caseId: 'objective-check',
+    kind: 'behavior',
+    definition: {
+      id: 'objective-check',
+      prompt: 'Return the observable marker.',
+      capabilities: ['read-workspace'],
+      expected: 'Candidate output contains the new marker.',
+      assertions: [{
+        id: 'candidate-gain',
+        kind: 'final-contains',
+        substring: 'candidate marker',
+        critical: true,
+      }, {
+        id: 'shared-observation',
+        kind: 'final-contains',
+        substring: 'shared marker',
+        critical: false,
+      }],
+    },
+  },
+  {
+    caseId: 'qualitative-check',
+    kind: 'behavior',
+    definition: {
+      id: 'qualitative-check',
+      prompt: 'Write a concise handoff.',
+      capabilities: ['read-workspace'],
+      expected: 'The handoff is clear.',
+      assertions: [{
+        id: 'clear-handoff',
+        kind: 'qualitative',
+        rubric: 'Does the handoff clearly state the next action?',
+        critical: false,
+      }],
+    },
+  },
+  {
+    caseId: 'negative-trigger',
+    kind: 'trigger',
+    definition: {
+      id: 'negative-trigger',
+      query: 'Review an existing pull request.',
+      shouldTrigger: false,
+      expectedSkill: 'none',
+      conflictsWith: [targetSkill, 'catalog-peer'],
+    },
+  },
+  {
+    caseId: 'positive-trigger',
+    kind: 'trigger',
+    definition: {
+      id: 'positive-trigger',
+      query: 'Evaluate the example skill.',
+      shouldTrigger: true,
+      expectedSkill: targetSkill,
+      conflictsWith: ['catalog-peer'],
+    },
+  },
+];
+
+function sha256(data) {
+  return `sha256:${createHash('sha256').update(data).digest('hex')}`;
+}
+
+async function writeIdentity(runRoot, relativePath, contents) {
+  const bytes = Buffer.from(contents, 'utf8');
+  const absolutePath = path.join(runRoot, relativePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, bytes, { flag: 'wx' });
+  return { path: relativePath, sha256: sha256(bytes), bytes: bytes.length };
+}
+
+function receiptName(kind, caseId, variant, repetition) {
+  return `action.${kind}.${caseId}.${variant}.${repetition}.json`;
+}
+
+function selectedSkill(caseId, variant) {
+  if (caseId === 'positive-trigger') {
+    return variant === 'candidate' ? targetSkill : 'none';
+  }
+  if (caseId === 'negative-trigger') {
+    return variant === 'candidate' ? targetSkill : 'catalog-peer';
+  }
+  return null;
+}
+
+function actionOutput(caseId, variant) {
+  if (caseId === 'objective-check') {
+    return variant === 'candidate'
+      ? 'candidate marker\nshared marker\n'
+      : 'baseline output\nshared marker\n';
+  }
+  if (caseId === 'qualitative-check') {
+    return variant === 'candidate' ? 'Next: run the focused check.\n' : 'Looks okay.\n';
+  }
+  return `catalog selection recorded for ${caseId}\n`;
+}
+
+async function writeActionReceipt(runRoot, item, variant, repetition) {
+  const stem = `${item.kind}.${item.caseId}.${variant}.${repetition}`;
+  const output = await writeIdentity(runRoot, `outputs/${stem}.txt`, actionOutput(item.caseId, variant));
+  // Transcript prose deliberately contradicts trigger selection. Aggregate metrics must use
+  // selectedSkill, never transcript text.
+  const transcriptText = item.kind === 'trigger'
+    ? (selectedSkill(item.caseId, variant) === targetSkill
+        ? 'Transcript says selected none.\n'
+        : `Transcript says selected ${targetSkill}.\n`)
+    : `Observed ${item.caseId}.\n`;
+  const transcript = await writeIdentity(runRoot, `transcripts/${stem}.txt`, transcriptText);
+  const receiptPackageHash = await hashPackage(
+    path.join(runRoot, 'cases', item.caseId, String(repetition), variant, 'package'),
+    { trackedOnly: false },
+  );
+  if (packageHash === null) packageHash = receiptPackageHash;
+  assert.equal(receiptPackageHash, packageHash, 'synthetic copied packages must hash identically');
+  const receipt = {
+    schemaVersion: 1,
+    runId,
+    caseId: item.caseId,
+    repetition,
+    variant,
+    kind: item.kind,
+    targetSkill,
+    baseline,
+    packageHash: receiptPackageHash,
+    capabilities: ['read-workspace'],
+    host: runConfiguration.host,
+    runner: runConfiguration.runner,
+    model: runConfiguration.model,
+    sessionIdentity: runConfiguration.sessionIdentity,
+    tier: runConfiguration.tier,
+    effort: runConfiguration.effort,
+    startedAt: `2026-07-15T12:00:0${repetition}.000Z`,
+    durationMs: variant === 'candidate' ? repetition * 100 : repetition * 200 + 100,
+    output,
+    transcript,
+    tokenUsage: 'unavailable',
+    selectedSkill: selectedSkill(item.caseId, variant),
+    completionStatus: 'complete',
+    error: null,
+  };
+  await writeFile(
+    path.join(runRoot, 'evidence', receiptName(item.kind, item.caseId, variant, repetition)),
+    `${JSON.stringify(receipt, null, 2)}\n`,
+    { flag: 'wx' },
+  );
+}
+
+async function writeGrade(runRoot, variant, repetition) {
+  const graderId = 'clarity-grader';
+  const anonymizedOutputId =
+    variant === 'candidate' ? `output-7f3a-${repetition}` : `output-91bc-${repetition}`;
+  const graderOutput = await writeIdentity(
+    runRoot,
+    `outputs/grader.qualitative-check.${variant}.${graderId}.${repetition}.txt`,
+    variant === 'candidate' ? 'The next action is missing.\n' : 'The next action is explicit.\n',
+  );
+  // The host-owned action.grader.* receipt carries the manifest variant. The grade payload stays
+  // blind; aggregate may restore its variant only after this linked receipt validates.
+  const graderReceipt = {
+    schemaVersion: 1,
+    runId,
+    caseId: 'qualitative-check',
+    repetition,
+    variant,
+    kind: 'grader',
+    targetSkill,
+    baseline,
+    packageHash,
+    capabilities: ['read-workspace'],
+    host: runConfiguration.host,
+    runner: 'grader',
+    model: 'grader-model',
+    sessionIdentity: null,
+    tier: 'standard',
+    effort: 'high',
+    startedAt: `2026-07-15T12:01:0${repetition}.000Z`,
+    durationMs: 50,
+    output: graderOutput,
+    transcript: 'unavailable',
+    tokenUsage: 'unavailable',
+    selectedSkill: null,
+    completionStatus: 'complete',
+    error: null,
+  };
+  const receiptPath = `evidence/action.grader.qualitative-check.${variant}.${repetition}.${graderId}.json`;
+  const receiptBytes = Buffer.from(`${JSON.stringify(graderReceipt, null, 2)}\n`, 'utf8');
+  await writeFile(path.join(runRoot, receiptPath), receiptBytes, { flag: 'wx' });
+  const workerReceipt = JSON.parse(await readFile(path.join(
+    runRoot,
+    'evidence',
+    receiptName('behavior', 'qualitative-check', variant, repetition),
+  ), 'utf8'));
+  const inputPath =
+    `evidence/input.qualitative-check.${variant}.${repetition}.${graderId}.json`;
+  const inputMapping = {
+    schemaVersion: 1,
+    runId,
+    caseId: 'qualitative-check',
+    repetition,
+    graderId,
+    assertionId: 'clear-handoff',
+    anonymizedOutputId,
+    source: workerReceipt.output,
+  };
+  const inputBytes = Buffer.from(`${JSON.stringify(inputMapping, null, 2)}\n`, 'utf8');
+  await writeFile(path.join(runRoot, inputPath), inputBytes, { flag: 'wx' });
+  const grade = {
+    schemaVersion: 1,
+    runId,
+    caseId: 'qualitative-check',
+    repetition,
+    graderId,
+    assertionId: 'clear-handoff',
+    anonymizedOutputId,
+    completionStatus: 'complete',
+    pass: variant === 'baseline',
+    rationale: variant === 'candidate'
+      ? 'The handoff does not identify a next action.'
+      : 'The handoff names the required next action.',
+    error: null,
+    input: { path: inputPath, sha256: sha256(inputBytes) },
+    receipt: { path: receiptPath, sha256: sha256(receiptBytes) },
+  };
+  assert.equal(Object.hasOwn(grade, 'variant'), false, 'qualitative grade must stay blinded');
+  await writeFile(
+    path.join(runRoot, 'evidence', `grade.qualitative-check.${variant}.${repetition}.${graderId}.json`),
+    `${JSON.stringify(grade, null, 2)}\n`,
+    { flag: 'wx' },
+  );
+}
+
+async function writeCorpus(runRoot, item, repetition, variant) {
+  const evalRoot = path.join(runRoot, 'cases', item.caseId, String(repetition), variant, 'package', 'evals');
+  await mkdir(evalRoot, { recursive: true });
+  await writeFile(
+    path.join(path.dirname(evalRoot), 'SKILL.md'),
+    `---\nname: ${targetSkill}\ndescription: Synthetic aggregate fixture.\n---\n`,
+  );
+  const behavior = {
+    schemaVersion: 1,
+    skill: targetSkill,
+    cases: cases.filter((entry) => entry.kind === 'behavior').map((entry) => entry.definition),
+  };
+  const trigger = {
+    schemaVersion: 1,
+    skill: targetSkill,
+    cases: cases.filter((entry) => entry.kind === 'trigger').map((entry) => entry.definition),
+  };
+  await writeFile(path.join(evalRoot, 'evals.json'), `${JSON.stringify(behavior, null, 2)}\n`);
+  await writeFile(path.join(evalRoot, 'trigger-evals.json'), `${JSON.stringify(trigger, null, 2)}\n`);
+}
+
+async function createRun(name, repetitions) {
+  const runRoot = path.join(root, name);
+  await mkdir(runRoot, { mode: 0o700 });
+  await mkdir(path.join(runRoot, 'evidence'));
+  await mkdir(path.join(runRoot, 'definitions'));
+  for (const item of cases) {
+    await writeFile(
+      path.join(runRoot, 'definitions', `${item.kind}.${item.caseId}.json`),
+      `${JSON.stringify(item.definition)}\n`,
+      { flag: 'wx' },
+    );
+  }
+  const expected = [];
+  const pairs = [];
+  for (const item of cases) {
+    for (let repetition = 1; repetition <= repetitions; repetition += 1) {
+      const candidate = `cases/${item.caseId}/${repetition}/candidate`;
+      const baselinePath = `cases/${item.caseId}/${repetition}/baseline`;
+      for (const variant of ['candidate', 'baseline']) {
+        expected.push({ caseId: item.caseId, variant, repetition, kind: item.kind });
+        await writeCorpus(runRoot, item, repetition, variant);
+        await writeActionReceipt(runRoot, item, variant, repetition);
+      }
+      pairs.push({ caseId: item.caseId, repetition, candidate, baseline: baselinePath });
+      if (item.caseId === 'qualitative-check') {
+        await writeGrade(runRoot, 'candidate', repetition);
+        await writeGrade(runRoot, 'baseline', repetition);
+      }
+    }
+  }
+  const manifest = {
+    schemaVersion: 1,
+    runId,
+    targetSkill,
+    mode: 'all',
+    runs: repetitions,
+    baseline,
+    runConfiguration,
+    originalPackageHash: packageHash,
+    packageHashes: { candidate: packageHash, baseline: packageHash },
+    gradingPlan: Array.from({ length: repetitions }, (_, index) => ({
+      caseId: 'qualitative-check',
+      repetition: index + 1,
+      assertionId: 'clear-handoff',
+      graderId: 'clarity-grader',
+    })),
+    expected,
+    pairs,
+  };
+  await writeFile(path.join(runRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeFile(
+    path.join(runRoot, 'quiescence.json'),
+    `${JSON.stringify({ schemaVersion: 1, runId, dispatchClosed: true }, null, 2)}\n`,
+    { flag: 'wx', mode: 0o600 },
+  );
+  return runRoot;
+}
+
+async function cloneRun(sourceName, targetName) {
+  await cp(path.join(root, sourceName), path.join(root, targetName), { recursive: true, errorOnExist: true });
+  await rm(path.join(root, targetName, 'aggregate.json'), { force: true });
+  return path.join(root, targetName);
+}
+
+async function treeUsage(directory) {
+  let entries = 1;
+  let bytes = 0;
+  async function walk(current) {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      entries += 1;
+      const absolute = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absolute);
+      } else if (entry.isFile()) {
+        bytes += Number((await lstat(absolute, { bigint: true })).size);
+      }
+    }
+  }
+  await walk(directory);
+  return { entries, bytes };
+}
+
+async function mutateReceipt(runRoot, transform) {
+  const receiptPath = path.join(runRoot, 'evidence', receiptName('behavior', 'objective-check', 'candidate', 1));
+  const receipt = JSON.parse(await readFile(receiptPath, 'utf8'));
+  transform(receipt);
+  await writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+}
+
+async function mutateActionReceipt(runRoot, kind, caseId, variant, repetition, transform) {
+  const receiptPath = path.join(
+    runRoot,
+    'evidence',
+    receiptName(kind, caseId, variant, repetition),
+  );
+  const receipt = JSON.parse(await readFile(receiptPath, 'utf8'));
+  transform(receipt);
+  await writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+}
+
+async function mutateGraderReceiptForVariant(runRoot, variant, transform) {
+  const receiptPath = path.join(
+    runRoot,
+    'evidence',
+    `action.grader.qualitative-check.${variant}.1.clarity-grader.json`,
+  );
+  const receipt = JSON.parse(await readFile(receiptPath, 'utf8'));
+  transform(receipt);
+  const receiptBytes = Buffer.from(`${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+  await writeFile(receiptPath, receiptBytes);
+
+  const gradePath = path.join(
+    runRoot,
+    'evidence',
+    `grade.qualitative-check.${variant}.1.clarity-grader.json`,
+  );
+  const grade = JSON.parse(await readFile(gradePath, 'utf8'));
+  grade.receipt.sha256 = sha256(receiptBytes);
+  await writeFile(gradePath, `${JSON.stringify(grade, null, 2)}\n`);
+}
+
+async function mutateGraderReceipt(runRoot, transform) {
+  await mutateGraderReceiptForVariant(runRoot, 'candidate', transform);
+}
+
+async function mutateCandidateGrade(runRoot, transform) {
+  const gradePath = path.join(
+    runRoot,
+    'evidence',
+    'grade.qualitative-check.candidate.1.clarity-grader.json',
+  );
+  const grade = JSON.parse(await readFile(gradePath, 'utf8'));
+  transform(grade);
+  await writeFile(gradePath, `${JSON.stringify(grade, null, 2)}\n`);
+}
+
+async function mutateGradeInput(runRoot, variant, transform) {
+  const inputPath = path.join(
+    runRoot,
+    'evidence',
+    `input.qualitative-check.${variant}.1.clarity-grader.json`,
+  );
+  const input = JSON.parse(await readFile(inputPath, 'utf8'));
+  transform(input);
+  const inputBytes = Buffer.from(`${JSON.stringify(input, null, 2)}\n`, 'utf8');
+  await writeFile(inputPath, inputBytes);
+  const gradePath = path.join(
+    runRoot,
+    'evidence',
+    `grade.qualitative-check.${variant}.1.clarity-grader.json`,
+  );
+  const grade = JSON.parse(await readFile(gradePath, 'utf8'));
+  grade.input.sha256 = sha256(inputBytes);
+  await writeFile(gradePath, `${JSON.stringify(grade, null, 2)}\n`);
+}
+
+async function addObjectiveQualitativePair(runRoot) {
+  const definitionPath = path.join(runRoot, 'definitions', 'behavior.objective-check.json');
+  const definition = JSON.parse(await readFile(definitionPath, 'utf8'));
+  definition.assertions.push({
+    id: 'cross-case-grade',
+    kind: 'qualitative',
+    rubric: 'Does the output provide a clear marker?',
+    critical: false,
+  });
+  await writeFile(definitionPath, `${JSON.stringify(definition)}\n`);
+
+  for (const variant of ['candidate', 'baseline']) {
+    const sourceReceiptPath = path.join(
+      runRoot,
+      'evidence',
+      `action.grader.qualitative-check.${variant}.1.clarity-grader.json`,
+    );
+    const graderReceipt = JSON.parse(await readFile(sourceReceiptPath, 'utf8'));
+    graderReceipt.caseId = 'objective-check';
+    const graderReceiptPath = `evidence/action.grader.objective-check.${variant}.1.clarity-grader.json`;
+    const graderReceiptBytes =
+      Buffer.from(`${JSON.stringify(graderReceipt, null, 2)}\n`, 'utf8');
+    await writeFile(path.join(runRoot, graderReceiptPath), graderReceiptBytes, { flag: 'wx' });
+
+    const workerReceipt = JSON.parse(await readFile(path.join(
+      runRoot,
+      'evidence',
+      receiptName('behavior', 'objective-check', variant, 1),
+    ), 'utf8'));
+    const anonymizedOutputId =
+      variant === 'candidate' ? 'output-7f3a-1' : 'output-objective-baseline-1';
+    const inputPath = `evidence/input.objective-check.${variant}.1.clarity-grader.json`;
+    const input = {
+      schemaVersion: 1,
+      runId,
+      caseId: 'objective-check',
+      repetition: 1,
+      graderId: 'clarity-grader',
+      assertionId: 'cross-case-grade',
+      anonymizedOutputId,
+      source: workerReceipt.output,
+    };
+    const inputBytes = Buffer.from(`${JSON.stringify(input, null, 2)}\n`, 'utf8');
+    await writeFile(path.join(runRoot, inputPath), inputBytes, { flag: 'wx' });
+    const grade = {
+      schemaVersion: 1,
+      runId,
+      caseId: 'objective-check',
+      repetition: 1,
+      graderId: 'clarity-grader',
+      assertionId: 'cross-case-grade',
+      anonymizedOutputId,
+      completionStatus: 'complete',
+      pass: true,
+      rationale: 'The output provides the requested marker.',
+      error: null,
+      input: { path: inputPath, sha256: sha256(inputBytes) },
+      receipt: { path: graderReceiptPath, sha256: sha256(graderReceiptBytes) },
+    };
+    await writeFile(
+      path.join(runRoot, 'evidence', `grade.objective-check.${variant}.1.clarity-grader.json`),
+      `${JSON.stringify(grade, null, 2)}\n`,
+      { flag: 'wx' },
+    );
+  }
+}
+
+const complete = await createRun('complete', 2);
+const oneRun = await createRun('one-run', 1);
+
+const sessionIdentityRun = await cloneRun('one-run', 'session-identity');
+const sessionManifestPath = path.join(sessionIdentityRun, 'manifest.json');
+const sessionManifest = JSON.parse(await readFile(sessionManifestPath, 'utf8'));
+sessionManifest.runConfiguration.model = null;
+sessionManifest.runConfiguration.sessionIdentity = 'shared-session';
+await writeFile(sessionManifestPath, `${JSON.stringify(sessionManifest, null, 2)}\n`);
+for (const expected of sessionManifest.expected) {
+  await mutateActionReceipt(
+    sessionIdentityRun,
+    expected.kind,
+    expected.caseId,
+    expected.variant,
+    expected.repetition,
+    (receipt) => {
+      receipt.model = null;
+      receipt.sessionIdentity = 'shared-session';
+    },
+  );
+}
+for (const variant of ['candidate', 'baseline']) {
+  await mutateGraderReceiptForVariant(sessionIdentityRun, variant, (receipt) => {
+    receipt.model = null;
+    receipt.sessionIdentity = 'shared-grader-session';
+  });
+}
+
+const tokenUsageRun = await cloneRun('one-run', 'token-usage');
+const tokenUsageManifest =
+  JSON.parse(await readFile(path.join(tokenUsageRun, 'manifest.json'), 'utf8'));
+for (const expected of tokenUsageManifest.expected) {
+  await mutateActionReceipt(
+    tokenUsageRun,
+    expected.kind,
+    expected.caseId,
+    expected.variant,
+    expected.repetition,
+    (receipt) => {
+      receipt.tokenUsage = expected.variant === 'candidate'
+        ? { input: 10, output: 5, total: 15 }
+        : { input: 8, output: 4, total: 12 };
+    },
+  );
+}
+
+const objectiveAssertionKinds = await cloneRun('one-run', 'objective-assertion-kinds');
+const objectiveDefinitionPath =
+  path.join(objectiveAssertionKinds, 'definitions', 'behavior.objective-check.json');
+const objectiveDefinition = JSON.parse(await readFile(objectiveDefinitionPath, 'utf8'));
+objectiveDefinition.assertions.push(
+  { id: 'final-excludes-pass', kind: 'final-excludes', substring: 'forbidden marker', critical: false },
+  { id: 'final-excludes-fail', kind: 'final-excludes', substring: 'shared marker', critical: false },
+  { id: 'receipt-field-pass', kind: 'receipt-field-equals', pointer: '/selectedSkill', expected: null, critical: false },
+  { id: 'receipt-field-fail', kind: 'receipt-field-equals', pointer: '/selectedSkill', expected: 'none', critical: false },
+  { id: 'path-absent-pass', kind: 'path-absent', path: 'missing-dir/result.txt', critical: false },
+  { id: 'path-exists-pass', kind: 'path-exists', path: 'assertions/present.txt', critical: false },
+  { id: 'path-absent-fail', kind: 'path-absent', path: 'assertions/present.txt', critical: false },
+  { id: 'file-contains-pass', kind: 'file-contains', file: 'assertions/present.txt', substring: 'present marker', critical: false },
+  { id: 'file-contains-fail', kind: 'file-contains', file: 'assertions/present.txt', substring: 'absent marker', critical: false },
+  { id: 'file-contains-missing', kind: 'file-contains', file: 'assertions/missing.txt', substring: 'marker', critical: false },
+  { id: 'file-excludes-pass', kind: 'file-excludes', file: 'assertions/present.txt', substring: 'absent marker', critical: false },
+  { id: 'file-excludes-fail', kind: 'file-excludes', file: 'assertions/present.txt', substring: 'present marker', critical: false },
+  { id: 'file-excludes-missing', kind: 'file-excludes', file: 'assertions/missing.txt', substring: 'marker', critical: false },
+  { id: 'json-path-pass', kind: 'json-path-equals', file: 'assertions/valid.json', pointer: '/status', expected: 'ready', critical: false },
+  { id: 'json-path-mismatch', kind: 'json-path-equals', file: 'assertions/valid.json', pointer: '/status', expected: 'blocked', critical: false },
+  { id: 'json-path-missing', kind: 'json-path-equals', file: 'assertions/missing.json', pointer: '/status', expected: 'ready', critical: false },
+  { id: 'json-path-malformed', kind: 'json-path-equals', file: 'assertions/malformed.json', pointer: '/status', expected: 'ready', critical: false },
+);
+await writeFile(objectiveDefinitionPath, `${JSON.stringify(objectiveDefinition)}\n`);
+for (const variant of ['candidate', 'baseline']) {
+  const assertionRoot = path.join(
+    objectiveAssertionKinds,
+    'cases',
+    'objective-check',
+    '1',
+    variant,
+    'assertions',
+  );
+  await mkdir(assertionRoot);
+  await writeFile(path.join(assertionRoot, 'present.txt'), 'present marker\n');
+  await writeFile(path.join(assertionRoot, 'valid.json'), '{"status":"ready"}\n');
+  await writeFile(path.join(assertionRoot, 'malformed.json'), '{"status":\n');
+}
+
+const snapshotFileBoundary = await cloneRun('one-run', 'snapshot-file-boundary');
+await writeFile(
+  path.join(snapshotFileBoundary, 'snapshot-file-boundary.bin'),
+  Buffer.alloc(16 * 1024 * 1024),
+);
+
+const snapshotTotalBoundary = await cloneRun('one-run', 'snapshot-total-boundary');
+const snapshotTotalBoundaryRoot = path.join(snapshotTotalBoundary, 'snapshot-total-boundary');
+await mkdir(snapshotTotalBoundaryRoot);
+const snapshotTotalUsage = await treeUsage(snapshotTotalBoundary);
+let snapshotTotalPadding = (128 * 1024 * 1024) - snapshotTotalUsage.bytes;
+for (let index = 0; snapshotTotalPadding > 0; index += 1) {
+  const bytes = Math.min(snapshotTotalPadding, 16 * 1024 * 1024);
+  await writeFile(
+    path.join(snapshotTotalBoundaryRoot, `${String(index).padStart(2, '0')}.bin`),
+    Buffer.alloc(bytes),
+  );
+  snapshotTotalPadding -= bytes;
+}
+assert.equal((await treeUsage(snapshotTotalBoundary)).bytes, 128 * 1024 * 1024);
+
+const snapshotEntryBoundary = await cloneRun('one-run', 'snapshot-entry-boundary');
+const snapshotEntryBoundaryRoot = path.join(snapshotEntryBoundary, 'snapshot-entry-boundary');
+await mkdir(snapshotEntryBoundaryRoot);
+const snapshotEntryPadding = 4096 - (await treeUsage(snapshotEntryBoundary)).entries;
+assert.equal(snapshotEntryPadding > 0, true);
+for (let offset = 0; offset < snapshotEntryPadding; offset += 256) {
+  await Promise.all(Array.from(
+    { length: Math.min(256, snapshotEntryPadding - offset) },
+    (_, index) => writeFile(
+      path.join(snapshotEntryBoundaryRoot, `${offset + index}.txt`),
+      '',
+    ),
+  ));
+}
+assert.equal((await treeUsage(snapshotEntryBoundary)).entries, 4096);
+
+const snapshotFileLimit = await cloneRun('one-run', 'snapshot-file-limit');
+await writeFile(
+  path.join(snapshotFileLimit, 'snapshot-file-limit.bin'),
+  Buffer.alloc((16 * 1024 * 1024) + 1),
+);
+
+const snapshotTotalLimit = await cloneRun('one-run', 'snapshot-total-limit');
+const snapshotTotalRoot = path.join(snapshotTotalLimit, 'snapshot-total');
+await mkdir(snapshotTotalRoot);
+const snapshotTotalSource = path.join(snapshotTotalRoot, '00.bin');
+await writeFile(snapshotTotalSource, Buffer.alloc(16 * 1024 * 1024));
+for (let index = 1; index < 8; index += 1) {
+  await link(snapshotTotalSource, path.join(snapshotTotalRoot, `${String(index).padStart(2, '0')}.bin`));
+}
+
+const snapshotEntryLimit = await cloneRun('one-run', 'snapshot-entry-limit');
+const snapshotEntryRoot = path.join(snapshotEntryLimit, 'snapshot-entry-limit');
+await mkdir(snapshotEntryRoot);
+for (let offset = 0; offset < 4096; offset += 256) {
+  await Promise.all(Array.from({ length: 256 }, (_, index) =>
+    writeFile(path.join(snapshotEntryRoot, `${offset + index}.txt`), '')));
+}
+
+const missingQuiescence = await cloneRun('one-run', 'missing-quiescence');
+await rm(path.join(missingQuiescence, 'quiescence.json'));
+
+const invalidQuiescence = await cloneRun('one-run', 'invalid-quiescence');
+await writeFile(
+  path.join(invalidQuiescence, 'quiescence.json'),
+  `${JSON.stringify({ schemaVersion: 1, runId, dispatchClosed: false }, null, 2)}\n`,
+);
+
+for (const snapshotName of ['snapshot-rewrite', 'snapshot-replacement']) {
+  const snapshotRun = await cloneRun('one-run', snapshotName);
+  await writeFile(
+    path.join(snapshotRun, 'definitions', 'snapshot-target.json'),
+    `${'a'.repeat(256 * 1024)}\n`,
+    { flag: 'wx' },
+  );
+}
+const snapshotDirectorySwap =
+  await cloneRun('one-run', 'snapshot-directory-swap');
+const snapshotSwapTarget = path.join(snapshotDirectorySwap, 'snapshot-swap-target');
+await mkdir(snapshotSwapTarget);
+await writeFile(path.join(snapshotSwapTarget, 'marker.txt'), 'directory\n');
+const snapshotReadBinding =
+  await cloneRun('one-run', 'snapshot-read-binding');
+
+const publicRunRoot = await cloneRun('one-run', 'public-run-root');
+await chmod(publicRunRoot, 0o755);
+
+const duplicate = await cloneRun('one-run', 'duplicate');
+await cp(
+  path.join(duplicate, 'evidence', receiptName('behavior', 'objective-check', 'candidate', 1)),
+  path.join(duplicate, 'evidence', 'duplicate-objective-receipt.json'),
+);
+
+const unknown = await cloneRun('one-run', 'unknown');
+const unknownReceiptPath = path.join(unknown, 'evidence', 'action.behavior.unknown-case.candidate.1.json');
+const unknownReceipt = JSON.parse(await readFile(
+  path.join(unknown, 'evidence', receiptName('behavior', 'objective-check', 'candidate', 1)),
+  'utf8',
+));
+unknownReceipt.caseId = 'unknown-case';
+await writeFile(unknownReceiptPath, `${JSON.stringify(unknownReceipt, null, 2)}\n`);
+
+const malformed = await cloneRun('one-run', 'malformed');
+await writeFile(
+  path.join(malformed, 'evidence', receiptName('behavior', 'objective-check', 'candidate', 1)),
+  '{"schemaVersion":1,\n',
+);
+
+for (const [name, status] of [['timed-out', 'timed-out'], ['failed', 'failed']]) {
+  const runRoot = await cloneRun('one-run', name);
+  await mutateReceipt(runRoot, (receipt) => {
+    receipt.completionStatus = status;
+    receipt.error = { code: `worker-${status}`, message: `Worker ${status}.` };
+  });
+}
+
+const invalidActionStatus = await cloneRun('one-run', 'invalid-action-status');
+await mutateReceipt(invalidActionStatus, (receipt) => {
+  receipt.completionStatus = 'blocked';
+});
+
+const completeActionError = await cloneRun('one-run', 'complete-action-error');
+await mutateReceipt(completeActionError, (receipt) => {
+  receipt.error = { code: 'unexpected-error', message: 'Unexpected error.' };
+});
+
+const failedActionNullError = await cloneRun('one-run', 'failed-action-null-error');
+await mutateReceipt(failedActionNullError, (receipt) => {
+  receipt.completionStatus = 'failed';
+  receipt.error = null;
+});
+
+for (const [name, error] of [
+  ['failed-action-extra-error-key', { code: 'worker-failed', message: 'Worker failed.', extra: true }],
+  ['failed-action-invalid-error-code', { code: 'WorkerFailed', message: 'Worker failed.' }],
+  ['failed-action-unsanitized-message', { code: 'worker-failed', message: ' Worker\nfailed. ' }],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  await mutateReceipt(runRoot, (receipt) => {
+    receipt.completionStatus = 'failed';
+    receipt.error = error;
+  });
+}
+
+for (const [name, field, value] of [
+  ['model-mismatch', 'model', 'model-b'],
+  ['tier-mismatch', 'tier', 'deep'],
+  ['effort-mismatch', 'effort', 'low'],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  await mutateReceipt(runRoot, (receipt) => { receipt[field] = value; });
+}
+
+const repetitionMismatch = await cloneRun('one-run', 'repetition-mismatch');
+await mutateReceipt(repetitionMismatch, (receipt) => { receipt.repetition = 2; });
+
+const identityMismatch = await cloneRun('one-run', 'identity-mismatch');
+await mutateReceipt(identityMismatch, (receipt) => { receipt.runId = 'other-run'; });
+
+const packageMismatch = await cloneRun('one-run', 'package-mismatch');
+await mutateReceipt(packageMismatch, (receipt) => { receipt.packageHash = `sha256:${'b'.repeat(64)}`; });
+
+const refreshedBaselineMutation =
+  await cloneRun('one-run', 'refreshed-baseline-mutation');
+await writeFile(
+  path.join(
+    refreshedBaselineMutation,
+    'cases',
+    'objective-check',
+    '1',
+    'baseline',
+    'package',
+    'mutation.txt',
+  ),
+  'mutated baseline package\n',
+  { flag: 'wx' },
+);
+const refreshedBaselineHash = await hashPackage(
+  path.join(
+    refreshedBaselineMutation,
+    'cases',
+    'objective-check',
+    '1',
+    'baseline',
+    'package',
+  ),
+  { trackedOnly: false },
+);
+await mutateActionReceipt(
+  refreshedBaselineMutation,
+  'behavior',
+  'objective-check',
+  'baseline',
+  1,
+  (receipt) => { receipt.packageHash = refreshedBaselineHash; },
+);
+
+const distinctOriginalPackageHash =
+  await cloneRun('one-run', 'distinct-original-package-hash');
+const distinctOriginalManifestPath = path.join(distinctOriginalPackageHash, 'manifest.json');
+const distinctOriginalManifest =
+  JSON.parse(await readFile(distinctOriginalManifestPath, 'utf8'));
+distinctOriginalManifest.originalPackageHash = `sha256:${'f'.repeat(64)}`;
+await writeFile(
+  distinctOriginalManifestPath,
+  `${JSON.stringify(distinctOriginalManifest, null, 2)}\n`,
+);
+
+const missingDuration = await cloneRun('one-run', 'missing-duration');
+await mutateReceipt(missingDuration, (receipt) => { delete receipt.durationMs; });
+
+const invalidStartedAt = await cloneRun('one-run', 'invalid-started-at');
+await mutateReceipt(invalidStartedAt, (receipt) => {
+  receipt.startedAt = '2026-02-30T12:00:00Z';
+});
+
+const unsafeDuration = await cloneRun('one-run', 'unsafe-duration');
+await mutateReceipt(unsafeDuration, (receipt) => {
+  receipt.durationMs = Number.MAX_SAFE_INTEGER + 1;
+});
+
+const unsafeTokenUsage = await cloneRun('one-run', 'unsafe-token-usage');
+await mutateReceipt(unsafeTokenUsage, (receipt) => {
+  receipt.tokenUsage = {
+    input: Number.MAX_SAFE_INTEGER + 1,
+    output: 0,
+    total: Number.MAX_SAFE_INTEGER + 1,
+  };
+});
+
+const unsafeOutputBytes = await cloneRun('one-run', 'unsafe-output-bytes');
+await mutateReceipt(unsafeOutputBytes, (receipt) => {
+  receipt.output.bytes = Number.MAX_SAFE_INTEGER + 1;
+});
+
+const missingCompletionIdentity = await cloneRun('one-run', 'missing-completion-identity');
+await mutateReceipt(missingCompletionIdentity, (receipt) => {
+  receipt.model = null;
+  receipt.sessionIdentity = null;
+});
+
+const ambiguousCompletionIdentity = await cloneRun('one-run', 'ambiguous-completion-identity');
+await mutateReceipt(ambiguousCompletionIdentity, (receipt) => {
+  receipt.sessionIdentity = 'shared-session';
+});
+
+const duplicateCapability = await cloneRun('one-run', 'duplicate-capability');
+await mutateReceipt(duplicateCapability, (receipt) => {
+  receipt.capabilities = ['read-workspace', 'read-workspace'];
+});
+
+const missingOutput = await cloneRun('one-run', 'missing-output');
+await mutateReceipt(missingOutput, (receipt) => { delete receipt.output; });
+
+const outputHashMismatch = await cloneRun('one-run', 'output-hash-mismatch');
+await mutateReceipt(outputHashMismatch, (receipt) => {
+  receipt.output.sha256 = `sha256:${'b'.repeat(64)}`;
+});
+
+const oversizedOutput = await cloneRun('one-run', 'oversized-output');
+const oversizedOutputBytes = Buffer.alloc(materializationLimit + 1, 'a');
+await writeFile(
+  path.join(oversizedOutput, 'outputs', 'behavior.objective-check.candidate.1.txt'),
+  oversizedOutputBytes,
+);
+await mutateReceipt(oversizedOutput, (receipt) => {
+  receipt.output.sha256 = sha256(oversizedOutputBytes);
+  receipt.output.bytes = oversizedOutputBytes.length;
+});
+
+const streamedTranscript = await cloneRun('one-run', 'streamed-transcript');
+const streamedTranscriptBytes = Buffer.alloc(materializationLimit + 1, 't');
+await writeFile(
+  path.join(streamedTranscript, 'transcripts', 'behavior.objective-check.candidate.1.txt'),
+  streamedTranscriptBytes,
+);
+await mutateReceipt(streamedTranscript, (receipt) => {
+  receipt.transcript.sha256 = sha256(streamedTranscriptBytes);
+  receipt.transcript.bytes = streamedTranscriptBytes.length;
+});
+
+const outputBytesMismatch = await cloneRun('one-run', 'output-bytes-mismatch');
+await mutateReceipt(outputBytesMismatch, (receipt) => { receipt.output.bytes += 1; });
+
+const escapingOutput = await cloneRun('one-run', 'escaping-output');
+await mutateReceipt(escapingOutput, (receipt) => { receipt.output.path = '../escape.txt'; });
+
+const transcriptHashMismatch = await cloneRun('one-run', 'transcript-hash-mismatch');
+await mutateReceipt(transcriptHashMismatch, (receipt) => {
+  receipt.transcript.sha256 = `sha256:${'b'.repeat(64)}`;
+});
+
+const transcriptBytesMismatch = await cloneRun('one-run', 'transcript-bytes-mismatch');
+await mutateReceipt(transcriptBytesMismatch, (receipt) => { receipt.transcript.bytes += 1; });
+
+const escapingTranscript = await cloneRun('one-run', 'escaping-transcript');
+await mutateReceipt(escapingTranscript, (receipt) => {
+  receipt.transcript.path = '../escape-transcript.txt';
+});
+
+const nonRegularTranscript = await cloneRun('one-run', 'non-regular-transcript');
+await mkdir(path.join(nonRegularTranscript, 'transcripts', 'non-regular'));
+await mutateReceipt(nonRegularTranscript, (receipt) => {
+  receipt.transcript.path = 'transcripts/non-regular';
+});
+
+const nonRegularOutput = await cloneRun('one-run', 'non-regular-output');
+await mkdir(path.join(nonRegularOutput, 'outputs', 'non-regular'));
+await mutateReceipt(nonRegularOutput, (receipt) => {
+  receipt.output.path = 'outputs/non-regular';
+});
+
+const fifoOutput = await cloneRun('one-run', 'fifo-output');
+await mutateReceipt(fifoOutput, (receipt) => {
+  receipt.output.path = 'outputs/fifo';
+});
+
+const symlinkOutput = await cloneRun('one-run', 'symlink-output');
+try {
+  await symlink(
+    'behavior.objective-check.candidate.1.txt',
+    path.join(symlinkOutput, 'outputs', 'symlink.txt'),
+  );
+  await mutateReceipt(symlinkOutput, (receipt) => {
+    receipt.output.path = 'outputs/symlink.txt';
+  });
+  await writeFile(path.join(root, 'symlink-supported'), 'yes\n');
+} catch (error) {
+  if (!['EACCES', 'ENOSYS', 'ENOTSUP', 'EPERM'].includes(error?.code)) throw error;
+  await rm(symlinkOutput, { recursive: true, force: true });
+}
+
+for (const [name, status] of [
+  ['grader-failed', 'failed'],
+  ['grader-timed-out', 'timed-out'],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  await mutateGraderReceipt(runRoot, (receipt) => {
+    receipt.completionStatus = status;
+    receipt.error = { code: `grader-${status}`, message: `Grader ${status}.` };
+  });
+}
+
+const graderVariantMismatch = await cloneRun('one-run', 'grader-variant-mismatch');
+await mutateGraderReceipt(graderVariantMismatch, (receipt) => {
+  receipt.variant = 'baseline';
+});
+
+for (const [name, packageIdentity] of [
+  ['grader-package-noncanonical', 'not-a-hash'],
+  ['grader-package-mismatch', `sha256:${'e'.repeat(64)}`],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  await mutateGraderReceipt(runRoot, (receipt) => {
+    receipt.packageHash = packageIdentity;
+  });
+}
+
+for (const [name, field, value] of [
+  ['grader-host-mismatch', 'host', 'other-host'],
+  ['grader-runner-mismatch', 'runner', 'other-grader'],
+  ['grader-model-mismatch', 'model', 'other-grader-model'],
+  ['grader-tier-mismatch', 'tier', 'deep'],
+  ['grader-effort-mismatch', 'effort', 'low'],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  await mutateGraderReceipt(runRoot, (receipt) => { receipt[field] = value; });
+}
+
+for (const [name, transform] of [
+  ['paired-grader-wrong-host-type', (receipt) => { receipt.host = 7; }],
+  ['paired-grader-unknown-capability', (receipt) => {
+    receipt.capabilities = ['network'];
+  }],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  for (const variant of ['candidate', 'baseline']) {
+    await mutateGraderReceiptForVariant(runRoot, variant, transform);
+  }
+}
+
+const graderMissingCompletionIdentity = await cloneRun(
+  'one-run',
+  'grader-missing-completion-identity',
+);
+await mutateGraderReceipt(graderMissingCompletionIdentity, (receipt) => {
+  receipt.model = null;
+  receipt.sessionIdentity = null;
+});
+
+const graderOutputHashMismatch = await cloneRun('one-run', 'grader-output-hash-mismatch');
+await mutateGraderReceipt(graderOutputHashMismatch, (receipt) => {
+  receipt.output.sha256 = `sha256:${'b'.repeat(64)}`;
+});
+const graderHashReceiptPath = path.join(
+  graderOutputHashMismatch,
+  'evidence',
+  'action.grader.qualitative-check.candidate.1.clarity-grader.json',
+);
+const graderHashReceiptBytes = await readFile(graderHashReceiptPath);
+const graderHashReceipt = JSON.parse(graderHashReceiptBytes);
+const graderHashGrade = JSON.parse(await readFile(path.join(
+  graderOutputHashMismatch,
+  'evidence',
+  'grade.qualitative-check.candidate.1.clarity-grader.json',
+)));
+assert.equal(graderHashReceipt.output.sha256, `sha256:${'b'.repeat(64)}`);
+assert.equal(
+  graderHashGrade.receipt.sha256,
+  sha256(graderHashReceiptBytes),
+  'only the outer grade link is refreshed; the tested grader output hash stays tampered',
+);
+
+const graderOutputBytesMismatch = await cloneRun('one-run', 'grader-output-bytes-mismatch');
+await mutateGraderReceipt(graderOutputBytesMismatch, (receipt) => {
+  receipt.output.bytes += 1;
+});
+
+const graderEscapingOutput = await cloneRun('one-run', 'grader-escaping-output');
+await mutateGraderReceipt(graderEscapingOutput, (receipt) => {
+  receipt.output.path = '../grader-escape.txt';
+});
+
+const graderNonRegularOutput = await cloneRun('one-run', 'grader-non-regular-output');
+await mkdir(path.join(graderNonRegularOutput, 'outputs', 'grader-non-regular'));
+await mutateGraderReceipt(graderNonRegularOutput, (receipt) => {
+  receipt.output.path = 'outputs/grader-non-regular';
+});
+
+const staleGradeReceiptHash = await cloneRun('one-run', 'stale-grade-receipt-hash');
+await mutateCandidateGrade(staleGradeReceiptHash, (grade) => {
+  grade.receipt.sha256 = `sha256:${'b'.repeat(64)}`;
+});
+const staleGrade = JSON.parse(await readFile(path.join(
+  staleGradeReceiptHash,
+  'evidence',
+  'grade.qualitative-check.candidate.1.clarity-grader.json',
+)));
+const linkedReceiptBytes = await readFile(path.join(
+  staleGradeReceiptHash,
+  staleGrade.receipt.path,
+));
+assert.notEqual(
+  staleGrade.receipt.sha256,
+  sha256(linkedReceiptBytes),
+  'stale grade receipt hash fixture must not auto-refresh the tested hash',
+);
+
+const unsafeGradeReceiptPath = await cloneRun('one-run', 'unsafe-grade-receipt-path');
+await mutateCandidateGrade(unsafeGradeReceiptPath, (grade) => {
+  grade.receipt.path = '../grader-receipt.json';
+});
+
+const nonRegularGradeReceipt = await cloneRun('one-run', 'non-regular-grade-receipt');
+await mkdir(path.join(nonRegularGradeReceipt, 'evidence', 'receipt-directory'));
+await mutateCandidateGrade(nonRegularGradeReceipt, (grade) => {
+  grade.receipt.path = 'evidence/receipt-directory';
+});
+
+const twoFaults = await cloneRun('one-run', 'two-faults');
+await mutateReceipt(twoFaults, (receipt) => {
+  receipt.output.sha256 = `sha256:${'b'.repeat(64)}`;
+});
+await mutateActionReceipt(
+  twoFaults,
+  'trigger',
+  'negative-trigger',
+  'baseline',
+  1,
+  (receipt) => {
+    receipt.completionStatus = 'failed';
+    receipt.error = { code: 'worker-failed', message: 'Worker failed.' };
+  },
+);
+
+const partial = await cloneRun('one-run', 'partial');
+await rm(path.join(partial, 'evidence', receiptName('behavior', 'objective-check', 'candidate', 1)));
+
+const smoke = await cloneRun('one-run', 'smoke');
+// The orchestrator records explicit candidate-only smoke acceptance by intentionally narrowing
+// expected to candidate identities. Paired workspace paths remain available for provenance; an
+// ordinary paired manifest with a missing baseline receipt is still blocked by the missing case.
+const smokeManifestPath = path.join(smoke, 'manifest.json');
+const smokeManifest = JSON.parse(await readFile(smokeManifestPath, 'utf8'));
+smokeManifest.expected = smokeManifest.expected.filter((entry) => entry.variant === 'candidate');
+await writeFile(smokeManifestPath, `${JSON.stringify(smokeManifest, null, 2)}\n`);
+for (const item of cases) {
+  await rm(path.join(smoke, 'evidence', receiptName(item.kind, item.caseId, 'baseline', 1)));
+}
+await rm(path.join(smoke, 'evidence', 'grade.qualitative-check.baseline.1.clarity-grader.json'));
+await rm(path.join(smoke, 'evidence', 'action.grader.qualitative-check.baseline.1.clarity-grader.json'));
+await rm(path.join(smoke, 'evidence', 'input.qualitative-check.baseline.1.clarity-grader.json'));
+assert.equal(smokeManifest.expected.length, cases.length);
+assert.equal(smokeManifest.expected.every((entry) => entry.variant === 'candidate'), true);
+assert.equal(smokeManifest.pairs.length, cases.length);
+assert.equal(smokeManifest.pairs.every((pair) =>
+  pair.candidate.endsWith('/candidate') && pair.baseline.endsWith('/baseline')), true);
+
+const unsafeSmokePair = await cloneRun('smoke', 'unsafe-smoke-pair');
+const unsafeSmokePairManifestPath = path.join(unsafeSmokePair, 'manifest.json');
+const unsafeSmokePairManifest =
+  JSON.parse(await readFile(unsafeSmokePairManifestPath, 'utf8'));
+unsafeSmokePairManifest.pairs[0].baseline = '../baseline';
+await writeFile(
+  unsafeSmokePairManifestPath,
+  `${JSON.stringify(unsafeSmokePairManifest, null, 2)}\n`,
+);
+
+const missingSmokeBaselineWorkspace =
+  await cloneRun('smoke', 'missing-smoke-baseline-workspace');
+await rm(
+  path.join(missingSmokeBaselineWorkspace, 'cases', 'objective-check', '1', 'baseline'),
+  { recursive: true },
+);
+
+const smokePairedGrader = await cloneRun('one-run', 'smoke-paired-grader');
+const smokePairedManifestPath = path.join(smokePairedGrader, 'manifest.json');
+const smokePairedManifest = JSON.parse(await readFile(smokePairedManifestPath, 'utf8'));
+smokePairedManifest.expected =
+  smokePairedManifest.expected.filter((entry) => entry.variant === 'candidate');
+await writeFile(smokePairedManifestPath, `${JSON.stringify(smokePairedManifest, null, 2)}\n`);
+for (const item of cases) {
+  await rm(path.join(
+    smokePairedGrader,
+    'evidence',
+    receiptName(item.kind, item.caseId, 'baseline', 1),
+  ));
+}
+const smokeCandidateReceipt = JSON.parse(await readFile(path.join(
+  smokePairedGrader,
+  'evidence',
+  receiptName('behavior', 'qualitative-check', 'candidate', 1),
+), 'utf8'));
+await mutateGradeInput(smokePairedGrader, 'baseline', (input) => {
+  input.source = smokeCandidateReceipt.output;
+});
+
+const orphanGrade = await cloneRun('one-run', 'orphan-grade');
+await rm(path.join(orphanGrade, 'evidence', 'action.grader.qualitative-check.candidate.1.clarity-grader.json'));
+
+const relocatedReceipt = await cloneRun('one-run', 'relocated-receipt');
+await cp(
+  path.join(relocatedReceipt, 'evidence', receiptName('behavior', 'objective-check', 'candidate', 1)),
+  path.join(relocatedReceipt, 'evidence', 'relocated-objective-receipt.json'),
+);
+await rm(path.join(
+  relocatedReceipt,
+  'evidence',
+  receiptName('behavior', 'objective-check', 'candidate', 1),
+));
+
+for (const [name, transform] of [
+  ['extra-output-key', (receipt) => { receipt.output.extra = true; }],
+  ['extra-transcript-key', (receipt) => { receipt.transcript.extra = true; }],
+  ['extra-token-key', (receipt) => {
+    receipt.tokenUsage = { input: 1, output: 2, total: 3, cached: 0 };
+  }],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  await mutateReceipt(runRoot, transform);
+}
+
+const extraGradeReceiptKey = await cloneRun('one-run', 'extra-grade-receipt-key');
+await mutateCandidateGrade(extraGradeReceiptKey, (grade) => { grade.receipt.bytes = 1; });
+
+for (const [name, field, value] of [
+  ['invalid-grader-id', 'graderId', 'Not-Kebab'],
+  ['invalid-assertion-id', 'assertionId', 'Not-Kebab'],
+  ['invalid-anonymized-output-id', 'anonymizedOutputId', 'Not-Kebab'],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  await mutateCandidateGrade(runRoot, (grade) => { grade[field] = value; });
+}
+
+const invalidGradeStatus = await cloneRun('one-run', 'invalid-grade-status');
+await mutateCandidateGrade(invalidGradeStatus, (grade) => {
+  grade.completionStatus = 'blocked';
+});
+
+const completeGradeError = await cloneRun('one-run', 'complete-grade-error');
+await mutateCandidateGrade(completeGradeError, (grade) => {
+  grade.error = { code: 'unexpected-error', message: 'Unexpected error.' };
+});
+
+const failedGradeNullError = await cloneRun('one-run', 'failed-grade-null-error');
+await mutateCandidateGrade(failedGradeNullError, (grade) => {
+  grade.completionStatus = 'failed';
+  grade.pass = null;
+  grade.rationale = null;
+  grade.error = null;
+});
+
+const failedGradeInvalidCode = await cloneRun('one-run', 'failed-grade-invalid-code');
+await mutateCandidateGrade(failedGradeInvalidCode, (grade) => {
+  grade.completionStatus = 'failed';
+  grade.pass = null;
+  grade.rationale = null;
+  grade.error = { code: 'GraderFailed', message: 'Grader failed.' };
+});
+
+const failedGradeNonNullPass = await cloneRun('one-run', 'failed-grade-non-null-pass');
+await mutateCandidateGrade(failedGradeNonNullPass, (grade) => {
+  grade.completionStatus = 'failed';
+  grade.pass = false;
+  grade.rationale = null;
+  grade.error = { code: 'grader-failed', message: 'Grader failed.' };
+});
+
+const failedGradeInvalidReceiptType =
+  await cloneRun('one-run', 'failed-grade-invalid-receipt-type');
+await mutateCandidateGrade(failedGradeInvalidReceiptType, (grade) => {
+  grade.completionStatus = 'failed';
+  grade.pass = null;
+  grade.rationale = null;
+  grade.error = { code: 'grader-failed', message: 'Grader failed.' };
+  grade.receipt = 42;
+});
+
+const swappedGradeInputs = await cloneRun('one-run', 'swapped-grade-inputs');
+await mutateGradeInput(swappedGradeInputs, 'candidate', (input) => {
+  input.anonymizedOutputId = 'output-91bc-1';
+});
+await mutateGradeInput(swappedGradeInputs, 'baseline', (input) => {
+  input.anonymizedOutputId = 'output-7f3a-1';
+});
+
+const duplicateAnonymizedInput = await cloneRun('one-run', 'duplicate-anonymized-input');
+await mutateGradeInput(duplicateAnonymizedInput, 'baseline', (input) => {
+  input.anonymizedOutputId = 'output-7f3a-1';
+});
+const duplicateAnonymizedGradePath = path.join(
+  duplicateAnonymizedInput,
+  'evidence',
+  'grade.qualitative-check.baseline.1.clarity-grader.json',
+);
+const duplicateAnonymizedGrade =
+  JSON.parse(await readFile(duplicateAnonymizedGradePath, 'utf8'));
+duplicateAnonymizedGrade.anonymizedOutputId = 'output-7f3a-1';
+await writeFile(
+  duplicateAnonymizedGradePath,
+  `${JSON.stringify(duplicateAnonymizedGrade, null, 2)}\n`,
+);
+
+const duplicateInvalidProof =
+  await cloneRun('duplicate-anonymized-input', 'duplicate-invalid-proof');
+const duplicateInvalidGradePath = path.join(
+  duplicateInvalidProof,
+  'evidence',
+  'grade.qualitative-check.baseline.1.clarity-grader.json',
+);
+const duplicateInvalidGrade =
+  JSON.parse(await readFile(duplicateInvalidGradePath, 'utf8'));
+duplicateInvalidGrade.receipt.sha256 = `sha256:${'d'.repeat(64)}`;
+await writeFile(
+  duplicateInvalidGradePath,
+  `${JSON.stringify(duplicateInvalidGrade, null, 2)}\n`,
+);
+
+const duplicateOrphanMapping =
+  await cloneRun('one-run', 'duplicate-orphan-mapping');
+const orphanSourcePath = path.join(
+  duplicateOrphanMapping,
+  'evidence',
+  'input.qualitative-check.candidate.1.clarity-grader.json',
+);
+const orphanMapping = JSON.parse(await readFile(orphanSourcePath, 'utf8'));
+orphanMapping.graderId = 'orphan-grader';
+const orphanMappingPath =
+  path.join(
+    duplicateOrphanMapping,
+    'evidence',
+    'input.qualitative-check.candidate.1.orphan-grader.json',
+  );
+await writeFile(
+  orphanMappingPath,
+  `${JSON.stringify(orphanMapping, null, 2)}\n`,
+  { flag: 'wx' },
+);
+
+const repeatedAnonymizedInput = await cloneRun('complete', 'repeated-anonymized-input');
+const repeatedGradePath = path.join(
+  repeatedAnonymizedInput,
+  'evidence',
+  'grade.qualitative-check.candidate.2.clarity-grader.json',
+);
+const repeatedGrade = JSON.parse(await readFile(repeatedGradePath, 'utf8'));
+const repeatedInputPath =
+  path.join(repeatedAnonymizedInput, 'evidence', 'input.qualitative-check.candidate.2.clarity-grader.json');
+const repeatedInput = JSON.parse(await readFile(repeatedInputPath, 'utf8'));
+repeatedInput.anonymizedOutputId = 'output-7f3a-1';
+const repeatedInputBytes = Buffer.from(`${JSON.stringify(repeatedInput, null, 2)}\n`, 'utf8');
+await writeFile(repeatedInputPath, repeatedInputBytes);
+repeatedGrade.anonymizedOutputId = 'output-7f3a-1';
+repeatedGrade.input.sha256 = sha256(repeatedInputBytes);
+await writeFile(repeatedGradePath, `${JSON.stringify(repeatedGrade, null, 2)}\n`);
+
+const crossCaseAnonymizedInput = await cloneRun('one-run', 'cross-case-anonymized-input');
+await addObjectiveQualitativePair(crossCaseAnonymizedInput);
+const crossCaseManifestPath = path.join(crossCaseAnonymizedInput, 'manifest.json');
+const crossCaseManifest = JSON.parse(await readFile(crossCaseManifestPath, 'utf8'));
+crossCaseManifest.gradingPlan.unshift({
+  caseId: 'objective-check',
+  repetition: 1,
+  assertionId: 'cross-case-grade',
+  graderId: 'clarity-grader',
+});
+await writeFile(crossCaseManifestPath, `${JSON.stringify(crossCaseManifest, null, 2)}\n`);
+
+const wrongSourceGradeInput = await cloneRun('one-run', 'wrong-source-grade-input');
+const baselineWorkerReceipt = JSON.parse(await readFile(path.join(
+  wrongSourceGradeInput,
+  'evidence',
+  receiptName('behavior', 'qualitative-check', 'baseline', 1),
+), 'utf8'));
+await mutateGradeInput(wrongSourceGradeInput, 'candidate', (input) => {
+  input.source = baselineWorkerReceipt.output;
+});
+
+const differentValidGraderIds = await cloneRun('one-run', 'different-valid-grader-ids');
+const oldBaselineInputPath = path.join(
+  differentValidGraderIds,
+  'evidence',
+  'input.qualitative-check.baseline.1.clarity-grader.json',
+);
+const renamedBaselineInput = JSON.parse(await readFile(oldBaselineInputPath, 'utf8'));
+renamedBaselineInput.graderId = 'alternate-grader';
+const renamedBaselineInputBytes =
+  Buffer.from(`${JSON.stringify(renamedBaselineInput, null, 2)}\n`, 'utf8');
+const newBaselineInputRelative =
+  'evidence/input.qualitative-check.baseline.1.alternate-grader.json';
+await writeFile(
+  path.join(differentValidGraderIds, newBaselineInputRelative),
+  renamedBaselineInputBytes,
+  { flag: 'wx' },
+);
+await rm(oldBaselineInputPath);
+const oldBaselineGradePath = path.join(
+  differentValidGraderIds,
+  'evidence',
+  'grade.qualitative-check.baseline.1.clarity-grader.json',
+);
+const renamedBaselineGrade = JSON.parse(await readFile(oldBaselineGradePath, 'utf8'));
+renamedBaselineGrade.graderId = 'alternate-grader';
+renamedBaselineGrade.input = {
+  path: newBaselineInputRelative,
+  sha256: sha256(renamedBaselineInputBytes),
+};
+await writeFile(
+  path.join(
+    differentValidGraderIds,
+    'evidence',
+    'grade.qualitative-check.baseline.1.alternate-grader.json',
+  ),
+  `${JSON.stringify(renamedBaselineGrade, null, 2)}\n`,
+  { flag: 'wx' },
+);
+await rm(oldBaselineGradePath);
+
+const mismatchedGradingPlan = await cloneRun('one-run', 'mismatched-grading-plan');
+const mismatchedPlanPath = path.join(mismatchedGradingPlan, 'manifest.json');
+const mismatchedPlan = JSON.parse(await readFile(mismatchedPlanPath, 'utf8'));
+mismatchedPlan.gradingPlan[0].graderId = 'planned-grader';
+await writeFile(mismatchedPlanPath, `${JSON.stringify(mismatchedPlan, null, 2)}\n`);
+
+const missingSecondGrade = await cloneRun('one-run', 'missing-second-grade');
+const missingSecondDefinitionPath =
+  path.join(missingSecondGrade, 'definitions', 'behavior.qualitative-check.json');
+const missingSecondDefinition =
+  JSON.parse(await readFile(missingSecondDefinitionPath, 'utf8'));
+missingSecondDefinition.assertions.push({
+  id: 'second-grade',
+  kind: 'qualitative',
+  rubric: 'Does the handoff include sufficient context?',
+  critical: false,
+});
+await writeFile(
+  missingSecondDefinitionPath,
+  `${JSON.stringify(missingSecondDefinition, null, 2)}\n`,
+);
+const missingSecondManifestPath = path.join(missingSecondGrade, 'manifest.json');
+const missingSecondManifest = JSON.parse(await readFile(missingSecondManifestPath, 'utf8'));
+missingSecondManifest.gradingPlan.push({
+  caseId: 'qualitative-check',
+  repetition: 1,
+  assertionId: 'second-grade',
+  graderId: 'context-grader',
+});
+await writeFile(
+  missingSecondManifestPath,
+  `${JSON.stringify(missingSecondManifest, null, 2)}\n`,
+);
+
+const distinctGraders = await cloneRun('missing-second-grade', 'distinct-graders');
+for (const variant of ['candidate', 'baseline']) {
+  const sourceReceiptPath = path.join(
+    distinctGraders,
+    'evidence',
+    `action.grader.qualitative-check.${variant}.1.clarity-grader.json`,
+  );
+  const receiptPath =
+    `evidence/action.grader.qualitative-check.${variant}.1.context-grader.json`;
+  const receiptBytes = await readFile(sourceReceiptPath);
+  await writeFile(path.join(distinctGraders, receiptPath), receiptBytes, { flag: 'wx' });
+
+  const workerReceipt = JSON.parse(await readFile(path.join(
+    distinctGraders,
+    'evidence',
+    receiptName('behavior', 'qualitative-check', variant, 1),
+  ), 'utf8'));
+  const inputPath =
+    `evidence/input.qualitative-check.${variant}.1.context-grader.json`;
+  const input = {
+    schemaVersion: 1,
+    runId,
+    caseId: 'qualitative-check',
+    repetition: 1,
+    graderId: 'context-grader',
+    assertionId: 'second-grade',
+    anonymizedOutputId: `output-context-${variant}-1`,
+    source: workerReceipt.output,
+  };
+  const inputBytes = Buffer.from(`${JSON.stringify(input, null, 2)}\n`, 'utf8');
+  await writeFile(path.join(distinctGraders, inputPath), inputBytes, { flag: 'wx' });
+  const grade = {
+    schemaVersion: 1,
+    runId,
+    caseId: 'qualitative-check',
+    repetition: 1,
+    graderId: 'context-grader',
+    assertionId: 'second-grade',
+    anonymizedOutputId: input.anonymizedOutputId,
+    completionStatus: 'complete',
+    pass: true,
+    rationale: 'The handoff includes sufficient context.',
+    error: null,
+    input: { path: inputPath, sha256: sha256(inputBytes) },
+    receipt: { path: receiptPath, sha256: sha256(receiptBytes) },
+  };
+  await writeFile(
+    path.join(
+      distinctGraders,
+      'evidence',
+      `grade.qualitative-check.${variant}.1.context-grader.json`,
+    ),
+    `${JSON.stringify(grade, null, 2)}\n`,
+    { flag: 'wx' },
+  );
+}
+
+const duplicateGraderPlan = await cloneRun('missing-second-grade', 'duplicate-grader-plan');
+const duplicateGraderPlanPath = path.join(duplicateGraderPlan, 'manifest.json');
+const duplicateGraderManifest =
+  JSON.parse(await readFile(duplicateGraderPlanPath, 'utf8'));
+duplicateGraderManifest.gradingPlan[1].graderId = 'clarity-grader';
+await writeFile(
+  duplicateGraderPlanPath,
+  `${JSON.stringify(duplicateGraderManifest, null, 2)}\n`,
+);
+
+const malformedDistinctGrader =
+  await cloneRun('distinct-graders', 'malformed-distinct-grader');
+await writeFile(
+  path.join(
+    malformedDistinctGrader,
+    'evidence',
+    'grade.qualitative-check.candidate.1.context-grader.json',
+  ),
+  '{"schemaVersion":1,\n',
+);
+
+const oversizedDistinctGrader =
+  await cloneRun('distinct-graders', 'oversized-distinct-grader');
+await writeFile(
+  path.join(
+    oversizedDistinctGrader,
+    'evidence',
+    'grade.qualitative-check.candidate.1.context-grader.json',
+  ),
+  Buffer.alloc((1024 * 1024) + 1),
+);
+
+const pathDirectory = await cloneRun('one-run', 'path-directory');
+const pathDirectoryDefinitionPath =
+  path.join(pathDirectory, 'definitions', 'behavior.objective-check.json');
+const pathDirectoryDefinition =
+  JSON.parse(await readFile(pathDirectoryDefinitionPath, 'utf8'));
+pathDirectoryDefinition.assertions.push({
+  id: 'directory-is-not-regular',
+  kind: 'path-exists',
+  path: 'package/evals',
+  critical: false,
+});
+await writeFile(
+  pathDirectoryDefinitionPath,
+  `${JSON.stringify(pathDirectoryDefinition, null, 2)}\n`,
+);
+
+const corpusMutation = await cloneRun('one-run', 'corpus-mutation');
+const mutatedCorpusPath = path.join(
+  corpusMutation,
+  'cases',
+  'objective-check',
+  '1',
+  'candidate',
+  'package',
+  'evals',
+  'evals.json',
+);
+const mutatedCorpus = JSON.parse(await readFile(mutatedCorpusPath, 'utf8'));
+mutatedCorpus.cases.find((entry) => entry.id === 'objective-check').expected = 'Tampered.';
+await writeFile(mutatedCorpusPath, `${JSON.stringify(mutatedCorpus, null, 2)}\n`);
+
+for (const [name, select] of [
+  ['mixed-expected', (entry) =>
+    entry.variant === 'candidate' || entry.caseId !== 'objective-check'],
+  ['baseline-only-expected', (entry) => entry.variant === 'baseline'],
+  ['incomplete-expected', (entry) => entry.caseId !== 'objective-check'],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  const manifestPath = path.join(runRoot, 'manifest.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  manifest.expected = manifest.expected.filter(select);
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+for (const [name, transform] of [
+  ['invalid-run-id-dot', (manifest) => { manifest.runId = '.'; }],
+  ['invalid-run-id-dotdot', (manifest) => { manifest.runId = '..'; }],
+  ['invalid-run-id-long', (manifest) => { manifest.runId = 'a'.repeat(129); }],
+  ['invalid-run-id-type', (manifest) => { manifest.runId = ['valid-run']; }],
+  ['invalid-runs-high', (manifest) => { manifest.runs = 11; }],
+  ['invalid-case-id-long', (manifest) => {
+    manifest.expected[0].caseId = 'a'.repeat(65);
+  }],
+  ['invalid-baseline-git-ref', (manifest) => {
+    manifest.baseline = { kind: 'git-ref', identity: 'not-a-commit' };
+  }],
+  ['invalid-baseline-uppercase-git-ref', (manifest) => {
+    manifest.baseline = {
+      kind: 'git-ref',
+      identity: 'ABCDEF0123456789ABCDEF0123456789ABCDEF01',
+    };
+  }],
+  ['invalid-baseline-identity-type', (manifest) => {
+    manifest.baseline = {
+      kind: 'git-ref',
+      identity: ['0123456789abcdef0123456789abcdef01234567'],
+    };
+  }],
+  ['invalid-baseline-path', (manifest) => {
+    manifest.baseline = { kind: 'path', identity: `sha256:${'A'.repeat(64)}` };
+  }],
+  ['invalid-baseline-none', (manifest) => {
+    manifest.baseline = { kind: 'none', identity: `${'a'.repeat(40)}:missing` };
+  }],
+  ['invalid-baseline-uppercase-none', (manifest) => {
+    manifest.baseline = {
+      kind: 'none',
+      identity: '0123456789ABCDEF0123456789ABCDEF01234567:absent',
+    };
+  }],
+  ['manifest-model-empty', (manifest) => {
+    manifest.runConfiguration.model = '';
+  }],
+  ['manifest-inactive-empty', (manifest) => {
+    manifest.runConfiguration.sessionIdentity = '';
+  }],
+  ['manifest-inactive-wrong-type', (manifest) => {
+    manifest.runConfiguration.sessionIdentity = {};
+  }],
+  ['manifest-both-completion-identities', (manifest) => {
+    manifest.runConfiguration.sessionIdentity = 'other-session';
+  }],
+  ['path-baseline-hash-mismatch', (manifest) => {
+    manifest.baseline = { kind: 'path', identity: `sha256:${'e'.repeat(64)}` };
+  }],
+  ['behavior-mode-with-trigger', (manifest) => { manifest.mode = 'behavior'; }],
+  ['triggers-mode-with-behavior', (manifest) => { manifest.mode = 'triggers'; }],
+]) {
+  const runRoot = await cloneRun('one-run', name);
+  const manifestPath = path.join(runRoot, 'manifest.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  transform(manifest);
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+const missingRepetition = await cloneRun('complete', 'missing-repetition');
+const missingRepetitionManifestPath = path.join(missingRepetition, 'manifest.json');
+const missingRepetitionManifest =
+  JSON.parse(await readFile(missingRepetitionManifestPath, 'utf8'));
+missingRepetitionManifest.expected =
+  missingRepetitionManifest.expected.filter((entry) => entry.repetition === 1);
+missingRepetitionManifest.pairs =
+  missingRepetitionManifest.pairs.filter((pair) => pair.repetition === 1);
+await writeFile(
+  missingRepetitionManifestPath,
+  `${JSON.stringify(missingRepetitionManifest, null, 2)}\n`,
+);
+
+const outOfOrderExpected = await cloneRun('one-run', 'out-of-order-expected');
+const outOfOrderExpectedManifestPath = path.join(outOfOrderExpected, 'manifest.json');
+const outOfOrderExpectedManifest =
+  JSON.parse(await readFile(outOfOrderExpectedManifestPath, 'utf8'));
+[outOfOrderExpectedManifest.expected[0], outOfOrderExpectedManifest.expected[1]] =
+  [outOfOrderExpectedManifest.expected[1], outOfOrderExpectedManifest.expected[0]];
+await writeFile(
+  outOfOrderExpectedManifestPath,
+  `${JSON.stringify(outOfOrderExpectedManifest, null, 2)}\n`,
+);
+
+const outOfOrderPairs = await cloneRun('one-run', 'out-of-order-pairs');
+const outOfOrderPairsManifestPath = path.join(outOfOrderPairs, 'manifest.json');
+const outOfOrderPairsManifest =
+  JSON.parse(await readFile(outOfOrderPairsManifestPath, 'utf8'));
+[outOfOrderPairsManifest.pairs[0], outOfOrderPairsManifest.pairs[1]] =
+  [outOfOrderPairsManifest.pairs[1], outOfOrderPairsManifest.pairs[0]];
+await writeFile(
+  outOfOrderPairsManifestPath,
+  `${JSON.stringify(outOfOrderPairsManifest, null, 2)}\n`,
+);
+
+const noBaselinePackage = await cloneRun('one-run', 'no-baseline-package');
+const noBaselineManifestPath = path.join(noBaselinePackage, 'manifest.json');
+const noBaselineManifest = JSON.parse(await readFile(noBaselineManifestPath, 'utf8'));
+noBaselineManifest.baseline = {
+  kind: 'none',
+  identity: '0123456789abcdef0123456789abcdef01234567:absent',
+};
+noBaselineManifest.packageHashes.baseline = null;
+await writeFile(noBaselineManifestPath, `${JSON.stringify(noBaselineManifest, null, 2)}\n`);
+for (const item of cases) {
+  await rm(path.join(noBaselinePackage, 'cases', item.caseId, '1', 'baseline', 'package'), {
+    recursive: true,
+  });
+}
+const noBaselineEvidenceNames = await readdir(path.join(noBaselinePackage, 'evidence'));
+for (const name of noBaselineEvidenceNames.filter((entry) => entry.startsWith('action.'))) {
+  const receiptPath = path.join(noBaselinePackage, 'evidence', name);
+  const receipt = JSON.parse(await readFile(receiptPath, 'utf8'));
+  receipt.baseline = noBaselineManifest.baseline;
+  receipt.packageHash =
+    receipt.kind === 'grader' || receipt.variant === 'candidate'
+      ? noBaselineManifest.packageHashes.candidate
+      : null;
+  await writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+}
+for (const name of noBaselineEvidenceNames.filter((entry) => entry.startsWith('grade.'))) {
+  const gradePath = path.join(noBaselinePackage, 'evidence', name);
+  const grade = JSON.parse(await readFile(gradePath, 'utf8'));
+  const receiptBytes = await readFile(path.join(noBaselinePackage, grade.receipt.path));
+  grade.receipt.sha256 = sha256(receiptBytes);
+  await writeFile(gradePath, `${JSON.stringify(grade, null, 2)}\n`);
+}
+
+// Fixture self-review: every valid base manifest has the documented exact key sets, all expected
+// workspaces and receipts exist, output hashes/byte counts match, and grades expose no variant.
+for (const runRoot of [complete, oneRun, sessionIdentityRun, tokenUsageRun]) {
+  const manifest = JSON.parse(await readFile(path.join(runRoot, 'manifest.json'), 'utf8'));
+  assert.deepEqual(Object.keys(manifest).sort(), [
+    'baseline', 'expected', 'gradingPlan', 'mode', 'originalPackageHash', 'packageHashes',
+    'pairs', 'runConfiguration', 'runId', 'runs', 'schemaVersion', 'targetSkill',
+  ]);
+  assert.deepEqual(manifest.packageHashes, {
+    candidate: manifest.originalPackageHash,
+    baseline: manifest.originalPackageHash,
+  });
+  assert.deepEqual(manifest.gradingPlan, Array.from({ length: manifest.runs }, (_, index) => ({
+    caseId: 'qualitative-check',
+    repetition: index + 1,
+    assertionId: 'clear-handoff',
+    graderId: 'clarity-grader',
+  })));
+  assert.equal(manifest.expected.length, cases.length * manifest.runs * 2);
+  assert.equal(manifest.pairs.length, cases.length * manifest.runs);
+  const identities = new Set();
+  for (const expected of manifest.expected) {
+    const identity = `${expected.kind}:${expected.caseId}:${expected.variant}:${expected.repetition}`;
+    assert.equal(identities.has(identity), false, `duplicate manifest identity ${identity}`);
+    identities.add(identity);
+    const workspace = path.join(runRoot, 'cases', expected.caseId, String(expected.repetition), expected.variant);
+    assert.equal(path.resolve(workspace).startsWith(`${path.resolve(runRoot)}${path.sep}`), true);
+    const receiptPath = path.join(
+      runRoot,
+      'evidence',
+      receiptName(expected.kind, expected.caseId, expected.variant, expected.repetition),
+    );
+    const receipt = JSON.parse(await readFile(receiptPath, 'utf8'));
+    assert.equal(receipt.runId, manifest.runId);
+    assert.equal(receipt.caseId, expected.caseId);
+    assert.equal(receipt.variant, expected.variant);
+    assert.equal(receipt.repetition, expected.repetition);
+    assert.equal(receipt.kind, expected.kind);
+    assert.equal(receipt.targetSkill, manifest.targetSkill);
+    assert.deepEqual(receipt.baseline, manifest.baseline);
+    assert.equal(receipt.packageHash, manifest.packageHashes[expected.variant]);
+    assert.equal(receipt.model, manifest.runConfiguration.model);
+    assert.equal(receipt.sessionIdentity, manifest.runConfiguration.sessionIdentity);
+    assert.equal(Number.isInteger(receipt.durationMs) && receipt.durationMs >= 0, true);
+    for (const evidence of [receipt.output, receipt.transcript]) {
+      if (evidence === 'unavailable') continue;
+      const bytes = await readFile(path.join(runRoot, evidence.path));
+      assert.equal(bytes.length, evidence.bytes);
+      assert.equal(sha256(bytes), evidence.sha256);
+    }
+  }
+  for (let repetition = 1; repetition <= manifest.runs; repetition += 1) {
+    const pairedReceipts = [];
+    for (const variant of ['candidate', 'baseline']) {
+      const graderId = 'clarity-grader';
+      const gradePath = path.join(
+        runRoot,
+        'evidence',
+        `grade.qualitative-check.${variant}.${repetition}.${graderId}.json`,
+      );
+      const grade = JSON.parse(await readFile(gradePath, 'utf8'));
+      assert.deepEqual(Object.keys(grade).sort(), [
+        'anonymizedOutputId', 'assertionId', 'caseId', 'completionStatus', 'error',
+        'graderId', 'input', 'pass', 'rationale', 'receipt', 'repetition', 'runId', 'schemaVersion',
+      ]);
+      assert.equal(Object.hasOwn(grade, 'variant'), false);
+      const receiptBytes = await readFile(path.join(runRoot, grade.receipt.path));
+      assert.equal(sha256(receiptBytes), grade.receipt.sha256);
+      const graderReceipt = JSON.parse(receiptBytes);
+      assert.equal(graderReceipt.kind, 'grader');
+      assert.equal(graderReceipt.variant, variant);
+      assert.equal(graderReceipt.completionStatus, 'complete');
+      assert.equal(
+        Boolean(graderReceipt.model) !== Boolean(graderReceipt.sessionIdentity),
+        true,
+        'grader receipt requires exactly one concrete completion identity',
+      );
+      pairedReceipts.push(graderReceipt);
+    }
+    for (const field of ['host', 'runner', 'model', 'sessionIdentity', 'tier', 'effort']) {
+      assert.equal(pairedReceipts[0][field], pairedReceipts[1][field],
+        `paired grader receipt mismatch at ${field}`);
+    }
+  }
+}
+NODE
+
+mkfifo "$TMP_ROOT/fifo-output/outputs/fifo"
+
+if [ ! -f "$AGGREGATOR" ]; then
+  fail "aggregate.mjs is missing (expected Red: deterministic aggregate fixtures self-validated)"
+fi
+
+"$NODE" --input-type=module - "$SCRIPT_DIR/../aggregate/core.mjs" \
+  "$SCRIPT_DIR/../../references/schemas.md" <<'NODE'
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const [implementationPath, schemaPath] = process.argv.slice(2);
+const implementation = await readFile(implementationPath, 'utf8');
+const schemas = await readFile(schemaPath, 'utf8');
+const codeBlock = implementation.match(
+  /const AGGREGATE_ERROR_CODES = new Set\(\[([\s\S]*?)\]\);/,
+);
+assert.notEqual(codeBlock, null, 'aggregate must declare its emitted error-code set');
+const emitted = new Set(
+  [...codeBlock[1].matchAll(/'([a-z0-9]+(?:-[a-z0-9]+)*)'/g)].map((match) => match[1]),
+);
+const documented = new Set(
+  [...schemas.matchAll(/^\| `([a-z0-9]+(?:-[a-z0-9]+)*)` \|/gm)].map((match) => match[1]),
+);
+assert.deepEqual(
+  [...emitted].filter((code) => !documented.has(code)),
+  [],
+  'every implementation-emitted aggregate error code must be documented',
+);
+NODE
+
+INVOCATION=0
+STATUS=0
+STDOUT_FILE=
+STDERR_FILE=
+
+run_aggregate() {
+  run_name=$1
+  shift
+  INVOCATION=$((INVOCATION + 1))
+  STDOUT_FILE="$TMP_ROOT/stdout.$INVOCATION"
+  STDERR_FILE="$TMP_ROOT/stderr.$INVOCATION"
+  set +e
+  "$NODE" "$AGGREGATOR" \
+    --manifest "$TMP_ROOT/$run_name/manifest.json" \
+    --evidence "$TMP_ROOT/$run_name/evidence" \
+    --out "$TMP_ROOT/$run_name/aggregate.json" \
+    "$@" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+  STATUS=$?
+  set -e
+  [ "$STATUS" -eq 0 ] || {
+    cat "$STDERR_FILE" >&2
+    fail "$run_name: aggregate command exited $STATUS"
+  }
+  [ ! -s "$STDOUT_FILE" ] || fail "$run_name: aggregate command must not print success prose"
+  [ -f "$TMP_ROOT/$run_name/aggregate.json" ] || fail "$run_name: aggregate.json was not written"
+}
+
+assert_external_path_rejected() {
+  label=$1
+  evidence_path=$2
+  output_path=$3
+  expected_message=$4
+  INVOCATION=$((INVOCATION + 1))
+  STDOUT_FILE="$TMP_ROOT/stdout.$INVOCATION"
+  STDERR_FILE="$TMP_ROOT/stderr.$INVOCATION"
+  set +e
+  "$NODE" "$AGGREGATOR" \
+    --manifest "$TMP_ROOT/complete/manifest.json" \
+    --evidence "$evidence_path" \
+    --out "$output_path" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+  STATUS=$?
+  set -e
+  [ "$STATUS" -ne 0 ] || fail "$label: aggregate must reject a path outside the run root"
+  [ ! -e "$output_path" ] || fail "$label: rejected aggregate must not publish output"
+  case "$(cat "$STDERR_FILE")" in
+    *"$expected_message"*) ;;
+    *) fail "$label: aggregate did not report the containment failure" ;;
+  esac
+}
+run_bounded_aggregate() {
+  run_name=$1
+  "$NODE" --input-type=module - "$AGGREGATOR" "$TMP_ROOT/$run_name" <<'NODE'
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+const [aggregator, runRoot] = process.argv.slice(2);
+const child = spawn(process.execPath, [
+  aggregator,
+  '--manifest', path.join(runRoot, 'manifest.json'),
+  '--evidence', path.join(runRoot, 'evidence'),
+  '--out', path.join(runRoot, 'aggregate.json'),
+], { stdio: ['ignore', 'pipe', 'pipe'] });
+const stdout = [];
+const stderr = [];
+child.stdout.on('data', (chunk) => stdout.push(chunk));
+child.stderr.on('data', (chunk) => stderr.push(chunk));
+let timedOut = false;
+const timer = setTimeout(() => {
+  timedOut = true;
+  child.kill('SIGKILL');
+}, 5000);
+const [code] = await new Promise((resolve) => {
+  child.once('exit', (...result) => resolve(result));
+});
+clearTimeout(timer);
+assert.equal(timedOut, false, 'aggregate blocked while opening FIFO evidence');
+assert.equal(code, 0, Buffer.concat(stderr).toString('utf8'));
+assert.equal(Buffer.concat(stdout).length, 0);
+NODE
+}
+
+
+assert_no_clobber() {
+  run_name=$1
+  aggregate_path="$TMP_ROOT/$run_name/aggregate.json"
+  before=$(cksum <"$aggregate_path")
+  INVOCATION=$((INVOCATION + 1))
+  STDOUT_FILE="$TMP_ROOT/stdout.$INVOCATION"
+  STDERR_FILE="$TMP_ROOT/stderr.$INVOCATION"
+  set +e
+  "$NODE" "$AGGREGATOR" \
+    --manifest "$TMP_ROOT/$run_name/manifest.json" \
+    --evidence "$TMP_ROOT/$run_name/evidence" \
+    --out "$aggregate_path" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+  STATUS=$?
+  set -e
+  [ "$STATUS" -ne 0 ] || fail "$run_name: aggregate output must be create-new"
+  [ ! -s "$STDOUT_FILE" ] || fail "$run_name: failed output write must not print success prose"
+  [ "$(cksum <"$aggregate_path")" = "$before" ] ||
+    fail "$run_name: failed output write changed the existing aggregate"
+  [ "$(wc -c <"$STDERR_FILE")" -le 512 ] ||
+    fail "$run_name: failed output write diagnostic is not bounded"
+  for temp_path in "$TMP_ROOT/$run_name"/.aggregate.json.*.tmp; do
+    [ ! -e "$temp_path" ] || fail "$run_name: failed output write left a temp file"
+  done
+}
+
+assert_snapshot_rejected() {
+  run_name=$1
+  mutation=$2
+  "$NODE" --input-type=module - "$AGGREGATOR" "$TMP_ROOT/$run_name" "$mutation" <<'NODE'
+import assert from 'node:assert/strict';
+import { open, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [aggregatorPath, runRoot, mutation] = process.argv.slice(2);
+const { aggregate } = await import(pathToFileURL(aggregatorPath).href);
+const target = path.join(runRoot, 'definitions', 'snapshot-target.json');
+let running = true;
+let iteration = 0;
+const mutator = (async () => {
+  while (running) {
+    const bytes = `${iteration % 2 === 0 ? 'b' : 'c'}${'a'.repeat((256 * 1024) - 1)}\n`;
+    if (mutation === 'replacement') {
+      const temporary = path.join(path.dirname(runRoot), `.snapshot-replacement-${process.pid}`);
+      await writeFile(temporary, bytes);
+      await rename(temporary, target);
+    } else {
+      const handle = await open(target, 'r+');
+      try {
+        await handle.writeFile(bytes);
+        await handle.sync();
+      } finally {
+        await handle.close();
+      }
+    }
+    iteration += 1;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+})();
+
+let failure;
+try {
+  await aggregate({
+    manifest: path.join(runRoot, 'manifest.json'),
+    evidence: path.join(runRoot, 'evidence'),
+    out: path.join(runRoot, 'aggregate.json'),
+  });
+} catch (error) {
+  failure = error;
+} finally {
+  running = false;
+  await mutator;
+}
+assert.equal(failure?.code, 'snapshot-mutation');
+assert.equal(failure?.field, '');
+assert.equal(
+  ['', 'definitions', 'definitions/snapshot-target.json'].includes(failure?.path),
+  true,
+);
+NODE
+  [ ! -e "$TMP_ROOT/$run_name/aggregate.json" ] ||
+    fail "$run_name: snapshot mutation must prevent publication"
+}
+
+assert_snapshot_limit() {
+  run_name=$1
+  expected_path_prefix=$2
+  "$NODE" --input-type=module - "$AGGREGATOR" "$TMP_ROOT/$run_name" "$expected_path_prefix" <<'NODE'
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [aggregatorPath, runRoot, expectedPathPrefix] = process.argv.slice(2);
+const { aggregate } = await import(pathToFileURL(aggregatorPath).href);
+let failure;
+try {
+  await aggregate({
+    manifest: path.join(runRoot, 'manifest.json'),
+    evidence: path.join(runRoot, 'evidence'),
+    out: path.join(runRoot, 'aggregate.json'),
+  });
+} catch (error) {
+  failure = error;
+}
+assert.equal(failure?.code, 'snapshot-limit-exceeded');
+assert.equal(failure?.field, '');
+assert.equal(failure?.path.startsWith(expectedPathPrefix), true);
+await assert.rejects(
+  readFile(path.join(runRoot, 'aggregate.json')),
+  (error) => error?.code === 'ENOENT',
+);
+NODE
+}
+
+assert_rejected_manifest() {
+  run_name=$1
+  expected_diagnostic=${2:-}
+  INVOCATION=$((INVOCATION + 1))
+  STDOUT_FILE="$TMP_ROOT/stdout.$INVOCATION"
+  STDERR_FILE="$TMP_ROOT/stderr.$INVOCATION"
+  set +e
+  "$NODE" "$AGGREGATOR" \
+    --manifest "$TMP_ROOT/$run_name/manifest.json" \
+    --evidence "$TMP_ROOT/$run_name/evidence" \
+    --out "$TMP_ROOT/$run_name/aggregate.json" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+  STATUS=$?
+  set -e
+  [ "$STATUS" -ne 0 ] || fail "$run_name: invalid manifest must fail"
+  [ ! -e "$TMP_ROOT/$run_name/aggregate.json" ] ||
+    fail "$run_name: invalid manifest must not write an aggregate"
+  [ ! -s "$STDOUT_FILE" ] || fail "$run_name: invalid manifest must not print success prose"
+  [ -s "$STDERR_FILE" ] || fail "$run_name: invalid manifest must emit bounded diagnostics"
+  [ "$(wc -c <"$STDERR_FILE")" -le 512 ] || fail "$run_name: diagnostics are not bounded"
+  if [ -n "$expected_diagnostic" ]; then
+    [ "$(cat "$STDERR_FILE")" = "aggregate: $expected_diagnostic" ] ||
+      fail "$run_name: unexpected manifest diagnostic"
+  fi
+}
+
+assert_aggregate() {
+  run_name=$1
+  assertion=$2
+  "$NODE" --input-type=module - "$TMP_ROOT/$run_name/aggregate.json" "$assertion" <<'NODE'
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const [aggregatePath, assertion] = process.argv.slice(2);
+const runRoot = path.dirname(aggregatePath);
+const aggregate = JSON.parse(await readFile(aggregatePath, 'utf8'));
+assert.deepEqual(Object.keys(aggregate).sort(), [
+  'baseline', 'cases', 'evidenceErrors', 'executionStatus', 'overall',
+  'runId', 'runs', 'schemaVersion', 'targetSkill',
+]);
+assert.equal(aggregate.schemaVersion, 1);
+assert.equal(aggregate.runId, '20260715T120000Z-4242');
+assert.equal(aggregate.targetSkill, 'woostack-example');
+const expectedBaseline = assertion === 'no-baseline-package'
+  ? {
+      kind: 'none',
+      identity: '0123456789abcdef0123456789abcdef01234567:absent',
+    }
+  : {
+      kind: 'git-ref',
+      identity: '0123456789abcdef0123456789abcdef01234567',
+    };
+assert.deepEqual(aggregate.baseline, expectedBaseline);
+assert.equal(Array.isArray(aggregate.cases), true);
+assert.equal(Array.isArray(aggregate.evidenceErrors), true);
+assert.deepEqual(
+  aggregate.cases
+    .map((entry) => `${entry.caseId}|${entry.kind}`)
+    .sort(),
+  [
+    'negative-trigger|trigger',
+    'objective-check|behavior',
+    'positive-trigger|trigger',
+    'qualitative-check|behavior',
+  ],
+  'aggregate cases must have the exact manifest membership and kinds',
+);
+
+function caseResult(caseId) {
+  const matches = aggregate.cases.filter((entry) => entry.caseId === caseId);
+  assert.equal(matches.length, 1, `expected exactly one aggregate case ${caseId}`);
+  return matches[0];
+}
+
+function repetition(caseId, variant, number = 1) {
+  const entry = caseResult(caseId);
+  assert.equal(Array.isArray(entry[variant]), true, `${caseId}.${variant} must be an array`);
+  const matches = entry[variant].filter((result) => result.repetition === number);
+  assert.equal(matches.length, 1, `expected ${caseId}.${variant} repetition ${number}`);
+  return matches[0];
+}
+
+function assertionResult(caseId, variant, assertionId, number = 1) {
+  const result = repetition(caseId, variant, number);
+  assert.equal(Array.isArray(result.assertions), true);
+  const matches = result.assertions.filter((entry) => entry.assertionId === assertionId);
+  assert.equal(matches.length, 1, `expected assertion ${assertionId}`);
+  return matches[0];
+}
+
+function assertExactErrors(expected) {
+  const normalized = aggregate.evidenceErrors.map((error) => {
+    assert.deepEqual(Object.keys(error).sort(), ['code', 'field', 'message', 'path']);
+    assert.equal(typeof error.message, 'string');
+    assert.notEqual(error.message.length, 0);
+    return { code: error.code, field: error.field, path: error.path };
+  });
+  assert.deepEqual(normalized, expected, 'evidenceErrors must contain only the canonical fault');
+}
+
+function assertExactRepetitions(count) {
+  const expected = Array.from({ length: count }, (_, index) => index + 1);
+  for (const entry of aggregate.cases) {
+    for (const variant of ['candidate', 'baseline']) {
+      assert.deepEqual(
+        entry[variant].map((result) => result.repetition).sort((a, b) => a - b),
+        expected,
+        `${entry.caseId}.${variant} repetition set`,
+      );
+    }
+  }
+}
+
+function assertBlockedMetricsAndProof() {
+  assert.equal(aggregate.executionStatus, 'blocked');
+  for (const metric of [
+    'objectivePassRate', 'durationMs', 'tokenUsage', 'triggerPrecision', 'triggerRecall',
+  ]) {
+    assert.equal(aggregate.overall[metric], 'unavailable', `blocked ${metric}`);
+  }
+  for (const variant of ['candidate', 'baseline']) {
+    const proven = repetition('positive-trigger', variant);
+    assert.equal(proven.completionStatus, 'complete');
+    assert.equal(
+      proven.receipt.path,
+      `evidence/action.trigger.positive-trigger.${variant}.1.json`,
+    );
+  }
+}
+
+function assertBlindGrade(variant, number = 1) {
+  const result = repetition('qualitative-check', variant, number);
+  const leaked = result.assertions?.some((entry) =>
+    entry.assertionId === 'clear-handoff' && (entry.pass !== null || entry.rationale !== null));
+  assert.notEqual(leaked, true, `invalid paired grader proof must not unblind ${variant} grade`);
+}
+
+async function identity(relativePath) {
+  const bytes = await readFile(path.join(runRoot, relativePath));
+  return {
+    path: relativePath,
+    sha256: `sha256:${createHash('sha256').update(bytes).digest('hex')}`,
+  };
+}
+
+async function assertGradeProof(variant, number = 1) {
+  const result = assertionResult('qualitative-check', variant, 'clear-handoff', number);
+  const gradePath = `evidence/grade.qualitative-check.${variant}.${number}.clarity-grader.json`;
+  const receiptPath = `evidence/action.grader.qualitative-check.${variant}.${number}.clarity-grader.json`;
+  assert.deepEqual(result.grade, await identity(gradePath));
+  assert.deepEqual(result.graderReceipt, await identity(receiptPath));
+  return result;
+}
+
+if (assertion === 'complete') {
+  assert.equal(aggregate.executionStatus, 'complete', 'assertion failures are not execution failure');
+  assert.equal(aggregate.runs, 2);
+  assert.deepEqual(aggregate.evidenceErrors, []);
+  assertExactRepetitions(2);
+  assert.deepEqual(aggregate.overall.objectivePassRate, { candidate: 1, baseline: 0.5, delta: 0.5 });
+  assert.deepEqual(aggregate.overall.criticalFailures, [{
+    caseId: 'objective-check',
+    assertionId: 'candidate-gain',
+    repetitions: { candidate: [], baseline: [1, 2] },
+  }]);
+  assert.deepEqual(aggregate.overall.durationMs, {
+    candidate: { mean: 150, variance: 2500 },
+    baseline: { mean: 400, variance: 10000 },
+    delta: -250,
+  });
+  assert.equal(aggregate.overall.tokenUsage, 'unavailable');
+  assert.deepEqual(aggregate.overall.triggerPrecision, {
+    candidate: 0.5,
+    baseline: 'unavailable',
+    delta: 'unavailable',
+  });
+  assert.deepEqual(aggregate.overall.triggerRecall, { candidate: 1, baseline: 0, delta: 1 });
+
+  for (let number = 1; number <= 2; number += 1) {
+    assert.equal(assertionResult('objective-check', 'candidate', 'candidate-gain', number).pass, true);
+    assert.equal(assertionResult('objective-check', 'baseline', 'candidate-gain', number).pass, false);
+    assert.equal(
+      assertionResult('objective-check', 'candidate', 'shared-observation', number).pass,
+      true,
+    );
+    assert.equal(
+      assertionResult('objective-check', 'baseline', 'shared-observation', number).pass,
+      true,
+    );
+    for (const variant of ['candidate', 'baseline']) {
+      const grade = assertionResult('qualitative-check', variant, 'clear-handoff', number);
+      const gradePath =
+        `evidence/grade.qualitative-check.${variant}.${number}.clarity-grader.json`;
+      const receiptPath = `evidence/action.grader.qualitative-check.${variant}.${number}.clarity-grader.json`;
+      assert.deepEqual(grade.grade, await identity(gradePath));
+      assert.deepEqual(grade.graderReceipt, await identity(receiptPath));
+      assert.equal(Object.hasOwn(grade, 'anonymizedOutputId'), true);
+      assert.equal(grade.pass, variant === 'baseline');
+      assert.equal(
+        grade.rationale,
+        variant === 'candidate'
+          ? 'The handoff does not identify a next action.'
+          : 'The handoff names the required next action.',
+      );
+    }
+  }
+  assert.notDeepEqual(
+    [
+      assertionResult('qualitative-check', 'candidate', 'clear-handoff').pass,
+      assertionResult('qualitative-check', 'baseline', 'clear-handoff').pass,
+    ],
+    [
+      assertionResult('objective-check', 'candidate', 'candidate-gain').pass,
+      assertionResult('objective-check', 'baseline', 'candidate-gain').pass,
+    ],
+    'opposite qualitative outcomes must not affect objective rates',
+  );
+  assert.equal(repetition('positive-trigger', 'candidate').completionStatus, 'complete');
+  assert.equal(repetition('negative-trigger', 'baseline').completionStatus, 'complete');
+} else if (assertion === 'one-run') {
+  assert.equal(aggregate.executionStatus, 'complete');
+  assert.equal(aggregate.runs, 1);
+  assertExactRepetitions(1);
+  assert.deepEqual(aggregate.overall.durationMs, {
+    candidate: { mean: 100, variance: 'unavailable' },
+    baseline: { mean: 300, variance: 'unavailable' },
+    delta: -200,
+  });
+  for (const entry of aggregate.cases) {
+    assert.equal(entry.durationMs.candidate.variance, 'unavailable');
+    assert.equal(entry.durationMs.baseline.variance, 'unavailable');
+  }
+} else if (assertion === 'token-usage') {
+  assert.equal(aggregate.executionStatus, 'complete');
+  assert.deepEqual(aggregate.evidenceErrors, []);
+  assert.deepEqual(aggregate.overall.tokenUsage, {
+    candidate: {
+      input: { mean: 40, variance: 'unavailable' },
+      output: { mean: 20, variance: 'unavailable' },
+      total: { mean: 60, variance: 'unavailable' },
+    },
+    baseline: {
+      input: { mean: 32, variance: 'unavailable' },
+      output: { mean: 16, variance: 'unavailable' },
+      total: { mean: 48, variance: 'unavailable' },
+    },
+    delta: { input: 8, output: 4, total: 12 },
+  });
+  for (const entry of aggregate.cases) {
+    assert.deepEqual(entry.candidate[0].tokenUsage, { input: 10, output: 5, total: 15 });
+    assert.deepEqual(entry.baseline[0].tokenUsage, { input: 8, output: 4, total: 12 });
+  }
+} else if (assertion === 'objective-assertion-kinds') {
+  assert.equal(aggregate.executionStatus, 'complete');
+  assert.deepEqual(aggregate.evidenceErrors, []);
+  const passing = [
+    'final-excludes-pass',
+    'receipt-field-pass',
+    'path-absent-pass',
+    'path-exists-pass',
+    'file-contains-pass',
+    'file-excludes-pass',
+    'json-path-pass',
+  ];
+  const failing = [
+    'final-excludes-fail',
+    'receipt-field-fail',
+    'path-absent-fail',
+    'file-contains-fail',
+    'file-contains-missing',
+    'file-excludes-fail',
+    'file-excludes-missing',
+    'json-path-mismatch',
+    'json-path-missing',
+    'json-path-malformed',
+  ];
+  for (const variant of ['candidate', 'baseline']) {
+    for (const assertionId of passing) {
+      assert.equal(
+        assertionResult('objective-check', variant, assertionId).pass,
+        true,
+        `${assertionId} must pass for ${variant}`,
+      );
+    }
+    for (const assertionId of failing) {
+      assert.equal(
+        assertionResult('objective-check', variant, assertionId).pass,
+        false,
+        `${assertionId} must fail for ${variant}`,
+      );
+    }
+  }
+} else if (assertion === 'partial') {
+  assertBlockedMetricsAndProof();
+  assertExactErrors([{
+    code: 'missing-receipt',
+    field: '',
+    path: 'evidence/action.behavior.objective-check.candidate.1.json',
+  }]);
+  assertExactRepetitions(1);
+  for (const [caseId, kind] of [
+    ['objective-check', 'behavior'],
+    ['qualitative-check', 'behavior'],
+    ['positive-trigger', 'trigger'],
+    ['negative-trigger', 'trigger'],
+  ]) {
+    for (const variant of ['candidate', 'baseline']) {
+      if (caseId === 'objective-check' && variant === 'candidate') continue;
+      const result = repetition(caseId, variant);
+      assert.equal(result.completionStatus, 'complete');
+      const receiptPath = `evidence/action.${kind}.${caseId}.${variant}.1.json`;
+      assert.deepEqual(result.receipt, await identity(receiptPath));
+    }
+  }
+  const missing = repetition('objective-check', 'candidate');
+  assert.deepEqual(
+    Object.keys(missing).sort(),
+    ['assertions', 'completionStatus', 'receipt', 'repetition'],
+    'missing expected identity must have one explicit blocked/absent result',
+  );
+  assert.equal(missing.completionStatus, 'blocked');
+  assert.equal(missing.receipt, null);
+  assert.deepEqual(missing.assertions, []);
+  assert.equal(assertionResult('objective-check', 'baseline', 'candidate-gain').pass, false);
+  assert.equal(assertionResult('objective-check', 'baseline', 'shared-observation').pass, true);
+  assert.equal((await assertGradeProof('candidate')).pass, false);
+  assert.equal((await assertGradeProof('baseline')).pass, true);
+} else if (assertion === 'smoke') {
+  assert.equal(aggregate.executionStatus, 'degraded');
+  assert.equal(aggregate.overall.objectivePassRate, 'unavailable');
+  assert.equal(aggregate.overall.durationMs, 'unavailable');
+  assert.equal(aggregate.overall.tokenUsage, 'unavailable');
+  assert.equal(aggregate.overall.triggerPrecision, 'unavailable');
+  assert.equal(aggregate.overall.triggerRecall, 'unavailable');
+  assert.equal(repetition('objective-check', 'candidate').completionStatus, 'complete');
+  assert.deepEqual(caseResult('objective-check').baseline, []);
+  assert.deepEqual(aggregate.evidenceErrors, []);
+  assertBlindGrade('candidate');
+} else if (assertion === 'smoke-paired-grader') {
+  assert.equal(aggregate.executionStatus, 'degraded');
+  assert.deepEqual(aggregate.evidenceErrors, []);
+  assert.deepEqual(caseResult('qualitative-check').baseline, []);
+  assert.equal((await assertGradeProof('candidate')).pass, false);
+} else if (assertion.startsWith('grader-invalid|')) {
+  const [, code, field, errorPath] = assertion.split('|');
+  assertBlockedMetricsAndProof();
+  assertExactErrors([{ code, field, path: errorPath }]);
+  assertBlindGrade('candidate');
+  assertBlindGrade('baseline');
+} else if (assertion.startsWith('paired-grader-invalid|')) {
+  const [, code, field] = assertion.split('|');
+  assertBlockedMetricsAndProof();
+  assertExactErrors(['baseline', 'candidate'].map((variant) => ({
+    code,
+    field,
+    path: `evidence/action.grader.qualitative-check.${variant}.1.clarity-grader.json`,
+  })));
+  assertBlindGrade('candidate');
+  assertBlindGrade('baseline');
+} else if (assertion.startsWith('qualitative-binding|')) {
+  const [, scenario] = assertion.split('|');
+  assertBlockedMetricsAndProof();
+  const expected = {
+    'swapped-grade-inputs': ['baseline', 'candidate'].map((variant) => ({
+      code: 'grade-input-mismatch',
+      field: '/anonymizedOutputId',
+      path: `evidence/input.qualitative-check.${variant}.1.clarity-grader.json`,
+    })),
+    'duplicate-anonymized-input': [{
+      code: 'anonymized-output-collision',
+      field: '/anonymizedOutputId',
+      path: 'evidence/input.qualitative-check.candidate.1.clarity-grader.json',
+    }],
+    'repeated-anonymized-input': [{
+      code: 'anonymized-output-collision',
+      field: '/anonymizedOutputId',
+      path: 'evidence/input.qualitative-check.candidate.2.clarity-grader.json',
+    }],
+    'cross-case-anonymized-input': [{
+      code: 'anonymized-output-collision',
+      field: '/anonymizedOutputId',
+      path: 'evidence/input.qualitative-check.candidate.1.clarity-grader.json',
+    }],
+    'duplicate-invalid-proof': [{
+      code: 'grade-receipt-hash-mismatch',
+      field: '/receipt/sha256',
+      path: 'evidence/grade.qualitative-check.baseline.1.clarity-grader.json',
+    }, {
+      code: 'anonymized-output-collision',
+      field: '/anonymizedOutputId',
+      path: 'evidence/input.qualitative-check.candidate.1.clarity-grader.json',
+    }],
+    'duplicate-orphan-mapping': [{
+      code: 'unknown-receipt',
+      field: '',
+      path: 'evidence/input.qualitative-check.candidate.1.orphan-grader.json',
+    }, {
+      code: 'anonymized-output-collision',
+      field: '/anonymizedOutputId',
+      path: 'evidence/input.qualitative-check.candidate.1.orphan-grader.json',
+    }],
+    'wrong-source-grade-input': [{
+      code: 'grade-input-mismatch',
+      field: '/source',
+      path: 'evidence/input.qualitative-check.candidate.1.clarity-grader.json',
+    }],
+    'different-valid-grader-ids': [{
+      code: 'identity-mismatch',
+      field: '/graderId',
+      path: 'evidence/grade.qualitative-check.baseline.1.alternate-grader.json',
+    }],
+    'mismatched-grading-plan': ['baseline', 'candidate'].map((variant) => ({
+      code: 'identity-mismatch',
+      field: '/graderId',
+      path: `evidence/grade.qualitative-check.${variant}.1.clarity-grader.json`,
+    })),
+  }[scenario];
+  assertExactErrors(expected);
+  assertBlindGrade('candidate');
+  assertBlindGrade('baseline');
+  if (scenario === 'repeated-anonymized-input') {
+    assertBlindGrade('candidate', 2);
+    assertBlindGrade('baseline', 2);
+  }
+  if (scenario === 'cross-case-anonymized-input') {
+    for (const variant of ['candidate', 'baseline']) {
+      const objectiveGrade =
+        assertionResult('objective-check', variant, 'cross-case-grade');
+      assert.equal(objectiveGrade.pass, null);
+      assert.equal(objectiveGrade.rationale, null);
+    }
+  }
+} else if (assertion === 'orphan-grade') {
+  assertBlockedMetricsAndProof();
+  assertExactErrors([{
+    code: 'missing-grade-receipt',
+    field: '/receipt/path',
+    path: 'evidence/grade.qualitative-check.candidate.1.clarity-grader.json',
+  }]);
+  assertBlindGrade('candidate');
+  assertBlindGrade('baseline');
+} else if (assertion === 'distinct-graders') {
+  assert.equal(aggregate.executionStatus, 'complete');
+  assert.deepEqual(aggregate.evidenceErrors, []);
+  for (const variant of ['candidate', 'baseline']) {
+    assert.equal(
+      assertionResult('qualitative-check', variant, 'second-grade').pass,
+      true,
+    );
+  }
+} else if (assertion === 'missing-second-grade') {
+  assertBlockedMetricsAndProof();
+  assertExactErrors([{
+    code: 'missing-receipt',
+    field: '',
+    path: 'evidence/grade.qualitative-check.baseline.1.context-grader.json',
+  }, {
+    code: 'missing-receipt',
+    field: '',
+    path: 'evidence/grade.qualitative-check.candidate.1.context-grader.json',
+  }]);
+} else if (assertion === 'path-directory') {
+  assert.equal(aggregate.executionStatus, 'complete');
+  assert.equal(
+    assertionResult('objective-check', 'candidate', 'directory-is-not-regular').pass,
+    false,
+  );
+  assert.equal(
+    assertionResult('objective-check', 'baseline', 'directory-is-not-regular').pass,
+    false,
+  );
+} else if (assertion === 'no-baseline-package') {
+  assert.equal(aggregate.executionStatus, 'complete');
+  assert.deepEqual(aggregate.evidenceErrors, []);
+  assert.equal(assertionResult('objective-check', 'baseline', 'candidate-gain').pass, false);
+  assert.equal(assertionResult('objective-check', 'baseline', 'shared-observation').pass, true);
+} else if (assertion === 'two-faults') {
+  assertBlockedMetricsAndProof();
+  assertExactErrors([{
+    code: 'output-hash-mismatch',
+    field: '/output/sha256',
+    path: 'evidence/action.behavior.objective-check.candidate.1.json',
+  }, {
+    code: 'incomplete-receipt',
+    field: '/completionStatus',
+    path: 'evidence/action.trigger.negative-trigger.baseline.1.json',
+  }]);
+} else {
+  const [status, code, field, errorPath] = assertion.split('|');
+  assert.equal(status, 'blocked');
+  assertBlockedMetricsAndProof();
+  assertExactErrors([{ code, field, path: errorPath }]);
+}
+NODE
+}
+
+run_aggregate complete
+assert_aggregate complete complete
+assert_no_clobber complete
+assert_external_path_rejected \
+  outside-evidence \
+  "$TMP_ROOT/one-run/evidence" \
+  "$TMP_ROOT/complete/outside-evidence.json" \
+  'evidence directory must be contained by the run root'
+assert_external_path_rejected \
+  outside-output \
+  "$TMP_ROOT/complete/evidence" \
+  "$TMP_ROOT/outside-output.json" \
+  'output must be contained by the run root'
+"$NODE" --input-type=module - "$AGGREGATOR" "$TMP_ROOT/publication-rollback" <<'NODE'
+import assert from 'node:assert/strict';
+import { chmod, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [aggregatorPath, root] = process.argv.slice(2);
+const { writeCreateNew } = await import(pathToFileURL(aggregatorPath).href);
+await mkdir(root, { mode: 0o700 });
+const out = path.join(root, 'aggregate.json');
+let syncCalls = 0;
+await assert.rejects(
+  writeCreateNew(out, { attempt: 1 }, {
+    syncDirectory: async (handle) => {
+      syncCalls += 1;
+      if (syncCalls === 1) throw new Error('injected directory sync failure');
+      await handle.sync();
+    },
+  }),
+  /injected directory sync failure/,
+);
+await assert.rejects(readFile(out), (error) => error?.code === 'ENOENT');
+assert.deepEqual(await readdir(root), []);
+await writeCreateNew(out, { attempt: 2 });
+assert.deepEqual(JSON.parse(await readFile(out, 'utf8')), { attempt: 2 });
+
+const publicParent = path.join(root, 'public-parent');
+await mkdir(publicParent, { mode: 0o700 });
+await chmod(publicParent, 0o755);
+await assert.rejects(
+  writeCreateNew(path.join(publicParent, 'aggregate.json'), { attempt: 'public' }),
+  /publication parent must be an owner-private non-symlink directory/,
+);
+assert.deepEqual(await readdir(publicParent), []);
+
+const symlinkTarget = path.join(root, 'symlink-target');
+const symlinkParent = path.join(root, 'symlink-parent');
+await mkdir(symlinkTarget, { mode: 0o700 });
+await symlink('symlink-target', symlinkParent);
+await assert.rejects(
+  writeCreateNew(path.join(symlinkParent, 'aggregate.json'), { attempt: 'symlink' }),
+  /publication parent must be an owner-private non-symlink directory/,
+);
+assert.deepEqual(await readdir(symlinkTarget), []);
+
+const rollbackFailureRoot = path.join(root, 'rollback-failure');
+await mkdir(rollbackFailureRoot, { mode: 0o700 });
+let rollbackCloseCalls = 0;
+let rollbackFailure;
+try {
+  await writeCreateNew(
+    path.join(rollbackFailureRoot, 'aggregate.json'),
+    { attempt: 3 },
+    {
+      syncDirectory: async () => {
+        throw new Error('injected persistent directory sync failure');
+      },
+      closeOpenedHandle: async (handle) => {
+        rollbackCloseCalls += 1;
+        await handle.close();
+        if (rollbackCloseCalls === 2) {
+          throw new Error('injected rollback final-handle close failure');
+        }
+      },
+    },
+  );
+} catch (error) {
+  rollbackFailure = error;
+}
+assert.equal(rollbackFailure instanceof AggregateError, true);
+assert.match(rollbackFailure.message, /publication and rollback failed/);
+assert.equal(rollbackFailure.errors.length, 2);
+assert.match(rollbackFailure.message, /injected rollback final-handle close failure/);
+await assert.rejects(
+  readFile(path.join(rollbackFailureRoot, 'aggregate.json')),
+  (error) => error?.code === 'ENOENT',
+);
+assert.deepEqual(await readdir(rollbackFailureRoot), []);
+
+const cleanupFailureRoot = path.join(root, 'cleanup-failure');
+await mkdir(cleanupFailureRoot, { mode: 0o700 });
+let cleanupFailure;
+try {
+  await writeCreateNew(
+    path.join(cleanupFailureRoot, 'aggregate.json'),
+    { attempt: 4 },
+    {
+      removeTemp: async () => {
+        throw new Error('injected temporary-file removal failure');
+      },
+    },
+  );
+} catch (error) {
+  cleanupFailure = error;
+}
+assert.equal(cleanupFailure instanceof AggregateError, true);
+assert.match(cleanupFailure.message, /publication and temporary-file cleanup failed/);
+assert.equal(cleanupFailure.errors.length, 2);
+await assert.rejects(
+  readFile(path.join(cleanupFailureRoot, 'aggregate.json')),
+  (error) => error?.code === 'ENOENT',
+);
+const cleanupEntries = await readdir(cleanupFailureRoot);
+assert.equal(cleanupEntries.length, 1);
+assert.match(cleanupEntries[0], /^\.aggregate\.json\..+\.tmp$/);
+await rm(cleanupFailureRoot, { recursive: true });
+
+const collisionRoot = path.join(root, 'temporary-collision');
+await mkdir(collisionRoot, { mode: 0o700 });
+const collisionOut = path.join(collisionRoot, 'aggregate.json');
+const collisionTemp = path.join(
+  collisionRoot,
+  `.aggregate.json.${process.pid}.0000000000000000.tmp`,
+);
+await writeFile(collisionTemp, 'pre-existing\n', { flag: 'wx', mode: 0o600 });
+await assert.rejects(
+  writeCreateNew(collisionOut, { attempt: 5 }, {
+    randomBytes: () => Buffer.alloc(8),
+  }),
+  (error) => error?.code === 'EEXIST',
+);
+assert.equal(await readFile(collisionTemp, 'utf8'), 'pre-existing\n');
+assert.deepEqual(await readdir(collisionRoot), [path.basename(collisionTemp)]);
+
+const committedCleanupRoot = path.join(root, 'committed-cleanup-failure');
+await mkdir(committedCleanupRoot, { mode: 0o700 });
+const committedOut = path.join(committedCleanupRoot, 'aggregate.json');
+let committedCloseCalls = 0;
+let committedCleanupFailure;
+try {
+  await writeCreateNew(
+    committedOut,
+    { attempt: 6 },
+    {
+      closeOpenedHandle: async (handle) => {
+        committedCloseCalls += 1;
+        await handle.close();
+        if (committedCloseCalls === 2) {
+          throw new Error('injected committed directory-handle close failure');
+        }
+      },
+    },
+  );
+} catch (error) {
+  committedCleanupFailure = error;
+}
+assert.match(
+  committedCleanupFailure?.message,
+  /publication committed but directory-handle cleanup failed/,
+);
+assert.deepEqual(JSON.parse(await readFile(committedOut, 'utf8')), { attempt: 6 });
+assert.deepEqual(await readdir(committedCleanupRoot), ['aggregate.json']);
+await assert.rejects(
+  writeCreateNew(committedOut, { attempt: 7 }),
+  (error) => error?.code === 'EEXIST',
+);
+assert.deepEqual(JSON.parse(await readFile(committedOut, 'utf8')), { attempt: 6 });
+NODE
+
+run_aggregate one-run
+assert_aggregate one-run one-run
+run_aggregate session-identity
+assert_aggregate session-identity one-run
+run_aggregate token-usage
+assert_aggregate token-usage token-usage
+run_aggregate objective-assertion-kinds
+assert_aggregate objective-assertion-kinds objective-assertion-kinds
+run_aggregate distinct-original-package-hash
+assert_aggregate distinct-original-package-hash one-run
+run_aggregate distinct-graders
+assert_aggregate distinct-graders distinct-graders
+for boundary_run in snapshot-file-boundary snapshot-total-boundary snapshot-entry-boundary; do
+  run_aggregate "$boundary_run"
+  assert_aggregate "$boundary_run" one-run
+done
+
+invalid_case() {
+  run_name=$1
+  code=$2
+  field=$3
+  error_path=$4
+  run_aggregate "$run_name"
+  assert_aggregate "$run_name" "blocked|$code|$field|$error_path"
+}
+
+invalid_case duplicate duplicate-receipt '' evidence/duplicate-objective-receipt.json
+invalid_case unknown unknown-receipt /caseId evidence/action.behavior.unknown-case.candidate.1.json
+invalid_case malformed malformed-receipt '' \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case timed-out incomplete-receipt /completionStatus \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case failed incomplete-receipt /completionStatus \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case invalid-action-status identity-mismatch /completionStatus \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case complete-action-error identity-mismatch /error \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case failed-action-null-error identity-mismatch /error \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case failed-action-extra-error-key identity-mismatch /error \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case failed-action-invalid-error-code identity-mismatch /error \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case failed-action-unsanitized-message identity-mismatch /error \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case model-mismatch configuration-mismatch /model \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case tier-mismatch configuration-mismatch /tier \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case effort-mismatch configuration-mismatch /effort \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case repetition-mismatch identity-mismatch /repetition \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case identity-mismatch identity-mismatch /runId \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case package-mismatch package-hash-mismatch /packageHash \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case refreshed-baseline-mutation package-hash-mismatch /packageHash \
+  evidence/action.behavior.objective-check.baseline.1.json
+invalid_case corpus-mutation package-hash-mismatch /packageHash \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case missing-duration missing-field /durationMs \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case invalid-started-at identity-mismatch /startedAt \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case unsafe-duration identity-mismatch /durationMs \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case unsafe-token-usage identity-mismatch /tokenUsage \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case unsafe-output-bytes output-bytes-mismatch /output/bytes \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case missing-completion-identity missing-completion-identity /model \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case ambiguous-completion-identity missing-completion-identity /model \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case duplicate-capability identity-mismatch /capabilities \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case missing-output missing-field /output \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case output-hash-mismatch output-hash-mismatch /output/sha256 \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case output-bytes-mismatch output-bytes-mismatch /output/bytes \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case escaping-output unsafe-evidence-path /output/path \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case transcript-hash-mismatch transcript-hash-mismatch /transcript/sha256 \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case transcript-bytes-mismatch transcript-bytes-mismatch /transcript/bytes \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case escaping-transcript unsafe-evidence-path /transcript/path \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case non-regular-transcript non-regular-evidence /transcript/path \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case oversized-output evidence-too-large /output/path \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case non-regular-output non-regular-evidence /output/path \
+  evidence/action.behavior.objective-check.candidate.1.json
+run_bounded_aggregate fifo-output
+assert_aggregate fifo-output \
+  'blocked|non-regular-evidence|/output/path|evidence/action.behavior.objective-check.candidate.1.json'
+if [ -f "$TMP_ROOT/symlink-supported" ]; then
+  invalid_case symlink-output non-regular-evidence /output/path \
+    evidence/action.behavior.objective-check.candidate.1.json
+fi
+invalid_case relocated-receipt unknown-receipt '' \
+  evidence/relocated-objective-receipt.json
+invalid_case extra-output-key malformed-receipt '' \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case extra-transcript-key malformed-receipt '' \
+  evidence/action.behavior.objective-check.candidate.1.json
+invalid_case extra-token-key malformed-receipt '' \
+  evidence/action.behavior.objective-check.candidate.1.json
+
+grader_invalid_case() {
+  run_name=$1
+  code=$2
+  field=$3
+  error_path=$4
+  run_aggregate "$run_name"
+  assert_aggregate "$run_name" "grader-invalid|$code|$field|$error_path"
+}
+
+paired_grader_invalid_case() {
+  run_name=$1
+  code=$2
+  field=$3
+  run_aggregate "$run_name"
+  assert_aggregate "$run_name" "paired-grader-invalid|$code|$field"
+}
+
+qualitative_binding_invalid_case() {
+  run_name=$1
+  run_aggregate "$run_name"
+  assert_aggregate "$run_name" "qualitative-binding|$run_name"
+}
+
+grader_invalid_case grader-failed incomplete-receipt /completionStatus \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-timed-out incomplete-receipt /completionStatus \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-variant-mismatch identity-mismatch /variant \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-package-noncanonical package-hash-mismatch /packageHash \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-package-mismatch package-hash-mismatch /packageHash \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-host-mismatch grader-configuration-mismatch /host \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-runner-mismatch grader-configuration-mismatch /runner \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-model-mismatch grader-configuration-mismatch /model \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-tier-mismatch grader-configuration-mismatch /tier \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-effort-mismatch grader-configuration-mismatch /effort \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-missing-completion-identity missing-completion-identity /model \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+paired_grader_invalid_case paired-grader-wrong-host-type identity-mismatch /host
+paired_grader_invalid_case paired-grader-unknown-capability identity-mismatch /capabilities
+grader_invalid_case grader-output-hash-mismatch output-hash-mismatch /output/sha256 \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-output-bytes-mismatch output-bytes-mismatch /output/bytes \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-escaping-output unsafe-evidence-path /output/path \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case grader-non-regular-output non-regular-evidence /output/path \
+  evidence/action.grader.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case stale-grade-receipt-hash grade-receipt-hash-mismatch /receipt/sha256 \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case unsafe-grade-receipt-path unsafe-evidence-path /receipt/path \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case non-regular-grade-receipt non-regular-evidence /receipt/path \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case extra-grade-receipt-key malformed-receipt '' \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case invalid-grader-id identity-mismatch /graderId \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case invalid-assertion-id identity-mismatch /assertionId \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case invalid-anonymized-output-id identity-mismatch /anonymizedOutputId \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case invalid-grade-status malformed-receipt /completionStatus \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case complete-grade-error malformed-receipt /error \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case failed-grade-null-error malformed-receipt /error \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case failed-grade-invalid-code malformed-receipt /error \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case failed-grade-non-null-pass malformed-receipt /pass \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+grader_invalid_case failed-grade-invalid-receipt-type missing-grade-receipt /receipt/path \
+  evidence/grade.qualitative-check.candidate.1.clarity-grader.json
+qualitative_binding_invalid_case swapped-grade-inputs
+qualitative_binding_invalid_case duplicate-anonymized-input
+qualitative_binding_invalid_case duplicate-invalid-proof
+qualitative_binding_invalid_case duplicate-orphan-mapping
+qualitative_binding_invalid_case repeated-anonymized-input
+qualitative_binding_invalid_case cross-case-anonymized-input
+qualitative_binding_invalid_case wrong-source-grade-input
+qualitative_binding_invalid_case different-valid-grader-ids
+qualitative_binding_invalid_case mismatched-grading-plan
+
+invalid_case malformed-distinct-grader malformed-receipt '' \
+  evidence/grade.qualitative-check.candidate.1.context-grader.json
+invalid_case oversized-distinct-grader evidence-too-large '' \
+  evidence/grade.qualitative-check.candidate.1.context-grader.json
+
+run_aggregate two-faults
+assert_aggregate two-faults two-faults
+
+run_aggregate partial
+assert_aggregate partial partial
+
+# Explicit candidate-only acceptance is encoded by the deliberately candidate-only expected set;
+# no undocumented CLI flag or manifest field is introduced.
+run_aggregate streamed-transcript
+assert_aggregate streamed-transcript one-run
+run_aggregate smoke
+assert_aggregate smoke smoke
+
+run_aggregate smoke-paired-grader
+assert_aggregate smoke-paired-grader smoke-paired-grader
+
+run_aggregate orphan-grade
+assert_aggregate orphan-grade orphan-grade
+
+run_aggregate missing-second-grade
+assert_aggregate missing-second-grade missing-second-grade
+
+run_aggregate path-directory
+assert_aggregate path-directory path-directory
+
+run_aggregate no-baseline-package
+assert_aggregate no-baseline-package no-baseline-package
+
+assert_rejected_manifest mixed-expected
+assert_rejected_manifest baseline-only-expected
+assert_rejected_manifest incomplete-expected
+assert_rejected_manifest invalid-run-id-dot 'manifest identity is invalid'
+assert_rejected_manifest invalid-run-id-dotdot 'manifest identity is invalid'
+assert_rejected_manifest invalid-run-id-long 'manifest identity is invalid'
+assert_rejected_manifest invalid-run-id-type 'manifest identity is invalid'
+assert_rejected_manifest invalid-runs-high 'manifest run selection is invalid'
+assert_rejected_manifest invalid-case-id-long \
+  'manifest contains an invalid expected identity'
+assert_rejected_manifest invalid-baseline-git-ref 'manifest baseline is invalid'
+assert_rejected_manifest invalid-baseline-uppercase-git-ref 'manifest baseline is invalid'
+assert_rejected_manifest invalid-baseline-identity-type 'manifest baseline is invalid'
+assert_rejected_manifest invalid-baseline-path 'manifest baseline is invalid'
+assert_rejected_manifest invalid-baseline-none 'manifest baseline is invalid'
+assert_rejected_manifest invalid-baseline-uppercase-none 'manifest baseline is invalid'
+assert_rejected_manifest manifest-model-empty 'manifest run configuration is invalid'
+assert_rejected_manifest manifest-inactive-empty 'manifest run configuration is invalid'
+assert_rejected_manifest manifest-inactive-wrong-type 'manifest run configuration is invalid'
+assert_rejected_manifest manifest-both-completion-identities \
+  'manifest run configuration is invalid'
+assert_rejected_manifest duplicate-grader-plan \
+  'manifest grading plan contains duplicate grader identities'
+assert_rejected_manifest path-baseline-hash-mismatch 'manifest package hashes are invalid'
+assert_rejected_manifest behavior-mode-with-trigger \
+  'manifest contains an invalid expected identity'
+assert_rejected_manifest triggers-mode-with-behavior \
+  'manifest contains an invalid expected identity'
+assert_rejected_manifest unsafe-smoke-pair \
+  'manifest contains an invalid workspace pair'
+assert_rejected_manifest missing-smoke-baseline-workspace \
+  'manifest baseline workspace objective-check/1 must already exist as a directory'
+assert_rejected_manifest missing-quiescence 'host quiescence proof is missing or unsafe'
+assert_rejected_manifest invalid-quiescence 'host quiescence proof is invalid'
+assert_rejected_manifest public-run-root 'run root must be a private mode-0700 non-symlink directory'
+assert_rejected_manifest missing-repetition \
+  'manifest expected set is incomplete for configured runs'
+assert_rejected_manifest out-of-order-expected \
+  'manifest expected identities are not in canonical order'
+assert_rejected_manifest out-of-order-pairs \
+  'manifest workspace pairs are not in canonical order'
+
+assert_snapshot_rejected snapshot-rewrite rewrite
+assert_snapshot_rejected snapshot-replacement replacement
+assert_snapshot_limit snapshot-file-limit snapshot-file-limit.bin
+assert_snapshot_limit snapshot-total-limit snapshot-total/
+assert_snapshot_limit snapshot-entry-limit snapshot-entry-limit
+
+"$NODE" --input-type=module - "$AGGREGATOR" "$TMP_ROOT/snapshot-directory-swap" <<'NODE'
+import assert from 'node:assert/strict';
+import { rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [aggregatorPath, runRoot] = process.argv.slice(2);
+const safeAccessPath =
+  path.join(path.dirname(aggregatorPath), 'aggregate', 'safe-access.mjs');
+const { buildRunSnapshot } = await import(pathToFileURL(safeAccessPath).href);
+let swapped = false;
+let failure;
+try {
+  await buildRunSnapshot(runRoot, {
+    beforeOpenEntry: async ({ absoluteEntry, relativeEntry }) => {
+      if (swapped || relativeEntry !== 'snapshot-swap-target') return;
+      swapped = true;
+      await rename(absoluteEntry, `${absoluteEntry}.original`);
+      await writeFile(absoluteEntry, Buffer.alloc((16 * 1024 * 1024) + 1));
+    },
+  });
+} catch (error) {
+  failure = error;
+}
+assert.equal(swapped, true);
+assert.equal(failure?.code, 'snapshot-mutation');
+assert.equal(failure?.path, 'snapshot-swap-target');
+NODE
+
+"$NODE" --input-type=module - "$AGGREGATOR" "$TMP_ROOT/snapshot-read-binding" <<'NODE'
+import assert from 'node:assert/strict';
+import { rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [aggregatorPath, runRoot] = process.argv.slice(2);
+const safeAccessPath =
+  path.join(path.dirname(aggregatorPath), 'aggregate', 'safe-access.mjs');
+const {
+  buildRunSnapshot,
+  indexRunSnapshot,
+  regularFile,
+} = await import(pathToFileURL(safeAccessPath).href);
+const relativeTarget = 'evidence/action.behavior.objective-check.candidate.1.json';
+const target = path.join(runRoot, ...relativeTarget.split('/'));
+const snapshot = indexRunSnapshot(await buildRunSnapshot(runRoot));
+await rename(target, `${target}.original`);
+await writeFile(target, '{"schemaVersion":1,"runId":"substituted"}\n');
+await assert.rejects(
+  regularFile(runRoot, relativeTarget, { snapshot }),
+  (error) =>
+    error?.code === 'snapshot-mutation'
+    && error?.path === relativeTarget,
+);
+NODE
+
+"$NODE" --input-type=module - "$AGGREGATOR" "$TMP_ROOT/snapshot-file-limit" <<'NODE'
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const [aggregatorPath, runRoot] = process.argv.slice(2);
+const safeAccessPath =
+  path.join(path.dirname(aggregatorPath), 'aggregate', 'safe-access.mjs');
+const { buildRunSnapshot } = await import(pathToFileURL(safeAccessPath).href);
+let failure;
+try {
+  await buildRunSnapshot(runRoot, {
+    closeOpenedHandle: async (handle, evidencePath) => {
+      await handle.close();
+      if (evidencePath === 'snapshot-file-limit.bin') {
+        throw new Error('injected snapshot file-handle close failure');
+      }
+    },
+  });
+} catch (error) {
+  failure = error;
+}
+assert.equal(failure?.code, 'snapshot-limit-exceeded');
+assert.match(failure.message, /injected snapshot file-handle close failure/);
+assert.equal(failure.cleanupErrors?.length, 1);
+NODE
+
+printf 'PASS: aggregate receipt, grading, assertion, and metric contract\n'


### PR DESCRIPTION
## Goal

Turn prepared skill-evaluation runs into trustworthy aggregate evidence without adding the report-rendering surface yet.

## Summary

- Validate exact manifests and evidence with safe file access, immutable snapshots, and frozen package/definition proof.
- Evaluate deterministic assertions and blinded paired qualitative grades, then calculate trigger metrics and complete, blocked, or degraded outcomes.
- Publish aggregate JSON through durable create-new semantics with focused integrity, grading, metric, and failure-path coverage.

## Test plan

### Automated

- [ ] `bash skills/woostack-eval/scripts/tests/test-aggregate.sh` — PASS

### Manual

**Before merge**

- [ ] Inspect blocked and degraded fixtures to confirm incomplete or mismatched proof never becomes a clean comparison.
- [ ] Confirm qualitative grades remain blind until candidate and baseline mappings plus grader receipts validate.
- [ ] Confirm existing aggregate outputs are never overwritten and publication failures leave no partial final artifact.

Spec: .woostack/specs/2026-07-15-skill-evaluation-optimization.md

## Final stack verification

### Automated

- [ ] `bash skills/woostack-eval/scripts/tests/run-tests.sh` — passed all 9 evaluator script suites.
- [ ] `bash skills/woostack-eval/scripts/tests/test-critical-corpora.sh` — validated exactly 15 required packages.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-package.sh` — passed 45/45.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-package-ci.sh` — passed 18/18.
- [ ] `bash skills/woostack-review/scripts/tests/test-prefetch-skill-small-diff.sh` — passed 19/19.
- [ ] `bash skills/woostack-review/scripts/tests/test-skills-angle-rubric.sh` — passed 28/28.
- [ ] `bash skills/woostack-review/scripts/tests/test-progressive-disclosure.sh` — passed 190/190.
- [ ] `bash skills/woostack-commit/tests/test-linear-attribution.sh` — passed.
- [ ] `bash skills/woostack-commit/tests/test-progressive-disclosure.sh` — passed.
- [ ] `bash skills/woostack-build/tests/test-linear-build-contract.sh` — passed.
- [ ] `bash skills/woostack-build/scripts/tests/test-build-spec-commit-ordering.sh` — passed.
- [ ] `bash skills/woostack-build/scripts/tests/test-progressive-disclosure.sh` — passed 63/63.
- [ ] `bash skills/using-woostack/tests/test-artifact-reader-contract.sh` — passed 12/12.
- [ ] `bash skills/woostack-change/scripts/tests/test-command-surface.sh` — passed 12/12.
- [ ] `bash skills/woostack-respond/scripts/tests/test-command-surface.sh` — passed 15/15.
- [ ] `node --test site/scripts/gen-skills.test.mjs` — passed 14/14.
- [ ] `pnpm -C site build` — passed; 147 static pages generated.

### Comparative model evidence

- [ ] No model-backed old-versus-candidate run was dispatched: this host cannot prove the evaluator's required per-worker capability isolation. Therefore no receipt or report path exists, and no model-eval pass is claimed.
