### PR TITLE
Fix live receipts for OAuth workspace slugs

### DIFF
--- a/.woostack/config.json
+++ b/.woostack/config.json
@@ -1,30 +1,27 @@
 {
-	"linear": {
-		"repository": "https://github.com/howarewoo/woostack",
-		"workspace": "",
-		"team": "",
-		"projectStatuses": {
-			"backlog": "",
-			"planned": "",
-			"started": "",
-			"paused": "",
-			"completed": "",
-			"canceled": ""
-		},
-		"issueStates": {
-			"planned": "",
-			"executing": "",
-			"inReview": "",
-			"done": "",
-			"blocked": ""
-		}
-	},
-	"review": {
-		"metrics": true
-	},
-	"respond": {},
-	"status": {
-		"staleDays": 14
-	},
-	"models": {}
+  "linear": {
+    "repository": "https://github.com/howarewoo/woostack",
+    "workspace": "woostack",
+    "team": "WOO",
+    "projectStatuses": {
+      "backlog": "Backlog",
+      "planned": "Planned",
+      "started": "In Progress",
+      "completed": "Completed",
+      "canceled": "Canceled"
+    },
+    "issueStates": {
+      "planned": "Backlog",
+      "executing": "In Progress",
+      "inReview": "In Review",
+      "done": "Done",
+      "blocked": "In Progress"
+    }
+  },
+  "models": {},
+  "review": {},
+  "respond": {},
+  "status": {
+    "staleDays": 14
+  }
 }

--- a/skills/woostack-bootstrap/SKILL.md
+++ b/skills/woostack-bootstrap/SKILL.md
@@ -105,7 +105,8 @@ approval, perform no official-MCP development mutation and create no development
    non-directory/symlink, unreadable state, partial result, or ambiguity blocks before mkdir,
    write, scaffold, or Git while preserving and reporting the verified project/event receipts.
    Retain the approved-design key, feature client UUID, native project ID, canonical Linear project
-   URL, repository, workspace/team IDs, base intent, and native `designApproved` update ID in memory.
+   URL, repository, OAuth-scoped workspace slug, native team ID/key, base intent, and native
+   `designApproved` update ID in memory.
    Pass that exact identity into the scaffold procedure and any later build/planning continuation;
    callees refresh mutable state but never rediscover by title or select another project.
 9. **Scaffold and verify.** Follow [references/bootstrap.md](references/bootstrap.md), including all

--- a/skills/woostack-bootstrap/references/bootstrap.md
+++ b/skills/woostack-bootstrap/references/bootstrap.md
@@ -183,7 +183,7 @@ Retain one in-memory context containing:
 - feature resource client UUID;
 - native project ID and canonical Linear project URL;
 - canonical repository URL and intended initial base branch;
-- verified workspace/team native IDs and policy mappings;
+- verified OAuth-scoped workspace slug, native team ID/key, and policy mappings;
 - native `designApproved` update ID and stable event UUID; and
 - the latest independent project and event receipts.
 

--- a/skills/woostack-build/references/linear-context.md
+++ b/skills/woostack-build/references/linear-context.md
@@ -65,7 +65,7 @@ compatible executor. Do not serialize it as a development artifact. It contains:
 
 - authenticated actor type/native ID and the verified feature project's single lead type/native
   ID, which must match before a gate decision or project-update mutation;
-- canonical repository URL and verified workspace/team native IDs;
+- canonical repository URL, verified OAuth-scoped workspace slug, and native team ID/key;
 - configured names and independently resolved native IDs/categories for every project and issue
   state mapping;
 - feature resource client UUID and, after creation or resume, native project ID and canonical URL;

--- a/skills/woostack-doctor/SKILL.md
+++ b/skills/woostack-doctor/SKILL.md
@@ -32,8 +32,9 @@ It has two layers:
 - `/woostack-doctor [path] --live` — before touching the target, discover the host's official
   Linear MCP tools, authenticate through the host connection, and verify provider availability
   plus required read/mutation capabilities. Then resolve the target and its effective layered
-  policy, verify workspace/team, native mappings, and independent read-back, write only the
-  normalized non-secret result to a mode-0600 temporary receipt, invoke
+  policy, verify the OAuth-scoped workspace slug, native team ID/key, native mappings, and
+  independent read-back, write only the normalized non-secret result to a mode-0600 temporary
+  receipt, invoke
   `doctor.sh --live-receipt <path> [path]`, and delete the receipt. Missing MCP, authentication,
   capability, identity, mapping, or read-back blocks at its phase; provider-only failures occur
   before target filesystem or Git access.
