### PR TITLE
Progressively disclose woostack-build procedures

### DIFF
--- a/.woostack/memory/progressive-disclosure-direct-readers.md
+++ b/.woostack/memory/progressive-disclosure-direct-readers.md
@@ -7,4 +7,4 @@ hook: conditional detail uses direct when-to-read links while shared workflow st
 updated: 2026-07-16
 source: [[plans/2026-07-15-skill-evaluation-optimization]]
 ---
-Progressive disclosure: keep shared workflow in root; link each conditional reference directly.
+Procedure extraction: keep shared root dispatch, direct readers, stable anchors, and update every caller.

--- a/.woostack/plans/2026-07-15-skill-evaluation-optimization.md
+++ b/.woostack/plans/2026-07-15-skill-evaluation-optimization.md
@@ -1,7 +1,7 @@
 ---
 type: plan
 source: .woostack/specs/2026-07-15-skill-evaluation-optimization.md
-status: executing
+status: done
 branch: feature/skill-evaluation-optimization
 ---
 

--- a/site/content/docs/concepts/building-rules.mdx
+++ b/site/content/docs/concepts/building-rules.mdx
@@ -15,6 +15,11 @@ See [Workflow maps](/docs/concepts/workflows) for a cross-workflow comparison.
 > ideate → capture spec → harden spec → **approve spec** → plan → harden plan
 > → **execution handoff** → execute (per increment: implement → commit → review → distill)
 
+Markdown persists its artifacts between those shared gates:
+
+> harden spec → commit spec PR → **approve spec** → plan → harden plan
+> → append plan to spec+plan PR → **execution handoff**
+
 ## Exactly three hard gates
 
 The loop advances only on an explicit answer:
@@ -41,7 +46,7 @@ PR per independently shippable increment. Linear has no docs-only base PR: after
 explicitly approved, root increments begin at the frozen SHA and dependent increments use their
 declared Git parent.
 
