### PR TITLE
Progressively disclose woostack-commit guidance

### DIFF
--- a/skills/woostack-commit/SKILL.md
+++ b/skills/woostack-commit/SKILL.md
@@ -60,6 +60,20 @@ Rules:
 - Before using any draft, compare it against the staged diff and command results. Rewrite or
   discard anything stale, overstated, vague, or unsupported.
 
+## Hard constraints
+
+- Resolve the artifact backend before inspection, invariant checks, or drafting. Never fall back
+  from Linear to Markdown.
+- A verified `change/*` invocation remains artifact-neutral. Only the canonical isolation and
+  Graphite-registration guard enables it.
+- Stage only session-relevant changes. Never stage unrelated work, generated sidecars, secrets,
+  or `.env*`.
+- Never force-push. Do not merge.
+- Preserve failure state: a hook, commit, submission, PR edit, adapter mutation, or read-back
+  failure stops the workflow at its documented boundary; never infer success from transport
+  results or discard evidence needed for an explicit resume.
+- Report only commands and results actually observed.
+
 ## Workflow
 ### 0. Resolve the artifact backend
 
@@ -143,7 +157,9 @@ gt track feature/<short-slug> --parent "$base"
 
 - If current branch is anything else, stop and ask whether to continue on the current branch or create a new `feature/*` branch.
 
-Use a short slug based on the change, such as `feature/review-model-defaults` or `feature/add-commit-skill`. Prefer Graphite for branch creation and tracking: switch to the resolved base, run `gt create feature/<short-slug>`, then ensure the parent is registered with `gt track feature/<short-slug> --parent "$base"`. If Graphite is unavailable or clearly not initialized, fall back to raw git only: `git switch -c feature/<short-slug> "$base"`.
+When branch creation or tracking is needed, load
+[`references/graphite.md`](references/graphite.md) for Graphite commands and the raw-git fallback
+decision. Never load or use its fallback for a verified `change/*` invocation.
 
 **Running inside a worktree:** when a driving skill (build / execute / fix / `woostack-change`) has already created a per-PR worktree on a `feature/*`, `fix/*`, or `change/*` branch (see the [worktree contract](../woostack-init/references/worktrees.md)), this step finds a non-protected branch and continues — for `change/*`, only after the isolation and Graphite guard above succeeds. `woostack-commit` then commits whatever tree it is invoked in and creates no second branch.
 