@@ -54,8 +55,9 @@ siblings, so this holds by construction.
    failure stops with zero target filesystem or Git access.
 3. **Resolve policy and diagnose once.** Resolve the target and primary checkout, then load the
    effective committed plus primary-checkout local team policy. In live mode, verify the configured
-   workspace/team, native mappings, and independent read-back, write the normalized non-secret
-   mode-0600 receipt, and run `doctor.sh --live-receipt <path> [path]`. Otherwise run
+   OAuth-scoped workspace slug, native team ID/key, native mappings, and independent read-back,
+   write the normalized non-secret mode-0600 receipt, and run
+   `doctor.sh --live-receipt <path> [path]`. Otherwise run
    `doctor.sh [path]`. The engine validates policy, knowledge stores, diagnostics, and local
    worktree hygiene. Legacy `.woostack/specs/`, `.woostack/plans/`, `.woostack/fixes/`, or
    `.woostack/overnight/` sets produce one blocking migration finding per active or ambiguous set;

--- a/skills/woostack-doctor/evals/fixtures/receipts/provenance-drift.json
+++ b/skills/woostack-doctor/evals/fixtures/receipts/provenance-drift.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/acme/widgets",
   "workspace": "acme",
   "team": "ENG",
-  "workspaceResolution": {"status": "unique", "id": "11111111-1111-4111-8111-111111111111", "name": "acme"},
+  "workspaceResolution": {"status": "unique", "name": "acme"},
   "teamResolution": {"status": "unique", "id": "22222222-2222-4222-8222-222222222222", "name": "Engineering", "key": "ENG"},
   "projectStatuses": {"complete": true, "resolved": {
     "backlog": {"name": "Backlog", "category": "backlog"},

--- a/skills/woostack-doctor/evals/fixtures/receipts/success.json
+++ b/skills/woostack-doctor/evals/fixtures/receipts/success.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/acme/widgets",
   "workspace": "acme",
   "team": "ENG",
-  "workspaceResolution": {"status": "unique", "id": "11111111-1111-4111-8111-111111111111", "name": "acme"},
+  "workspaceResolution": {"status": "unique", "name": "acme"},
   "teamResolution": {"status": "unique", "id": "22222222-2222-4222-8222-222222222222", "name": "Engineering", "key": "ENG"},
   "projectStatuses": {"complete": true, "resolved": {
     "backlog": {"name": "Backlog", "category": "backlog"},

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -71,12 +71,15 @@ non-secret outcome to a mode-0600 temporary file, passes that path to
 `doctor.sh --live-receipt <path>`, and deletes it after consumption.
 
 The receipt's top level supplies `ready`, canonical `repository`, resolved `workspace` and `team`,
-and the capability booleans consumed by the shell engine. When memory notes contain valid Linear
-provenance, the same receipt may contain a `provenance` object keyed by the lowercase canonical
-`linear://project/<uuid>` or `linear://issue/<uuid>` URI. Each value is a normalized object with exact `kind`,
-lowercase `id`, `repository`, `workspace`, and `team`, plus boolean `verified`,
-`managedIdentityVerified`, and `relationsVerified` outcomes. The controller derives these
-non-secret outcomes from official host-MCP reads; raw provider responses are not receipt input.
+and the capability booleans consumed by the shell engine. `workspaceResolution` contains exactly
+the unique OAuth-scoped workspace `name` and `status`; it never invents a native workspace ID when
+official MCP omits one. `teamResolution` retains the independently read native team ID and key.
+When memory notes contain valid Linear provenance, the same receipt may contain a `provenance`
+object keyed by the lowercase canonical `linear://project/<uuid>` or `linear://issue/<uuid>` URI.
+Each value is a normalized object with exact `kind`, lowercase `id`,
+`repository`, `workspace`, and `team`, plus boolean `verified`, `managedIdentityVerified`, and
+`relationsVerified` outcomes. The controller derives these non-secret outcomes from official
+host-MCP reads; raw provider responses are not receipt input.
 A live note whose canonical URI has no entry, a partial entry, false verification, or mismatched
 identity is `memory-provenance-live`.
 

--- a/skills/woostack-doctor/scripts/checks/config-keys.sh
+++ b/skills/woostack-doctor/scripts/checks/config-keys.sh
@@ -118,10 +118,9 @@ if [ ! -r "$receipt" ] || ! jq -e \
       and .mcpAvailable == true
       and .authenticated == true
       and .ready == true
+      and (.workspaceResolution | type == "object" and (keys | sort) == ["name", "status"])
       and .workspaceResolution.status == "unique"
       and .workspaceResolution.name == .workspace
-      and (.workspaceResolution.id | type == "string"
-        and test("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"))
       and .teamResolution.status == "unique"
       and .teamResolution.key == .team
       and (.teamResolution.id | type == "string"

--- a/skills/woostack-doctor/scripts/tests/test-linear-mcp.sh
+++ b/skills/woostack-doctor/scripts/tests/test-linear-mcp.sh
@@ -27,7 +27,7 @@ complete_receipt() {
   jq -cn '{
     schemaVersion:1,provider:"official-linear-mcp",mcpAvailable:true,authenticated:true,ready:true,
     repository:"https://github.com/acme/widgets",workspace:"acme",team:"ENG",
-    workspaceResolution:{status:"unique",id:"11111111-1111-4111-8111-111111111111",name:"acme"},
+    workspaceResolution:{status:"unique",name:"acme"},
     teamResolution:{status:"unique",id:"22222222-2222-4222-8222-222222222222",name:"Engineering",key:"ENG"},
     projectStatuses:{complete:true,resolved:{
       backlog:{name:"Backlog",category:"backlog"},
@@ -149,6 +149,18 @@ complete_receipt >"$receipt"
 chmod 600 "$receipt"
 run_doctor "$repo" --live-receipt "$receipt"
 assert_exit 0 "$RC" "complete normalized live receipt passes"
+
+workspace_id="$TMP/workspace-id.json"
+jq '.workspaceResolution.id="11111111-1111-4111-8111-111111111111"' "$receipt" >"$workspace_id"
+chmod 600 "$workspace_id"
+run_doctor "$repo" --live-receipt "$workspace_id"
+assert_exit 1 "$RC" "workspace resolution rejects a fabricated native ID"
+
+workspace_mismatch="$TMP/workspace-mismatch.json"
+jq '.workspaceResolution.name="other"' "$receipt" >"$workspace_mismatch"
+chmod 600 "$workspace_mismatch"
+run_doctor "$repo" --live-receipt "$workspace_mismatch"
+assert_exit 1 "$RC" "workspace resolution must match configured OAuth-scoped workspace"
 
 while IFS='|' read -r field expected; do
   mutant="$TMP/missing-${field//./-}.json"

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -39,8 +39,9 @@ Three callers:
    provider-only preflight succeeds, resolve the retained target to the repository root and use
    Git's common directory to identify the primary checkout. Derive the canonical repository
    identity, read the committed policy plus the primary-checkout `.woostack/config.local.json`
-   team override, and verify exactly one workspace and effective team plus every project-status
-   and issue-state mapping through MCP. Require a complete independent read-back. Only then
+   team override, and verify exactly one OAuth-scoped workspace slug and one effective team by
+   native ID/key, plus every project-status and issue-state mapping through MCP. Require a complete
+   independent read-back. Only then
    inspect which managed workspace files already exist. The canonical capability, layering,
    policy, and receipt contracts are in
    [Linear MCP development authority](references/artifact-backends.md).

--- a/skills/woostack-init/evals/fixtures/receipts/ambiguous-workspace-missing-team.json
+++ b/skills/woostack-init/evals/fixtures/receipts/ambiguous-workspace-missing-team.json
@@ -8,8 +8,8 @@
   "workspaceResolution": {
     "status": "ambiguous",
     "matches": [
-      {"id": "11111111-1111-4111-8111-111111111111", "name": "acme"},
-      {"id": "22222222-2222-4222-8222-222222222222", "name": "acme"}
+      {"name": "acme"},
+      {"name": "acme-alt"}
     ]
   },
   "teamResolution": {"status": "missing", "matches": []},

--- a/skills/woostack-init/evals/fixtures/receipts/invalid-native-mappings.json
+++ b/skills/woostack-init/evals/fixtures/receipts/invalid-native-mappings.json
@@ -5,7 +5,7 @@
   "authenticated": true,
   "ready": true,
   "repository": "https://github.com/acme/widgets",
-  "workspaceResolution": {"status": "unique", "id": "11111111-1111-4111-8111-111111111111", "name": "acme"},
+  "workspaceResolution": {"status": "unique", "name": "acme"},
   "teamResolution": {"status": "unique", "id": "22222222-2222-4222-8222-222222222222", "name": "Engineering", "key": "ENG"},
   "projectStatuses": {
     "complete": false,

--- a/skills/woostack-init/evals/fixtures/receipts/read-only-capability.json
+++ b/skills/woostack-init/evals/fixtures/receipts/read-only-capability.json
@@ -5,7 +5,7 @@
   "authenticated": true,
   "ready": true,
   "repository": "https://github.com/acme/widgets",
-  "workspaceResolution": {"status": "unique", "id": "11111111-1111-4111-8111-111111111111", "name": "acme"},
+  "workspaceResolution": {"status": "unique", "name": "acme"},
   "teamResolution": {"status": "unique", "id": "22222222-2222-4222-8222-222222222222", "name": "Engineering", "key": "ENG"},
   "projectStatuses": {
     "complete": true,

--- a/skills/woostack-init/evals/fixtures/receipts/success.json
+++ b/skills/woostack-init/evals/fixtures/receipts/success.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/acme/widgets",
   "workspace": "acme",
   "team": "ENG",
-  "workspaceResolution": {"status": "unique", "id": "11111111-1111-4111-8111-111111111111", "name": "acme"},
+  "workspaceResolution": {"status": "unique", "name": "acme"},
   "teamResolution": {"status": "unique", "id": "22222222-2222-4222-8222-222222222222", "name": "Engineering", "key": "ENG"},
   "projectStatuses": {"complete": true, "resolved": {
     "backlog": {"name": "Backlog", "category": "backlog"},

--- a/skills/woostack-init/evals/fixtures/receipts/unknown-read-back.json
+++ b/skills/woostack-init/evals/fixtures/receipts/unknown-read-back.json
@@ -5,7 +5,7 @@
   "authenticated": true,
   "ready": true,
   "repository": "https://github.com/acme/widgets",
-  "workspaceResolution": {"status": "unique", "id": "11111111-1111-4111-8111-111111111111", "name": "acme"},
+  "workspaceResolution": {"status": "unique", "name": "acme"},
   "teamResolution": {"status": "unique", "id": "22222222-2222-4222-8222-222222222222", "name": "Engineering", "key": "ENG"},
   "projectStatuses": {"complete": true, "resolved": {
     "backlog": {"name": "Backlog", "category": "backlog"},

--- a/skills/woostack-init/references/artifact-backends.md
+++ b/skills/woostack-init/references/artifact-backends.md
@@ -17,6 +17,13 @@ GraphQL used for GitHub operations is unaffected.
 - `issueStates`: one team issue-state name for each semantic state `planned`, `executing`,
   `inReview`, `done`, and `blocked`.
 
+`workspace` is the canonical slug of the OAuth-scoped Linear workspace, not a fabricated native
+ID. The official MCP may omit the workspace's internal ID; uniqueness is proved from the
+authenticated connection plus matching workspace context on independently read resources. The
+effective team still requires its native ID and key. A normalized receipt therefore records
+`workspaceResolution` as exactly `{"name":"<slug>","status":"unique"}` and records the native
+team ID only under `teamResolution`.
+
 The ignored primary-checkout `.woostack/config.local.json` may contain only
 `{"linear":{"team":"<team>"}}`. [`scripts/config/resolve-config.sh`](../scripts/config/resolve-config.sh)
 locates that file through Git's common directory, so every linked worktree in one clone inherits


### PR DESCRIPTION
## Goal

Allow official Linear MCP preflight to complete when the provider exposes an OAuth-scoped workspace slug but no native workspace UUID.

## Summary

- Require `workspaceResolution` to contain only the verified workspace name and unique status while retaining native team ID/key verification.
- Update init, doctor, bootstrap, and build contracts plus receipt fixtures to distinguish workspace slug identity from native team identity.
- Normalize this repository's verified Linear policy for workspace `woostack` and team `WOO`.

## Test plan

### Automated

- [ ] `bash skills/woostack-doctor/scripts/tests/test-linear-mcp.sh` — 127 passed, 0 failed.
- [ ] `bash skills/woostack-init/scripts/tests/test-linear-only-contract.sh` — PASS.
- [ ] `bash skills/woostack-doctor/scripts/doctor.sh --live-receipt skills/woostack-doctor/evals/fixtures/receipts/success.json skills/woostack-doctor/evals/fixtures/project` — 0 errors; 12 fixture/environment warnings.
- [ ] `jq empty skills/woostack-init/evals/fixtures/receipts/*.json skills/woostack-doctor/evals/fixtures/receipts/*.json` — passed.

### Manual

**Before merge**

- [ ] Confirm a slug-only `workspaceResolution` receipt passes and adding a fabricated workspace `id` fails closed.
- [ ] Confirm `teamResolution` still requires the native team UUID and key.
