### PR TITLE
fix: address open comments before sweep transitions

### DIFF
--- a/skills/woostack-sweep/SKILL.md
+++ b/skills/woostack-sweep/SKILL.md
@@ -62,17 +62,28 @@ thread set, changed paths, and approved task contract.
 2. **Classify.** A round is clean only when the full review has no blocking findings, required
    checks pass, and no unresolved blocking thread remains. A missing reviewer, partial result,
    unknown check, or changed head is `blocked`, never clean.
-3. **Address once.** For confirmed findings or threads, invoke
-   [`woostack-address-comments`](../woostack-address-comments/SKILL.md) in the PR's isolated worktree.
-   It may fix, push back, clarify, or request a decision. Do not broaden the task contract.
+3. **Address once before any transition.** For every submitted PR, before moving to another PR or
+   returning any terminal result, refresh the exact current-head unresolved-thread snapshot. If
+   confirmed findings remain or the snapshot is nonempty, invoke
+   [`woostack-address-comments`](../woostack-address-comments/SKILL.md) once before advancing or
+   stopping, in the PR's isolated worktree. Do not broaden the task contract. Rely on its canonical
+   loop to continue all other independent threads; one blocked thread cannot be used to skip them.
+   After the attempt, refetch the canonical PR/head and complete unresolved-thread set. Head and
+   thread-set changes attributable to the completed addressing attempt are the expected refreshed
+   state for the next decision. Only unexpected or concurrent head or thread-set drift invalidates
+   the round, restarts discovery, and requires a fresh stable snapshot before deciding the next
+   action. If the snapshot is empty, do not invoke address-comments solely for this gate;
+   continue the existing no-thread flow. An unsafe, failed, or decision-blocked attempt may stop
+   truthfully, but only after the attempt.
 4. **Verify.** Require focused verification and the calling workflow's complete review boundary on
    the unchanged addressed diff before commit/submission.
 5. **Restack affected descendants.** If the PR head changed, follow the restack boundary below.
 6. **Re-review.** Fetch the updated PR/head and run a new full review. Never reuse a result from a
    prior head.
 
-Stop a PR after `review.max_rounds`, a repeated complete finding/thread signature on the same head,
-no repository progress, a blocker, or a required decision. Do not silently downgrade full review to
+Only after this gate, including the required attempt for a nonempty snapshot, may
+`review.max_rounds`, a repeated complete finding/thread signature on the same head, no repository
+progress, a blocker, or a required decision stop the PR. Do not silently downgrade full review to
 self-review or a narrower angle.
 
 ## Stack-scoped restack boundary

--- a/skills/woostack-sweep/scripts/tests/test-round-verdict-contract.sh
+++ b/skills/woostack-sweep/scripts/tests/test-round-verdict-contract.sh
@@ -5,25 +5,61 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 python3 - "$ROOT" <<'PY'
 import re, sys
 from pathlib import Path
