### PR TITLE
docs: define and plan workflow visualizations

### DIFF
--- a/.woostack/plans/2026-07-16-workflow-visualizations.md
+++ b/.woostack/plans/2026-07-16-workflow-visualizations.md
@@ -1,0 +1,167 @@
+---
+type: plan
+source: .woostack/specs/2026-07-16-workflow-visualizations.md
+status: ready
+branch: feature/workflow-visualizations
+---
+
+**Source:** [[specs/2026-07-16-workflow-visualizations]]
+
+# Workflow Visualizations Implementation Plan
+
+**Goal:** Add one discoverable, accessible workflow-maps page that accurately compares the Bootstrap, Build, Fix, and Change loops.
+
+**Architecture:** Render four typed static workflow definitions through one server-rendered `WorkflowAtlas` component. Semantic HTML owns reading order and meaning; a scoped CSS module turns the ordered content into horizontal desktop rails and vertical mobile rails without client state or a new dependency. The authored MDX page frames the comparison and links back to the canonical generated skill references.
+
+**Tech Stack:** Next.js App Router, React Server Components, TypeScript, MDX/Fumadocs, CSS Modules, Fumadocs theme tokens.
+
+## File structure
+
+- Create `site/components/concepts/workflow-atlas.tsx`: workflow types, four canonical static definitions, legend, and semantic renderer.
+- Create `site/components/concepts/workflow-atlas.module.css`: scoped rail geometry, node/gate/branch/terminal treatments, responsive layout, wrapping, theme compatibility, and focus-visible styling.
+- Create `site/content/docs/concepts/workflows.mdx`: authored comparison page, usage guidance, component import, and canonical skill links.
+- Modify `site/content/docs/concepts/meta.json`: register `workflows` immediately after `building-rules`.
+- Modify `site/content/docs/concepts/index.mdx`: add the Workflow maps discovery card.
+- Modify `site/content/docs/getting-started.mdx`: link the command-selection guidance to Workflow maps.
+- Modify `site/content/docs/concepts/building-rules.mdx`: point readers from the shared Build loop to the four-workflow comparison.
+
+## Increment 1: Add the workflow maps page
+
+> One independently shippable PR, stacked on `feature/workflow-visualizations`. Expected implementation is below the 500 LOC soft target and contains the complete UI, discovery links, and verification.
+
+**Dependencies:** none.
+
+**Git parent:** `feature/workflow-visualizations`.
+
+### Task 1: Build the semantic workflow atlas
+
+**Files:**
+- Create: `site/components/concepts/workflow-atlas.tsx`
+- Create: `site/components/concepts/workflow-atlas.module.css`
+
+- [ ] **Step 1: Confirm the component baseline is absent.**
+  Run: `test -e site/components/concepts/workflow-atlas.tsx`
+  Expected: exit 1 because the component does not exist on the spec+plan base branch.
+
+- [ ] **Step 2: Define the workflow model and canonical content.**
+  In `workflow-atlas.tsx`, define local discriminated types equivalent to:
+  ```ts
+  type StepKind = 'work' | 'gate' | 'handoff' | 'terminal';
+
+  type WorkflowStep = {
+    label: string;
+    detail?: string;
+    kind: StepKind;
+  };
+
+  type WorkflowBranch = {
+    label: string;
+    steps: readonly WorkflowStep[];
+  };
+
+  type Workflow = {
+    id: 'change' | 'fix' | 'build' | 'bootstrap';
+    title: string;
+    useWhen: string;
+    href: string;
+    gateCount: number;
+    steps: readonly WorkflowStep[];
+    branches?: readonly WorkflowBranch[];
+  };
+  ```
+  Populate `readonly Workflow[]` in this order and with these contracts:
+  - Change: classify scope → isolate worktree → implement → verify and smoke-test → two-lens inline review → commit and submit → verify PR and tear down → one reviewed PR; `gateCount: 0` and visible “No approval gate”.
+  - Fix: diagnose root cause → write combined fix plan → harden and commit → approve-to-execute gate; branches are Go → TDD execute → one reviewed PR, Hand off → approved plan PR with no code, Revise → update and re-present the committed plan, and Abandon → close/remove temporary artifacts.
+  - Build: ideate → design approval gate → capture and harden spec → written-spec approval gate → plan/decompose/harden → prepare backend handoff → execution handoff gate; branches are Go → reviewed PR stack, Run overnight → reviewed or truthfully blocked stack plus morning report, and Hand off → ready artifacts with no implementation PR. The prepare-handoff detail names Markdown’s spec+plan base PR and Linear’s project/issues plus frozen base without drawing separate loops.
+  - Bootstrap: gather requirements → live industry research → compare stack options → explicit stack choice → load reference contracts → scaffold and clean boilerplate → verify pipelines and boot surfaces → bootable project.
+  Link each title to `/docs/skills/woostack-change`, `/docs/skills/woostack-fix`, `/docs/skills/woostack-build`, or `/docs/skills/woostack-bootstrap` respectively.
+
+- [ ] **Step 3: Render semantic groups before visual connectors.**
+  Export a named `WorkflowAtlas` function and default export. Render a `<figure>` containing a visible legend and one `<section aria-labelledby>` per workflow. Render the primary sequence as `<ol>` and each branch as a labelled nested `<div>` plus `<ol>`. Include visible `Gate`, `Handoff`, `Outcome`, and `No approval gate` text; set decorative connector elements or pseudo-elements outside the accessibility tree. Keep the component server-rendered: do not add `'use client'`, hooks, event handlers, or runtime data.
+
+- [ ] **Step 4: Style responsive workflow rails.**
+  In the CSS module:
+  - derive foreground, muted foreground, card, border, and primary surfaces from `--color-fd-*` tokens;
+  - define a local amber gate accent with verified readable foreground in light and dark themes;
+  - use shape plus visible labels so color is never the only distinction;
+  - render desktop primary sequences left-to-right with CSS grid/flex and connector pseudo-elements;
+  - render branches as compact continuations that remain visually attached to their decision node;
+  - at a narrow breakpoint, switch every sequence and branch to vertical rails, preserve DOM order, remove horizontal connector assumptions, and avoid horizontal scrolling;
+  - cap node corner radii at 12px, allow long labels to wrap, and use the surrounding docs type scale rather than shrinking diagram text;
+  - add visible `:focus-visible` treatment for skill links and a non-color-only gate marker;
+  - add no animation and change no global stylesheet.
+
+- [ ] **Step 5: Run the component-level type check.**
+  Run: `pnpm -C site types:check`
+  Expected: PASS with no TypeScript, CSS-module, MDX-generation, or Next.js type errors.
+
+### Task 2: Add the authored page and discovery links
+
+**Files:**
+- Create: `site/content/docs/concepts/workflows.mdx`
+- Modify: `site/content/docs/concepts/meta.json`
+- Modify: `site/content/docs/concepts/index.mdx`
+- Modify: `site/content/docs/getting-started.mdx`
+- Modify: `site/content/docs/concepts/building-rules.mdx`
+
+- [ ] **Step 1: Confirm the route baseline is absent.**
+  Run: `test -e site/content/docs/concepts/workflows.mdx`
+  Expected: exit 1 because the authored route does not exist on the spec+plan base branch.
+
+- [ ] **Step 2: Author the workflow comparison page.**
+  Create `workflows.mdx` with frontmatter title `Workflow maps` and a description that names the four compared loops. Import `WorkflowAtlas` from `@/components/concepts/workflow-atlas`. Explain in concise prose that the maps summarize canonical skills and that work steps are not approval gates. Render `<WorkflowAtlas />`, then add a short “Choose the loop” section linking Bootstrap for greenfield creation, Build for multi-PR features, Fix for diagnosed bugs/root-cause work, and Change for bounded non-bug work that fits one PR.
+
+- [ ] **Step 3: Register the page in Core concepts navigation.**
+  Insert `"workflows"` immediately after `"building-rules"` in `site/content/docs/concepts/meta.json`; preserve the existing page order otherwise.
+
+- [ ] **Step 4: Add three bounded discovery links.**
+  - In `concepts/index.mdx`, add one `Workflow maps` card beside Building rules with a description that compares Bootstrap, Build, Fix, and Change.
+  - In `getting-started.mdx`, add one sentence after the Bootstrap/Build/Change/Fix command-selection bullets linking to `/docs/concepts/workflows` for the visual comparison.
+  - In `concepts/building-rules.mdx`, add one sentence after the shared loop introduction linking to Workflow maps for the cross-workflow comparison.
+  Do not copy stage-by-stage operational instructions into these pages.
+
+- [ ] **Step 5: Run the complete production checks.**
+  Run: `pnpm -C site types:check`
+  Expected: PASS.
+  Run: `pnpm -C site build`
+  Expected: PASS with no MDX, CSS-module, TypeScript, or production-rendering error; route behavior is proven by the built-app browser exercise in Task 3.
+
+### Task 3: Exercise the workflow maps as a reader
+
+**Files:**
+- Verify: `site/content/docs/concepts/workflows.mdx`
+- Verify: `site/components/concepts/workflow-atlas.tsx`
+- Verify: `site/components/concepts/workflow-atlas.module.css`
+
+- [ ] **Step 1: Start the built documentation app.**
+  Start `pnpm -C site start --port 4173` through the host’s long-running-process manager after the successful production build and wait for port 4173 to accept connections.
+
+- [ ] **Step 2: Verify the desktop route in both themes.**
+  Open `/docs/concepts/workflows` at 1440×900. Confirm four workflow sections in Change, Fix, Build, Bootstrap order; readable left-to-right rails; visible gate and outcome labels; correct branch attachment; working canonical skill links; no clipped labels; and no document-level horizontal overflow. Toggle light/dark theme and confirm every label and node remains readable.
+
+- [ ] **Step 3: Verify the narrow layout and source order.**
+  Recheck at 390×844. Confirm all rails reflow vertically, branch continuations remain associated with their decision, long labels wrap, the document has no horizontal overflow, and all content remains at the surrounding documentation text scale.
+
+- [ ] **Step 4: Verify accessibility and discovery.**
+  Inspect the browser accessibility tree for four labelled workflow groups, ordered primary steps, labelled branches, visible gate/outcome meaning, and no duplicate announcements from decorative connectors. Keyboard through every skill and discovery link and confirm visible focus. Follow the links from Core concepts, Getting started, and Building rules back to `/docs/concepts/workflows`.
+
+- [ ] **Step 5: Commit the reviewed increment.**
+  Invoke `woostack-commit` from the increment worktree with subject `feat(site): add workflow maps`. The PR body must report both production commands and the desktop/mobile, light/dark, accessibility, focus, and discovery-link browser evidence. Do not merge.
+
+## Acceptance coverage
+
+- **AC1 — discoverability:** Task 2 steps 2–5 and Task 3 step 4.
+- **AC2 — workflow accuracy:** Task 1 steps 2–3 and Task 3 step 2.
+- **AC3 — responsive/theme usability:** Task 1 step 4 and Task 3 steps 2–3.
+- **AC4 — semantic accessibility:** Task 1 steps 3–4 and Task 3 step 4.
+- **AC5 — existing architecture:** Task 1 steps 3–5, Task 2 step 5, and Task 3 step 1.
+
+## Plan checks
+
+- **Spec coverage:** every requirement and non-goal maps to the file structure, implementation tasks, or verification tasks.
+- **AC coverage:** AC1–AC5 each map to concrete implementation and reader-observed verification above.
+- **Premise:** the approved source spec records the user’s explicit request and the current prose-only comparison gap in §1.
+- **No placeholders:** paths, types, content contracts, commands, expected outcomes, breakpoints, and browser viewports are concrete; there are no TBD/TODO markers.
+- **Type consistency:** the component is a Server Component, the static definitions use local readonly discriminated types, and MDX imports the named export.
+- **Angle coverage:** architecture, tests/verification, dependency, i18n, infrastructure, accessibility, and error/edge behavior are addressed. Security, observability, API, and database surfaces remain correctly skipped because no input, network, persistence, or executable workflow action is introduced.
+- **Graph validity:** one independently shippable increment, no dependency cycle, and one representable Git parent (`feature/workflow-visualizations`).

