### PR TITLE
docs(patterns): require sibling test folders

### DIFF
--- a/skills/woostack-bootstrap/references/patterns.md
+++ b/skills/woostack-bootstrap/references/patterns.md
@@ -132,7 +132,7 @@ coverage classes, and no-runner substitution — lives once in
 [woostack-tdd](../../woostack-tdd/SKILL.md); follow it. This section records only the
 **project-specific** standard layered on top:
 
-**Frameworks:** Vitest everywhere except React Native (uses Jest via `jest-expo`). Playwright for E2E. Test files colocated with source as `*.test.ts(x)` or in `__tests__/`.
+**Frameworks:** Vitest everywhere except React Native (uses Jest via `jest-expo`). Playwright for E2E. Tests for a source file live in a sibling `__tests__/` directory.
 
 A feature is **not complete** until all tests pass.
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [x] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices

## Goal
Require tests for a source file to live in a sibling `__tests__/` directory.

## Summary
- Remove the alternative that allowed direct `*.test.ts(x)` placement beside source files.
- Preserve the existing Vitest, React Native Jest/`jest-expo`, and Playwright guidance.

## Test plan
### Automated
- Desired-contract assertion — passed:
  ```sh
  python3 -c 'from pathlib import Path; t=Path("skills/woostack-bootstrap/references/patterns.md").read_text(); assert "**Frameworks:** Vitest everywhere except React Native (uses Jest via `jest-expo`). Playwright for E2E. Tests for a source file live in a sibling `__tests__/` directory." in t; print("PASS: sibling __tests__/ placement is required")'
  ```
- `git diff --check` — passed

### Manual
- Inspected `patterns.md` §7 and confirmed the TDD reference, framework guidance, E2E guidance, and completion requirement remain intact.