-text=re.sub(r"\s+"," ",(Path(sys.argv[1])/"skills/woostack-sweep/SKILL.md").read_text())
-checks={
- "bottom up":r"Process PRs bottom-up",
- "identity":r"canonical PR number, head SHA, base SHA/branch, complete thread set, changed paths, and approved task contract",
- "full review":r"woostack-review --full.*exact PR/head",
- "independent reviewer":r"implementing coder cannot act as the independent reviewer",
- "clean classification":r"clean only when.*no blocking findings.*checks pass.*no unresolved blocking thread",
- "fail closed":r"missing reviewer, partial result, unknown check, or changed head is `blocked`",
- "address":r"woostack-address-comments.*isolated worktree",
- "no broaden":r"Do not broaden the task contract",
- "verify":r"focused verification.*unchanged addressed diff",
- "fresh re-review":r"Fetch the updated PR/head and run a new full review.*Never reuse a result from a prior head",
- "bounds":r"review.max_rounds.*repeated complete finding/thread signature.*no repository progress",
- "no downgrade":r"Do not silently downgrade full review to self-review",
+
+text = re.sub(
+    r"\s+",
+    " ",
+    (Path(sys.argv[1]) / "skills/woostack-sweep/SKILL.md").read_text(),
+)
+checks = {
+    "bottom up": r"Process PRs bottom-up",
+    "identity": r"canonical PR number, head SHA, base SHA/branch, complete thread set, changed paths, and approved task contract",
+    "full review": r"woostack-review --full.*exact PR/head",
+    "independent reviewer": r"implementing coder cannot act as the independent reviewer",
+    "clean classification": r"clean only when.*no blocking findings.*checks pass.*no unresolved blocking thread",
+    "fail closed": r"missing reviewer, partial result, unknown check, or changed head is `blocked`",
+    "transition gate": r"\*\*Address once before any transition\.\*\*",
+    "current-head refresh": r"Before moving to another PR or returning any terminal result, refresh the exact current-head unresolved-thread snapshot",
+    "address before transition": r"snapshot is nonempty.*invoke.*woostack-address-comments.*once before advancing or stopping",
+    "independent threads": r"canonical loop.*other independent threads.*one blocked thread.*skip",
+    "post-attempt refresh": r"After the attempt, refetch.*canonical PR/head.*complete unresolved-thread set",
+    "address result snapshot": r"changes attributable to the completed addressing attempt are the expected refreshed state for the next decision",
+    "unexpected drift discovery": r"Only unexpected or concurrent head or thread-set drift invalidates the round.*restarts discovery.*fresh stable snapshot",
+    "no-thread flow": r"snapshot is empty.*do not invoke.*solely for this gate.*existing no-thread flow",
+    "truthful unsafe stop": r"unsafe, failed, or decision-blocked attempt may stop truthfully, but only after the attempt",
+    "verify": r"focused verification.*unchanged addressed diff",
+    "fresh re-review": r"Fetch the updated PR/head and run a new full review.*Never reuse a result from a prior head",
+    "post-attempt bounds": r"Only after this gate.*required attempt.*review\.max_rounds.*repeated complete finding/thread signature.*no repository progress.*blocker.*required decision",
+    "no downgrade": r"Do not silently downgrade full review to self-review",
 }
-failures=[name for name,pat in checks.items() if not re.search(pat,text,re.I|re.S)]
+failures = [
+    name for name, pattern in checks.items() if not re.search(pattern, text, re.I | re.S)
+]
+
+round_tail = re.search(
+    r"3\. \*\*Address once before any transition\.\*\*(.*?)## Stack-scoped restack boundary",
+    text,
+    re.I | re.S,
+)
+if not round_tail:
+    failures.append("transition ordering section")
+else:
+    ordered = [
+        "refresh the exact current-head unresolved-thread snapshot",
+        "invoke [`woostack-address-comments`",
+        "After the attempt, refetch",
+        "changes attributable to the completed addressing attempt",
+        "Only unexpected or concurrent head or thread-set drift",
+        "Only after this gate",
+        "`review.max_rounds`",
+    ]
+    positions = [round_tail.group(1).find(marker) for marker in ordered]
+    if any(position < 0 for position in positions) or positions != sorted(positions):
+        failures.append("max-round open-thread address-before-stop ordering")
+
 if failures:
- print("sweep round contract violations:",file=sys.stderr)
- print("\n".join(f"- {f}" for f in failures),file=sys.stderr)
- raise SystemExit(1)
-print("bounded sweep rounds: ok")
+    print("sweep round contract violations:", file=sys.stderr)
+    print("\n".join(f"- {failure}" for failure in failures), file=sys.stderr)
+    raise SystemExit(1)
+print("bounded sweep rounds (open-thread address precedes max-round stop): ok")
 PY


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices

## Goal
Ensure sweep attempts every open review comment before advancing or stopping.

## Summary
- Add a current-head unresolved-thread gate before every transition or terminal stop.
- Retain expected address-attributable head and thread changes while restarting discovery only for unexpected or concurrent drift.
- Add structural contract regression coverage for transition ordering, independent-thread handling, snapshot refresh, and post-attempt bounds.

## Test plan
### Automated
- `bash skills/woostack-sweep/scripts/tests/test-round-verdict-contract.sh` — passed
- `bash skills/woostack-sweep/scripts/tests/run-tests.sh` — passed

### Manual
- Max-round/current-head open-thread ordering was exercised by the focused structural smoke; address precedes stop.
