### PR TITLE
fix(init): restore canonical worktree paths

### DIFF
--- a/skills/woostack-init/references/__tests__/test-worktrees-contract.sh
+++ b/skills/woostack-init/references/__tests__/test-worktrees-contract.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Structural contract for documented worktree helpers and task placement.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INIT_DIR="$(cd "$HERE/../.." && pwd)"
+REPO_ROOT="$(cd "$INIT_DIR/../.." && pwd)"
+CONTRACT="$HERE/../worktrees.md"
+AUTHORED_PAGE="$REPO_ROOT/site/content/docs/concepts/worktrees.mdx"
+failures=0
+
+while IFS= read -r reference; do
+  asset="${reference#<wi>/}"
+  if [ ! -f "$INIT_DIR/$asset" ]; then
+    printf 'missing worktree helper asset: %s\n' "$reference" >&2
+    failures=$((failures + 1))
+  fi
+done < <(LC_ALL=C grep -oE '<wi>/scripts/[A-Za-z0-9._/-]+' "$CONTRACT" | LC_ALL=C sort -u)
+
+contract_paths="$(LC_ALL=C grep -oE '\.woostack/worktrees/tasks/<[A-Za-z0-9._-]+>' "$CONTRACT" | LC_ALL=C sort -u || true)"
+authored_paths="$(LC_ALL=C grep -oE '\.woostack/worktrees/tasks/<[A-Za-z0-9._-]+>' "$AUTHORED_PAGE" | LC_ALL=C sort -u || true)"
+if [ "$contract_paths" != "$authored_paths" ] || [ -z "$authored_paths" ]; then
+  printf 'task worktree path drift:\n  worktrees.md: %s\n  authored page: %s\n' \
+    "${contract_paths:-<missing>}" "${authored_paths:-<missing>}" >&2
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+  exit 1
+fi
+
+printf 'PASS worktrees contract\n'

--- a/skills/woostack-init/references/worktrees.md
+++ b/skills/woostack-init/references/worktrees.md
@@ -5,21 +5,29 @@ own scope, allocation, dependencies, approval, acceptance, or merge authority. T
 workflow contract owns those decisions; Git, Graphite, and canonical GitHub reads own repository
 state. Linear is optional artifact context only.
 
-`<wi>` below means the installed `woostack-init` skill directory. The helpers are:
+`<wi>` below means the installed `woostack-init` skill directory. Its worktree helper is:
 
-- `<wi>/scripts/resolve-base.sh` — resolve the configured integration base;
-- `<wi>/scripts/worktree-common-root.sh` — resolve the common primary root; and
-- `<wi>/scripts/worktree-id.sh` — collision-safe stable-task-ID encoding.
+- `<wi>/scripts/resolve-base.sh` — resolve the configured integration base.
 
 ## 1. Identity and placement
 
 Every active implementation task has one stable task ID, one controller/engineer run, one branch,
-one worktree, and one registry claim. Never derive identity from a title, ordinal, recent activity,
-issue key, shortened hash, or disposable directory name.
+one worktree, and one registry claim. For filesystem placement, require the ID to be one non-empty
+path component matching `^[A-Za-z0-9][A-Za-z0-9._-]*$`; reject separators, whitespace, and any
+other encoding. Never derive identity from a title, ordinal, recent activity, issue key, shortened
+hash, or disposable directory name.
 
 The physical primary root is the common Git directory's repository root, not whichever worktree the
-caller currently occupies. Place task worktrees under a sibling administration root resolved by the
-helper; never nest them inside another worktree or a tracked source directory.
+caller currently occupies. Resolve it inline from any checkout:
+
+```sh
+git_common_dir="$(git rev-parse --git-common-dir)"
+WOOSTACK_ROOT="$(cd "$git_common_dir/.." && pwd -P)"
+```
+
+Place each task worktree at
+`$WOOSTACK_ROOT/.woostack/worktrees/tasks/<stable-task-id>`; never nest it inside another task
+worktree or a tracked source directory.
 
 Optional exact Linear project/issue IDs may be recorded as descriptive context, but cannot replace
 the stable task ID or any repository identity.


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices

## Goal
Restore an executable, collision-safe worktree contract without references to assets that never existed.

## Summary
- Remove the phantom `worktree-common-root.sh` and `worktree-id.sh` references introduced by PR #576.
- Restore inline Git common-root resolution and the established task worktree path with filesystem-safe stable IDs.
- Add colocated structural regression coverage for helper existence and authored-doc path alignment.

## Test plan
### Automated
- `bash skills/woostack-init/references/__tests__/test-worktrees-contract.sh` — passed
- `bash skills/woostack-init/scripts/tests/test-provision-omp-agents.sh` — passed (25 passed, 0 failed)
- `git diff --check` — passed

### Manual
- From the linked task worktree, inline Git common-root resolution returned the canonical primary checkout.