@@ -223,62 +239,29 @@ Only the canonical branch/worktree/Graphite guard in step 2 enables this path; `
 
 #### Markdown
 
-When the staged changes touch `.woostack/specs/*.md`, `.woostack/plans/*.md`, or `.woostack/fixes/*.md`, run the cheap feature-state invariant checks on every affected spec/fix so the `/woostack-status` board stays honest. The affected set is every directly touched spec/fix plus the spec named by each touched plan's `source:` frontmatter or `**Source:**` line (a `[[specs/<basename>]]` wikilink, or the legacy `.woostack/specs/<file>.md` path). These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
-
-For each affected spec/fix, check:
-
-- **1:1 plan** — exactly one plan resolves to it (for specs). (For fixes under `fixes/`, they are self-contained plans and this check is skipped).
-- **`branch:` present** — the active lifecycle artifact frontmatter (`spec` before planning, `plan` after planning, `fix` for fixes) is non-empty and not the literal `unknown`.
-- **`status:` in the enum** — spec frontmatter uses `draft|hardened|approved|abandoned`; plan frontmatter uses `planning|ready|executing|in-review|done|abandoned`; fix frontmatter uses the full fix lifecycle.
-
-The phase enum and the join contracts are defined once in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md) — do not restate them here. If the `woostack-status` skill is not installed, skip this check silently.
+When the resolved backend is Markdown, load and follow
+[`references/markdown-attribution.md`](references/markdown-attribution.md) for the advisory
+artifact invariants and exact `Spec: .woostack/specs/<file>.md` or
+`Spec: .woostack/fixes/<file>.md` trailer decision. Load no Linear attribution procedure.
 
 #### Linear
 
-Linear attribution is blocking, not advisory. Validate the preflight-resolved `LINEAR_CONTEXT`,
-then extract `LINEAR_PROJECT_STATUSES="$(jq -c '.projectStatuses' <<<"$LINEAR_CONTEXT")"` and
-`LINEAR_ISSUE_STATES="$(jq -c '.issueStates' <<<"$LINEAR_CONTEXT")"`. Using the repository,
-project UUID, issue identifier, and those extracted UUID maps, fetch the managed project and issue
-set with `linear.sh feature-read`. Require successful API verification, require the returned
-`feature.id` equals the supplied project UUID, and select exactly one increment whose `identifier`
-equals the supplied `<TEAM-NUMBER>`. The selected issue must come from that verified feature issue
-set, be managed by woostack, be owned by the resolved repository, and be in the execution
-lifecycle expected by the driving flow.
+When the resolved backend is Linear:
 
-Before commit or submission, validate the proposed PR body against that verified pair. It must
-end with exactly one `Linear-Project:` trailer containing `<uuid>` and exactly one
-`Linear-Issue:` trailer containing `<TEAM-NUMBER>`, in that order, whose rendered lines are
-`Linear-Project: <uuid>` and `Linear-Issue: <TEAM-NUMBER>` and whose values exactly equal the fetched
-project and issue. A mismatch, duplicate trailer, foreign project issue, missing issue,
-ambiguous issue, malformed identifier, missing credentials, missing or failed API verification,
-or adapter failure must block submission and PR update. Do not include a `Spec:` trailer in a
-Linear-backed PR. Existing PR bodies with any Linear attribution are subject to the same exact
-check; do not silently normalize or replace foreign, mismatched, partial, or duplicate
-attribution. One recovery case is allowed when PR updates are enabled: the verified current
-branch's existing PR may have neither Linear trailer. Treat it as unattributed, validate the
-proposed body containing the exact pair, and add that pair through the post-submit `gh pr edit`
-path. `--no-pr-update` never permits this missing-pair recovery.
+1. Unless `--no-pr-update` applies, load [`references/pr-body.md`](references/pr-body.md) to compose the proposed title/body; do not apply it yet.
+2. Load and follow only [Verify the owned project and issue](references/linear-attribution.md#verify-the-owned-project-and-issue), then stop at the next heading. Do not submit, edit the PR, invoke `issue-transition`, or perform the post-mutation read-back during step 4.5.
+
+Load no Markdown attribution procedure. Missing or failed API verification, foreign project
+ownership, or any ambiguous attribution must block submission and PR update.
 
 ### 5. Commit
 
 If a fast-subagent draft is available, use it only after validating that the proposed
 subject describes the staged diff accurately and follows the rules below.
 
-Use Graphite:
-
-```bash
-gt modify -m "<type>: <concise subject>"
-```
-
-For a verified `change/*` invocation this command is mandatory; its pre-existing tracked branch
-must not use `gt create` or raw git. For other invocations, prefer `gt modify`, use
-`gt create -m "<type>: <concise subject>"` only when creating the branch and committing in one
-Graphite flow is appropriate for the local stack state, and fall back to raw git only when
-Graphite is unavailable:
-
-```bash
-git commit -m "<type>: <concise subject>"
-```
+Commit with `gt modify -m "<type>: <concise subject>"`. Only when branch creation, tracking, or
+fallback mechanics are needed, load [`references/graphite.md`](references/graphite.md). For a
+verified `change/*` invocation, `gt modify` is mandatory and raw git is forbidden.
 
 Commit message rules:
 
@@ -288,27 +271,13 @@ Commit message rules:
 
 ### 6. Push or submit
 
-#### Verified `change/*`
+Submit exactly once on the applicable backend path:
 
-Run `gt submit` and require success. The already verified Graphite-tracked branch has no raw-git
-or `gh pr create` fallback; a failure stops before PR update.
+- For Linear, follow only [Submit with Graphite](references/linear-attribution.md#submit-with-graphite), then stop at the next heading.
+- For a verified `change/*` invocation, run `gt submit` and require success.
+- For Markdown, run `gt submit`. Only when it fails or fallback eligibility must be decided, load [`references/graphite.md`](references/graphite.md).
 
-#### Markdown
-
-Prefer Graphite:
-
-```bash
-gt submit
-```
-
-If a PR already exists, `gt submit` should update it. If Graphite is unavailable, push the branch and use `gh pr create` or `gh pr edit` as appropriate.
-
-#### Linear
-
-Graphite submission is mandatory because the verified issue owns one exact branch/PR
-attribution pair. Run `gt submit` and require success; do not use raw-git or `gh pr create`
-fallbacks when it fails or Graphite is unavailable. A failed submit leaves the issue unchanged
-and blocks PR update.
+Any mandatory Graphite failure stops before PR update and retains existing artifact state.
 
 Do not merge. Do not force-push.
 
@@ -319,15 +288,9 @@ Resolve the PR after the successful commit/push so it reflects the latest branch
 If the `--no-pr-update` flag is specified (or if a context signal like
 `WOOSTACK_COMMIT_NO_PR_UPDATE=1` is set in the environment), skip updating the PR title and body
 description and do not run `gh pr edit`, but still ensure the PR is created if it does not exist.
-For non-change Linear invocations this branch requires the existing PR body to carry the exact
-verified trailer pair, then still records attribution through `linear.sh issue-transition` and
-performs the mandatory `feature-read` read-back. The flag skips only the field edit; it never
-skips attribution validation, adapter recording, or read-back. Verified `change/*` invocations
-perform no Linear attribution or adapter mutation.
-
-Use a validated fast-subagent draft for the PR title/body when available. The main agent
-must still preserve accurate existing context, remove stale generated content, and ensure
-the Goal, Summary, and Test plan mention only committed changes and real verification.
+For a non-change Linear invocation, the flag skips only the field edit; continue through the
+phase-scoped identity, adapter-recording, and read-back sections below. A verified `change/*`
+invocation performs no Linear attribution or adapter mutation.
 
 Resolve the PR:
 
@@ -336,116 +299,33 @@ gh pr view --json number,title,body,headRefName,baseRefName,url
 ```
 
 For a verified `change/*` invocation, require the PR created by successful `gt submit` to exist,
-match the current head branch and resolved repository, and target the resolved base. Update and
-read back its normal title/body through the standard `gh pr edit` / `gh pr view` path unless
-`--no-pr-update` applies. Its body must contain no `Spec:`, `Linear-Project:`, or `Linear-Issue:`
-trailer, and no Linear adapter transition or read-back occurs.
+match the current head branch and resolved repository, and target the resolved base. Its body must
+contain no `Spec:`, `Linear-Project:`, or `Linear-Issue:` trailer, and no Linear adapter transition
+or read-back occurs.
 
-For any invocation other than verified `change/*`, if no PR exists after submit/push, create one targeting the resolved base branch (`<wi>` = the installed `woostack-init` scripts dir, as in step 2):
+For any invocation other than verified `change/*`, if no PR exists after submit/push, create one
+targeting the resolved base branch (`<wi>` = the installed `woostack-init` scripts dir, as in step
+2):
 
 ```bash
 base="$(bash <wi>/resolve-base.sh)"
 gh pr create --base "$base" --head "$(git branch --show-current)" --title "<concise title>" --body-file <tmp-body-file>
 ```
 
-For a **stacked** increment PR the base is the **parent branch**, not `$base` (see the [worktree contract](../woostack-init/references/worktrees.md) §4); Graphite sets it automatically via `gt submit` when the branch was `gt track --parent`ed.
+For a **stacked** increment PR the base is the **parent branch**, not `$base` (see the
+[worktree contract](../woostack-init/references/worktrees.md) §4); Graphite sets it automatically
+via `gt submit` when the branch was `gt track --parent`ed.
 
-For non-change Linear invocations, a PR must already exist from the successful Graphite submit. Require its head branch
-to equal `git branch --show-current`, its repository to equal the backend resolver's repository,
-and its URL to be the canonical PR URL for that repository. Unless `--no-pr-update` applies,
-apply the validated title/body with `gh pr edit`, then re-fetch its body with `gh pr view` and
-require the exact verified trailer pair. With `--no-pr-update`, require the submitted PR body
-already contains that exact pair. An edit failure, read failure, missing trailer, duplicate,
-or mismatch leaves the issue unchanged. Only after `gt submit` succeeds and all of these checks
-pass, invoke the atomic state-plus-evidence transition exactly once through the adapter:
+For Linear, a PR must already exist after successful Graphite submission. Follow
+[Identify and verify the PR](references/linear-attribution.md#identify-and-verify-the-pr), then
+[Record and read back attribution](references/linear-attribution.md#record-and-read-back-attribution)
+in that order. Do not repeat the step-4.5 preflight or step-6 submission.
 
-```bash
-linear.sh issue-transition \
-  --project "<verified-project-uuid>" \
-  --repository "<owner/repo>" \
-  --issue "<TEAM-NUMBER>" \
-  --issue-state-map "$LINEAR_ISSUE_STATES" \
-  --target inReview \
-  --branch "<submitted-branch>" \
-  --pull-request "<canonical-pr-url>"
-```
+For Markdown-backed and verified `change/*` invocations only, unless `--no-pr-update` applies, perform all three steps:
 
-Immediately call `linear.sh feature-read` with both captured UUID maps regardless of whether
-the mutation returned success, an error, or timed out; never infer mutation outcome from the
-transport result. Resolve the outcome only from the owned project/issue read-back:
-
-- The exact intended read-back is success: one matching issue has the exact submitted branch and PR URL
-  in managed metadata, `status: inReview`, and the verified project UUID. When a mutation
-  receipt was returned, also require `verified: true` and an empty `pending` array.
-- An unchanged issue still at `executing` with no branch/PR evidence is a safe stopped outcome.
-  Do not retry in the same invocation; only a later explicit resume may retry after another
-  fresh read confirms the same unchanged state.
-- Any partial or mismatched evidence requires manual reconciliation. Do not retry, overwrite
-  evidence, edit lifecycle state separately, or report success.
-- A failed or ambiguous read-back is unresolved. Stop without retrying or changing the PR again.
-
-Never write branch/PR evidence before successful submission and exact PR-body verification,
-and never write it directly through GraphQL or PR text; the adapter owns the atomic mutation
-and read-back.
-
-Compose the validated body with this structure. Markdown and verified `change/*` invocations set
-or update it at this point; non-change Linear applied and verified it before adapter attribution
-above:
-
-```markdown
-## Goal
-
-<1-2 sentences: why this PR exists / the problem it solves>
-
-## Summary
-
-- <concise bullet describing a user-visible or reviewer-relevant change>
-- <concise bullet describing another relevant change>
-
-## Test plan
-
-### Automated
-
-- [ ] <command run and result, or "Not run (reason)">
-
-### Manual
-
-**Before merge**
-
-- [ ] <step a reviewer can inspect or exercise on the branch or preview>
-
-**After merge**
-
-- [ ] <step only verifiable post-merge — deploy / migration / env-gated>
-
-Spec: .woostack/specs/<file>.md
-```
-For a non-change Linear-backed PR, replace the Markdown `Spec:` trailer with this exact final pair:
-
-```text
-Linear-Project: <uuid>
-Linear-Issue: <TEAM-NUMBER>
-```
-
-Rules:
-
-- **Verified `change/*`:** omit `Spec:`, `Linear-Project:`, and `Linear-Issue:` trailers. The
-  invocation is artifact-neutral even when the backend resolver reports Linear.
-- **Markdown (non-change):** end the body with the exact `Spec: .woostack/specs/<file>.md` or `Spec: .woostack/fixes/<file>.md` **trailer line** naming the spec/fix this PR's increments trace to — the spec/fix whose `branch:` matches the current branch, or the spec/fix under active work. The `/woostack-status` board enumerates a spec/fix's increment PRs by searching this exact trailer (`gh pr list --search "Spec: <path>"`); the contract is defined in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md). Omit the trailer only when the Markdown change traces to no spec/fix (for example a repo-meta or tooling edit).
-- **Linear (non-change):** the final two nonblank lines are exactly one `Linear-Project: <uuid>` trailer followed by exactly one `Linear-Issue: <TEAM-NUMBER>` trailer. Both values come from the blocking adapter verification in step 4.5. A Linear implementation PR may never omit these trailers or use a Markdown `Spec:` trailer.
-- State the **Goal** as intent or the problem solved in one or two sentences — not a change list. It is distinct from Summary, which lists *what* changed. Always present it.
-- Keep Summary bullets concise and specific. Include only changes in the committed diff.
-- Under **Automated**, list the commands/tests actually run, plus the configured `commit.pre_commit` command and result when it ran. Show this group whenever an automated check (test, lint, typecheck, `pre_commit`) could have run for the change: list results, or `Not run` with the reason when one was expected but skipped. Omit `### Automated` entirely when no automated check applies to the change (for example a doc-only edit in a repo with no test harness) rather than emitting a `Not run` placeholder.
-- Under **Manual**, group human verification into **Before merge** and **After merge**. Before-merge steps are what a reviewer can inspect or exercise now — read the diff, run the command locally, exercise the change on the branch or a preview, for example `Run /woostack-commit on a dirty feature branch and confirm the PR body shows Goal, Summary, and the Automated/Manual test plan`. After-merge steps are verification only possible once the PR lands — staging/prod deploy behavior, migrations, env-specific config. Include the After-merge group only when such steps exist; this is the "if applicable".
-- Omit any empty group — `### Automated`, `### Manual`, or either before/after block — rather than leaving placeholder bullets.
-- Preserve important existing PR context when it is still accurate. Replace stale generated summaries/test plans with the current ones.
-- Format test-plan items as unchecked Markdown checkboxes (`- [ ] ...`) so reviewers can mark verification complete.
-
-Update with:
-
-```bash
-gh pr edit <number> --title "<concise title>" --body-file <tmp-body-file>
-```
+1. Load [`references/pr-body.md`](references/pr-body.md) for the title/body template and formatting rules.
+2. Apply the validated fields with its documented `gh pr edit` command.
+3. Re-fetch them with `gh pr view`; only the observed intended read-back is success.
 
 ### 8. Report
 

--- a/skills/woostack-commit/references/graphite.md
+++ b/skills/woostack-commit/references/graphite.md
@@ -1,0 +1,41 @@
+# Graphite mechanics and fallbacks
+
+Load this reference only when branch creation, commit, or submission needs Graphite command details or an allowed fallback decision.
+
+## Create or track a branch
+
+Use a short slug based on the change, such as `feature/review-model-defaults` or `feature/add-commit-skill`. Prefer Graphite for branch creation and tracking: switch to the resolved base, run `gt create feature/<short-slug>`, then ensure the parent is registered with `gt track feature/<short-slug> --parent "$base"`. If Graphite is unavailable or clearly not initialized, fall back to raw git only:
+
+```bash
+git switch -c feature/<short-slug> "$base"
+```
+
+This fallback is forbidden for a verified `change/*` invocation because its branch must already pass the canonical worktree and Graphite-registration guard.
+
+## Commit
+
+Use Graphite:
+
+```bash
+gt modify -m "<type>: <concise subject>"
+```
+
+For a verified `change/*` invocation this command is mandatory; its pre-existing tracked branch must not use `gt create` or raw git. For other invocations, prefer `gt modify`, use `gt create -m "<type>: <concise subject>"` only when creating the branch and committing in one Graphite flow is appropriate for the local stack state, and fall back to raw git only when Graphite is unavailable:
+
+```bash
+git commit -m "<type>: <concise subject>"
+```
+
+## Submit
+
+Run:
+
+```bash
+gt submit
+```
+
+If a PR already exists, `gt submit` should update it. For a Markdown-backed invocation, if Graphite is unavailable, push the branch and use `gh pr create` or `gh pr edit` as appropriate.
+
+A verified `change/*` invocation has no raw-git or `gh pr create` fallback. A Linear-backed invocation also requires successful Graphite submission because the verified issue owns one exact branch/PR attribution pair; do not use raw-git or `gh pr create` fallbacks when submission fails or Graphite is unavailable.
+
+Never force-push. Do not merge.

--- a/skills/woostack-commit/references/linear-attribution.md
+++ b/skills/woostack-commit/references/linear-attribution.md
@@ -1,0 +1,57 @@
+# Linear attribution
+
+Load this reference only after the backend resolver selects Linear and step 2 has ruled out the verified `change/*` artifact-neutral path.
+
+## Verify the owned project and issue
+
+Linear attribution is blocking, not advisory. Validate the preflight-resolved `LINEAR_CONTEXT`, then extract `LINEAR_PROJECT_STATUSES="$(jq -c '.projectStatuses' <<<"$LINEAR_CONTEXT")"` and `LINEAR_ISSUE_STATES="$(jq -c '.issueStates' <<<"$LINEAR_CONTEXT")"`. Using the repository, project UUID, issue identifier, and those extracted UUID maps, fetch the managed project and issue set with `linear.sh feature-read`. Require successful API verification, require the returned `feature.id` equals the supplied project UUID, and select exactly one increment whose `identifier` equals the supplied `<TEAM-NUMBER>`. The selected issue must come from that verified feature issue set, be managed by woostack, be owned by the resolved repository, and be in the execution lifecycle expected by the driving flow.
+
+Before commit or submission, validate the proposed PR body against that verified pair. It must end with exactly one `Linear-Project:` trailer containing `<uuid>` and exactly one `Linear-Issue:` trailer containing `<TEAM-NUMBER>`, in that order, whose rendered lines are:
+
+```text
+Linear-Project: <uuid>
+Linear-Issue: <TEAM-NUMBER>
+```
+
+Both values must exactly equal the fetched project and issue. A mismatch, duplicate trailer, foreign project issue, missing issue, ambiguous issue, malformed identifier, missing credentials, missing or failed API verification, or adapter failure must block submission and PR update. Do not include a `Spec:` trailer in a Linear-backed PR. Existing PR bodies with any Linear attribution are subject to the same exact check; do not silently normalize or replace foreign, mismatched, partial, or duplicate attribution.
+
+One recovery case is allowed when PR updates are enabled: the verified current branch's existing PR may have neither Linear trailer. Treat it as unattributed, validate the proposed body containing the exact pair, and add that pair through the post-submit `gh pr edit` path. `--no-pr-update` never permits this missing-pair recovery.
+
+## Submit with Graphite
+
+Graphite submission is mandatory because the verified issue owns one exact branch/PR attribution pair. Run `gt submit` and require success; do not use raw-git or `gh pr create` fallbacks when it fails or Graphite is unavailable. A failed submit leaves the issue unchanged and blocks PR update.
+
+## Identify and verify the PR
+
+For Linear, a PR must already exist from the successful Graphite submit. Require its head branch to equal `git branch --show-current`, its repository to equal the backend resolver's repository, and its URL to be the canonical PR URL for that repository. Unless `--no-pr-update` applies, apply the validated title/body with `gh pr edit`, then re-fetch its body with `gh pr view` and require the exact verified trailer pair. With `--no-pr-update`, require the submitted PR body already contains that exact pair. An edit failure, read failure, missing trailer, duplicate, or mismatch leaves the issue unchanged.
+
+## Record and read back attribution
+
+Only after `gt submit` succeeds and all PR identity/body checks pass, invoke the atomic state-plus-evidence transition exactly once through the adapter:
+
+```bash
+linear.sh issue-transition \
+  --project "<verified-project-uuid>" \
+  --repository "<owner/repo>" \
+  --issue "<TEAM-NUMBER>" \
+  --issue-state-map "$LINEAR_ISSUE_STATES" \
+  --target inReview \
+  --branch "<submitted-branch>" \
+  --pull-request "<canonical-pr-url>"
+```
+
+Immediately call `linear.sh feature-read` with both captured UUID maps regardless of whether the mutation returned success, an error, or timed out; never infer mutation outcome from the transport result. Resolve the outcome only from the owned project/issue read-back:
+
+- The exact intended read-back is success: one matching issue has the exact submitted branch and PR URL in managed metadata, `status: inReview`, and the verified project UUID. When a mutation receipt was returned, also require `verified: true` and an empty `pending` array.
+- An unchanged issue still at `executing` with no branch/PR evidence is a safe stopped outcome. Do not retry in the same invocation; only a later explicit resume may retry after another fresh read confirms the same unchanged state.
+- Any partial or mismatched evidence requires manual reconciliation. Do not retry, overwrite evidence, edit lifecycle state separately, or report success.
+- A failed or ambiguous read-back is unresolved. Stop without retrying or changing the PR again.
+
+Never write branch/PR evidence before successful submission and exact PR-body verification, and never write it directly through GraphQL or PR text; the adapter owns the atomic mutation and read-back.
+
+## `--no-pr-update`
+
+If the `--no-pr-update` flag is specified, do not run `gh pr edit`. This path requires the
+existing PR body to carry the exact verified trailer pair, records attribution through
+`linear.sh issue-transition`, and performs the mandatory `feature-read` read-back. The flag
+skips only the field edit; it never skips attribution validation, adapter recording, or read-back.

--- a/skills/woostack-commit/references/markdown-attribution.md
+++ b/skills/woostack-commit/references/markdown-attribution.md
@@ -1,0 +1,19 @@
+# Markdown attribution
+
+Load this reference only after the backend resolver selects Markdown and step 2 has ruled out the verified `change/*` artifact-neutral path.
+
+## Invariant checks
+
+When the staged changes touch `.woostack/specs/*.md`, `.woostack/plans/*.md`, or `.woostack/fixes/*.md`, run the cheap feature-state invariant checks on every affected spec/fix so the `/woostack-status` board stays honest. The affected set is every directly touched spec/fix plus the spec named by each touched plan's `source:` frontmatter or `**Source:**` line (a `[[specs/<basename>]]` wikilink, or the legacy `.woostack/specs/<file>.md` path). These are **advisory**: print any violation as a single non-blocking line in the commit report and continue. Never abort, stage differently, or change the commit because of them.
+
+For each affected spec/fix, check:
+
+- **1:1 plan** — exactly one plan resolves to it (for specs). (For fixes under `fixes/`, they are self-contained plans and this check is skipped).
+- **`branch:` present** — the active lifecycle artifact frontmatter (`spec` before planning, `plan` after planning, `fix` for fixes) is non-empty and not the literal `unknown`.
+- **`status:` in the enum** — spec frontmatter uses `draft|hardened|approved|abandoned`; plan frontmatter uses `planning|ready|executing|in-review|done|abandoned`; fix frontmatter uses the full fix lifecycle.
+
+The phase enum and the join contracts are defined once in [`../../woostack-status/references/conventions.md`](../../woostack-status/references/conventions.md) — do not restate them here. If the `woostack-status` skill is not installed, skip this check silently.
+
+## PR trailer
+
+End the body with the exact `Spec: .woostack/specs/<file>.md` or `Spec: .woostack/fixes/<file>.md` **trailer line** naming the spec/fix this PR's increments trace to — the spec/fix whose `branch:` matches the current branch, or the spec/fix under active work. The `/woostack-status` board enumerates a spec/fix's increment PRs by searching this exact trailer (`gh pr list --search "Spec: <path>"`); the contract is defined in [`../../woostack-status/references/conventions.md`](../../woostack-status/references/conventions.md). Omit the trailer only when the Markdown change traces to no spec/fix (for example a repo-meta or tooling edit).

--- a/skills/woostack-commit/references/pr-body.md
+++ b/skills/woostack-commit/references/pr-body.md
@@ -1,0 +1,56 @@
+# PR title and body
+
+Load this reference only when drafting or updating PR fields. The root workflow supplies the valid
+artifact trailer, if any; this procedure does not select or validate backend attribution.
+
+Use a validated fast-subagent draft for the PR title/body when available. The main agent must still preserve accurate existing context, remove stale generated content, and ensure the Goal, Summary, and Test plan mention only committed changes and real verification.
+
+Compose the validated body with this structure:
+
+```markdown
+## Goal
+
+<1-2 sentences: why this PR exists / the problem it solves>
+
+## Summary
+
+- <concise bullet describing a user-visible or reviewer-relevant change>
+- <concise bullet describing another relevant change>
+
+## Test plan
+
+### Automated
+
+- [ ] <command run and result, or "Not run (reason)">
+
+### Manual
+
+**Before merge**
+
+- [ ] <step a reviewer can inspect or exercise on the branch or preview>
+
+**After merge**
+
+- [ ] <step only verifiable post-merge — deploy / migration / env-gated>
+
+<selected backend trailer, when required>
+```
+
+Rules:
+
+- **Verified `change/*`:** omit `Spec:`, `Linear-Project:`, and `Linear-Issue:` trailers. The invocation is artifact-neutral even when the backend resolver reports Linear.
+- State the **Goal** as intent or the problem solved in one or two sentences — not a change list. It is distinct from Summary, which lists *what* changed. Always present it.
+- Keep Summary bullets concise and specific. Include only changes in the committed diff.
+- Under **Automated**, list the commands/tests actually run, plus the configured `commit.pre_commit` command and result when it ran. Show this group whenever an automated check (test, lint, typecheck, `pre_commit`) could have run for the change: list results, or `Not run` with the reason when one was expected but skipped. Omit `### Automated` entirely when no automated check applies to the change (for example a doc-only edit in a repo with no test harness) rather than emitting a `Not run` placeholder.
+- Under **Manual**, group human verification into **Before merge** and **After merge**. Before-merge steps are what a reviewer can inspect or exercise now — read the diff, run the command locally, exercise the change on the branch or a preview, for example `Run /woostack-commit on a dirty feature branch and confirm the PR body shows Goal, Summary, and the Automated/Manual test plan`. After-merge steps are verification only possible once the PR lands — staging/prod deploy behavior, migrations, env-specific config. Include the After-merge group only when such steps exist; this is the "if applicable".
+- Omit any empty group — `### Automated`, `### Manual`, or either before/after block — rather than leaving placeholder bullets.
+- Preserve important existing PR context when it is still accurate. Replace stale generated summaries/test plans with the current ones.
+- Format test-plan items as unchecked Markdown checkboxes (`- [ ] ...`) so reviewers can mark verification complete.
+
+Update with:
+
+```bash
+gh pr edit <number> --title "<concise title>" --body-file <tmp-body-file>
+```
+
+Re-fetch with `gh pr view`; the exact intended read-back is success. Never report a title or body that was not observed in the read-back.

--- a/skills/woostack-commit/tests/test-linear-attribution.sh
+++ b/skills/woostack-commit/tests/test-linear-attribution.sh
@@ -8,7 +8,19 @@ import sys
 from pathlib import Path
 
 root = Path(sys.argv[1])
-commit = (root / "skills/woostack-commit/SKILL.md").read_text(encoding="utf-8")
+commit_root = (root / "skills/woostack-commit/SKILL.md").read_text(encoding="utf-8")
+markdown_attribution = (
+    root / "skills/woostack-commit/references/markdown-attribution.md"
+).read_text(encoding="utf-8")
+linear_attribution = (
+    root / "skills/woostack-commit/references/linear-attribution.md"
+).read_text(encoding="utf-8")
+pr_body = (root / "skills/woostack-commit/references/pr-body.md").read_text(encoding="utf-8")
+graphite = (root / "skills/woostack-commit/references/graphite.md").read_text(encoding="utf-8")
+shared_commit = "\n".join((commit_root, pr_body, graphite))
+markdown_commit = "\n".join((shared_commit, markdown_attribution))
+linear_commit = "\n".join((shared_commit, linear_attribution))
+commit = linear_commit
 conventions = (root / "skills/woostack-status/references/conventions.md").read_text(encoding="utf-8")
 controller = (root / "skills/woostack-execute/references/controller.md").read_text(encoding="utf-8")
 
@@ -48,7 +60,7 @@ def section(text, start, end):
 
 
 # Backend selection is authoritative and precedes every invariant or draft operation.
-ordered(commit, (
+ordered(commit_root, (
     "resolve-backend.sh <repo-root>",
     "### 1. Inspect state",
     "### 4.5 Backend-specific invariant and attribution checks",
@@ -57,10 +69,47 @@ ordered(commit, (
 must(commit, "Do not inspect invariants, dispatch a drafting", "backend-first workflow")
 must(commit, "draft commit/PR text before this succeeds", "backend-first workflow")
 must(commit, "never fall back from Linear to Markdown", "backend-first workflow")
+ordered(commit_root, (
+    "When the resolved backend is Linear:",
+    "references/pr-body.md",
+    "do not apply it yet",
+    "Verify the owned project and issue",
+    "stop at the next heading",
+    "Do not submit, edit the PR, invoke `issue-transition`",
+    "### 5. Commit",
+), "Linear pre-commit reader phase")
+ordered(commit_root, (
+    "### 6. Push or submit",
+    "Submit exactly once on the applicable backend path",
+    "Submit with Graphite",
+    "stop at the next heading",
+    "### 7. Resolve and attribute the PR",
+    "Identify and verify the PR",
+    "Record and read back attribution",
+    "Do not repeat the step-4.5 preflight or step-6 submission",
+), "Linear post-commit reader phases")
+must(
+    commit_root,
+    "For Markdown-backed and verified `change/*` invocations only",
+    "generic PR update backend scope",
+)
+
+# Moved PR formatting and Graphite fallback law remain part of the lockstep contract.
+for token in (
+    "Format test-plan items as unchecked Markdown checkboxes",
+    "Re-fetch with `gh pr view`",
+):
+    must(pr_body, token, "PR body procedure")
+for token in (
+    "For a Markdown-backed invocation, if Graphite is unavailable",
+    "A verified `change/*` invocation has no raw-git or `gh pr create` fallback",
+    "A Linear-backed invocation also requires successful Graphite submission",
+):
+    must(graphite, token, "Graphite fallback procedure")
 
 # Markdown attribution remains byte-for-byte compatible with status discovery.
 markdown_trailer = "Spec: .woostack/specs/<file>.md"
-if commit.count(markdown_trailer) < 2:
+if markdown_commit.count(markdown_trailer) < 2:
     fail("commit workflow no longer preserves the exact Markdown Spec trailer")
 must(conventions, "trailer line `Spec: .woostack/specs/<file>.md`", "Markdown conventions")
 
@@ -107,7 +156,7 @@ for token in (
     must(commit, token, "unattributed PR recovery")
 
 linear_pr_resolution = section(
-    commit,
+    linear_attribution,
     "For Linear, a PR must already exist",
     "Immediately call `linear.sh feature-read`",
 )
@@ -145,11 +194,11 @@ for token in (
 ):
     must(commit, token, "post-submit attribution")
 
-no_update = section(
-    commit,
-    "If the `--no-pr-update` flag is specified",
-    "Use a validated fast-subagent draft",
-)
+no_update_start = "If the `--no-pr-update` flag is specified"
+try:
+    no_update = linear_attribution[linear_attribution.index(no_update_start):]
+except ValueError:
+    fail(f"section boundary missing: {no_update_start!r}")
 for token in (
     "do not run `gh pr edit`",
     "existing PR body to carry the exact verified trailer pair",

--- a/skills/woostack-commit/tests/test-progressive-disclosure.sh
+++ b/skills/woostack-commit/tests/test-progressive-disclosure.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+python3 - "$ROOT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+skill_path = root / "skills/woostack-commit/SKILL.md"
+reference_dir = skill_path.parent / "references"
+reference_names = (
+    "markdown-attribution.md",
+    "linear-attribution.md",
+    "pr-body.md",
+    "graphite.md",
+)
+skill = skill_path.read_text(encoding="utf-8")
+references = {}
+errors = []
+
+
+def check(condition, message):
+    if not condition:
+        errors.append(message)
+
+
+def compact(text):
+    return re.sub(r"\s+", " ", text)
+
+
+# The root remains the shared orchestrator and safety boundary.
+for heading in (
+    "### 1. Inspect state",
+    "### 2. Enforce branch shape before committing",
+    "### 3. Run configured pre-commit command",
+    "### 4. Stage only session-relevant changes",
+    "### 4.5 Backend-specific invariant and attribution checks",
+    "### 5. Commit",
+    "### 6. Push or submit",
+    "### 7. Resolve and attribute the PR",
+    "### 8. Report",
+):
+    check(heading in skill, f"root missing shared workflow stage {heading!r}")
+check(re.search(r"^## Hard constraints\s*$", skill, re.MULTILINE), "root missing prominent Hard constraints section")
+check(len(skill.splitlines()) <= 500, "root exceeds approximately 500 lines")
+default_update = re.search(
+    r"For Markdown-backed and verified `change/\*` invocations only, unless `--no-pr-update` applies, perform all three steps:(.*?)(?=### 8\. Report)",
+    skill,
+    re.DOTALL,
+)
+check(default_update is not None, "root no longer scopes PR field updates to the default path")
+if default_update:
+    for token in (
+        "1. Load [`references/pr-body.md`](references/pr-body.md)",
+        "2. Apply the validated fields",
+        "3. Re-fetch them with `gh pr view`",
+    ):
+        check(token in default_update.group(1), f"default PR update path missing {token!r}")
+
+# Each conditional procedure is a direct reader from root, never an index chain.
+for name in reference_names:
+    path = reference_dir / name
+    if path.is_file():
+        references[name] = path.read_text(encoding="utf-8")
+    else:
+        references[name] = ""
+        errors.append(f"direct reference missing: references/{name}")
+
+    href = f"(references/{name}"
+    paragraphs = [compact(part) for part in re.split(r"\n\s*\n", skill) if href in part]
+    check(bool(paragraphs), f"root does not directly dispatch references/{name}")
+    if paragraphs:
+        context = " ".join(paragraphs)
+        check(
+            re.search(r"\b(when|if|only|for|read|use|load)\b", context, re.IGNORECASE),
+            f"references/{name} lacks conditional when-to-read context",
+        )
+
+for name, text in references.items():
+    for other in reference_names:
+        if other == name:
+            continue
+        for paragraph in (compact(part) for part in re.split(r"\n\s*\n", text)):
+            links_other = f"({other}" in paragraph or f"(./{other}" in paragraph
+            requires_other = re.search(r"\b(must|required|before continuing|first)\b", paragraph, re.IGNORECASE)
+            check(not (links_other and requires_other), f"references/{name} requires nested procedure references/{other}")
+
+corpus = "\n".join((skill, *references.values()))
+normalized = compact(corpus)
+
+# The split may relocate detail, but it may not weaken the observable commit/PR contract.
+for token in (
+    "Spec: .woostack/specs/<file>.md",
+    "Spec: .woostack/fixes/<file>.md",
+    "Linear-Project: <uuid>",
+    "Linear-Issue: <TEAM-NUMBER>",
+    "gh pr edit <number> --title \"<concise title>\" --body-file <tmp-body-file>",
+    "gt submit",
+    "gh pr view",
+    "re-fetch its body",
+    "exact intended read-back is success",
+    "Never force-push",
+    "Do not merge",
+):
+    check(compact(token) in normalized, f"combined package missing exact behavior {token!r}")
+
+
+if errors:
+    raise SystemExit("test-progressive-disclosure:\n- " + "\n- ".join(errors))
+print("test-progressive-disclosure: OK")
+PY


### PR DESCRIPTION
## Goal

Reduce `woostack-commit` context cost by loading backend attribution, PR-body, and Graphite fallback detail only at the workflow phase that owns it, without weakening commit, submission, PR-update, or Linear read-back ordering.

## Summary

- Split Markdown attribution, Linear attribution, PR-body formatting, and Graphite mechanics into four directly linked conditional references while retaining shared orchestration and hard constraints in `SKILL.md`.
- Made Linear reader execution phase-scoped: preflight before commit, one Graphite submission, then PR identity and adapter mutation/read-back after submission.
- Added deterministic structural progressive-disclosure coverage and strengthened attribution lockstep tests to assemble backend-specific reader corpora.
- Reduced representative normal-path context from the 26,006-byte baseline to 23,055 bytes for Markdown and 25,987 bytes for Linear.
- Model-backed comparison is optional advisory evidence under the superseding 2026-07-25 spec decision; this PR does not claim one passed.

## Test plan

- [x] `bash skills/woostack-commit/tests/test-linear-attribution.sh` — passed.
- [x] `bash skills/woostack-commit/tests/test-progressive-disclosure.sh` — passed.
- [x] `bash skills/woostack-commit/tests/test-markdown-attribution.sh` — passed on the cumulative stack.
- [x] `node skills/woostack-eval/scripts/validate.mjs --package skills/woostack-commit` — valid.
- [x] Manual review confirmed preflight occurs before commit, Graphite submits exactly once, and PR identity/attribution read-back occurs after submission.
- [x] Cumulative `node --test site/scripts/gen-skills.test.mjs` passed 14/14 in an LF Linux checkout.
- [x] `pnpm@11.1.2 -C site build` passed and generated 147 static pages.
- [x] `git diff --check` passed.

Spec: .woostack/specs/2026-07-15-skill-evaluation-optimization.md
