### PR TITLE
fix(omp): provision review tier agents

### DIFF
--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -21,8 +21,9 @@ static policy; optional live artifact checks run only when explicitly requested.
 
 **OMP exception:** woostack uses
 [host-owned role routing](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/hosts/omp.md)
-through bundled workers. OMP ignores `.woostack/config.json` model settings and owns its isolated
-profile, role configuration, concrete model identity, provider authentication, and recovery.
+through three init-managed project workers. OMP ignores `.woostack/config.json` model settings and
+owns its isolated profile, role configuration, concrete model identity, provider authentication,
+and recovery.
 
 There are nine top-level settings:
 
@@ -193,8 +194,8 @@ model and optional effort. The namespace sits at the root, not under `review`, s
 and local subagent drivers can share it.
 
 omp is the host-owned exception. It ignores the entire `models` namespace and maps the effective
-tier to its fixed bundled worker instead. Changing a flat or provider-specific model leaf never
-changes an omp dispatch.
+tier to its fixed init-managed role worker instead. Changing a flat or provider-specific model leaf
+never changes an omp dispatch.
 
 | Host | Repository model config | Flat fallback | Dispatch behavior |
 | --- | --- | --- | --- |

--- a/site/content/docs/getting-started.mdx
+++ b/site/content/docs/getting-started.mdx
@@ -28,8 +28,9 @@ From the target repository, invoke:
 /woostack-init
 ```
 
-Initialization creates or repairs non-secret `.woostack/config.json`, diagnostic report roots, and
-worktree support. It does not create a specification, plan, fix, issue, project, branch, or PR.
+Initialization creates or repairs non-secret `.woostack/config.json`, diagnostic report roots,
+worktree support, and the three project-scoped OMP role workers. It preserves other project agents
+and does not create a specification, plan, fix, issue, project, branch, or PR.
 
 Read [Configuration](/docs/configuration) for optional policy. Artifact-free workflows need no
 provider connection.

--- a/site/content/docs/harnesses/index.mdx
+++ b/site/content/docs/harnesses/index.mdx
@@ -20,7 +20,7 @@ same authority, identity, worktree, and evidence boundaries.
 | Harness | Model and effort routing | Working directory | Host behavior |
 | --- | --- | --- | --- |
 | [Hermes Agent](/docs/harnesses/hermes) | Profile-owned delegation; optional pinned OMP implementation profile | Explicit profile and canonical worktree pins | In the selected pair, Hermes decides, reviews, and comments but never codes |
-| [omp (Oh My Pi)](/docs/harnesses/omp) | Host-owned roles through bundled workers; no per-call model knob | Passed when exposed; explicit `--cwd` in the paired process | OMP-owned model identity and recovery; optional isolated coder role |
+| [omp (Oh My Pi)](/docs/harnesses/omp) | Host-owned roles through init-managed project workers; no per-call model knob | Passed when exposed; explicit `--cwd` in the paired process | OMP-owned model identity and recovery; optional isolated coder role |
 | [opencode](/docs/harnesses/opencode) | Per-call model routing | Passed when exposed; prompt pin always | Provider exhaustion surfaces as an error |
 | [Claude Code](/docs/harnesses/claude-code) | Per-call model and supported effort routing | No per-call cwd; subagent self-pins | Provider exhaustion surfaces as an error |
 | [Codex](/docs/harnesses/codex) | Per-call locally; one model per Codex Action job | Passed when exposed; prompt pin always | Local and CI routing differ |
@@ -29,7 +29,8 @@ same authority, identity, worktree, and evidence boundaries.
 
 For normal in-process OMP use,
 [host-owned role routing](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/hosts/omp.md)
-selects bundled workers while OMP owns concrete models, provider credentials, and fallback policy.
+selects init-managed project workers while OMP owns concrete models, provider credentials, and
+fallback policy.
 The optional engineer pairing is different: a deliberately selected, isolated OMP profile receives
 one approved bounded task from Hermes through the exact profile-pinned process described on the
 [OMP page](/docs/harnesses/omp). Linear is optional artifact context.

--- a/site/content/docs/harnesses/omp.mdx
+++ b/site/content/docs/harnesses/omp.mdx
@@ -3,25 +3,32 @@ title: omp (Oh My Pi)
 description: Host-owned worker routing and an optional isolated implementation profile.
 ---
 
-OMP has two distinct woostack uses. Native in-process OMP routes work through bundled workers. In
-the optional [Hermes engineer pairing](/docs/harnesses/hermes), a separate profile-pinned OMP
-process implements one approved bounded task. Selecting one mode never activates the other.
+OMP has two distinct woostack uses. Native in-process OMP routes work through project-scoped
+role workers provisioned by `woostack-init`. In the optional
+[Hermes engineer pairing](/docs/harnesses/hermes), a separate profile-pinned OMP process implements
+one approved bounded task. Selecting one mode never activates the other.
 
 ## Native OMP worker routing
 
 OMP's `task` primitive accepts a worker selector but no per-call model, tier, or effort argument.
-Woostack uses the host-owned role mapping from the active installation. OMP owns concrete models,
-provider credentials, thinking level, and retry/fallback behavior.
+Woostack provisions three neutral project workers whose model fields point to OMP-owned role
+aliases. OMP owns concrete models, provider credentials, thinking level, and retry/fallback
+behavior; repository model leaves are ignored.
 
+- Run `woostack-init` before review; gated `woostack-doctor` repair restores missing or drifted
+  managed definitions while preserving other project agents.
+- After review angle detection, OMP verifies the complete planned selector set in the active agent
+  registry before launching any summary, angle, or validator worker.
+- Review never generates or repairs agents and never launches a partial swarm.
 - Batch dependency-independent bounded tasks in one dispatch.
 - Pass the exact worktree and complete task contract.
-- Use the most specific worker role available.
 - Workers return observations/changes; the controller owns synthesis and acceptance.
 - If the spawn API cannot set cwd, pin it in the prompt and require the worker to verify it.
 
-See OMP's published [model roles](https://omp.sh/docs/roles),
-[bundled subagents](https://omp.sh/docs/subagents), and the canonical
-[host adapter](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/hosts/omp.md).
+See OMP's published [model roles](https://omp.sh/docs/roles), [custom
+subagents](https://omp.sh/docs/subagents), and the canonical
+[host adapter](https://github.com/howarewoo/woostack/blob/main/skills/using-woostack/references/hosts/omp.md)
+for the exact mapping and lifecycle.
 
 ## Isolated coder in the Hermes pairing
 

--- a/skills/using-woostack/references/hosts/omp.md
+++ b/skills/using-woostack/references/hosts/omp.md
@@ -9,8 +9,9 @@ authoritative. Linear is optional artifact context.
 ## Subagent spawn
 
 OMP's `task` primitive accepts a worker selector but no per-call model/tier/effort argument.
-Woostack uses the canonical host-owned role mapping from the active installation rather than
-inventing model names or reading repository model preferences.
+Woostack uses three project-scoped neutral workers provisioned by
+[`woostack-init`](../../../woostack-init/SKILL.md). Their model fields point only to OMP's
+host-owned roles; they never read repository model preferences or name a concrete model.
 
 - Batch dependency-independent bounded tasks in one `tasks` call.
 - Pass the exact worktree path and complete contract in each dispatch.
@@ -27,15 +28,20 @@ prompt and require the worker to verify it before reading or writing. A cwd mism
 
 After the calling skill resolves the effective tier, use this fixed host-owned map:
 
-| Effective tier | OMP model role | Built-in worker selector |
+| Effective tier | OMP model role | Project worker selector |
 |---|---|---|
-| `deep -> slow` | `slow` | `agent: oracle` |
-| `standard -> default` | `default` | `agent: task` |
-| `fast -> smol` | `smol` | `agent: quick_task` |
+| `deep -> slow` | `@slow` | `agent: woostack-deep` |
+| `standard -> default` | `@default` | `agent: woostack-standard` |
+| `fast -> smol` | `@smol` | `agent: woostack-fast` |
 
 OMP owns each role's concrete model, provider, thinking level, credential rotation, and retry
 policy. Do not inspect repository model leaves or translate repository fallbacks into a second
 worker dispatch.
+
+The three definitions share one neutral general-purpose worker body. Init creates or updates only
+those managed files under `.omp/agents/` and preserves every other project agent. Review never
+creates or repairs workers; a missing or drifted managed definition must return to init or the
+gated [`woostack-doctor`](../../../woostack-doctor/SKILL.md) repair path.
 
 ## Host-level fallback
 
@@ -67,11 +73,14 @@ artifact synchronization, not otherwise authorized repository work.
 
 ## Per-skill notes
 
-- `woostack-review`: map each angle's tier through the table above; missing receipts fail the
-  existing hard receipt gate.
-- `woostack-commit`: map optional fast drafting to `agent: quick_task`; draft inline if unavailable.
+- `woostack-review`: after angle detection and before any summary, angle, or validator worker,
+  discover the active task-agent registry and require every distinct selector needed by the
+  complete planned run. Missing support aborts the whole swarm before launch. Missing receipts
+  still fail the existing hard receipt gate.
+- `woostack-commit`: map optional fast drafting to `agent: woostack-fast`; draft inline if
+  unavailable.
 - **woostack-eval (comparative dispatch):** map the candidate and baseline's common effective tier
-  to the same bundled worker and start both siblings in the same `tasks[]` call. The selector is a
+  to the same managed worker and start both siblings in the same `tasks[]` call. The selector is a
   role pin, not proof of a concrete model. Use OMP-provided completion identity to prove both
   actions ran with the required identical model and effort; an unprovable identity, host fallback
   divergence, or model/effort divergence fails the mechanics proof. A host mode unable to start
@@ -81,9 +90,10 @@ artifact synchronization, not otherwise authorized repository work.
 
 ## Degradation
 
-Never generate project workers to replace unavailable built-ins. A workflow may fall back inline
-only when its own driver contract explicitly allows it. Preserve the effective tier and report the
-actual missing capability or receipt.
+Never generate or repair project workers during review. Missing managed workers are a capability
+failure that returns to init or gated doctor repair. A workflow may fall back inline only when its
+own driver contract explicitly allows it. Preserve the effective tier and report the actual
+missing capability or receipt.
 
 ## Recovery and handback
 

--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -27,7 +27,7 @@ to the current host's capability class. The context/summary helper subagent is i
 Three capability classes: **per-call model routing** (the spawn accepts an explicit model/effort;
 resolve the effective tier and pass everything it specifies), **single model per session**
 (resolve one run model up front; per-tier behavior collapses onto it), and **host-owned role
-routing** (the spawn selects a role-backed built-in worker; the host owns the concrete model).
+routing** (the spawn selects a role-backed worker; the host owns the concrete model).
 Host-owned role routing is non-degraded and bypasses repository model resolution. Which class a
 host falls in, its spawn mechanics, its fixed role mapping where applicable, its per-skill notes,
 and its host-level fallback behavior live in one file per host under

--- a/skills/woostack-doctor/SKILL.md
+++ b/skills/woostack-doctor/SKILL.md
@@ -56,7 +56,9 @@ the `templates/` shipped there; the woostack collection installs both as sibling
    OAuth-scoped workspace slug, native team ID/key, native mappings, and independent read-back,
    write the normalized non-secret mode-0600 receipt, and run
    `doctor.sh --live-receipt <path> [path]`. Otherwise run
-   `doctor.sh [path]`. The engine validates policy, diagnostics, and local worktree hygiene.
+   `doctor.sh [path]`. The engine validates policy, diagnostics, managed project OMP role-agent
+   definitions, and local worktree hygiene. OMP diagnosis is read-only; only the approved,
+   auto-fixable doctor path may invoke the init provisioner.
    Legacy `.woostack/specs/`, `.woostack/plans/`, `.woostack/fixes/`, or
    `.woostack/overnight/` sets produce one blocking migration finding per active or ambiguous set;
    doctor does not run normal lifecycle lint on them and points at the explicit

--- a/skills/woostack-doctor/references/checks.md
+++ b/skills/woostack-doctor/references/checks.md
@@ -30,6 +30,7 @@ never inspect credentials or invoke HTTP, GraphQL, provider adapters, or hard-co
 | `orphan-worktree` (present) | unregistered dir under `.woostack/worktrees/` (may hold work) | warn | report | — |
 | `orphan-worktree` (stale) | registered worktree whose dir is gone | warn | auto | `<root>` (runs `git worktree prune`) |
 | `gitignore-drift` | a shipped-template managed line missing from `.woostack/.gitignore` | warn | auto | `<root>` (appends missing lines) |
+| `omp-agent` | a managed project OMP role definition is missing, malformed, drifted, or mapped to the wrong host role, or its scoped ignore rule is missing/drifted | warn | auto | `<root>` (reinstalls only the three managed definitions and their scoped ignore rule) |
 | `config-key` | a required non-secret config key (per the init template) is absent | warn | auto | `<root> <key>` (merges template default) |
 | `linear-policy` | backend selector, credential-like key, incomplete repository/workspace/team, or incomplete category/state mapping | error | report | — |
 | `legacy-development-records` | active or ambiguous local spec/plan/fix/overnight set requires one-way migration | error | report | — |

--- a/skills/woostack-doctor/scripts/checks/omp-agents.sh
+++ b/skills/woostack-doctor/scripts/checks/omp-agents.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# omp-agents.sh — verify one optional trusted per-engineer launcher directory.
-# The historical check name is retained; project .omp/agents are never generated.
+# omp-agents.sh — verify project OMP role agents and the optional trusted launchers.
+# The two generated surfaces retain separate installation authorities.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALLER="$HERE/../../../woostack-init/scripts/gen-omp-agents.sh"
+PROVISIONER="$HERE/../../../woostack-init/scripts/provision-omp-agents.sh"
 emit() { printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"; }
 
 if [ "${1:-}" = "--fix" ]; then
@@ -13,6 +14,8 @@ if [ "${1:-}" = "--fix" ]; then
     echo "omp-agents.sh: usage: omp-agents.sh [--fix [workspace]]" >&2
     exit 2
   }
+  WOO_ROOT="${1:-.}"
+  /bin/bash "$PROVISIONER" "$WOO_ROOT" >/dev/null || exit
   exec /bin/bash "$INSTALLER"
 fi
 
@@ -20,6 +23,12 @@ fi
   echo "omp-agents.sh: usage: omp-agents.sh [workspace]" >&2
   exit 2
 }
+WOO_ROOT="${1:-.}"
+while IFS=$'\t' read -r state path message; do
+  [ -n "$state" ] || continue
+  emit warn omp-agent auto "$path" "$state: $message; --fix repairs only woostack-managed OMP agent content"
+done < <(/bin/bash "$PROVISIONER" --check "$WOO_ROOT")
+
 
 launcher_root="${WOO_ENGINEER_LAUNCHER_ROOT:-${HOME:-}/.local/libexec/woostack}"
 engineer_name="${ENGINEER_NAME:-}"

--- a/skills/woostack-doctor/scripts/tests/test-omp-agents.sh
+++ b/skills/woostack-doctor/scripts/tests/test-omp-agents.sh
@@ -54,6 +54,10 @@ PY
 }
 
 missing="$(run_check)"
+assert_contains "$missing" $'warn\tomp-agent\tauto\t' "missing project OMP agents produce auto-fixable doctor findings"
+for tier in fast standard deep; do
+  assert_contains "$missing" "woostack-$tier.md" "doctor identifies missing $tier role definition"
+done
 assert_contains "$missing" $'warn\tomp-agents\tauto\t' "missing per-engineer launchers produce an auto-fixable doctor finding"
 for launcher in launch-omp bind-engineer-unit; do
   assert_contains "$missing" "$launcher" "doctor identifies missing $launcher"
@@ -66,7 +70,32 @@ assert_eq "$(mode_of "$LAUNCHER_DIR")" "0700" "doctor fix creates a private per-
 for launcher in launch-omp bind-engineer-unit; do
   assert_eq "$(mode_of "$LAUNCHER_DIR/$launcher")" "0500" "doctor fix restores $launcher mode 0500"
 done
-[ ! -e "$REPO/.omp/agents" ] && pass || fail "doctor repair never revives project .omp/agents"
+for tier in fast standard deep; do
+  [ -f "$REPO/.omp/agents/woostack-$tier.md" ] \
+    && pass || fail "doctor repair creates the managed $tier role definition"
+done
+printf '%s\n' 'consumer-owned' >"$REPO/.omp/agents/custom.md"
+printf '%s\n' '---' 'name: woostack-standard' 'model: "@smol"' '---' >"$REPO/.omp/agents/woostack-standard.md"
+role_drift="$(run_check)"
+assert_contains "$role_drift" $'warn\tomp-agent\tauto\t' "doctor reports a wrong-role managed definition"
+assert_contains "$role_drift" "wrong-role:" "doctor distinguishes wrong-role drift"
+fix_check
+assert_contains "$(cat "$REPO/.omp/agents/woostack-standard.md")" 'model: "@default"' \
+  "doctor restores the standard host role"
+assert_eq "$(cat "$REPO/.omp/agents/custom.md")" "consumer-owned" \
+  "doctor repair preserves unrelated project agents"
+printf '%s\n' '# stale body' >>"$REPO/.omp/agents/woostack-fast.md"
+definition_drift="$(run_check)"
+assert_contains "$definition_drift" "drifted:" "doctor reports stale managed definition content"
+fix_check
+assert_eq "$(run_check)" "" "doctor repair clears managed definition drift"
+printf '%s\n' 'consumer-ignore' 'woostack-*.md' 'woostack-*.md' >"$REPO/.omp/agents/.gitignore"
+ignore_drift="$(run_check)"
+assert_contains "$ignore_drift" ".omp/agents/.gitignore" \
+  "doctor reports duplicate generated-agent ignore coverage"
+fix_check
+assert_eq "$(cat "$REPO/.omp/agents/.gitignore")" $'consumer-ignore\nwoostack-*.md' \
+  "doctor repair preserves consumer ignore lines and one managed rule"
 printf '%s\n' 'retired launcher' >"$LAUNCHER_DIR/launch-hermes-review"
 chmod 500 "$LAUNCHER_DIR/launch-hermes-review"
 retired_launcher="$(run_check)"
@@ -151,6 +180,7 @@ missing_name_status=$?
 set -e
 assert_exit 0 "$missing_name_status" "optional doctor check reports rather than crashes without a selected engineer"
 assert_contains "$missing_name" "ENGINEER_NAME must identify" "doctor refuses to guess a per-engineer directory"
-[ ! -e "$REPO/.omp/agents" ] && pass || fail "all doctor repairs remain host-only"
+assert_eq "$(run_check | grep -c $'warn\tomp-agent' || true)" "0" \
+  "agent diagnosis remains clean without a selected engineer"
 
 finish

--- a/skills/woostack-eval/scripts/tests/test-command-surface.sh
+++ b/skills/woostack-eval/scripts/tests/test-command-surface.sh
@@ -170,7 +170,7 @@ require(stale.search(adoption) is None, "stale 23-public/26-fixed adoption phras
 host_requirements = {
     "omp": (
         r"candidate and baseline's common effective tier",
-        r"same bundled worker",
+        r"same managed worker",
         r"same `tasks\[\]` call",
         r"role pin, not proof of a concrete model",
         r"completion identity",

--- a/skills/woostack-init/SKILL.md
+++ b/skills/woostack-init/SKILL.md
@@ -22,6 +22,8 @@ creates a spec, plan, fix, issue, project, branch, PR, or lifecycle state.
 Linear call.
 
 ## Procedure
+`<wi>` below means the installed `woostack-init` skill directory.
+
 
 1. Resolve the canonical target repository without changing it. Verify repository root, branch,
    working state, existing `.woostack/` files, and collision/symlink/path safety.
@@ -29,10 +31,16 @@ Linear call.
    policy without an exact approved repair.
 3. Create missing local support paths only:
    - `.woostack/config.json` from the shipped non-secret template;
-   - local diagnostic report roots for doctor, audit, QA, and response; and
-   - worktree/recovery support declared by the canonical worktree contract.
-4. Validate JSON/schema/path permissions, ignore policy, report roots, and cross-links. Run the
-   shipped doctor checks.
+   - local diagnostic report roots for doctor, audit, QA, and response;
+   - worktree/recovery support declared by the canonical worktree contract; and
+   - the three managed project OMP role agents by running
+     `bash <wi>/scripts/provision-omp-agents.sh <canonical-repository>`. This
+     deterministic provisioner updates only `woostack-fast`, `woostack-standard`, and
+     `woostack-deep` under `.omp/agents/`, preserves every other agent, ensures exactly one scoped
+     `woostack-*.md` rule without overwriting consumer-owned `.omp/agents/.gitignore` lines, and
+     never reads model configuration.
+4. Validate JSON/schema/path permissions, ignore policy, report roots, managed OMP role agents, and
+   cross-links. Run the shipped doctor checks.
 5. Report created, repaired, preserved, skipped, and blocked paths with exact validation results.
 
 ## Optional Linear setup
@@ -93,6 +101,7 @@ turns observability configuration into development authority.
 ## Hard constraints
 
 - Artifact-free by default; Linear never required for local initialization or repair.
-- No source edit outside `.woostack/`; no application scaffold.
+- No source edit outside `.woostack/` except the three init-managed `.omp/agents/woostack-*.md`
+  role definitions; no application scaffold.
 - No credential read/write, implicit migration, destructive cleanup, commit, push, PR, or merge.
 - Preserve user-owned content and fail closed on symlink/path/collision ambiguity.

--- a/skills/woostack-init/scripts/provision-omp-agents.sh
+++ b/skills/woostack-init/scripts/provision-omp-agents.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# provision-omp-agents.sh — install woostack's project-scoped OMP role selectors.
+set -euo pipefail
+
+exec /usr/bin/env python3 - "$@" <<'PY'
+import os
+import stat
+import sys
+import tempfile
+
+ROLES = {
+    "woostack-fast": "@smol",
+    "woostack-standard": "@default",
+    "woostack-deep": "@slow",
+}
+IGNORE_RULE = "woostack-*.md"
+BODY = """You are a general-purpose woostack worker for delegated tasks.
+
+Follow the supplied task contract, repository rules, worktree boundary, and authority constraints. Complete only the assigned work and return concise evidence.
+"""
+
+
+def usage():
+    print("usage: provision-omp-agents.sh [--check] [repository]", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def definition(name, role):
+    return f'''---
+name: {name}
+description: General-purpose woostack worker using a host-owned model role
+model: "{role}"
+---
+
+{BODY}'''
+
+
+def fail(message):
+    print(f"provision-omp-agents.sh: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def real_directory(path, label):
+    try:
+        metadata = os.lstat(path)
+    except OSError as error:
+        fail(f"{label} is inaccessible: {error.strerror}")
+    if not stat.S_ISDIR(metadata.st_mode) or os.path.realpath(path) != path:
+        fail(f"{label} must be a canonical real directory")
+
+
+def ensure_directory(parent, name):
+    path = os.path.join(parent, name)
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        os.mkdir(path, 0o755)
+        return path
+    except OSError as error:
+        fail(f"{path} is inaccessible: {error.strerror}")
+    if not stat.S_ISDIR(metadata.st_mode):
+        fail(f"{path} must be a real directory")
+    return path
+
+def read_regular(path):
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    descriptor = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError("not a regular file")
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks).decode("utf-8")
+    finally:
+        os.close(descriptor)
+
+
+def write_atomic(path, content):
+    directory = os.path.dirname(path)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.", dir=directory, text=True
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as destination:
+            destination.write(content)
+            destination.flush()
+            os.fsync(destination.fileno())
+        os.chmod(temporary, 0o644)
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def ignore_rule_count(raw):
+    return sum(line == IGNORE_RULE for line in raw.splitlines())
+
+
+def normalized_ignore(raw):
+    retained = [
+        segment
+        for segment in raw.splitlines(keepends=True)
+        if segment.rstrip("\r\n") != IGNORE_RULE
+    ]
+    prefix = "".join(retained)
+    if prefix and not prefix.endswith(("\n", "\r")):
+        prefix += "\n"
+    return f"{prefix}{IGNORE_RULE}\n"
+
+
+def classify(raw, name, role):
+    if raw == definition(name, role):
+        return None
+    if not raw.startswith("---\n") or "\n---\n" not in raw[4:]:
+        return "malformed", "managed OMP agent definition has malformed frontmatter"
+    header = raw[4:].split("\n---\n", 1)[0]
+    fields = {}
+    for line in header.splitlines():
+        if ":" not in line:
+            return "malformed", "managed OMP agent definition has malformed frontmatter"
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip().strip('"\'')
+    if fields.get("name") != name or "model" not in fields:
+        return "malformed", "managed OMP agent definition has an invalid name or model field"
+    if fields["model"] != role:
+        return "wrong-role", f"managed OMP agent must select the host-owned {role} role"
+    return "drifted", "managed OMP agent definition differs from the shipped definition"
+
+
+args = sys.argv[1:]
+check = bool(args and args[0] == "--check")
+if check:
+    args = args[1:]
+if len(args) > 1:
+    usage()
+root = os.path.abspath(args[0] if args else ".")
+if os.path.realpath(root) != root:
+    fail("repository must be a canonical path without symlink components")
+real_directory(root, "repository")
+agents = os.path.join(root, ".omp", "agents")
+
+if check:
+    directory_status = None
+    for directory in (os.path.join(root, ".omp"), agents):
+        try:
+            metadata = os.lstat(directory)
+        except FileNotFoundError:
+            directory_status = (
+                "missing",
+                "project OMP agent directory or managed definition is missing",
+            )
+            break
+        except OSError:
+            directory_status = ("malformed", "project OMP agent directory is inaccessible")
+            break
+        if not stat.S_ISDIR(metadata.st_mode) or os.path.realpath(directory) != directory:
+            directory_status = ("malformed", "project OMP agent directory is unsafe")
+            break
+    if directory_status:
+        for name in ROLES:
+            path = os.path.join(agents, f"{name}.md")
+            print(f"{directory_status[0]}\t{path}\t{directory_status[1]}")
+        raise SystemExit(0)
+    for name, role in ROLES.items():
+        path = os.path.join(agents, f"{name}.md")
+        try:
+            result = classify(read_regular(path), name, role)
+        except FileNotFoundError:
+            result = ("missing", "managed OMP agent definition is missing")
+        except (OSError, UnicodeError):
+            result = ("malformed", "managed OMP agent definition is unreadable or unsafe")
+        if result:
+            print(f"{result[0]}\t{path}\t{result[1]}")
+    ignore_path = os.path.join(agents, ".gitignore")
+    try:
+        ignore_count = ignore_rule_count(read_regular(ignore_path))
+        ignore_result = None if ignore_count == 1 else (
+            "drifted",
+            "project OMP agent ignore file must contain exactly one standalone woostack-*.md rule",
+        )
+    except FileNotFoundError:
+        ignore_result = ("missing", "project OMP agent ignore file is missing")
+    except (OSError, UnicodeError):
+        ignore_result = ("malformed", "project OMP agent ignore file is unreadable or unsafe")
+    if ignore_result:
+        print(f"{ignore_result[0]}\t{ignore_path}\t{ignore_result[1]}")
+    raise SystemExit(0)
+
+omp = ensure_directory(root, ".omp")
+agents = ensure_directory(omp, "agents")
+ignore_path = os.path.join(agents, ".gitignore")
+try:
+    ignore_raw = read_regular(ignore_path)
+except FileNotFoundError:
+    ignore_raw = ""
+except (OSError, UnicodeError) as error:
+    fail(f"{ignore_path} could not be read safely: {error}")
+
+for name, role in ROLES.items():
+    path = os.path.join(agents, f"{name}.md")
+    wanted = definition(name, role)
+    try:
+        if read_regular(path) == wanted:
+            print(f"preserved\t{path}")
+            continue
+    except (FileNotFoundError, OSError, UnicodeError):
+        pass
+    write_atomic(path, wanted)
+    print(f"installed\t{path}")
+
+if ignore_rule_count(ignore_raw) == 1:
+    print(f"preserved\t{ignore_path}")
+else:
+    write_atomic(ignore_path, normalized_ignore(ignore_raw))
+    print(f"installed\t{ignore_path}")
+PY

--- a/skills/woostack-init/scripts/tests/test-host-references.sh
+++ b/skills/woostack-init/scripts/tests/test-host-references.sh
@@ -25,14 +25,25 @@ model_tiers="$(cat "$S/using-woostack/references/model-tiers.md")"
 assert_contains "$model_tiers" "hosts/README.md" "model tiers links host adapters"
 assert_contains "$model_tiers" "| Tier | Use for | Anthropic | OpenAI (Codex) | Google (Gemini) | OpenRouter |" "provider table remains stable"
 assert_contains "$(cat "$S/woostack-review/prompts/_orchestrator-header.md")" "<!-- WOO_MODEL_TIERS_TABLE -->" "review inline marker remains stable"
+init="$(cat "$S/woostack-init/SKILL.md")"
+assert_contains "$init" '`<wi>` below means the installed `woostack-init` skill directory' \
+  "init defines its installed skill directory"
+assert_contains "$init" 'bash <wi>/scripts/provision-omp-agents.sh <canonical-repository>' \
+  "init invokes the provisioner from its installed skill directory"
+assert_not_contains "$init" 'bash skills/woostack-init/scripts/provision-omp-agents.sh' \
+  "init does not assume the source repository layout"
+
 
 omp="$(cat "$H/omp.md")"
 for row in \
-  '| `deep -> slow` | `slow` | `agent: oracle` |' \
-  '| `standard -> default` | `default` | `agent: task` |' \
-  '| `fast -> smol` | `smol` | `agent: quick_task` |'; do
+  '| `deep -> slow` | `@slow` | `agent: woostack-deep` |' \
+  '| `standard -> default` | `@default` | `agent: woostack-standard` |' \
+  '| `fast -> smol` | `@smol` | `agent: woostack-fast` |'; do
   assert_contains "$omp" "$row" "OMP maps $row"
 done
+assert_not_contains "$omp" 'agent: quick_task' "OMP never routes to the unavailable quick selector"
+assert_not_contains "$omp" 'agent: oracle' "OMP never routes to the unavailable deep selector"
+assert_contains "$omp" "Never generate or repair project workers during review" "OMP forbids review-time generation"
 assert_contains "$omp" "Artifact-free work makes no Linear call" "OMP keeps artifacts optional"
 assert_contains "$omp" "Missing Linear capability blocks only explicitly requested" "OMP degrades artifact work independently"
 
@@ -44,16 +55,17 @@ assert_contains "$hermes" "Arguments are values, not shell source" "Hermes quara
 assert_contains "$hermes" "distinct Hermes/OMP sessions and role credentials" "Hermes isolates paired roles"
 assert_contains "$hermes" "Without an artifact request, do not" "Hermes avoids implicit Linear calls"
 
-for consumer in \
-  "$S/woostack-init/SKILL.md" \
-  "$S/woostack-commit/SKILL.md" \
-  "$S/woostack-execute/references/subagent-driver.md" \
-  "$S/woostack-review/SKILL.md"; do
-  body="$(cat "$consumer")"
-  for stale in "woostack-fast" "woostack-standard" "woostack-deep" "agent-by-tier" "Agent-by-tier"; do
-    assert_not_contains "$body" "$stale" "consumer omits stale generated-worker guidance"
-  done
-done
+review="$(cat "$S/woostack-review/SKILL.md")"
+assert_eq "$([[ "$review" == *"after angle detection"* ]] && echo y)" "y" \
+  "review preflights after detecting planned angles"
+assert_eq "$([[ "$review" == *"Before launching any summary, angle, or validator"* ]] && echo y)" "y" \
+  "review preflights the complete selector set before launch"
+assert_eq "$([[ "$review" == *"never creates or repairs an agent during review"* ]] && echo y)" "y" \
+  "review does not generate workers at dispatch time"
+assert_eq "$([[ "$review" != *'agent: quick_task'* ]] && echo y)" "y" \
+  "review omits the unavailable quick selector"
+assert_eq "$([[ "$review" != *'agent: oracle'* ]] && echo y)" "y" \
+  "review omits the unavailable deep selector"
 
 ROOT="$(cd "$S/.." && pwd)"
 DOCS="$ROOT/site/content/docs"

--- a/skills/woostack-init/scripts/tests/test-provision-omp-agents.sh
+++ b/skills/woostack-init/scripts/tests/test-provision-omp-agents.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROVISIONER="$HERE/../provision-omp-agents.sh"
+# shellcheck disable=SC1091
+source "$HERE/assert.sh"
+
+ROOT="$(mktemp -d)"
+ROOT="$(cd "$ROOT" && pwd -P)"
+trap 'rm -rf "$ROOT"' EXIT
+file_state() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+value = os.stat(sys.argv[1], follow_symlinks=False)
+print(f"{value.st_dev}:{value.st_ino}:{value.st_mtime_ns}:{value.st_size}")
+PY
+}
+
+mkdir -p "$ROOT/.omp/agents"
+printf '%s\n' 'consumer-owned' >"$ROOT/.omp/agents/custom.md"
+
+bash "$PROVISIONER" "$ROOT" >/dev/null
+assert_eq "$(cat "$ROOT/.omp/agents/custom.md")" "consumer-owned" "provisioning preserves consumer-authored agents"
+assert_eq "$(cat "$ROOT/.omp/agents/.gitignore")" 'woostack-*.md' \
+  "provisioning creates the scoped generated-agent ignore rule"
+printf '%s' 'consumer-ignore' >"$ROOT/.omp/agents/.gitignore"
+bash "$PROVISIONER" "$ROOT" >/dev/null
+assert_eq "$(cat "$ROOT/.omp/agents/.gitignore")" $'consumer-ignore\nwoostack-*.md' \
+  "provisioning preserves an unterminated consumer-owned ignore line"
+
+
+body='You are a general-purpose woostack worker for delegated tasks.
+
+Follow the supplied task contract, repository rules, worktree boundary, and authority constraints. Complete only the assigned work and return concise evidence.'
+for entry in 'fast @smol' 'standard @default' 'deep @slow'; do
+  set -- $entry
+  tier="$1"; role="$2"; path="$ROOT/.omp/agents/woostack-$tier.md"
+  expected="---
+name: woostack-$tier
+description: General-purpose woostack worker using a host-owned model role
+model: \"$role\"
+---
+
+$body"
+  assert_eq "$(cat "$path")" "$expected" "generated $tier definition is exact"
+done
+assert_eq "$(bash "$PROVISIONER" --check "$ROOT")" "" "fresh definitions pass read-only diagnosis"
+
+before="$(file_state "$ROOT/.omp/agents/woostack-fast.md"):$(file_state "$ROOT/.omp/agents/.gitignore")"
+bash "$PROVISIONER" "$ROOT" >/dev/null
+after="$(file_state "$ROOT/.omp/agents/woostack-fast.md"):$(file_state "$ROOT/.omp/agents/.gitignore")"
+assert_eq "$after" "$before" "provisioning is idempotent for clean managed definitions and ignore coverage"
+printf '%s\n' 'woostack-*.md' >>"$ROOT/.omp/agents/.gitignore"
+ignore_drift="$(bash "$PROVISIONER" --check "$ROOT")"
+assert_contains "$ignore_drift" ".gitignore" "diagnosis reports duplicate generated-agent ignore rules"
+bash "$PROVISIONER" "$ROOT" >/dev/null
+assert_eq "$(cat "$ROOT/.omp/agents/.gitignore")" $'consumer-ignore\nwoostack-*.md' \
+  "repair leaves every consumer-owned ignore line and exactly one managed rule"
+printf '%s\n' '# stale body' >>"$ROOT/.omp/agents/woostack-fast.md"
+drifted="$(bash "$PROVISIONER" --check "$ROOT")"
+assert_contains "$drifted" $'drifted\t' "diagnosis reports stale managed definitions"
+bash "$PROVISIONER" "$ROOT" >/dev/null
+
+
+printf '%s\n' 'not frontmatter' >"$ROOT/.omp/agents/woostack-fast.md"
+malformed="$(bash "$PROVISIONER" --check "$ROOT")"
+assert_contains "$malformed" $'malformed\t' "diagnosis reports malformed managed definitions"
+printf '%s\n' '---' 'name: woostack-standard' 'model: "@smol"' '---' >"$ROOT/.omp/agents/woostack-standard.md"
+wrong_role="$(bash "$PROVISIONER" --check "$ROOT")"
+assert_contains "$wrong_role" $'wrong-role\t' "diagnosis reports the wrong host role"
+rm "$ROOT/.omp/agents/woostack-deep.md"
+missing="$(bash "$PROVISIONER" --check "$ROOT")"
+assert_contains "$missing" $'missing\t' "diagnosis reports missing managed definitions"
+
+bash "$PROVISIONER" "$ROOT" >/dev/null
+assert_eq "$(bash "$PROVISIONER" --check "$ROOT")" "" "provisioning repairs malformed, wrong-role, and missing definitions"
+assert_eq "$(cat "$ROOT/.omp/agents/custom.md")" "consumer-owned" "repair preserves unrelated agents"
+UNSAFE_ROOT="$ROOT/unsafe-consumer"
+mkdir -p "$UNSAFE_ROOT/.omp/agents"
+printf '%s\n' 'SYMLINK_TARGET_MUST_STAY_UNCHANGED' >"$UNSAFE_ROOT/ignore-target"
+ln -s "$UNSAFE_ROOT/ignore-target" "$UNSAFE_ROOT/.omp/agents/.gitignore"
+set +e
+bash "$PROVISIONER" "$UNSAFE_ROOT" >/dev/null 2>&1
+unsafe_status=$?
+set -e
+assert_exit 1 "$unsafe_status" "provisioning fails closed on a symlinked agent ignore file"
+for tier in fast standard deep; do
+  [ ! -e "$UNSAFE_ROOT/.omp/agents/woostack-$tier.md" ] \
+    && pass || fail "unsafe ignore preflight creates no managed $tier definition"
+done
+assert_eq "$(cat "$UNSAFE_ROOT/ignore-target")" "SYMLINK_TARGET_MUST_STAY_UNCHANGED" \
+  "unsafe ignore preflight never reads or changes the symlink target"
+FIFO_ROOT="$ROOT/fifo-consumer"
+mkdir -p "$FIFO_ROOT/.omp/agents"
+mkfifo "$FIFO_ROOT/.omp/agents/.gitignore"
+fifo_status="$(python3 - "$PROVISIONER" "$FIFO_ROOT" <<'PY'
+import subprocess
+import sys
+try:
+    result = subprocess.run(
+        ["bash", sys.argv[1], sys.argv[2]],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=3,
+    )
+    print(result.returncode)
+except subprocess.TimeoutExpired:
+    print(124)
+PY
+)"
+assert_exit 1 "$fifo_status" "provisioning promptly rejects a FIFO agent ignore path"
+for tier in fast standard deep; do
+  [ ! -e "$FIFO_ROOT/.omp/agents/woostack-$tier.md" ] \
+    && pass || fail "FIFO ignore preflight creates no managed $tier definition"
+done
+
+
+
+finish

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -216,7 +216,15 @@ Boundary precedence: workspace packages (`packages/<name>/`, `apps/<name>/`, `se
 
 **This is the local swarm step.** Local hosts MUST dispatch every detected angle or `(angle, chunk)` pair and let the host manage its own subagent queue by default. Do not impose a woostack hard cap: hosts with large subagent budgets can run every angle at once, while hosts with smaller limits can queue internally. Use an explicit cap only when the host or shell caller asks for bounded execution (for example `--max-concurrency`, `WOO_REVIEW_MAX_CONCURRENCY`, or `N=1` for a sequential fallback).
 