--- a/.woostack/specs/2026-07-16-workflow-visualizations.md
+++ b/.woostack/specs/2026-07-16-workflow-visualizations.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-visualizations
 type: spec
-status: hardened
+status: approved
 date: 2026-07-16
 branch: feature/workflow-visualizations
 links:

--- a/.woostack/specs/2026-07-16-workflow-visualizations.md
+++ b/.woostack/specs/2026-07-16-workflow-visualizations.md
@@ -1,0 +1,92 @@
+---
+name: workflow-visualizations
+type: spec
+status: hardened
+date: 2026-07-16
+branch: feature/workflow-visualizations
+links:
+---
+
+# Workflow Visualizations — Design Spec
+
+> Artifact: `.woostack/specs/2026-07-16-workflow-visualizations.md`. This Markdown file is the source of truth. Render with [spec-template.html](../../../skills/woostack-build/references/spec-template.html) for a rich presentation only.
+
+> `status:` follows the owning-artifact contract in [conventions.md](../../../skills/woostack-status/references/conventions.md).
+
+> **Plan:** [[plans/2026-07-16-workflow-visualizations]]
+
+## 1. Problem
+
+The documentation app explains the Bootstrap, Build, Fix, and Change workflows primarily as prose and inline arrow sequences. The user explicitly requested visualizations of all four loops. Readers currently lack one place to compare each workflow's sequence, approval gates, branch outcomes, and terminal artifact without reconstructing those relationships from separate generated skill references.
+
+## 2. Goal
+
+Add one authored, discoverable workflow-maps page to the documentation app. It must visualize Bootstrap, Build, Fix, and Change accurately; distinguish work steps, approval gates, branches, and terminal artifacts; remain readable on narrow screens and in both themes; and preserve semantic access when styling is unavailable.
+
+## 3. Non-goals
+
+- Rewriting or replacing the generated per-skill reference pages.
+- Changing any workflow, gate, lifecycle, artifact-backend, or worktree contract.
+- Adding client-side state, animation, a diagramming library, or another runtime dependency.
+- Duplicating detailed operational instructions already owned by the canonical `SKILL.md` files.
+- Redesigning the wider documentation site or changing its typography and global theme.
+
+## 4. Approach
+
+Create a dedicated `/docs/concepts/workflows` page backed by a server-rendered `WorkflowAtlas` React component. The component uses typed static definitions for the four workflows and renders semantic ordered lists. A scoped CSS module turns those lists into responsive workflow rails with explicit visual treatments for work steps, gates, branch choices, and terminal outcomes.
+
+The presentation uses Fumadocs theme tokens for its neutral structure and a local, accessible gate accent. Text and shape carry every distinction so color is never the sole signal. Desktop layouts use horizontal rails with compact branches; narrow layouts reflow into vertical rails rather than shrinking labels or introducing horizontal scrolling.
+
+The page orders the workflows from the lightest bounded path to the broadest setup path: Change, Fix, Build, Bootstrap. Each section states when to use the workflow and links to its canonical skill reference. Discovery links are added to the concepts overview, Getting started, and Building rules, and the page is registered in the concepts navigation.
+
+## 5. Components & data flow
+
+- `site/content/docs/concepts/workflows.mdx` owns the page introduction, legend, usage framing, canonical links, and `WorkflowAtlas` placement.
+- `site/components/concepts/workflow-atlas.tsx` owns the typed, static workflow definitions and semantic renderer. It remains a Server Component and introduces no client boundary.
+- `site/components/concepts/workflow-atlas.module.css` owns rail geometry, semantic node treatments, responsive reflow, theme-compatible colors, and focus-visible states.
+- `site/content/docs/concepts/meta.json` registers the authored page in navigation.
+- `site/content/docs/concepts/index.mdx`, `site/content/docs/getting-started.mdx`, and `site/content/docs/concepts/building-rules.mdx` link readers to the comparison page.
+
+The component receives no remote or runtime data. The committed definitions render deterministically during the docs build. Canonical workflow details remain in the four skills; the visualization page summarizes their stable sequence and links back for operational detail.
+
+## 6. Error handling
+
+- If CSS fails or is unavailable, ordered-list structure, node labels, gate labels, branch labels, and terminal outcomes remain readable in source order.
+- Narrow screens use a vertical flow and wrapped labels; no workflow requires horizontal scrolling or scaled-down text.
+- Gate, branch, and terminal meaning is expressed in visible text and semantic grouping, not color alone.
+- Light and dark themes derive surfaces and text from Fumadocs tokens; local accent values must retain readable contrast in both themes.
+- Long labels wrap inside their node rather than overflow or clip.
+- The page does not copy adapter commands or lifecycle implementation details that could drift from the skills.
+
+Security, observability, API, and database error paths are not implicated: this is static, local documentation rendering with no input, network request, persistence, or executable workflow action. The existing documentation source and search configuration are English-only, so this change follows that established copy contract rather than introducing an isolated translation layer. Dependency and infrastructure risk are bounded by adding no package and verifying against the existing typecheck and production-build commands.
+
+## 7. Acceptance criteria
+
+- **AC1 — Readers can discover one workflow comparison page.**
+  - happy: `/docs/concepts/workflows` is present in Core concepts navigation and linked from the concepts overview, Getting started, and Building rules.
+  - error: a missing component or invalid MDX import fails the existing docs typecheck/build rather than producing a partially rendered page.
+  - edge: generated per-skill reference pages remain generated and untouched.
+- **AC2 — The four workflow maps accurately communicate their contracts.**
+  - happy: Bootstrap, Build, Fix, and Change each show their ordered work steps, approval behavior, branches where applicable, and terminal artifact.
+  - error: no gate is implied where the canonical workflow has none, and no branch outcome is presented as execution approval.
+  - edge: Build shows the shared three-gate loop plus the Markdown/Linear pre-execution distinction without duplicating two full diagrams; Fix shows Go, Hand off, Revise, and Abandon; Change explicitly states that it has no approval gate.
+- **AC3 — The maps remain usable across layout and theme boundaries.**
+  - happy: desktop and mobile layouts show readable labels and unambiguous connector order in light and dark themes.
+  - error: styling loss still leaves a coherent ordered textual representation.
+  - edge: long labels wrap without clipping, text does not shrink below the surrounding documentation scale, and the page introduces no horizontal workflow scroll.
+- **AC4 — The maps expose accessible meaning without relying on color.**
+  - happy: workflow groups and ordered steps have meaningful accessible labels, gates and outcomes include visible text, and canonical links have visible keyboard focus.
+  - error: decorative connectors are hidden from assistive technology and do not create duplicate announcements.
+  - edge: the accessibility tree preserves each workflow's source order after responsive reflow.
+- **AC5 — The feature stays within the documentation app's existing architecture.**
+  - happy: the implementation is server-rendered, uses Fumadocs tokens, adds no dependency, and passes the site's existing typecheck and production build.
+  - error: any type, CSS-module, MDX, or production-rendering incompatibility fails verification before submission.
+  - edge: no global theme rule or unrelated docs surface is changed.
+
+## 8. Testing
+
+Run the existing documentation checks with `pnpm -C site types:check` and `pnpm -C site build`. Then launch the documentation app and exercise `/docs/concepts/workflows` in a real browser at desktop and mobile widths, in light and dark themes. Inspect the accessibility tree and keyboard-focus behavior, and confirm every discovery link reaches the page. No new unit or snapshot test is planned because the new contract is static visual/semantic rendering and is better verified through the production build plus browser behavior.
+
+## 9. Open questions
+
+N/A — the approved design settled placement, interaction model, visual semantics, workflow ordering, responsive behavior, and verification strategy.