-The [Linear build procedure](https://github.com/howarewoo/woostack/blob/main/skills/woostack-build/SKILL.md#linear-backend-procedure)
+The [Linear build procedure](https://github.com/howarewoo/woostack/blob/main/skills/woostack-build/references/linear-procedure.md)
 owns the operational lifecycle. [Configuration](/docs/configuration#artifact-backend) owns backend
 selection and environment authentication; [Status tracking](/docs/concepts/status-tracking)
 explains how each model reaches terminal truth.

--- a/skills/using-woostack/tests/test-artifact-reader-contract.sh
+++ b/skills/using-woostack/tests/test-artifact-reader-contract.sh
@@ -339,7 +339,7 @@ if validation_mode == "repository":
     require_doc("development", r"\.\./\.\./woostack-build/SKILL\.md", "does not link the build lifecycle authority")
     require_doc("development", r"\.\./\.\./woostack-init/references/worktrees\.md", "does not link the worktree authority")
     require_doc("development", r"\.\./\.\./woostack-status/references/conventions\.md", "does not link the status authority")
-    require_doc("worktrees", r"woostack-build/SKILL\.md#linear-backend-procedure", "does not link the Linear build authority")
+    require_doc("worktrees", r"woostack-build/references/linear-procedure\.md", "does not link the Linear build authority")
     require_doc("status-conventions", r"woostack-bootstrap/references/development\.md#artifact-backend", "does not link the adoption authority")
 
     require_doc("development", r"Markdown.{0,100}\bdefault\b", "does not describe Markdown as the default backend")
@@ -379,7 +379,7 @@ if validation_mode == "repository":
         require_doc("site-build-loop", re.escape(gate), f"does not preserve the {gate} gate")
     require_doc("site-build-loop", r"Markdown \(default\).{0,300}Linear", "does not compare backend handoffs")
     require_doc("site-build-loop", r"Linear has no docs-only base PR", "does not exclude a Linear docs-only base PR")
-    require_doc("site-build-loop", r"woostack-build/SKILL\.md#linear-backend-procedure", "does not link the Linear lifecycle authority")
+    require_doc("site-build-loop", r"woostack-build/references/linear-procedure\.md", "does not link the Linear lifecycle authority")
     require_doc("site-status", r"Status authenticates before reading Linear.{0,120}narrow terminal reconciliation", "does not preserve authenticated terminal reconciliation")
     require_doc("site-status", r"managed project.{0,120}spec document.{0,120}ordered increment issues", "does not preserve the canonical Linear model")
     require_doc("site-status", r"native project.{0,120}team issue states", "does not preserve native lifecycle state")

--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -13,352 +13,61 @@ through the configured artifact backend. It **inherits two gates** (design and w
 approval) and **adds exactly one** (the execution handoff). Storage changes neither their order
 nor their meaning.
 
-At the start of the run, execute
-`skills/woostack-init/scripts/artifacts/resolve-backend.sh <repo-root>` exactly once and
-retain its normalized JSON result. Branch on its `backend` value; never infer the backend
-from folders, arguments, or available credentials, and never fall back from Linear to
-Markdown.
+Lifecycle spelling is backend-specific: Markdown plan frontmatter uses `in-review`; the
+normalized Linear project/issue status is `inReview`. Never translate one storage token into
+the other.
 
-Both branches implement the same pre-execution chain:
+## Backend resolution
+
+1. Execute
+   [`resolve-backend.sh`](../woostack-init/scripts/artifacts/resolve-backend.sh) `<repo-root>` exactly once.
+   Continue only after it returns a successful normalized result; retain the repository identity
+   and resolved Linear configuration for adapter calls. Never infer a backend, retry resolution
+   as another backend, or fall back.
+2. Branch on that result and load exactly one direct procedure:
+
+   When the selected backend is `markdown`, read and follow only the
+   [Markdown backend procedure](references/markdown-procedure.md).
+
+   When the selected backend is `linear`, read and follow only the
+   [Linear backend procedure](references/linear-procedure.md).
+
+Do not read or combine the unselected backend procedure.
+
+## Shared chain and gate barriers
+
+The selected procedure must preserve this order:
 
 ```
 ideate → capture spec → harden + persist spec → spec approval → plan
   → verify decomposition → harden plan → mark ready → execution handoff
 ```
 
-Either backend may continue from that gate into per-increment execution and a reviewed PR stack.
 Markdown preserves its existing persistence order:
 `commit spec PR → approve spec → plan → append plan to spec+plan PR → execution handoff`.
 Linear passes its managed project and issue identities directly to execution and creates no
 docs-only base PR.
 
-The only hard stops are **design approval**, **spec approval**, and **execution handoff**.
-Hardening amends the selected artifact in place and owns no gate. Planning, persistence,
-read-back, lifecycle transitions, and Markdown's spec/plan PR are work steps, not approval
-stops.
+### HARD GATE 1 — design-approval
 
-Lifecycle spelling is backend-specific: Markdown plan frontmatter uses `in-review`; the
-normalized Linear project/issue status is `inReview`. Never translate one storage token into
-the other.
+The approved design authorizes capture of the selected backend's written spec. No backend
+artifact is created before this barrier clears.
 
-## Procedure
+### HARD GATE 2 — spec-approval
 
-1. Resolve the selected artifact backend with
-   [`resolve-backend.sh`](../woostack-init/scripts/artifacts/resolve-backend.sh). Keep the
-   returned repository identity and resolved Linear configuration for adapter calls. Then
-   follow exactly one procedure below.
+The hardened written spec must receive explicit approval before planning. In Markdown, commit
+the spec and open the spec+plan base PR before presenting this gate; revisions update the same
+PR, and Abandon must close the now-open PR before removing its branch and worktree. In Linear,
+every spec write and lifecycle transition must have a verified read-back receipt before this
+gate or any following work can advance.
 
-## Markdown backend procedure
+### HARD GATE 3 — execution-handoff
 
-{/* <!-- markdown-gates: design-approval | spec-approval | execution-handoff --> */}
-
-<HARD-GATE backend="markdown" name="design-approval">
-
-1. **Ideate.** Invoke [`woostack-ideate`](../woostack-ideate/SKILL.md) to explore
-   the problem and converge on a design. Let it run its own approval gate. It hands back an
-   approved design and stops there — it writes no spec and chains no plan, so the next steps
-   are yours to drive.
-   The design phase loads `.woostack/wisdom/*.md` wholesale as guidance (via `woostack-ideate`'s
-   context exploration); see the wisdom contract
-   [`../woostack-init/references/wisdom.md`](../woostack-init/references/wisdom.md).
-</HARD-GATE>
-2. **Write the spec as markdown.** When the design is approved, do **not** write to a generic
-   `docs/specs/` location. **First create the spec+plan worktree** (the first write of this run,
-   per the [worktree contract](../woostack-init/references/worktrees.md)): pick the branch
-   `feature/<slug>`, then `git worktree add -b feature/<slug>
-   "$WOOSTACK_ROOT/.woostack/worktrees/feature-<slug>" "$(bash <wi>/resolve-base.sh)"`, run
-   `gt track --parent "$(bash <wi>/resolve-base.sh)"` from inside that worktree, and run
-   **steps 2–7 with cwd = that worktree** — the spec, the `woostack-plan` plan, and both hardens
-   author into it, never the primary tree. (On abandon at the spec gate, `git worktree remove
-   --force` it and delete the branch.) Instead author a markdown spec to
-   `.woostack/specs/YYYY-MM-DD-<slug>.md`, populating
-   [references/spec-template.md](references/spec-template.md). Markdown specs are the source
-   of truth: they carry `type: spec` frontmatter, are Obsidian vault nodes that can `[[link]]`
-   memory notes, and are excluded from memory recall routing by type. **Visualize on demand** —
-   if a rich view is wanted, hand the markdown to
-   [`woostack-visualize`](../woostack-visualize/SKILL.md) (audience `engineer` for specs; it
-   uses [references/spec-template.html](references/spec-template.html) as a starting point).
-   The HTML is a presentation target only, never the authored source. Set the spec's
-   `status: draft` in frontmatter — the build loop owns the `status:` enum and authors a
-   transition at each step so `/woostack-status` can read it (the enum and join contracts live
-   in [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md);
-   link it, do not restate it).
-<HARD-GATE backend="markdown" name="spec-approval">
-
-3. **Harden the spec, commit it for review, then get spec approval.** Invoke
-   [`woostack-harden`](../woostack-harden/SKILL.md) against the spec. Amend the spec
-   in place until hardening stops producing new questions, then set `status: hardened`. **Then
-   commit the spec before the gate** so the user reviews it in a PR, not as a raw worktree file:
-   from inside the `feature/<slug>` worktree, commit the `.woostack/specs/` markdown via
-   [`woostack-commit`](../woostack-commit/SKILL.md) on the existing `feature/<slug>` branch and
-   submit it — this opens the spec+plan base PR, **initially spec-only** (the plan is appended in
-   step 7; it is the same base PR, not a separate one). Then **always present the spec to the user
-   and get explicit approval before planning** — this is a hard gate. Point the user at the **PR
-   URL** (the committed spec; offer the file path or a `woostack-visualize` render if it helps),
-   wait for a clear yes, and make any requested changes before advancing.
-   - **Go** → set `status: approved` (the worktree stays alive; steps 4–7 plan into it and step 7
-     appends the plan to this same PR).
-   - **Revise** → amend the spec in the still-alive worktree, **commit the revision** on the same
-     `feature/<slug>` branch (so the PR reflects it), and re-present at the gate.
-   - **Abandon** → `git worktree remove --force` the worktree, delete the `feature/<slug>` branch,
-     and **close the now-open PR**.
-   Do **not** proceed to step 4 on inferred or assumed approval; silence is not a yes. Committing
-   the spec here is a work step; it adds no gate.
-</HARD-GATE>
-4. **Plan.** Once the spec is approved, invoke
-   [`woostack-plan`](../woostack-plan/SKILL.md) with the approved spec path. It writes the
-   plan to `.woostack/plans/<spec-basename>.md` with YAML frontmatter followed by the
-   `**Source:** [[specs/<basename>]]` wikilink line so status and doctor join it 1:1, structures
-   it as PR-sized increments, and sets the plan's `status: planning`. It writes the plan and
-   ships in this collection, so the build loop has no external skill dependencies.
-5. **Verify the increment decomposition.** `woostack-plan` already structures the plan as
-   PR-sized increments; build confirms the increment boundaries are reviewable, independently
-   shippable, and feed cleanly into `woostack-execute`. Flag any slice that is not reviewable
-   or independently shippable and propose a further split before executing. The
-   `spec : plan : PRs = 1 : 1 : N` invariant holds throughout: exactly one plan per spec, and
-   that one plan owns the N increment PRs.
-6. **Harden the plan.** Invoke [`woostack-harden`](../woostack-harden/SKILL.md) again, this
-   time against the plan and its increment breakdown — stress-test the sequencing, the
-   increment boundaries, and the verifications until hardening stops producing new questions.
-   Amend the plan markdown in place as answers land. This adds **no approval gate**: harden
-   owns none and hands straight back. The chain's last hard stop is the **execution-handoff
-   gate (step 8)**, after the spec+plan PR — not a plan-*quality* gate here. Do not turn this
-   harden into a plan-approval gate. When hardening stops producing new questions, set the
-   plan's `status: ready` — the [conventions.md](../woostack-status/references/conventions.md)
-   value for "plan hardened, ready for execution" (mirroring step 3's `hardened`, but for the
-   plan). Plans own implementation lifecycle, so this transition is authored on the **plan**, not the spec.
-7. **Append the plan to the spec+plan PR.** The spec was already committed and its PR opened in
-   step 3, so this step **adds the plan to that same PR** — it does not open a second one. Before
-   any implementation, commit the `.woostack/` plan via
-   [`woostack-commit`](../woostack-commit/SKILL.md) onto the **same** `feature/<slug>` branch,
-   updating the existing PR so it now carries the spec **and** the plan. This docs-only PR is the
-   **base of the stack** — execution increments (step 9) stack on top of it via `gt create`. It
-   carries no code and is **never merged** by build. This is a work step, not an approval stop. The
-   commit happens inside the spec+plan worktree via `woostack-commit`; after the plan is committed,
-   **teardown** the worktree
-   (`git worktree remove "$WOOSTACK_ROOT/.woostack/worktrees/feature-<slug>"`) — the branch/commits/PR
-   persist as the stack base. Leave the worktree on failure and report its path
-   ([worktree contract](../woostack-init/references/worktrees.md)).
-<HARD-GATE backend="markdown" name="execution-handoff">
-
-8. **Stop before execute (execution-handoff gate).** After the spec+plan PR is open, **halt** —
-   this is a hard gate. Surface the handoff artifacts: the plan path (`.woostack/plans/…`), the
-   spec+plan PR URL, and — on request — a
-   [`woostack-visualize`](../woostack-visualize/SKILL.md) render of the plan (audience
-   `engineer`). Then ask the user to choose:
-   - **Go** → proceed to step 9 and run `woostack-execute` in this session.
-   - **Run overnight** → proceed to step 9 but run
-     [`woostack-execute-overnight`](../woostack-execute-overnight/SKILL.md) instead: it drives the
-     whole plan **unattended** (autonomous, no further input) and leaves a morning report under
-     `.woostack/overnight/` for you to test. Use this to let a well-made plan run overnight.
-   - **Hand off** → stop here. The user takes the plan PR and executes later or elsewhere (e.g.
-     Codex, or a fresh session via `/woostack-execute <plan-path>`).
-   Ambiguous or no answer is **not** a "go": never auto-run execute (supervised or overnight)
-   without an explicit go-ahead. This is the chain's last hard gate.
-</HARD-GATE>
-9. **Execute.** Invoke [`woostack-execute`](../woostack-execute/SKILL.md) — or, if the user chose
-   **Run overnight** at step 8, [`woostack-execute-overnight`](../woostack-execute-overnight/SKILL.md)
-   (unattended) — with the plan path to
-   work the plan as PR-sized stacked increments on top of the spec+plan PR — each implemented
-   with TDD (the [woostack-tdd kernel](../woostack-tdd/SKILL.md)), the plan's checkboxes
-   ticked in place, committed via `woostack-commit`, reviewed per
-   the execution mode the active driver selects (`woostack-execute`: shared task-level
-   spec-compliance and code-quality checks, performed inline by the controller or by reviewer
-   subagents depending on mode; `woostack-execute-overnight` drives its own autonomous review
-   policy), and distilled into
-   `.woostack/memory/` — `woostack-execute` pausing on a blocking stop, `woostack-execute-overnight`
-   instead logging the blocker and continuing per its halt policy. `woostack-execute` owns the
-   per-increment commit/review/distill cadence and the inline-vs-subagent mode choice (one plan
-   per spec, multiple stacked PRs per plan), so it absorbs what used to be separate "distill
-   memory" and "offer the PR" steps here. As branches, commits, and increment PRs appear the
-   plan advances into the `executing` → `in-review` band; `woostack-execute` authors the plan's
-   terminal `status: done` at the final increment (so the authored value no longer lags), while the
-   board still **computes** that band from the artifacts via its truth table — showing `in-review`
-   until the final PR merges, then `done` — so any still-lagging authored `status:` is reconciled
-   rather than trusted blindly.
-10. **End on the chosen terminal state.** Build ends in one of three shapes, never merging any:
-    - **Hand off** → only the spec+plan PR is open (no increment PRs), ready for external or
-      later execute.
-    - **Go** → a Graphite stack with the spec+plan PR at the base and a reviewed increment PR
-      above each step.
-    - **Run overnight** → an autonomous `woostack-execute-overnight` run: a reviewed (or partially
-      reviewed, blockers logged) stack — linear or tree-stacked across `## Track:`s — plus a
-      morning report under `.woostack/overnight/`.
-    Build does not separately ask to open a PR (step 7 and the execute phase open them as work
-    steps) and **never merges**.
-
-### Markdown hard constraints (preserved)
-
-- **Inherit two gates, add one.** Do not insert *extra* approval stops beyond the three hard
-  gates: **design approval** (step 1) and **spec approval** (step 3), both inherited, plus the
-  **execution handoff** (step 8), which build owns because the plan→execute boundary belongs to
-  no sub-skill. The spec commit (step 3), the plan harden (step 6), and appending the plan to the
-  spec+plan PR (step 7) are work steps, not gates.
-- **Harden twice, neither harden gates.** Harden the spec (step 3, feeds the spec-approval gate)
-  and the plan (step 6, amends in place, no gate). The execution-handoff gate (step 8) is
-  separate and build-owned, not a plan-*quality* gate; never turn the plan harden into a
-  plan-approval gate.
-- **Always get explicit spec approval before planning.** After the spec harden, present the
-  written spec and wait for the user's clear yes. Never advance to `woostack-plan` on assumed
-  or inferred approval.
-- **Markdown specs and plans, under `.woostack/`.** Never write specs to a generic location
-  outside `.woostack/`. HTML is a render-on-demand target only, not the authored format.
-- **Commit the spec before its approval gate.** After the spec harden (step 3), commit the
-  `.woostack/specs/` markdown on the `feature/<slug>` branch and open the base PR **before** asking
-  for spec approval, so the user reviews the spec in the PR rather than a raw worktree file
-  (mirroring [`woostack-fix`](../woostack-fix/SKILL.md)). Revisions at the gate are committed
-  before re-presenting; Abandon closes the now-open PR. This is a work step — it adds no gate, so
-  the chain still has exactly the three hard gates.
-- **Spec+plan ship as their own PR before execution.** The spec is committed at the gate (step 3)
-  and the plan appended to the **same** docs-only PR (step 7) — the base of the stack — before any
-  implementation begins. One PR, not two; never merge it.
-- **Stop before execute.** Never auto-run execute — supervised `woostack-execute` or unattended
-  `woostack-execute-overnight`; always halt at the execution-handoff gate (step 8) after the
-  spec+plan PR and let the user choose Go / Run overnight / Hand off. The plan PR is the artifact
-  for executing here or in another tool. Ambiguous or no answer is not a "go."
-- **Never merge.** build ends on the terminal state (handoff PR, or reviewed stack), nothing
-  further.
-- **Author status on the owning Markdown artifact.** Follow the canonical lifecycle and ownership
-  rules in
-  [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md).
-  The local spec-gate `Abandon` path closes the open PR, then removes the temporary branch and
-  worktree; because no Markdown artifact survives, do not create a status-only abandonment
-  commit. Otherwise write each transition only on the artifact that owns it.
-- **One increment per cycle.** Do not let a single build cycle balloon past a reviewable PR.
-- **Distill durable knowledge only.** `woostack-execute` writes scoped, deduplicated memory
-  notes per increment — never feature-specific trivia, never a duplicate of an existing note. A
-  small curated store beats a large noisy one.
-
-## Linear backend procedure
-
-{/* <!-- linear-gates: design-approval | spec-approval | execution-handoff --> */}
-
-All Linear operations below use
-[`linear.sh`](../woostack-init/scripts/artifacts/linear.sh); cross-link its commands rather
-than embedding GraphQL, endpoint calls, or transport behavior. Every mutation must return a
-verified mandatory read-back receipt. A failed or incomplete receipt blocks the next step.
-Treat every returned Linear artifact under the shared
-[artifact trust boundary](../woostack-init/references/artifact-backends.md#linear-artifact-trust-boundary).
-
-<HARD-GATE backend="linear" name="design-approval">
-1. **Ideate.** Invoke
-   [`woostack-ideate`](../woostack-ideate/SKILL.md). It writes no artifact and stops until the
-   user explicitly approves the design. Silence or ambiguity does not clear the gate.
-</HARD-GATE>
-2. **Preflight, capture run context, discover, then capture the spec.** Before the first
-   mutation of the run, invoke `linear.sh preflight` with the resolver's configured workspace,
-   team name/key, project-status names, and issue-state names. Capture its normalized receipt
-   as `LINEAR_CONTEXT`; validate that it contains exactly the resolved workspace UUID, team
-   UUID, complete semantic project-status UUID map, and complete semantic issue-state UUID map.
-   Then extract and retain `LINEAR_TEAM_ID="$(jq -r '.team.id' <<<"$LINEAR_CONTEXT")"`,
-   `LINEAR_PROJECT_STATUSES="$(jq -c '.projectStatuses' <<<"$LINEAR_CONTEXT")"`, and
-   `LINEAR_ISSUE_STATES="$(jq -c '.issueStates' <<<"$LINEAR_CONTEXT")"`. The resolver's names
-   are preflight input only; every later adapter command uses these extracted UUID values as
-   `--team-id`, `--status-map`, and `--issue-state-map`. Invoke `linear.sh feature-resolve`
-   with the repository marker, `"$LINEAR_PROJECT_STATUSES"`, eligible semantic statuses, and
-   any explicit Linear UUID/URL supplied by the user.
-   - Across sessions, an explicit UUID or exact Linear URL wins. Without one, continue only
-     when discovery returns **exactly one eligible managed project** for this repository. Zero
-     means create; multiple candidates require explicit selection and no mutation.
-   - For a new feature, render the approved design with the backend-neutral sections in
-     [references/spec-template.md](references/spec-template.md), then invoke
-     `linear.sh feature-create` with `"$LINEAR_TEAM_ID"` and
-     `"$LINEAR_PROJECT_STATUSES"`. It creates one project in `draft`, one managed
-     `designState: draft` spec document, and verifies both by discovery/read-back.
-   - Resume never adopts by title. There must be **one managed Linear project, exactly one
-     managed spec document, and one ordered managed issue set** for the feature.
-   Linear mode creates **no spec/plan worktree, branch, commit, or docs-only PR**. It writes no
-   `.woostack/specs/` or `.woostack/plans/` source file.
-<HARD-GATE backend="linear" name="spec-approval">
-3. **Harden and approve the Linear spec.**
-   Invoke `linear.sh spec-read`, harden that selected document through `woostack-harden`, and
-   persist each revision with `linear.sh spec-write` using the last observed revision. On the
-   final verified write, change the managed metadata only from `designState: draft` to
-   `designState: hardened`; then invoke `linear.sh feature-transition` from `draft` to
-   `hardened` and require its mandatory read-back receipt. Present the managed spec document
-   URL and wait:
-   - **Go** → read again, use evidence-aware `linear.sh spec-write` to change only
-     `designState: hardened` to `designState: approved`, verify it, invoke
-     `linear.sh feature-transition` from `hardened` to `approved`, verify the project read-back,
-     then plan.
-   - **Revise** → read again with `linear.sh spec-read`, amend the same document, write with
-     `linear.sh spec-write` and its optimistic revision without changing `designState:
-     hardened`, require read-back, and re-present. The project remains `hardened`.
-   - **Abandon** → read again, use `linear.sh spec-write` to change the managed lifecycle to
-     `designState: abandoned`, verify it, invoke `linear.sh feature-transition --target
-     abandoned`, require project read-back, preserve the project/document audit history, and
-     stop. Never delete or archive it.
-   Failed read-back, ambiguity, or silence never advances the gate.
-</HARD-GATE>
-4. **Plan in Linear.** Invoke [`woostack-plan`](../woostack-plan/SKILL.md) with the selected
-   project UUID or exact Linear URL plus the retained resolver result and `LINEAR_CONTEXT`.
-   The planning skill owns the complete Linear planning procedure and reuses that normalized
-   caller context without resolving or preflighting again. Continue only after it hands back the
-   same owned project and spec in `planning` with the managed increment issues reconciled and
-   verified.
-5. **Verify and read back the plan.** Invoke `linear.sh plan-read` with
-   `"$LINEAR_ISSUE_STATES"` and reject missing or duplicate ordinals, cycles, cross-project
-   dependencies, native/metadata relation drift, unreviewable slices, uncovered ACs, or Git
-   ancestry that Graphite cannot represent. Replanning must preserve stable issue identities
-   and implementation evidence, may safely add/reorder/rewire, and must **refuse to remove an
-   issue with branch or pull-request evidence**.
-6. **Harden the plan in place.** Invoke `woostack-harden` against the selected ordered issue
-   set. Reconcile changes with `linear.sh plan-reconcile` using `"$LINEAR_TEAM_ID"` and
-   `"$LINEAR_ISSUE_STATES"`, then verify with `linear.sh plan-read`. This adds no approval gate.
-   Only a clean read-back permits another `linear.sh spec-read` plus evidence-aware
-   `linear.sh spec-write` to author `designState: planning → ready`, followed by the project
-   `planning → ready` through `linear.sh feature-transition` using
-   `"$LINEAR_PROJECT_STATUSES"` and another mandatory read-back receipt.
-7. **Freeze the execution base.** **Immediately before the execution-handoff gate**, resolve
-   the base branch with
-   [`resolve-base.sh`](../woostack-init/scripts/resolve-base.sh) and resolve its exact commit
-   SHA. Read the spec with `linear.sh spec-read`, write exactly the canonical `baseBranch`,
-   `baseCommitSha`, and `designState: ready` fields into its owned metadata with
-   `linear.sh spec-write --issue-state-map "$LINEAR_ISSUE_STATES"` using the observed revision,
-   then call `linear.sh feature-read` with both extracted UUID maps and require those exact
-   values in its normalized read-back. No lifecycle or artifact mutation may intervene
-   between this verified freeze and the gate. The pair is provisional while `designState` is
-   `ready`: an accidental `ready → ready` pair change fails closed, but explicit pre-execution
-   replanning may replace it only while every managed increment has null `branch` and
-   `pullRequest`.
-   - **Explicit replan sequence:** call `linear.sh plan-read` and verify that live evidence is
-     empty, then call `linear.sh spec-read` and retain its `.revision`. Call
-     `linear.sh feature-transition --target planning --replan --expected-revision
-     '<revision-json>'` with `"$LINEAR_PROJECT_STATUSES"` and `"$LINEAR_ISSUE_STATES"`. The
-     adapter resolves the repository-owned spec, requires the
-     project and managed spec lifecycle to match, rechecks null branch/PR evidence, and
-     optimistically claims the revisioned spec as
-     `planning` before it attempts the project transition. A concurrent execution approval loses
-     or wins that spec-revision race before the project can be mutated. If the project transition
-     then fails, stop on the verified, resumable `planning` spec receipt; only a later explicit
-     resume after fresh reads may complete the idempotent project transition. After a verified
-     return, the spec is already `planning`: reconcile and harden the new increment plan, return
-     `planning → ready`, resolve the new base immediately before handoff, and repeat this step's
-     verified freeze. Any branch or pull-request evidence, project/spec lifecycle mismatch, or
-     execution-approved/later `designState` rejects the change.
-8. <HARD-GATE backend="linear" name="execution-handoff">**Stop before execute.** Present the
-   project URL, spec document URL, ordered issue URLs and dependency/Git-parent shape, and frozen
-   base branch+SHA. Up to this point there is **no implementation branch, worktree, commit, or
-   PR**. Ask the user to choose:
-   - **Go** → record execution approval as described below, then run `woostack-execute` in this
-     session.
-   - **Run overnight** → record execution approval as described below, then run
-     `woostack-execute-overnight` unattended.
-   - **Hand off** → stop with the Linear artifacts ready for later or external execution; the
-     base remains provisional until that executor records approval.
-   For **Go** or **Run overnight**, before creating any implementation Git artifact, call
-   `linear.sh plan-read` and require null branch/PR evidence, call `linear.sh spec-read`, then
-   call `linear.sh spec-write --issue-state-map "$LINEAR_ISSUE_STATES"` with the observed
-   revision to change only `designState: ready` to `designState: executionApproved`. Verify it
-   with `linear.sh feature-read`. This work step is not another gate; it is the point where the
-   base pair becomes immutable. Ambiguous or no answer is not Go. Create no implementation Git
-   artifact until the user explicitly chooses **Go** or **Run overnight** and that verified
-   approval marker exists.
-</HARD-GATE>
-9. **Execute.** Invoke the selected execution skill with the Linear project UUID/URL. Linear
-   mode has no docs-only base PR: root increment branches start from the frozen SHA and
-   dependent increments use their declared Git parent. Execution owns issue/PR evidence and
-   lifecycle updates; build never merges.
+Stop after the selected plan is hardened and ready. Markdown must first append the plan to the
+same never-merged docs-only base PR. Linear must first verify and freeze `baseBranch` and
+`baseCommitSha`; after explicit **Go** or **Run overnight**, it must verify the
+`designState: executionApproved` write before creating any implementation Git artifact. Only an
+explicit **Go**, **Run overnight**, or **Hand off** clears this barrier.
 
 ## Shared terminal states
 
@@ -379,6 +88,7 @@ Build never separately asks to open a PR and never merges.
 - **Harden twice, neither harden gates.** Amend the selected spec and plan artifacts in place;
   hand directly back when no new questions remain.
 - **Always get explicit spec approval before planning.** Never advance on inferred approval.
+- **Silence is not approval.** Ambiguous, inferred, or missing answers never clear any gate.
 - **Markdown compatibility is exact.** Preserve `.woostack/specs/` and `.woostack/plans/`
   paths, YAML frontmatter, reciprocal Obsidian source joins, the feature worktree, and the
   single docs-only spec+plan base PR.
@@ -395,6 +105,11 @@ Build never separately asks to open a PR and never merges.
   `done`/`abandoned` are terminal. Every other jump or backtrack fails closed.
 - **One feature join.** Markdown remains `spec : plan : PRs = 1 : 1 : N`; Linear remains
   `project : spec document : increment issues : implementation PRs = 1 : 1 : N : N`.
+- **Lifecycle authority stays canonical.** Follow the canonical lifecycle and ownership rules in
+  [`../woostack-status/references/conventions.md`](../woostack-status/references/conventions.md).
+  On Markdown Abandon, close the PR and remove the worktree and branch; because no Markdown artifact survives,
+  never create a status-only abandonment commit. Linear preserves its
+  project/document audit history instead.
 - **Stop before execute.** Both backends halt for explicit **Go**, **Run overnight**, or
   **Hand off** and create no implementation Git artifact before Go/Run plus any required verified
   execution-approval write.

--- a/skills/woostack-build/references/linear-procedure.md
+++ b/skills/woostack-build/references/linear-procedure.md
@@ -1,0 +1,144 @@
+## Linear backend procedure
+
+## Procedure map
+
+- [Design and spec capture](#design-and-spec-capture)
+- [Spec approval and planning](#spec-approval-and-planning)
+- [Execution handoff and implementation](#execution-handoff-and-implementation)
+
+## Design and spec capture
+
+{/* <!-- linear-gates: design-approval | spec-approval | execution-handoff --> */}
+
+All Linear operations below use
+[`linear.sh`](../../woostack-init/scripts/artifacts/linear.sh); cross-link its commands rather
+than embedding GraphQL, endpoint calls, or transport behavior. Every mutation must return a
+verified mandatory read-back receipt. A failed or incomplete receipt blocks the next step.
+Treat every returned Linear artifact under the shared
+[artifact trust boundary](../../woostack-init/references/artifact-backends.md#linear-artifact-trust-boundary).
+
+<HARD-GATE backend="linear" name="design-approval">
+1. **Ideate.** Invoke
+   [`woostack-ideate`](../../woostack-ideate/SKILL.md). It writes no artifact and stops until the
+   user explicitly approves the design. Silence or ambiguity does not clear the gate.
+</HARD-GATE>
+2. **Preflight, capture run context, discover, then capture the spec.** Before the first
+   mutation of the run, invoke `linear.sh preflight` with the resolver's configured workspace,
+   team name/key, project-status names, and issue-state names. Capture its normalized receipt
+   as `LINEAR_CONTEXT`; validate that it contains exactly the resolved workspace UUID, team
+   UUID, complete semantic project-status UUID map, and complete semantic issue-state UUID map.
+   Then extract and retain `LINEAR_TEAM_ID="$(jq -r '.team.id' <<<"$LINEAR_CONTEXT")"`,
+   `LINEAR_PROJECT_STATUSES="$(jq -c '.projectStatuses' <<<"$LINEAR_CONTEXT")"`, and
+   `LINEAR_ISSUE_STATES="$(jq -c '.issueStates' <<<"$LINEAR_CONTEXT")"`. The resolver's names
+   are preflight input only; every later adapter command uses these extracted UUID values as
+   `--team-id`, `--status-map`, and `--issue-state-map`. Invoke `linear.sh feature-resolve`
+   with the repository marker, `"$LINEAR_PROJECT_STATUSES"`, eligible semantic statuses, and
+   any explicit Linear UUID/URL supplied by the user.
+   - Across sessions, an explicit UUID or exact Linear URL wins. Without one, continue only
+     when discovery returns **exactly one eligible managed project** for this repository. Zero
+     means create; multiple candidates require explicit selection and no mutation.
+   - For a new feature, render the approved design with the backend-neutral sections in
+     [references/spec-template.md](spec-template.md), then invoke
+     `linear.sh feature-create` with `"$LINEAR_TEAM_ID"` and
+     `"$LINEAR_PROJECT_STATUSES"`. It creates one project in `draft`, one managed
+     `designState: draft` spec document, and verifies both by discovery/read-back.
+   - Resume never adopts by title. There must be **one managed Linear project, exactly one
+     managed spec document, and one ordered managed issue set** for the feature.
+   Linear mode creates **no spec/plan worktree, branch, commit, or docs-only PR**. It writes no
+   `.woostack/specs/` or `.woostack/plans/` source file.
+
+## Spec approval and planning
+
+<HARD-GATE backend="linear" name="spec-approval">
+3. **Harden and approve the Linear spec.**
+   Invoke `linear.sh spec-read`, harden that selected document through `woostack-harden`, and
+   persist each revision with `linear.sh spec-write` using the last observed revision. On the
+   final verified write, change the managed metadata only from `designState: draft` to
+   `designState: hardened`; then invoke `linear.sh feature-transition` from `draft` to
+   `hardened` and require its mandatory read-back receipt. Present the managed spec document
+   URL and wait:
+   - **Go** → read again, use evidence-aware `linear.sh spec-write` to change only
+     `designState: hardened` to `designState: approved`, verify it, invoke
+     `linear.sh feature-transition` from `hardened` to `approved`, verify the project read-back,
+     then plan.
+   - **Revise** → read again with `linear.sh spec-read`, amend the same document, write with
+     `linear.sh spec-write` and its optimistic revision without changing `designState:
+     hardened`, require read-back, and re-present. The project remains `hardened`.
+   - **Abandon** → read again, use `linear.sh spec-write` to change the managed lifecycle to
+     `designState: abandoned`, verify it, invoke `linear.sh feature-transition --target
+     abandoned`, require project read-back, preserve the project/document audit history, and
+     stop. Never delete or archive it.
+   Failed read-back, ambiguity, or silence never advances the gate.
+</HARD-GATE>
+4. **Plan in Linear.** Invoke [`woostack-plan`](../../woostack-plan/SKILL.md) with the selected
+   project UUID or exact Linear URL plus the retained resolver result and `LINEAR_CONTEXT`.
+   The planning skill owns the complete Linear planning procedure and reuses that normalized
+   caller context without resolving or preflighting again. Continue only after it hands back the
+   same owned project and spec in `planning` with the managed increment issues reconciled and
+   verified.
+5. **Verify and read back the plan.** Invoke `linear.sh plan-read` with
+   `"$LINEAR_ISSUE_STATES"` and reject missing or duplicate ordinals, cycles, cross-project
+   dependencies, native/metadata relation drift, unreviewable slices, uncovered ACs, or Git
+   ancestry that Graphite cannot represent. Replanning must preserve stable issue identities
+   and implementation evidence, may safely add/reorder/rewire, and must **refuse to remove an
+   issue with branch or pull-request evidence**.
+6. **Harden the plan in place.** Invoke `woostack-harden` against the selected ordered issue
+   set. Reconcile changes with `linear.sh plan-reconcile` using `"$LINEAR_TEAM_ID"` and
+   `"$LINEAR_ISSUE_STATES"`, then verify with `linear.sh plan-read`. This adds no approval gate.
+   Only a clean read-back permits another `linear.sh spec-read` plus evidence-aware
+   `linear.sh spec-write` to author `designState: planning → ready`, followed by the project
+   `planning → ready` through `linear.sh feature-transition` using
+   `"$LINEAR_PROJECT_STATUSES"` and another mandatory read-back receipt.
+7. **Freeze the execution base.** **Immediately before the execution-handoff gate**, resolve
+   the base branch with
+   [`resolve-base.sh`](../../woostack-init/scripts/resolve-base.sh) and resolve its exact commit
+   SHA. Read the spec with `linear.sh spec-read`, write exactly the canonical `baseBranch`,
+   `baseCommitSha`, and `designState: ready` fields into its owned metadata with
+   `linear.sh spec-write --issue-state-map "$LINEAR_ISSUE_STATES"` using the observed revision,
+   then call `linear.sh feature-read` with both extracted UUID maps and require those exact
+   values in its normalized read-back. No lifecycle or artifact mutation may intervene
+   between this verified freeze and the gate. The pair is provisional while `designState` is
+   `ready`: an accidental `ready → ready` pair change fails closed, but explicit pre-execution
+   replanning may replace it only while every managed increment has null `branch` and
+   `pullRequest`.
+   - **Explicit replan sequence:** call `linear.sh plan-read` and verify that live evidence is
+     empty, then call `linear.sh spec-read` and retain its `.revision`. Call
+     `linear.sh feature-transition --target planning --replan --expected-revision
+     '<revision-json>'` with `"$LINEAR_PROJECT_STATUSES"` and `"$LINEAR_ISSUE_STATES"`. The
+     adapter resolves the repository-owned spec, requires the
+     project and managed spec lifecycle to match, rechecks null branch/PR evidence, and
+     optimistically claims the revisioned spec as
+     `planning` before it attempts the project transition. A concurrent execution approval loses
+     or wins that spec-revision race before the project can be mutated. If the project transition
+     then fails, stop on the verified, resumable `planning` spec receipt; only a later explicit
+     resume after fresh reads may complete the idempotent project transition. After a verified
+     return, the spec is already `planning`: reconcile and harden the new increment plan, return
+     `planning → ready`, resolve the new base immediately before handoff, and repeat this step's
+     verified freeze. Any branch or pull-request evidence, project/spec lifecycle mismatch, or
+     execution-approved/later `designState` rejects the change.
+
+## Execution handoff and implementation
+
+8. <HARD-GATE backend="linear" name="execution-handoff">**Stop before execute.** Present the
+   project URL, spec document URL, ordered issue URLs and dependency/Git-parent shape, and frozen
+   base branch+SHA. Up to this point there is **no implementation branch, worktree, commit, or
+   PR**. Ask the user to choose:
+   - **Go** → record execution approval as described below, then run `woostack-execute` in this
+     session.
+   - **Run overnight** → record execution approval as described below, then run
+     `woostack-execute-overnight` unattended.
+   - **Hand off** → stop with the Linear artifacts ready for later or external execution; the
+     base remains provisional until that executor records approval.
+   For **Go** or **Run overnight**, before creating any implementation Git artifact, call
+   `linear.sh plan-read` and require null branch/PR evidence, call `linear.sh spec-read`, then
+   call `linear.sh spec-write --issue-state-map "$LINEAR_ISSUE_STATES"` with the observed
+   revision to change only `designState: ready` to `designState: executionApproved`. Verify it
+   with `linear.sh feature-read`. This work step is not another gate; it is the point where the
+   base pair becomes immutable. Ambiguous or no answer is not Go. Create no implementation Git
+   artifact until the user explicitly chooses **Go** or **Run overnight** and that verified
+   approval marker exists.
+</HARD-GATE>
+9. **Execute.** Invoke the selected execution skill with the Linear project UUID/URL. Linear
+   mode has no docs-only base PR: root increment branches start from the frozen SHA and
+   dependent increments use their declared Git parent. Execution owns issue/PR evidence and
+   lifecycle updates; build never merges.

--- a/skills/woostack-build/references/markdown-procedure.md
+++ b/skills/woostack-build/references/markdown-procedure.md
@@ -1,0 +1,195 @@
+## Markdown backend procedure
+
+## Procedure map
+
+- [Design and spec capture](#design-and-spec-capture)
+- [Spec approval and planning](#spec-approval-and-planning)
+- [Execution handoff and implementation](#execution-handoff-and-implementation)
+- [Preserved hard constraints](#markdown-hard-constraints-preserved)
+
+## Design and spec capture
+
+{/* <!-- markdown-gates: design-approval | spec-approval | execution-handoff --> */}
+
+<HARD-GATE backend="markdown" name="design-approval">
+
+1. **Ideate.** Invoke [`woostack-ideate`](../../woostack-ideate/SKILL.md) to explore
+   the problem and converge on a design. Let it run its own approval gate. It hands back an
+   approved design and stops there — it writes no spec and chains no plan, so the next steps
+   are yours to drive.
+   The design phase loads `.woostack/wisdom/*.md` wholesale as guidance (via `woostack-ideate`'s
+   context exploration); see the wisdom contract
+   [`../../woostack-init/references/wisdom.md`](../../woostack-init/references/wisdom.md).
+</HARD-GATE>
+2. **Write the spec as markdown.** When the design is approved, do **not** write to a generic
+   `docs/specs/` location. **First create the spec+plan worktree** (the first write of this run,
+   per the [worktree contract](../../woostack-init/references/worktrees.md)): pick the branch
+   `feature/<slug>`, then `git worktree add -b feature/<slug>
+   "$WOOSTACK_ROOT/.woostack/worktrees/feature-<slug>" "$(bash <wi>/resolve-base.sh)"`, run
+   `gt track --parent "$(bash <wi>/resolve-base.sh)"` from inside that worktree, and run
+   **steps 2–7 with cwd = that worktree** — the spec, the `woostack-plan` plan, and both hardens
+   author into it, never the primary tree. (On abandon at the spec gate, `git worktree remove
+   --force` it and delete the branch.) Instead author a markdown spec to
+   `.woostack/specs/YYYY-MM-DD-<slug>.md`, populating
+   [references/spec-template.md](spec-template.md). Markdown specs are the source
+   of truth: they carry `type: spec` frontmatter, are Obsidian vault nodes that can `[[link]]`
+   memory notes, and are excluded from memory recall routing by type. **Visualize on demand** —
+   if a rich view is wanted, hand the markdown to
+   [`woostack-visualize`](../../woostack-visualize/SKILL.md) (audience `engineer` for specs; it
+   uses [references/spec-template.html](spec-template.html) as a starting point).
+   The HTML is a presentation target only, never the authored source. Set the spec's
+   `status: draft` in frontmatter — the build loop owns the `status:` enum and authors a
+   transition at each step so `/woostack-status` can read it (the enum and join contracts live
+   in [`../../woostack-status/references/conventions.md`](../../woostack-status/references/conventions.md);
+   link it, do not restate it).
+
+## Spec approval and planning
+
+<HARD-GATE backend="markdown" name="spec-approval">
+
+3. **Harden the spec, commit it for review, then get spec approval.** Invoke
+   [`woostack-harden`](../../woostack-harden/SKILL.md) against the spec. Amend the spec
+   in place until hardening stops producing new questions, then set `status: hardened`. **Then
+   commit the spec before the gate** so the user reviews it in a PR, not as a raw worktree file:
+   from inside the `feature/<slug>` worktree, commit the `.woostack/specs/` markdown via
+   [`woostack-commit`](../../woostack-commit/SKILL.md) on the existing `feature/<slug>` branch and
+   submit it — this opens the spec+plan base PR, **initially spec-only** (the plan is appended in
+   step 7; it is the same base PR, not a separate one). Then **always present the spec to the user
+   and get explicit approval before planning** — this is a hard gate. Point the user at the **PR
+   URL** (the committed spec; offer the file path or a `woostack-visualize` render if it helps),
+   wait for a clear yes, and make any requested changes before advancing.
+   - **Go** → set `status: approved` (the worktree stays alive; steps 4–7 plan into it and step 7
+     appends the plan to this same PR).
+   - **Revise** → amend the spec in the still-alive worktree, **commit the revision** on the same
+     `feature/<slug>` branch (so the PR reflects it), and re-present at the gate.
+   - **Abandon** → **close the now-open PR**, then `git worktree remove --force` the worktree
+     and delete the `feature/<slug>` branch.
+   Do **not** proceed to step 4 on inferred or assumed approval; silence is not a yes. Committing
+   the spec here is a work step; it adds no gate.
+</HARD-GATE>
+4. **Plan.** Once the spec is approved, invoke
+   [`woostack-plan`](../../woostack-plan/SKILL.md) with the approved spec path. It writes the
+   plan to `.woostack/plans/<spec-basename>.md` with YAML frontmatter followed by the
+   `**Source:** [[specs/<basename>]]` wikilink line so status and doctor join it 1:1, structures
+   it as PR-sized increments, and sets the plan's `status: planning`. It writes the plan and
+   ships in this collection, so the build loop has no external skill dependencies.
+5. **Verify the increment decomposition.** `woostack-plan` already structures the plan as
+   PR-sized increments; build confirms the increment boundaries are reviewable, independently
+   shippable, and feed cleanly into `woostack-execute`. Flag any slice that is not reviewable
+   or independently shippable and propose a further split before executing. The
+   `spec : plan : PRs = 1 : 1 : N` invariant holds throughout: exactly one plan per spec, and
+   that one plan owns the N increment PRs.
+6. **Harden the plan.** Invoke [`woostack-harden`](../../woostack-harden/SKILL.md) again, this
+   time against the plan and its increment breakdown — stress-test the sequencing, the
+   increment boundaries, and the verifications until hardening stops producing new questions.
+   Amend the plan markdown in place as answers land. This adds **no approval gate**: harden
+   owns none and hands straight back. The chain's last hard stop is the **execution-handoff
+   gate (step 8)**, after the spec+plan PR — not a plan-*quality* gate here. Do not turn this
+   harden into a plan-approval gate. When hardening stops producing new questions, set the
+   plan's `status: ready` — the [conventions.md](../../woostack-status/references/conventions.md)
+   value for "plan hardened, ready for execution" (mirroring step 3's `hardened`, but for the
+   plan). Plans own implementation lifecycle, so this transition is authored on the **plan**, not the spec.
+7. **Append the plan to the spec+plan PR.** The spec was already committed and its PR opened in
+   step 3, so this step **adds the plan to that same PR** — it does not open a second one. Before
+   any implementation, commit the `.woostack/` plan via
+   [`woostack-commit`](../../woostack-commit/SKILL.md) onto the **same** `feature/<slug>` branch,
+   updating the existing PR so it now carries the spec **and** the plan. This docs-only PR is the
+   **base of the stack** — execution increments (step 9) stack on top of it via `gt create`. It
+   carries no code and is **never merged** by build. This is a work step, not an approval stop. The
+   commit happens inside the spec+plan worktree via `woostack-commit`; after the plan is committed,
+   **teardown** the worktree
+   (`git worktree remove "$WOOSTACK_ROOT/.woostack/worktrees/feature-<slug>"`) — the branch/commits/PR
+   persist as the stack base. Leave the worktree on failure and report its path
+   ([worktree contract](../../woostack-init/references/worktrees.md)).
+
+## Execution handoff and implementation
+
+<HARD-GATE backend="markdown" name="execution-handoff">
+
+8. **Stop before execute (execution-handoff gate).** After the spec+plan PR is open, **halt** —
+   this is a hard gate. Surface the handoff artifacts: the plan path (`.woostack/plans/…`), the
+   spec+plan PR URL, and — on request — a
+   [`woostack-visualize`](../../woostack-visualize/SKILL.md) render of the plan (audience
+   `engineer`). Then ask the user to choose:
+   - **Go** → proceed to step 9 and run `woostack-execute` in this session.
+   - **Run overnight** → proceed to step 9 but run
+     [`woostack-execute-overnight`](../../woostack-execute-overnight/SKILL.md) instead: it drives the
+     whole plan **unattended** (autonomous, no further input) and leaves a morning report under
+     `.woostack/overnight/` for you to test. Use this to let a well-made plan run overnight.
+   - **Hand off** → stop here. The user takes the plan PR and executes later or elsewhere (e.g.
+     Codex, or a fresh session via `/woostack-execute <plan-path>`).
+   Ambiguous or no answer is **not** a "go": never auto-run execute (supervised or overnight)
+   without an explicit go-ahead. This is the chain's last hard gate.
+</HARD-GATE>
+9. **Execute.** Invoke [`woostack-execute`](../../woostack-execute/SKILL.md) — or, if the user chose
+   **Run overnight** at step 8, [`woostack-execute-overnight`](../../woostack-execute-overnight/SKILL.md)
+   (unattended) — with the plan path to
+   work the plan as PR-sized stacked increments on top of the spec+plan PR — each implemented
+   with TDD (the [woostack-tdd kernel](../../woostack-tdd/SKILL.md)), the plan's checkboxes
+   ticked in place, committed via `woostack-commit`, reviewed per
+   the execution mode the active driver selects (`woostack-execute`: shared task-level
+   spec-compliance and code-quality checks, performed inline by the controller or by reviewer
+   subagents depending on mode; `woostack-execute-overnight` drives its own autonomous review
+   policy), and distilled into
+   `.woostack/memory/` — `woostack-execute` pausing on a blocking stop, `woostack-execute-overnight`
+   instead logging the blocker and continuing per its halt policy. `woostack-execute` owns the
+   per-increment commit/review/distill cadence and the inline-vs-subagent mode choice (one plan
+   per spec, multiple stacked PRs per plan), so it absorbs what used to be separate "distill
+   memory" and "offer the PR" steps here. As branches, commits, and increment PRs appear the
+   plan advances into the `executing` → `in-review` band; `woostack-execute` authors the plan's
+   terminal `status: done` at the final increment (so the authored value no longer lags), while the
+   board still **computes** that band from the artifacts via its truth table — showing `in-review`
+   until the final PR merges, then `done` — so any still-lagging authored `status:` is reconciled
+   rather than trusted blindly.
+10. **End on the chosen terminal state.** Build ends in one of three shapes, never merging any:
+    - **Hand off** → only the spec+plan PR is open (no increment PRs), ready for external or
+      later execute.
+    - **Go** → a Graphite stack with the spec+plan PR at the base and a reviewed increment PR
+      above each step.
+    - **Run overnight** → an autonomous `woostack-execute-overnight` run: a reviewed (or partially
+      reviewed, blockers logged) stack — linear or tree-stacked across `## Track:`s — plus a
+      morning report under `.woostack/overnight/`.
+    Build does not separately ask to open a PR (step 7 and the execute phase open them as work
+    steps) and **never merges**.
+
+### Markdown hard constraints (preserved)
+
+- **Inherit two gates, add one.** Do not insert *extra* approval stops beyond the three hard
+  gates: **design approval** (step 1) and **spec approval** (step 3), both inherited, plus the
+  **execution handoff** (step 8), which build owns because the plan→execute boundary belongs to
+  no sub-skill. The spec commit (step 3), the plan harden (step 6), and appending the plan to the
+  spec+plan PR (step 7) are work steps, not gates.
+- **Harden twice, neither harden gates.** Harden the spec (step 3, feeds the spec-approval gate)
+  and the plan (step 6, amends in place, no gate). The execution-handoff gate (step 8) is
+  separate and build-owned, not a plan-*quality* gate; never turn the plan harden into a
+  plan-approval gate.
+- **Always get explicit spec approval before planning.** After the spec harden, present the
+  written spec and wait for the user's clear yes. Never advance to `woostack-plan` on assumed
+  or inferred approval.
+- **Markdown specs and plans, under `.woostack/`.** Never write specs to a generic location
+  outside `.woostack/`. HTML is a render-on-demand target only, not the authored format.
+- **Commit the spec before its approval gate.** After the spec harden (step 3), commit the
+  `.woostack/specs/` markdown on the `feature/<slug>` branch and open the base PR **before** asking
+  for spec approval, so the user reviews the spec in the PR rather than a raw worktree file
+  (mirroring [`woostack-fix`](../../woostack-fix/SKILL.md)). Revisions at the gate are committed
+  before re-presenting; Abandon closes the now-open PR. This is a work step — it adds no gate, so
+  the chain still has exactly the three hard gates.
+- **Spec+plan ship as their own PR before execution.** The spec is committed at the gate (step 3)
+  and the plan appended to the **same** docs-only PR (step 7) — the base of the stack — before any
+  implementation begins. One PR, not two; never merge it.
+- **Stop before execute.** Never auto-run execute — supervised `woostack-execute` or unattended
+  `woostack-execute-overnight`; always halt at the execution-handoff gate (step 8) after the
+  spec+plan PR and let the user choose Go / Run overnight / Hand off. The plan PR is the artifact
+  for executing here or in another tool. Ambiguous or no answer is not a "go."
+- **Never merge.** build ends on the terminal state (handoff PR, or reviewed stack), nothing
+  further.
+- **Author status on the owning Markdown artifact.** Follow the canonical lifecycle and ownership
+  rules in
+  [`../../woostack-status/references/conventions.md`](../../woostack-status/references/conventions.md).
+  The local spec-gate `Abandon` path closes the open PR, then removes the temporary branch and
+  worktree; because no Markdown artifact survives, do not create a status-only abandonment
+  commit. Otherwise write each transition only on the artifact that owns it.
+- **One increment per cycle.** Do not let a single build cycle balloon past a reviewable PR.
+- **Distill durable knowledge only.** `woostack-execute` writes scoped, deduplicated memory
+  notes per increment — never feature-specific trivia, never a duplicate of an existing note. A
+  small curated store beats a large noisy one.

--- a/skills/woostack-build/scripts/tests/test-progressive-disclosure.sh
+++ b/skills/woostack-build/scripts/tests/test-progressive-disclosure.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+
+SKILL="$ROOT/skills/woostack-build/SKILL.md"
+MARKDOWN_REF="$ROOT/skills/woostack-build/references/markdown-procedure.md"
+LINEAR_REF="$ROOT/skills/woostack-build/references/linear-procedure.md"
+ROOT_TEXT="$(cat "$SKILL")"
+
+assert_matches() { # content regex message
+  if grep -Eq -- "$2" <<< "$1"; then pass; else
+    fail "$3"
+    echo "    content does not match [$2]"
+  fi
+}
+
+assert_ordered() { # content scope tokens...
+  local content="$1" scope="$2" token rest
+  shift 2
+  rest="$content"
+  for token in "$@"; do
+    if [[ "$rest" == *"$token"* ]]; then
+      rest="${rest#*"$token"}"
+    else
+      fail "$scope missing or misorders [$token]"
+      return
+    fi
+  done
+  pass
+}
+
+paragraph_for_href() { # file href
+  awk -v href="$2" 'BEGIN { RS=""; ORS="\n" } index($0, href) { gsub(/[[:space:]]+/, " "); print }' "$1"
+}
+
+MARKDOWN=""
+LINEAR=""
+if [ -f "$MARKDOWN_REF" ]; then pass; MARKDOWN="$(cat "$MARKDOWN_REF")"; else fail 'direct reference exists: references/markdown-procedure.md'; fi
+if [ -f "$LINEAR_REF" ]; then pass; LINEAR="$(cat "$LINEAR_REF")"; else fail 'direct reference exists: references/linear-procedure.md'; fi
+
+# Root remains a useful orchestrator: resolve once, run the shared chain, expose
+# the three approval barriers, terminal states, and the non-negotiable rules.
+assert_matches "$ROOT_TEXT" '^## .*([Bb]ackend|[Rr]esol)' 'root retains backend resolution'
+assert_matches "$ROOT_TEXT" 'resolve-backend\.sh.*<repo-root>' 'root retains the backend resolver argument contract'
+assert_matches "$ROOT_TEXT" '^## .*[Ss]hared.*([Cc]hain|[Pp]rocedure)|^## (Procedure|Shared chain)$' 'root retains the shared chain'
+assert_matches "$ROOT_TEXT" '^## Shared terminal states' 'root retains shared terminal states'
+assert_matches "$ROOT_TEXT" '^## Hard constraints' 'root has a prominent Hard constraints section'
+for gate in design-approval spec-approval execution-handoff; do
+  assert_matches "$ROOT_TEXT" "${gate}|${gate//-/[ -]}" "root names the $gate barrier"
+done
+assert_matches "$ROOT_TEXT" 'silence is not (a yes|approval)|[Ss]ilence.*(does not|never).*([Aa]pprov|gate)' 'Hard constraints say silence is not approval'
+assert_matches "$ROOT_TEXT" '[Ee]xactly three hard gates|three hard gates' 'Hard constraints retain exactly three gates'
+assert_matches "$ROOT_TEXT" '[Nn]ever mix backends|Linear failure never falls back' 'Hard constraints prohibit backend mixing'
+
+# Each backend is selected directly and conditionally from root; neither reader
+# has to discover or traverse the other backend's procedure.
+for reference in markdown-procedure.md linear-procedure.md; do
+  href="(references/$reference)"
+  context="$(paragraph_for_href "$SKILL" "$href")"
+  if [ -n "$context" ]; then pass; else fail "root directly links exact href references/$reference"; continue; fi
+  assert_matches "$context" '([Ww]hen|[Ii]f|[Oo]nly|[Rr]ead.*(when|for)|[Uu]se.*(when|for)|[Ss]elected)' "references/$reference link has meaningful when-to-read context"
+  case "$reference" in
+    markdown-procedure.md)
+      assert_matches "$context" '[Mm]arkdown' 'Markdown reader is conditional on Markdown selection'
+      assert_not_contains "$context" 'references/linear-procedure.md' 'Markdown reader does not select Linear procedure'
+      ;;
+    linear-procedure.md)
+      assert_matches "$context" '[Ll]inear' 'Linear reader is conditional on Linear selection'
+      assert_not_contains "$context" 'references/markdown-procedure.md' 'Linear reader does not select Markdown procedure'
+      ;;
+  esac
+done
+assert_not_contains "$ROOT_TEXT" 'Read both' 'root never requires both backend references'
+assert_not_contains "$ROOT_TEXT" 'read both' 'root never requires both backend references (lowercase)'
+
+root_lines="$(wc -l < "$SKILL" | tr -d ' ')"
+if [ "$root_lines" -le 500 ]; then pass; else fail "root stays at or below approximately 500 lines (actual: $root_lines)"; fi
+
+# Both direct references independently retain the same explicit, ordered gate
+# barriers. Tags and comments make the barriers resistant to prose reshuffling.
+for backend in markdown linear; do
+  if [ "$backend" = markdown ]; then procedure="$MARKDOWN"; other=linear; else procedure="$LINEAR"; other=markdown; fi
+  [ -n "$procedure" ] || continue
+  assert_contains "$procedure" "<!-- $backend-gates: design-approval | spec-approval | execution-handoff -->" "$backend reference retains the ordered gate manifest"
+  assert_ordered "$procedure" "$backend reference gate barriers" \
+    "<HARD-GATE backend=\"$backend\" name=\"design-approval\">" '</HARD-GATE>' \
+    "<HARD-GATE backend=\"$backend\" name=\"spec-approval\">" '</HARD-GATE>' \
+    "<HARD-GATE backend=\"$backend\" name=\"execution-handoff\">" '</HARD-GATE>'
+  count="$(grep -Ec "<HARD-GATE backend=\"$backend\" name=\"(design-approval|spec-approval|execution-handoff)\">" <<< "$procedure" || true)"
+  assert_eq "$count" 3 "$backend reference has exactly three structural barriers"
+  assert_not_contains "$procedure" "$other-procedure.md" "$backend reference does not nest the $other reader"
+  assert_not_contains "$procedure" "backend=\"$other\"" "$backend reference contains no $other gate"
+done
+
+# The split moves content, not behavior: pin distinctive markers spanning the
+# complete existing procedures, including ordering, handoff, and terminal work.
+for token in \
+  '.woostack/specs/YYYY-MM-DD-<slug>.md' \
+  '`**Source:** [[specs/<basename>]]`' \
+  'close the now-open PR' \
+  'per-increment commit/review/distill cadence' \
+  'terminal `status: done`' \
+  'only the spec+plan PR is open (no increment PRs)' \
+  'reviewed increment PR' \
+  'morning report under'; do
+  [ -z "$MARKDOWN" ] || assert_contains "$MARKDOWN" "$token" "Markdown procedure retains $token"
+done
+for token in \
+  'linear.sh preflight' 'LINEAR_CONTEXT' 'LINEAR_TEAM_ID' \
+  'linear.sh feature-resolve' 'linear.sh feature-create' \
+  'linear.sh plan-reconcile' 'baseBranch' 'baseCommitSha' \
+  'Explicit replan sequence' '--target planning --replan' \
+  'linear.sh plan-read' 'linear.sh spec-read' 'linear.sh spec-write' \
+  'designState: executionApproved' 'preserve the project/document audit history' \
+  'root increment branches start from the frozen SHA'; do
+  [ -z "$LINEAR" ] || assert_contains "$LINEAR" "$token" "Linear procedure retains $token"
+done
+if [ -n "$LINEAR" ]; then
+  assert_not_contains "$LINEAR" 'git worktree add' 'Linear procedure has no Markdown worktree authoring'
+  assert_not_contains "$LINEAR" 'gt create' 'Linear procedure has no docs-only Graphite authoring'
+  assert_not_contains "$LINEAR" 'api.linear.app/graphql' 'Linear procedure uses adapters, not GraphQL'
+  assert_not_contains "$LINEAR" 'query {' 'Linear procedure contains no raw GraphQL query'
+  assert_not_contains "$LINEAR" 'mutation {' 'Linear procedure contains no raw GraphQL mutation'
+fi
+
+finish

--- a/skills/woostack-build/tests/test-linear-build-contract.sh
+++ b/skills/woostack-build/tests/test-linear-build-contract.sh
@@ -10,6 +10,8 @@ from pathlib import Path
 root = Path(sys.argv[1])
 paths = {
     "build": root / "skills/woostack-build/SKILL.md",
+    "markdown_procedure": root / "skills/woostack-build/references/markdown-procedure.md",
+    "linear_procedure": root / "skills/woostack-build/references/linear-procedure.md",
     "plan": root / "skills/woostack-plan/SKILL.md",
     "harden": root / "skills/woostack-harden/SKILL.md",
     "ideate": root / "skills/woostack-ideate/SKILL.md",
@@ -51,8 +53,10 @@ def ordered(text, tokens, scope):
             fail(f"{scope} missing or misorders {token!r}")
 
 build = texts["build"]
-markdown_branch = section(build, "## Markdown backend procedure", "## Linear backend procedure")
-linear_branch = section(build, "## Linear backend procedure", "## Shared terminal states")
+markdown_branch = build + "\n" + texts["markdown_procedure"]
+linear_branch = build + "\n" + texts["linear_procedure"]
+must_not(texts["markdown_procedure"], "linear-procedure.md", "Markdown selected procedure")
+must_not(texts["linear_procedure"], "markdown-procedure.md", "Linear selected procedure")
 linear_spec_gate = section(
     linear_branch,
     '<HARD-GATE backend="linear" name="spec-approval">',
@@ -126,7 +130,7 @@ for token in (
     "close the now-open PR",
 ):
     must(markdown_branch, token, "Markdown abandon cleanup")
-must_not(markdown_branch, "`abandoned`", "Markdown branch")
+must_not(texts["markdown_procedure"], "`abandoned`", "Markdown procedure")
 must(linear_branch, "preserve the project/document audit history", "Linear abandon persistence")
 
 # Linear preflight is captured once and every later command consumes UUID context, not names.
@@ -161,7 +165,7 @@ for token in (
 must(linear_branch, "no spec/plan worktree, branch, commit, or docs-only PR", "Linear branch")
 must(linear_branch, "`.woostack/specs/` or `.woostack/plans/` source file", "Linear branch")
 for forbidden in ("git worktree add", "gt create", "woostack-commit"):
-    must_not(linear_branch, forbidden, "Linear branch")
+    must_not(texts["linear_procedure"], forbidden, "Linear procedure")
 
 # Ready precedes the provisional branch/SHA freeze; explicit Go/overnight approval makes the
 # frozen base immutable before either executor starts.
@@ -263,8 +267,8 @@ for token in ("baseBranch", "baseCommitSha", "GIT_COMMIT_SHA_RE", "DESIGN_SEQUEN
 for token in ("baseBranch:$baseBranch", "baseCommitSha:$baseCommitSha", "--replan", "--issue-state-map", "--expected-revision", "project and managed spec lifecycle mismatch blocks replanning"):
     must(texts["linear"], token, "Linear adapter")
 for token in ("retain its `.revision`", "--expected-revision", "claims the revisioned spec as", "before it attempts the project transition", "verified, resumable `planning` spec receipt"):
-    must(build, token, "Linear replan caller")
-for workflow in (build, texts["plan"], texts["harden"], texts["ideate"]):
+    must(linear_branch, token, "Linear replan caller")
+for workflow in (build, texts["linear_procedure"], texts["plan"], texts["harden"], texts["ideate"]):
     for forbidden in ("api.linear.app/graphql", "query {", "mutation {"):
         must_not(workflow, forbidden, "workflow skill")
 

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -6,8 +6,8 @@ description: Use to execute an approved Markdown plan or Linear project as PR-si
 # woostack-execute
 
 Execute an approved plan by driving it to implementation as a sequence of PR-sized, stacked
-increments. This is woostack's own execution phase — [`woostack-build`](../woostack-build/SKILL.md)
-step 8. It keeps the discipline that makes plan execution reliable (load the plan, review it
+increments. This is woostack's own execution phase after
+[`woostack-build`](../woostack-build/SKILL.md) clears its execution-handoff gate. It keeps the discipline that makes plan execution reliable (load the plan, review it
 critically, follow steps exactly, run verifications, stop when blocked) and adds the woostack PR
 cadence: **one plan per spec, multiple stacked PRs per plan**, each increment committed,
 reviewed, and distilled before the next. It never merges and owns no approval gate.
@@ -74,10 +74,11 @@ is available), otherwise inline. If `--subagent` is requested but the host canno
 subagents, say so and fall back to inline (degraded, not equivalent) or stop and ask — never
 pretend subagent mode ran.
 
-When `woostack-build` reaches step 8 it invokes this skill with its selected artifact. In Markdown
-mode, build has already committed the spec and plan as their own PR (build step 7), and that
-docs-only PR is the base of the stack. Linear has no docs-only PR; its frozen base and declared
-issue Git parents drive implementation ancestry.
+When `woostack-build` clears the execution-handoff gate, it invokes this skill with its selected
+artifact. In Markdown mode, the [Markdown procedure](../woostack-build/references/markdown-procedure.md)
+has already committed the spec and plan in one docs-only PR that forms the stack base. The
+[Linear procedure](../woostack-build/references/linear-procedure.md) creates no docs-only PR;
+its frozen base and declared issue Git parents drive implementation ancestry.
 
 ## Load and review the artifact
 
@@ -99,8 +100,8 @@ do not rely on commit-time branch creation after work has already changed the tr
 ## PR-sized increments
 
 Implement the plan as a sequence of independently shippable increments — preferably ≤500 LOC
-each (a soft target, not a gate). When `woostack-build` invoked this skill, its step 5 already
-decomposed the plan into increments. When run standalone, perform the same decomposition:
+each (a soft target, not a gate). When `woostack-build` invoked this skill, its plan-verification
+phase already decomposed the plan into increments. When run standalone, perform the same decomposition:
 structure the work as increments, flag any slice that can't reasonably stay under the target,
 and propose a split before executing it. Genuinely atomic changes may exceed the target.
 
@@ -176,7 +177,7 @@ frontmatter or arbitrary issue checkboxes.
    for every non-final increment, and use terminal `status: done` for the final increment. These
    are Markdown execute's authored lifecycle transitions after `planning`
    ([`woostack-plan`](../woostack-plan/SKILL.md)) and `ready`
-   ([`woostack-build`](../woostack-build/SKILL.md) step 6). **Skip it for a `.woostack/fixes/`
+   (the [`woostack-build`](../woostack-build/SKILL.md) plan-hardening phase). **Skip it for a `.woostack/fixes/`
    file:** a fix file's frontmatter lifecycle stays owned by
    [`woostack-fix`](../woostack-fix/SKILL.md). The board still derives the `in-review` band from
    artifacts and shows `in-review` while an increment PR is open, reconciling to `done` at merge

--- a/skills/woostack-harden/SKILL.md
+++ b/skills/woostack-harden/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: woostack-harden
-description: Use to harden a plan, spec, or design by relentless interview — walk every branch of the decision tree, resolve each open question one at a time with a recommended answer, and amend the artifact in place until no new questions remain. This is the harden phase of the woostack build loop (woostack-build steps 3 and 6 — first the spec, then the plan); also usable standalone to stress-test or "grill me" on a design before committing to it.
+description: Use to harden a plan, spec, or design by relentless interview — walk every branch of the decision tree, resolve each open question one at a time with a recommended answer, and amend the artifact in place until no new questions remain. This is the spec-and-plan hardening phase of the woostack build loop; also usable standalone to stress-test or "grill me" on a design before committing to it.
 ---
 
 # woostack-harden
 
 Harden a plan, spec, or design by interviewing the user relentlessly until you reach shared
-understanding and the artifact stops producing new questions. This is woostack's own hardening
-phase — [`woostack-build`](../woostack-build/SKILL.md) steps 3 (the spec) and 6 (the plan).
+understanding and the artifact stops producing new questions. This is woostack's own spec-and-plan
+hardening phase in the [`woostack-build`](../woostack-build/SKILL.md) shared chain.
 Resolve the configured backend when the target is a stored spec or plan and **amend the selected
 backend artifact in place**. An explicitly named design or fix file remains backend-neutral and
 is amended directly. Stop when no new questions remain. This skill owns **no approval gate**.

--- a/skills/woostack-init/references/worktrees.md
+++ b/skills/woostack-init/references/worktrees.md
@@ -40,7 +40,7 @@ in Linear, so it creates no authoring worktree or docs-only base branch; only im
 issues receive worktrees.
 
 This boundary implements the backend-specific persistence steps in the
-[`woostack-build` Linear procedure](../../woostack-build/SKILL.md#linear-backend-procedure);
+[`woostack-build` Linear procedure](../../woostack-build/references/linear-procedure.md);
 that workflow remains the lifecycle authority.
 
 For a Linear dependency root, create its implementation branch at the project's exact frozen root

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -6,9 +6,9 @@ description: "Use to write the implementation plan for an approved woostack spec
 # woostack-plan
 
 Write a comprehensive implementation plan from one approved spec, structured as PR-sized
-increments. This is woostack's own planning phase — [`woostack-build`](../woostack-build/SKILL.md)
-step 4. It preserves one normalized planning contract across storage backends: file-structure
-first, bite-sized TDD tasks, no placeholders, explicit dependency/Git-parent shape, acceptance
+increments. This is woostack's own planning phase in the
+[`woostack-build`](../woostack-build/SKILL.md) shared chain. It preserves one normalized
+planning contract across storage backends: file-structure first, bite-sized TDD tasks, no placeholders, explicit dependency/Git-parent shape, acceptance
 coverage, and a self-review pass.
 
 When `woostack-build` supplies its retained resolver result and, for Linear, the normalized


### PR DESCRIPTION
## Goal

Reduce `woostack-build` context cost by loading only the selected backend procedure after resolver success, while preserving all three gates, backend-specific lifecycle safety, and terminal behavior.

## Summary

- Split the complete Markdown and Linear procedures into directly selected references with stable phase navigation; retained shared resolution, gate barriers, terminal states, and hard constraints in the root skill.
- Preserved Markdown commit-before-approval/base-PR ordering and Linear preflight/replan/frozen-base/read-back behavior, with tests assembling root plus only the selected backend reader.
- Updated stale deep links and step-number callers, strengthened backend-isolation/raw-GraphQL guards, and synchronized the authored build-loop page.
- Reduced selected context from the 29,091-byte baseline to 21,018 bytes for Markdown and 16,881 bytes for Linear.
- Model-backed comparison is optional advisory evidence under the superseding 2026-07-25 spec decision; this PR does not claim one passed.

## Test plan

- [x] `bash skills/woostack-build/tests/test-linear-build-contract.sh` — passed.
- [x] `bash skills/woostack-build/scripts/tests/test-build-spec-commit-ordering.sh` — passed.
- [x] `bash skills/woostack-build/scripts/tests/test-progressive-disclosure.sh` — 63 passed, 0 failed.
- [x] `bash skills/using-woostack/tests/test-artifact-reader-contract.sh` — 12 passed, 0 failed.
- [x] `node skills/woostack-eval/scripts/validate.mjs --package skills/woostack-build` — valid.
- [x] Manual review confirmed root dispatch reads exactly one backend reference only after `resolve-backend.sh <repo-root>` succeeds.
- [x] Cumulative `node --test site/scripts/gen-skills.test.mjs` passed 14/14 in an LF Linux checkout.
- [x] `pnpm@11.1.2 -C site build` passed and generated 147 static pages.
- [x] `git diff --check` passed.

Spec: .woostack/specs/2026-07-15-skill-evaluation-optimization.md