-**Preflight (local).** Before dispatching workers, confirm your host can actually run review sub-agents (its `Task`/sub-agent primitive is available). If it cannot, stop now with an actionable error — do not dispatch a swarm that will produce no receipts and then hard-fail the gate. In the GitHub Action, `detect-provider.sh` performs the equivalent provider/runner preflight.
+**Preflight (local, after angle detection).** Read the complete planned work from `angles.txt`, apply
+any forced tier, include the fast context/summary helper and both deep validators, and derive the
+distinct selector set required by the whole run. Before launching any summary, angle, or validator
+worker, discover the active host task-agent registry and prove that its spawn primitive and every
+planned selector are available. On OMP this checks the managed selectors from the canonical host
+adapter; it never creates or repairs an agent during review. Any missing capability aborts the
+entire swarm before the first worker, with the missing selectors named—never launch a partial swarm
+that will later fail receipts. In the GitHub Action, `detect-provider.sh` performs the equivalent
+provider/runner preflight.
 
 Review swarm execution means:
 
@@ -235,7 +243,7 @@ Use your host's primitive for host-managed fan-out — the current host's refere
 Angle workers MUST be spawned with no `woostack-review` skill scope attached and with a fresh
 independent reviewer profile/session that is not the paired implementation coding profile or its
 session. Use the worker selector required by the current host file; a host with role-backed