### PR DESCRIPTION
## Goal

Create an approved, implementation-ready specification and plan for an authored documentation page that compares the Bootstrap, Build, Fix, and Change workflows, including their ordered steps, approval gates, branches, and terminal artifacts, while remaining responsive, theme-compatible, and semantically accessible.

## Summary

- Advance the hardened workflow-visualizations specification to approved after written-spec approval.
- Add a ready implementation plan for the server-rendered workflow atlas, authored page, scoped styling, navigation, discovery links, and reader-focused verification.
- Decompose the complete feature into one coherent, independently shippable implementation increment below the 500 LOC soft target, with concrete tasks and AC1–AC5 coverage.
- Preserve canonical workflow contracts and exclude generated-reference rewrites, client-side state, animation, new dependencies, and wider site redesign.

## Test plan

### Automated

- [ ] `git diff --cached --check` passed before the plan commit.
- [ ] Site typecheck and production build await implementation; this docs-only base PR currently contains only the approved spec and ready plan.

### Manual

**Before merge**

- [ ] Confirm the single-increment decomposition is coherent, independently shippable, and covers the complete UI, discovery links, and verification work.
- [ ] Confirm AC1–AC5 map to concrete tasks covering discoverability, workflow accuracy, responsive/theme usability, semantic accessibility, and existing architecture.
- [ ] Confirm the spec-plan join is 1:1: approved spec, ready plan, matching `feature/workflow-visualizations` branch, and reciprocal wikilinks.
- [ ] Review each planned workflow sequence, approval gate, branch outcome, and terminal artifact against its canonical skill contract.

Spec: .woostack/specs/2026-07-16-workflow-visualizations.md