-built-in workers selects the independent worker mapped from the angle's effective tier. On hosts
+workers selects the independent worker mapped from the angle's effective tier. On hosts
 without that mechanism, choose a fresh plain/general/default reviewer profile (Claude Code:
 `general-purpose`). Never reuse the implementing coder, share its profile/session/credential
 context, or use a `woostack-review`-scoped profile, `@woostack-review`,
@@ -333,8 +341,8 @@ single-session hosts that consume repository model configuration, resolve it wit
 `models.<provider>.<tier>` and flat `models.<tier>` overrides first. A fallback leaf must be a
 non-empty ordered array; entry 0 is the primary, and the resolver falls back to the default table in
 `prompts/_orchestrator-header.md`. On a host with host-owned role routing, resolve only the
-effective tier and select its fixed role-backed built-in worker; do not invoke the repository
-model resolver or read model leaves for that dispatch. Tier assignments:
+effective tier and select its fixed role-backed worker; do not invoke the repository model resolver
+or read model leaves for that dispatch. Tier assignments:
 
 | Stage | Tier | Why |
 |---|---|---|
@@ -377,8 +385,8 @@ Per-provider resolution (canonical table in `../using-woostack/references/model-
   `FORCE_TIER`, otherwise `standard`); `tier:` is informational after that, and separate jobs are
   required for per-angle fast/deep behavior.
 - On host-owned role-routing hosts, apply `FORCE_TIER` when present, map the effective tier to the
-  host file's fixed built-in worker, and let the host own the concrete model and fallback. Never
-  call the repository model resolver for that route.
+  host file's fixed worker, and let the host own the concrete model and fallback. Never call the
+  repository model resolver for that route.
 
 Review runners MUST preserve the route actually used for every worker. Repository-model hosts
 preserve the resolved tier/model context: per-call hosts set the resolved spawn values, and


### PR DESCRIPTION
## Goal
Make OMP full reviews dispatch fast, standard, and deep tiers through supported project role agents, with all-or-nothing capability preflight before the swarm starts.

## Summary
- Provision `woostack-fast`, `woostack-standard`, and `woostack-deep` with OMP-owned `@smol`, `@default`, and `@slow` roles while preserving consumer agents and scoped ignore content.
- Route OMP review tiers through those selectors and require the complete planned selector set to pass active-registry preflight before any summary, angle, or validator worker launches.
- Diagnose and repair missing or drifted managed definitions through `woostack-doctor`; update focused regression coverage and authored OMP docs.

Closes #577

## Test plan
### Automated
- `bash skills/woostack-init/scripts/tests/test-host-references.sh` — passed (84 passed, 0 failed)
- `bash skills/woostack-init/scripts/tests/test-provision-omp-agents.sh` — passed (25 passed, 0 failed)
- `bash skills/woostack-doctor/scripts/tests/test-omp-agents.sh` — passed (53 passed, 0 failed)
- `bash skills/woostack-eval/scripts/tests/test-command-surface.sh` — passed
- `pnpm -C site build` — passed (144 static pages generated)

### Manual
- Provisioned a temporary consumer repository and observed exact role mappings: fast `@smol`, standard `@default`, deep `@slow`; unrelated `custom.md` and scoped `.gitignore` behavior were preserved.
- Ran OMP 17.2.2 from that consumer and dispatched all three selectors in one `task` batch; each returned its expected `RESOLVED woostack-*` receipt.