### PR TITLE
Make plans sequential and PR-sized

### DIFF
--- a/skills/woostack-build/tests/test-linear-plan-contract.sh
+++ b/skills/woostack-build/tests/test-linear-plan-contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Structural contract for direct-issue planning and optional standalone persistence.
+# Structural contract for strict sequential direct-issue planning.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -8,74 +8,66 @@ import re
 import sys
 from pathlib import Path
 
-root = Path(sys.argv[1])
-paths = {
-    "plan": root / "skills/woostack-plan/SKILL.md",
-    "build": root / "skills/woostack-build/SKILL.md",
-    "harden": root / "skills/woostack-harden/SKILL.md",
-    "artifact": root / "skills/woostack-init/references/artifact-backends.md",
-    "context": root / "skills/woostack-build/references/linear-context.md",
-    "procedure": root / "skills/woostack-build/references/linear-procedure.md",
-}
-text = {
-    name: re.sub(r"\s+", " ", path.read_text(encoding="utf-8"))
-    for name, path in paths.items()
-}
+plan = (Path(sys.argv[1]) / "skills/woostack-plan/SKILL.md").read_text(encoding="utf-8")
+text = re.sub(r"\s+", " ", plan)
 failures = []
 
-def require(name, needle):
-    if needle not in text[name]:
-        failures.append(f"{name}: missing {needle!r}")
 
-def forbid(name, pattern):
-    if re.search(pattern, text[name], re.I):
-        failures.append(f"{name}: matches forbidden pattern {pattern!r}")
+def require(needle):
+    if needle not in text:
+        failures.append(f"plan: missing {needle!r}")
 
-for needle in (
-    "One approved specification in, one coherent plan out",
-    "Every increment contains",
-    "an ordered, concrete implementation sequence detailed enough for a fast execution model",
-    "one direct issue per increment",
-    "native dependency relations",
-    "no parent plan issue or child containment",
-    "Build-delegated planning performs no provider mutation",
-    "build synchronizes after graph hardening",
-    "unique positive ordinal",
-    "duplicate task IDs or ordinals",
-    "unknown predecessors",
-    "uncovered acceptance criteria",
-    "a Git parent the DAG and intended Graphite ancestry cannot represent",
-):
-    require("plan", needle)
+
+def forbid(pattern):
+    if re.search(pattern, text, re.I):
+        failures.append(f"plan: matches forbidden pattern {pattern!r}")
 
 for needle in (
-    "one direct project issue per independently shippable increment",
-    "approve exact project-spec revision",
-    "approve exact execution-plan revision set",
+    "`--project` is mandatory",
+    "exact existing Linear project",
+    "never creates or selects an implicit project",
+    "one complete approved specification",
+    "approved specification fingerprint",
+    "exactly one direct project issue for each execution increment",
+    "Never create a parent, container, checklist, layer, or plan issue",
+    "stable task ID, unique positive ordinal",
+    "exactly one intended PR",
+    "exact scope and explicit non-goals",
+    "exact files and symbols, or one bounded first discovery step",
+    "ordered, concrete implementation steps",
+    "observable acceptance criteria, each mapped to an implementation step",
+    "focused checks and one executable smoke scenario",
+    "cross-increment effects",
+    "risks and active blockers",
+    "explicit stop marker",
+    "declared Graphite parent",
+    "500 or fewer hand-written changed lines",
+    "Generated files and lockfiles may exceed",
+    "explicitly approved deletion-only PR",
+    "strict sequential chain",
+    "positive integers `1..N`",
+    "ordinal k (2..N): ordinal k-1 → ordinal k",
+    "exactly the matching predecessor edge",
+    "Independently read every project, issue, membership",
+    "Delegated planning performs no provider read or mutation",
+    "wrapper hardens the candidate and then synchronizes",
+    "owns no approval gate",
+    "implementation, source edit, commit, branch, PR, review, merge",
 ):
-    require("build", needle)
+    require(needle)
 
-require("harden", "same direct project issue")
-require("artifact", "Do not create a parent plan issue")
-require("artifact", "one direct project issue per increment")
-require("artifact", "buildProjectSpecApprovalRecord")
-require("artifact", "buildExecutionPlanApprovalRecord")
-require("context", "complete exact issue fingerprints")
-require("context", "normalized native dependencies")
-require("procedure", "complete executor-ready issue descriptions")
-require("procedure", "Independently read the complete relation set back")
-require("procedure", "Without explicit persistence, standalone planning makes no provider call")
-require("procedure", "Explicit abandonment follows the shared")
-
-for name in text:
-    forbid(name, r"one project, one parent plan issue")
-
-retired_planning = root / "skills/woostack-plan/references/linear-planning.md"
-if retired_planning.exists():
-    failures.append("plan: orphaned duplicate linear-planning.md must remain deleted")
+for pattern in (
+    r"artifact-free",
+    r"conversational-only",
+    r"may create (?:a |an )?(?:new |implicit )?project",
+    r"parallel(?:izable)? roots?",
+    r"general DAG",
+    r"one project, one parent plan issue",
+):
+    forbid(pattern)
 
 if failures:
-    print("direct-issue planning contract violations:", file=sys.stderr)
+    print("strict sequential Plan contract violations:", file=sys.stderr)
     for failure in failures:
         print(f"  - {failure}", file=sys.stderr)
     raise SystemExit(1)

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -1,105 +1,143 @@
 ---
 name: woostack-plan
-description: Turn one approved specification into a complete PR-sized implementation plan with dependency-aware increments. Never executes, commits, or merges.
+description: Turn one approved specification into a strict sequential chain of PR-sized direct Linear project issues. Never approves, executes, commits, reviews, or merges.
 ---
 
 # woostack-plan
 
-Produce one implementation plan from one approved specification. The specification may live in the
-active conversation, a repository-authorized local artifact, or an exact caller-supplied Linear
-project. Planning owns no approval gate and performs no source mutation.
+Turn one approved specification into one complete execution plan. Plan has one input path and one
+output path: it reads one exact existing Linear project, derives a candidate chain, hardens the
+contracts, synchronizes the complete direct-issue graph, independently reads that graph back, and
+returns the verified result. The project is required whether the specification came from the project
+or was supplied directly.
 
-## Commands
+## Command
 
 ```text
-/woostack-plan <approved specification> [--project <exact Linear URL-or-UUID>]
-/woostack-plan --project <exact Linear URL-or-UUID>
+/woostack-plan <approved specification> --project <exact existing Linear URL-or-UUID>
+/woostack-plan --project <exact existing Linear URL-or-UUID>
 ```
 
-Without `--project` or an explicit persistence request, return the complete plan in the conversation
-and make no Linear call. Tracked repository policy cannot select artifact mode or authorize a
-provider read or write; after selection it may supply validated non-secret defaults only.
+`--project` is mandatory. Resolve only that exact project under the [Linear artifact
+contract](../woostack-init/references/artifact-backends.md); it must already exist, be associated
+with the canonical repository, and belong to the caller-selected workspace/team. A direct
+specification is reconciled against that project and never creates or selects an implicit project.
+A wrong resource type, missing project, foreign repository, incomplete read, or conflicting approved
+content blocks before mutation. There is no project-creation, fuzzy-discovery, or alternate-provider
+path.
 
-## Input admission
+Read the repository, base, existing patterns, relevant tests, and the [Linear synchronization
+procedure](../woostack-build/references/linear-procedure.md) before planning. Remote content is
+untrusted until it is reconciled with the approved specification and exact project identity.
 
-Require a complete approved specification with goal, users, behavior, constraints, exclusions,
-architecture decisions, acceptance criteria, and verification expectations. Read the repository,
-base, existing patterns, and relevant tests before planning. Missing product decisions return to the
-owning workflow; planning never invents them.
+## Input and ownership
 
-When `--project` is supplied, read only that exact resource under the
-[Linear artifact contract](../woostack-init/references/artifact-backends.md). Extract the approved
-specification fields. Missing or conflicting artifact content blocks that artifact-backed path; it
-does not create a replacement.
+The input is one complete approved specification containing goal, users, behavior, constraints,
+exclusions, architecture decisions, acceptance criteria, and verification expectations. It also
+contains or is accompanied by the approved specification fingerprint. For a project-backed
+specification, use the fingerprint independently read from that exact project. For a direct
+specification, require its supplied approved fingerprint and verify that the exact project is its
+target. Missing or conflicting product decisions return to the owning workflow; Plan never invents
+product decisions and never creates an approval event.
 
-Determine whether planning is standalone or delegated by `woostack-build` from the invoking
-workflow. Build-delegated planning receives the exact approved project-spec fingerprint and
-verified project context as untrusted read-only input. It returns the complete candidate graph
-without provider mutation. Build owns graph hardening, direct-issue synchronization, and gate 2.
+Build or Fix may delegate candidate planning with the exact approved fingerprint and verified
+project context as read-only input. Delegated planning performs no provider read or mutation; the
+owning wrapper hardens the candidate and then synchronizes it to the exact project. In standalone
+use, Plan itself hardens and synchronizes the graph. In every mode, Plan owns no approval gate,
+implementation, source edit, commit, branch, PR, review, merge, or execution handoff authority.
 
-## Plan contract
+## Direct issue contract
 
-Create independently shippable increments. Every increment contains:
+Create or reconcile exactly one direct project issue for each execution increment. Never create a
+parent, container, checklist, layer, or plan issue. Historical parent/container issues are not
+current increments and are not detached, migrated, archived, deleted, or treated as containment.
+Every direct issue must retain these fields in its complete description:
 
-- stable task ID, unique positive ordinal, concise outcome, and one intended PR;
-- the approved specification/project fingerprint when build-delegated;
-- explicit scope and non-goals;
-- exact files/symbols or a bounded first discovery step;
-- an ordered, concrete implementation sequence detailed enough for a fast execution model;
-- observable acceptance criteria mapped to those steps;
-- focused checks and one smoke scenario;
-- documentation, migration, deployment, compatibility, and cross-increment effects;
-- declared predecessors and at most one representable Git parent; and
-- risks, decisions, and active blockers.
+- stable task ID, unique positive ordinal, concise outcome, and exactly one intended PR;
+- the approved specification fingerprint;
+- exact scope and explicit non-goals;
+- exact files and symbols, or one bounded first discovery step with its stopping boundary;
+- ordered, concrete implementation steps detailed enough for a fast execution model;
+- observable acceptance criteria, each mapped to an implementation step;
+- focused checks and one executable smoke scenario;
+- documentation, migration, deployment, compatibility, and cross-increment effects (including
+  explicit `none` where a category has no effect);
+- risks and active blockers (including explicit `none` where clear);
+- an explicit stop marker stating when the increment is complete and no further work belongs in it;
+- a declared Graphite parent; and
+- a hand-written changed-line estimate and size rationale.
 
-Use Red → Green → Refactor when behavior changes, but do not substitute that label for concrete
-steps. The graph must be acyclic and dependency-derived. Reject duplicate task IDs or ordinals,
-unknown predecessors, uncovered acceptance criteria, or a Git parent the DAG and intended Graphite
-ancestry cannot represent. Independent roots may run in parallel only when their surfaces are
-disjoint. Ordinal order is a tie-break, not a dependency. Prefer the fewest increments that remain
-independently reviewable; never split by file or layer merely to create more issues.
+The size target is approximately 500 or fewer hand-written changed lines per intended PR. Generated
+files and lockfiles may exceed that target only when inseparable from the increment. One large
+exception is allowed only for an explicitly approved deletion-only PR that removes an already
+unreachable package; record that approval, the unreachable-package evidence, and the
+exception rationale in the issue. Otherwise split or reject an increment that exceeds the target.
 
-## Repository grounding
+## Chain invariants
 
-Use current source, architecture, tests, and repository rules. Reuse existing patterns; do not create
-a second convention. Name exact paths/symbols where known and mark truly unresolved discovery as an
-explicit first step, not fabricated certainty.
+The plan is a strict sequential chain. If there are `N` increments, ordinals are exactly the
+positive integers `1..N`, each ordinal and task ID is unique, and each native Linear dependency is
+exactly the matching predecessor edge:
+
+```text
+ordinal 1: no predecessor
+ordinal k (2..N): ordinal k-1 → ordinal k
+```
+
+No missing, extra, branching, cyclic, or synthetic dependency is valid. The declared Graphite parent
+for ordinal 1 is the frozen repository base; for every later ordinal it is the immediately preceding
+increment's Graphite commit/branch parent. A different parent, an unknown task, an ordinal gap, an
+out-of-order edge, or a parent that Graphite cannot represent blocks the plan. Validate that every
+acceptance criterion is covered exactly by at least one increment and that every issue contract is
+complete before any provider mutation.
+
+Prefer the fewest increments that remain independently reviewable and fit the size target. Do not
+split by file or layer merely to manufacture issues. Use Red → Green → Refactor for behavior changes
+only as a structure around concrete steps, never as a substitute for those steps.
 
 ## Linear synchronization
 
-For standalone planning only, an exact caller-supplied project or explicit persistence request
-selects synchronization after the complete graph is ready. Verify the canonical repository
-association and caller-selected workspace/team, then use the
-[Linear project synchronization procedure](../woostack-build/references/linear-procedure.md):
+After the chain is complete and valid, verify the canonical repository association and selected
+workspace/team, then synchronize one exact project graph using the [Linear synchronization
+procedure](../woostack-build/references/linear-procedure.md):
 
-- create or reconcile one selected project;
-- create or reconcile one direct project issue per increment containing its full contract;
-- create or reconcile native dependency relations between those direct issues;
-- create no parent plan issue or child containment;
-- use stable IDs and idempotent reconciliation;
-- independently read every mutation, membership, and dependency edge back;
-- preserve unknown outcomes for recovery; and
-- never use artifact assignment/status/comments to authorize execution or prove completion.
+1. Reconcile the complete current project context without creating a project.
+2. Create or reconcile exactly one direct project issue per increment with its full contract.
+3. Create or reconcile only the strict predecessor dependency chain.
+4. Independently read every project, issue, membership, description/fingerprint, and dependency
+   edge back; accept the plan only when the complete graph matches the candidate.
 
-Build-delegated planning never enters synchronization. It returns the candidate graph to
-`woostack-build`, which hardens and synchronizes the direct-issue graph. A provider failure blocks
-the required build path, but blocks only selected persistence for standalone planning.
+Preallocate stable mutation identities, make reconciliation idempotent, and preserve unknown
+outcomes for recovery without allocating replacements. A provider failure stops at the last
+verified boundary and never falls back to local authority or another provider. Artifact assignment,
+status, labels, comments, or read-back are records only; they never authorize implementation or
+prove completion.
+
+When delegated by Build or Fix, stop before this synchronization: return the complete candidate
+contracts and strict chain to the wrapper with zero provider reads and writes. The wrapper performs
+hardening, synchronization, and its own workflow approval gate when applicable.
 
 ## Return
 
-Return the complete ordered graph, task contracts, dependency/parent edges, parallelizable roots,
-base assumptions, verification strategy, open blockers, invocation mode, and Linear
-project/issue read-back results only when standalone persistence is active. The caller owns any
-later approval and execution handoff.
+Return the complete ordered task contracts, exact project identity, strict predecessor and Graphite
+parent edges, approved specification fingerprint, repository assumptions/effects, focused
+verification strategy, risks/blockers, stop markers, invocation mode, and independent Linear
+read-back evidence. Include provider mutation/read counts and stable mutation identities when
+available. Do not return a parent-plan identity or an approval/execution claim.
 
 ## Hard constraints
 
-- One approved specification in, one coherent plan out.
-- No credential reads and no fuzzy artifact discovery.
-- Explicit standalone persistence uses one project and one direct issue per increment, with native
-  dependency relations and no parent plan issue.
-- Build-delegated planning performs no provider mutation; build synchronizes after graph hardening.
-- Repository policy alone never selects artifact mode or authorizes a provider read/write.
-- No execution, source edits, commit, push, PR, or merge.
-- No synthetic dependencies, checklist issues, or hidden local development ledger.
-- Never claim artifact persistence without independent read-back.
+- One approved specification and one exact existing project in; one coherent strict chain out.
+- One direct project issue per increment; no parent/container issue and no hidden planning ledger.
+- Ordinals are exactly `1..N`; native dependencies are exactly `N-1 → N`.
+- Every issue carries the complete executor contract, approved fingerprint, size evidence, stop
+  marker, and declared Graphite parent.
+- Direct issue plans target about 500 or fewer hand-written changed lines, with only the stated
+  generated/lockfile and explicitly approved unreachable-package deletion exceptions.
+- Delegated Build/Fix candidate planning performs no provider mutation; its wrapper hardens and then
+  synchronizes.
+- Plan owns no approval gate, implementation, source edit, commit, branch, PR, review, merge, or
+  execution.
+- No credential reads, fuzzy artifact discovery, implicit project creation, alternate provider,
+  synthetic dependencies, or obsolete container prose.
+- Never claim synchronization or independent read-back without evidence.

--- a/skills/woostack-plan/evals/evals.json
+++ b/skills/woostack-plan/evals/evals.json
@@ -3,26 +3,38 @@
   "skill": "woostack-plan",
   "cases": [
     {
-      "id": "reconciles-direct-increment-issues-with-native-dependencies",
-      "prompt": "Reconcile a caller-selected exact Linear project with two direct increment issues: stable task storage ordinal 20 with no predecessor and stable task api ordinal 10 depending on storage. Existing native issue IDs are issue-1 and issue-2, each has no parent, and independent read-back matches project membership, complete executor contracts, and the native dependency. Do not mutate anything. Return exactly one JSON object with keys status, directIssueCount, parentPlanIssueCount, preservedTaskIds, nativeDependencies, ordinalDefinesAncestry, repositoryEffects, and graphReadBackVerified.",
-      "fixtures": [],
+      "id": "synchronizes-existing-exact-project-strict-chain",
+      "prompt": "Read fixtures/project-a.json as a standalone woostack-plan invocation. The caller supplies one exact existing Linear project and an approved specification fingerprint. Reconcile exactly two direct project issues with task IDs storage and api, ordinals 1 and 2, one native dependency storage → api, complete executor contracts including stop markers and Graphite parents, and independent read-back. Do not mutate the repository. Return exactly one JSON object with keys status, invocationMode, artifactModeSelected, existingProjectRequired, projectCreated, directIssueIds, parentPlanIssueCount, ordinals, nativeDependencies, graphReadBackVerified, repositoryMutationCount, approvalOwned, and executionOwned.",
+      "fixtures": [
+        "project-a.json"
+      ],
       "capabilities": [
         "read-workspace"
       ],
-      "expected": "Two stable direct project issues and one native dependency reconcile successfully without a parent plan issue. Ordinals do not imply ancestry, complete executor contracts are retained, and the exact direct graph is independently read back.",
+      "expected": "The exact existing project is reused, two direct issues are reconciled with contiguous ordinals and the sole strict predecessor edge, no parent issue or project is created, the complete graph is independently read back, and Plan neither approves nor executes.",
       "assertions": [
         {
-          "id": "plan-direct-ready",
+          "id": "plan-existing-project-required",
           "kind": "final-json-path-equals",
-          "pointer": "/status",
-          "expected": "ready",
+          "pointer": "/existingProjectRequired",
+          "expected": true,
+          "critical": true
+        },
+        {
+          "id": "plan-project-reused",
+          "kind": "final-json-path-equals",
+          "pointer": "/projectCreated",
+          "expected": false,
           "critical": true
         },
         {
           "id": "plan-two-direct-issues",
           "kind": "final-json-path-equals",
-          "pointer": "/directIssueCount",
-          "expected": 2,
+          "pointer": "/directIssueIds",
+          "expected": [
+            "issue-plan-a-storage",
+            "issue-plan-a-api"
+          ],
           "critical": true
         },
         {
@@ -33,179 +45,17 @@
           "critical": true
         },
         {
-          "id": "plan-stable-tasks",
+          "id": "plan-contiguous-ordinals",
           "kind": "final-json-path-equals",
-          "pointer": "/preservedTaskIds",
+          "pointer": "/ordinals",
           "expected": [
-            "storage",
-            "api"
-          ]
-        },
-        {
-          "id": "plan-native-dependency",
-          "kind": "final-json-path-equals",
-          "pointer": "/nativeDependencies",
-          "expected": [
-            [
-              "issue-1",
-              "issue-2"
-            ]
+            1,
+            2
           ],
           "critical": true
         },
         {
-          "id": "plan-ordinal-not-ancestry",
-          "kind": "final-json-path-equals",
-          "pointer": "/ordinalDefinesAncestry",
-          "expected": false
-        },
-        {
-          "id": "plan-no-repository-effects",
-          "kind": "final-json-path-equals",
-          "pointer": "/repositoryEffects",
-          "expected": []
-        },
-        {
-          "id": "plan-graph-readback",
-          "kind": "final-json-path-equals",
-          "pointer": "/graphReadBackVerified",
-          "expected": true,
-          "critical": true
-        }
-      ]
-    },
-    {
-      "id": "refuses-evidence-bearing-increment-removal",
-      "prompt": "Replan one exact selected project whose direct issues are stable task storage and stable task api. The requested graph retains storage but removes api, and api has verified implementation evidence. Do not mutate anything. Return exactly one JSON object with keys status, reasonCode, preservedTaskIds, executionPlanApprovalInvalidated, providerMutationCount, repositoryEffects, and graphReadBackVerified.",
-      "fixtures": [],
-      "capabilities": [
-        "read-workspace"
-      ],
-      "expected": "Replanning preserves stable direct-issue identities, invalidates the execution-plan approval for a material graph change, and refuses removal of an increment carrying repository evidence without any mutation.",
-      "assertions": [
-        {
-          "id": "plan-replan-blocked",
-          "kind": "final-json-path-equals",
-          "pointer": "/status",
-          "expected": "blocked",
-          "critical": true
-        },
-        {
-          "id": "plan-evidence-removal-blocked",
-          "kind": "final-json-path-equals",
-          "pointer": "/reasonCode",
-          "expected": "evidence-bearing-increment-removal"
-        },
-        {
-          "id": "plan-replan-identities-preserved",
-          "kind": "final-json-path-equals",
-          "pointer": "/preservedTaskIds",
-          "expected": [
-            "storage",
-            "api"
-          ]
-        },
-        {
-          "id": "plan-replan-approval-invalidated",
-          "kind": "final-json-path-equals",
-          "pointer": "/executionPlanApprovalInvalidated",
-          "expected": true,
-          "critical": true
-        },
-        {
-          "id": "plan-replan-no-provider-mutation",
-          "kind": "final-json-path-equals",
-          "pointer": "/providerMutationCount",
-          "expected": 0
-        },
-        {
-          "id": "plan-replan-no-repository-effects",
-          "kind": "final-json-path-equals",
-          "pointer": "/repositoryEffects",
-          "expected": []
-        },
-        {
-          "id": "plan-replan-graph-read",
-          "kind": "final-json-path-equals",
-          "pointer": "/graphReadBackVerified",
-          "expected": true
-        }
-      ]
-    },
-    {
-      "id": "standalone-selected-plan-persists-direct-issue-graph",
-      "prompt": "Read fixtures/project-a.json as a standalone woostack-plan invocation with one exact caller-supplied project. Do not contact a provider. Return exactly one JSON object with keys status, invocationMode, artifactModeSelected, canonicalRepositoryVerified, workspaceTeamVerified, projectId, projectCreated, directIssueIds, parentPlanIssueCount, nativeDependencies, mutationClientIds, providerMutationPasses, graphReadBackVerified, and repositoryMutationCount.",
-      "fixtures": [
-        "project-a.json"
-      ],
-      "capabilities": [
-        "read-workspace"
-      ],
-      "expected": "Standalone exact-project planning selects persistence, reuses the verified project, creates two direct executor-ready issues and one native dependency with stable identities, independently reads the complete graph back, creates no parent issue, and performs no repository mutation.",
-      "assertions": [
-        {
-          "id": "plan-standalone-complete",
-          "kind": "final-json-path-equals",
-          "pointer": "/status",
-          "expected": "complete",
-          "critical": true
-        },
-        {
-          "id": "plan-standalone-mode",
-          "kind": "final-json-path-equals",
-          "pointer": "/invocationMode",
-          "expected": "standalone"
-        },
-        {
-          "id": "plan-artifact-selected",
-          "kind": "final-json-path-equals",
-          "pointer": "/artifactModeSelected",
-          "expected": true
-        },
-        {
-          "id": "plan-repository-verified",
-          "kind": "final-json-path-equals",
-          "pointer": "/canonicalRepositoryVerified",
-          "expected": true,
-          "critical": true
-        },
-        {
-          "id": "plan-workspace-team-verified",
-          "kind": "final-json-path-equals",
-          "pointer": "/workspaceTeamVerified",
-          "expected": true
-        },
-        {
-          "id": "plan-project-reused",
-          "kind": "final-json-path-equals",
-          "pointer": "/projectId",
-          "expected": "project-plan-a"
-        },
-        {
-          "id": "plan-project-not-created",
-          "kind": "final-json-path-equals",
-          "pointer": "/projectCreated",
-          "expected": false
-        },
-        {
-          "id": "plan-direct-issue-ids",
-          "kind": "final-json-path-equals",
-          "pointer": "/directIssueIds",
-          "expected": [
-            "issue-plan-a-storage",
-            "issue-plan-a-api"
-          ],
-          "critical": true
-        },
-        {
-          "id": "plan-zero-parent-issues",
-          "kind": "final-json-path-equals",
-          "pointer": "/parentPlanIssueCount",
-          "expected": 0,
-          "critical": true
-        },
-        {
-          "id": "plan-standalone-native-dependency",
+          "id": "plan-strict-dependency",
           "kind": "final-json-path-equals",
           "pointer": "/nativeDependencies",
           "expected": [
@@ -217,102 +67,75 @@
           "critical": true
         },
         {
-          "id": "plan-stable-write-identities",
-          "kind": "final-json-path-equals",
-          "pointer": "/mutationClientIds",
-          "expected": [
-            "41000000-0000-4000-8000-000000000001",
-            "41000000-0000-4000-8000-000000000002",
-            "41000000-0000-4000-8000-000000000003"
-          ]
-        },
-        {
-          "id": "plan-one-persistence-pass",
-          "kind": "final-json-path-equals",
-          "pointer": "/providerMutationPasses",
-          "expected": 1
-        },
-        {
-          "id": "plan-standalone-graph-readback",
+          "id": "plan-readback",
           "kind": "final-json-path-equals",
           "pointer": "/graphReadBackVerified",
           "expected": true,
           "critical": true
         },
         {
-          "id": "plan-standalone-no-repository-mutation",
+          "id": "plan-no-repository-mutation",
           "kind": "final-json-path-equals",
           "pointer": "/repositoryMutationCount",
           "expected": 0
+        },
+        {
+          "id": "plan-does-not-approve",
+          "kind": "final-json-path-equals",
+          "pointer": "/approvalOwned",
+          "expected": false,
+          "critical": true
+        },
+        {
+          "id": "plan-does-not-execute",
+          "kind": "final-json-path-equals",
+          "pointer": "/executionOwned",
+          "expected": false,
+          "critical": true
         }
       ]
     },
     {
-      "id": "blocks-selected-persistence-on-unavailable-or-partial-official-mcp",
-      "prompt": "Read fixtures/project-b.json as two independent official-MCP preflights after standalone persistence was explicitly selected. Do not contact a provider. Return exactly one JSON object with keys status, decisions, projectMutationIds, issueMutationIds, relationMutationIds, and repositoryMutationCount. Decisions must preserve each scenario name and list missing capabilities.",
-      "fixtures": [
-        "project-b.json"
-      ],
-      "capabilities": [
-        "read-workspace"
-      ],
-      "expected": "Missing connection and partial native dependency capabilities both block selected standalone persistence before any provider or repository mutation, without inventing a direct-issue graph or alternate provider fallback.",
+      "id": "requires-exact-project-for-direct-specification",
+      "prompt": "Evaluate two independent woostack-plan inputs: a complete approved specification supplied directly without --project, and the same specification supplied with an exact project that is missing or foreign. Do not contact a provider or mutate the repository. Return exactly one JSON object with keys status, decisions, providerMutationCount, and repositoryMutationCount.",
+      "fixtures": [],
+      "capabilities": [],
+      "expected": "Both inputs are blocked before planning or mutation: Plan requires one exact existing project for a direct specification and never creates an implicit project or fuzzy-matches another resource.",
       "assertions": [
         {
-          "id": "plan-mcp-blocked",
+          "id": "plan-exact-project-blocked",
           "kind": "final-json-path-equals",
           "pointer": "/status",
           "expected": "blocked",
           "critical": true
         },
         {
-          "id": "plan-mcp-decisions",
+          "id": "plan-direct-project-decision",
           "kind": "final-json-path-equals",
           "pointer": "/decisions",
           "expected": [
             {
-              "id": "missing-connection",
+              "id": "direct-specification-without-project",
               "advance": false,
-              "missingCapabilities": [
-                "project-read",
-                "issue-read",
-                "issue-write",
-                "dependency-read",
-                "dependency-write"
-              ]
+              "reasonCode": "exact-existing-project-required"
             },
             {
-              "id": "partial-direct-graph-capability",
+              "id": "missing-or-foreign-project",
               "advance": false,
-              "missingCapabilities": [
-                "dependency-read",
-                "dependency-write"
-              ]
+              "reasonCode": "exact-existing-project-invalid"
             }
           ],
           "critical": true
         },
         {
-          "id": "plan-mcp-no-project-mutation",
+          "id": "plan-no-provider-mutation",
           "kind": "final-json-path-equals",
-          "pointer": "/projectMutationIds",
-          "expected": []
-        },
-        {
-          "id": "plan-mcp-no-issue-mutation",
-          "kind": "final-json-path-equals",
-          "pointer": "/issueMutationIds",
-          "expected": [],
+          "pointer": "/providerMutationCount",
+          "expected": 0,
           "critical": true
         },
         {
-          "id": "plan-mcp-no-relation-mutation",
-          "kind": "final-json-path-equals",
-          "pointer": "/relationMutationIds",
-          "expected": []
-        },
-        {
-          "id": "plan-mcp-no-repository-mutation",
+          "id": "plan-no-repository-mutation",
           "kind": "final-json-path-equals",
           "pointer": "/repositoryMutationCount",
           "expected": 0
@@ -320,56 +143,63 @@
       ]
     },
     {
-      "id": "blocks-wrong-resource-type-or-repository",
-      "prompt": "Read fixtures/project-c.json as two exact --project inputs. Do not mutate anything. Return exactly one JSON object with keys status, decisions, graphReadsStarted, providerMutationIds, and repositoryMutationCount. Decisions must classify suppliedIssue and foreignRepositoryProject as blocked.",
+      "id": "rejects-nonsequential-or-incomplete-contract",
+      "prompt": "Evaluate each scenario in fixtures/invalid-graphs.json independently against the packaged Plan contract. Reject before any provider or repository mutation when task IDs or ordinals are invalid, ordinals are not exactly 1..N, a dependency is not the matching immediate predecessor, a required executor field is absent, or the PR size exceeds the allowed threshold without the deletion-only exception. Return exactly one JSON object with keys status, decisions, providerMutationCount, and repositoryMutationCount.",
       "fixtures": [
-        "project-c.json"
+        "invalid-graphs.json"
       ],
-      "capabilities": [
-        "read-workspace"
-      ],
-      "expected": "An issue supplied where a project is required and a project associated with another canonical repository both fail before graph reads or provider and repository mutations.",
+      "capabilities": [],
+      "expected": "Every invalid chain or incomplete/oversized issue contract is rejected before persistence, with no provider or repository mutation.",
       "assertions": [
         {
-          "id": "plan-identity-blocked",
+          "id": "plan-invalid-contracts-blocked",
           "kind": "final-json-path-equals",
           "pointer": "/status",
           "expected": "blocked",
           "critical": true
         },
         {
-          "id": "plan-identity-decisions",
+          "id": "plan-invalid-contract-reasons",
           "kind": "final-json-path-equals",
           "pointer": "/decisions",
           "expected": [
             {
-              "id": "suppliedIssue",
-              "advance": false,
-              "reasonCode": "project-required"
+              "id": "duplicate-task-id",
+              "valid": false,
+              "reasonCode": "duplicate-task-id"
             },
             {
-              "id": "foreignRepositoryProject",
-              "advance": false,
-              "reasonCode": "foreign-project-repository"
+              "id": "ordinal-gap",
+              "valid": false,
+              "reasonCode": "ordinals-not-contiguous"
+            },
+            {
+              "id": "wrong-predecessor",
+              "valid": false,
+              "reasonCode": "strict-predecessor-chain-required"
+            },
+            {
+              "id": "missing-stop-marker",
+              "valid": false,
+              "reasonCode": "incomplete-executor-contract"
+            },
+            {
+              "id": "oversized-pr",
+              "valid": false,
+              "reasonCode": "pr-size-target-exceeded"
             }
           ],
           "critical": true
         },
         {
-          "id": "plan-identity-no-graph-read",
+          "id": "plan-invalid-no-provider-mutation",
           "kind": "final-json-path-equals",
-          "pointer": "/graphReadsStarted",
-          "expected": false
-        },
-        {
-          "id": "plan-identity-no-provider-mutation",
-          "kind": "final-json-path-equals",
-          "pointer": "/providerMutationIds",
-          "expected": [],
+          "pointer": "/providerMutationCount",
+          "expected": 0,
           "critical": true
         },
         {
-          "id": "plan-identity-no-repository-mutation",
+          "id": "plan-invalid-no-repository-mutation",
           "kind": "final-json-path-equals",
           "pointer": "/repositoryMutationCount",
           "expected": 0
@@ -377,15 +207,15 @@
       ]
     },
     {
-      "id": "build-delegated-planning-returns-candidate-without-provider-mutation",
-      "prompt": "Read fixtures/project-d.json as a woostack-build delegated planning invocation with exact read-only project context. Do not contact a provider. Return exactly one JSON object with keys status, invocationMode, candidateTaskIds, executorContractsComplete, graphValid, providerReadCount, providerWriteCount, synchronizationOwner, graphHardeningOwner, and repositoryMutationCount.",
+      "id": "delegated-candidate-does-not-touch-provider",
+      "prompt": "Read fixtures/project-d.json as a woostack-build delegated planning invocation with the exact approved project fingerprint and read-only project context. The candidate has two increments and must be normalized to ordinals 1 and 2 with storage → api. Do not contact a provider. Return exactly one JSON object with keys status, invocationMode, candidateTaskIds, ordinals, nativeDependencies, executorContractsComplete, graphValid, providerReadCount, providerWriteCount, synchronizationOwner, graphHardeningOwner, and repositoryMutationCount.",
       "fixtures": [
         "project-d.json"
       ],
       "capabilities": [
         "read-workspace"
       ],
-      "expected": "Build-delegated planning returns the complete candidate direct-issue graph and executor-ready contracts without provider access; build owns graph hardening and synchronization to the canonical project.",
+      "expected": "Delegated planning returns a complete strict-chain candidate without provider reads or writes; the Build wrapper owns hardening and then synchronization.",
       "assertions": [
         {
           "id": "plan-delegated-candidate",
@@ -407,10 +237,33 @@
           "expected": [
             "storage",
             "api"
-          ]
+          ],
+          "critical": true
         },
         {
-          "id": "plan-delegated-executor-ready",
+          "id": "plan-delegated-ordinals",
+          "kind": "final-json-path-equals",
+          "pointer": "/ordinals",
+          "expected": [
+            1,
+            2
+          ],
+          "critical": true
+        },
+        {
+          "id": "plan-delegated-dependency",
+          "kind": "final-json-path-equals",
+          "pointer": "/nativeDependencies",
+          "expected": [
+            [
+              "storage",
+              "api"
+            ]
+          ],
+          "critical": true
+        },
+        {
+          "id": "plan-delegated-contracts",
           "kind": "final-json-path-equals",
           "pointer": "/executorContractsComplete",
           "expected": true,
@@ -436,7 +289,7 @@
           "critical": true
         },
         {
-          "id": "plan-delegated-synchronization-owner",
+          "id": "plan-delegated-sync-owner",
           "kind": "final-json-path-equals",
           "pointer": "/synchronizationOwner",
           "expected": "woostack-build",
@@ -446,8 +299,7 @@
           "id": "plan-delegated-hardening-owner",
           "kind": "final-json-path-equals",
           "pointer": "/graphHardeningOwner",
-          "expected": "woostack-build",
-          "critical": true
+          "expected": "woostack-build"
         },
         {
           "id": "plan-delegated-no-repository-mutation",
@@ -458,245 +310,63 @@
       ]
     },
     {
-      "id": "preserves-direct-graph-identities-after-unknown-project-create",
-      "prompt": "Read fixtures/project-e.json as an explicit standalone project creation transcript with an unknown project-create outcome. Do not contact a provider. Return exactly one JSON object with keys status, reasonCode, projectMutationId, directIssueMutationIds, relationMutationIds, projectCreateAttempts, rediscoveryComplete, replacementIdentityAllocated, issueMutationIds, laterProviderMutationCount, and repositoryMutationCount.",
-      "fixtures": [
-        "project-e.json"
-      ],
-      "capabilities": [
-        "read-workspace"
-      ],
-      "expected": "The unknown project create retains every preallocated direct-graph identity, performs one create attempt, stops on incomplete recovery read, allocates no replacement, and starts no issue, relation, later provider, or repository mutation.",
+      "id": "refuses-approval-or-execution-claims",
+      "prompt": "Given a valid exact-project strict-chain plan, return the Plan handoff record only. Do not approve a specification or execution graph, create implementation branches, execute tasks, commit, open or review PRs, or merge. Return exactly one JSON object with keys status, approvalOwned, executionOwned, commitOwned, reviewOwned, mergeOwned, repositoryMutationCount, and graphReadBackVerified.",
+      "fixtures": [],
+      "capabilities": [],
+      "expected": "Plan returns a verified planning handoff while owning none of the approval, implementation, commit, PR, review, or merge actions.",
       "assertions": [
         {
-          "id": "plan-unknown-blocked",
+          "id": "plan-handoff-ready",
           "kind": "final-json-path-equals",
           "pointer": "/status",
-          "expected": "blocked",
+          "expected": "ready",
           "critical": true
         },
         {
-          "id": "plan-unknown-reason",
+          "id": "plan-no-approval",
           "kind": "final-json-path-equals",
-          "pointer": "/reasonCode",
-          "expected": "unknown-project-create-incomplete-recovery-read"
-        },
-        {
-          "id": "plan-unknown-project-id",
-          "kind": "final-json-path-equals",
-          "pointer": "/projectMutationId",
-          "expected": "50000000-0000-4000-8000-000000000000"
-        },
-        {
-          "id": "plan-unknown-direct-issue-ids",
-          "kind": "final-json-path-equals",
-          "pointer": "/directIssueMutationIds",
-          "expected": [
-            "50000000-0000-4000-8000-000000000001",
-            "50000000-0000-4000-8000-000000000002"
-          ]
-        },
-        {
-          "id": "plan-unknown-relation-ids",
-          "kind": "final-json-path-equals",
-          "pointer": "/relationMutationIds",
-          "expected": [
-            "50000000-0000-4000-8000-000000000003"
-          ]
-        },
-        {
-          "id": "plan-unknown-one-create",
-          "kind": "final-json-path-equals",
-          "pointer": "/projectCreateAttempts",
-          "expected": 1,
-          "critical": true
-        },
-        {
-          "id": "plan-unknown-recovery-incomplete",
-          "kind": "final-json-path-equals",
-          "pointer": "/rediscoveryComplete",
-          "expected": false
-        },
-        {
-          "id": "plan-unknown-no-replacement",
-          "kind": "final-json-path-equals",
-          "pointer": "/replacementIdentityAllocated",
+          "pointer": "/approvalOwned",
           "expected": false,
           "critical": true
         },
         {
-          "id": "plan-unknown-no-issues",
+          "id": "plan-no-execution",
           "kind": "final-json-path-equals",
-          "pointer": "/issueMutationIds",
-          "expected": []
+          "pointer": "/executionOwned",
+          "expected": false,
+          "critical": true
         },
         {
-          "id": "plan-unknown-no-later-provider-mutations",
+          "id": "plan-no-commit",
           "kind": "final-json-path-equals",
-          "pointer": "/laterProviderMutationCount",
-          "expected": 0
+          "pointer": "/commitOwned",
+          "expected": false
         },
         {
-          "id": "plan-unknown-no-repository-mutation",
+          "id": "plan-no-review",
+          "kind": "final-json-path-equals",
+          "pointer": "/reviewOwned",
+          "expected": false
+        },
+        {
+          "id": "plan-no-merge",
+          "kind": "final-json-path-equals",
+          "pointer": "/mergeOwned",
+          "expected": false
+        },
+        {
+          "id": "plan-no-repository-mutation",
           "kind": "final-json-path-equals",
           "pointer": "/repositoryMutationCount",
           "expected": 0
-        }
-      ]
-    },
-    {
-      "id": "blocks-relations-on-incomplete-direct-issue-readback",
-      "prompt": "Read fixtures/project-f.json at selected standalone persistence. Do not contact a provider. Return exactly one JSON object with keys status, reasonCode, projectMutationId, projectReadBackVerified, directIssueMutationId, directIssueNativeId, directIssueReadBackAccepted, directIssueCreateAttempts, relationMutationIds, graphAccepted, stableIssueIdPreserved, and repositoryMutationCount.",
-      "fixtures": [
-        "project-f.json"
-      ],
-      "capabilities": [
-        "read-workspace"
-      ],
-      "expected": "A verified project permits one direct issue create, but an independent issue read that omits exact project membership blocks relation creation and graph acceptance while preserving the stable issue identity.",
-      "assertions": [
-        {
-          "id": "plan-issue-readback-blocked",
-          "kind": "final-json-path-equals",
-          "pointer": "/status",
-          "expected": "blocked",
-          "critical": true
         },
         {
-          "id": "plan-issue-readback-reason",
+          "id": "plan-readback-required",
           "kind": "final-json-path-equals",
-          "pointer": "/reasonCode",
-          "expected": "direct-issue-project-membership-readback-mismatch"
-        },
-        {
-          "id": "plan-issue-project-client",
-          "kind": "final-json-path-equals",
-          "pointer": "/projectMutationId",
-          "expected": "60000000-0000-4000-8000-000000000000"
-        },
-        {
-          "id": "plan-issue-project-read",
-          "kind": "final-json-path-equals",
-          "pointer": "/projectReadBackVerified",
-          "expected": true
-        },
-        {
-          "id": "plan-issue-client",
-          "kind": "final-json-path-equals",
-          "pointer": "/directIssueMutationId",
-          "expected": "60000000-0000-4000-8000-000000000001"
-        },
-        {
-          "id": "plan-issue-native",
-          "kind": "final-json-path-equals",
-          "pointer": "/directIssueNativeId",
-          "expected": "issue-storage"
-        },
-        {
-          "id": "plan-issue-readback-rejected",
-          "kind": "final-json-path-equals",
-          "pointer": "/directIssueReadBackAccepted",
-          "expected": false,
-          "critical": true
-        },
-        {
-          "id": "plan-issue-one-attempt",
-          "kind": "final-json-path-equals",
-          "pointer": "/directIssueCreateAttempts",
-          "expected": 1
-        },
-        {
-          "id": "plan-issue-no-relations",
-          "kind": "final-json-path-equals",
-          "pointer": "/relationMutationIds",
-          "expected": []
-        },
-        {
-          "id": "plan-issue-graph-rejected",
-          "kind": "final-json-path-equals",
-          "pointer": "/graphAccepted",
-          "expected": false
-        },
-        {
-          "id": "plan-issue-stable-id",
-          "kind": "final-json-path-equals",
-          "pointer": "/stableIssueIdPreserved",
+          "pointer": "/graphReadBackVerified",
           "expected": true,
           "critical": true
-        },
-        {
-          "id": "plan-issue-no-repository-mutation",
-          "kind": "final-json-path-equals",
-          "pointer": "/repositoryMutationCount",
-          "expected": 0
-        }
-      ]
-    },
-    {
-      "id": "rejects-invalid-plan-graphs-before-persistence",
-      "prompt": "Evaluate each scenario in fixtures/invalid-graphs.json independently against the packaged Plan contract. Derive the result from task identity, ordinal, acceptance coverage, predecessor, and Git-parent evidence. Do not mutate a provider or repository. Return exactly one JSON object with keys status, decisions, providerMutationCount, and repositoryMutationCount.",
-      "fixtures": [
-        "invalid-graphs.json"
-      ],
-      "capabilities": [],
-      "expected": "Every invalid graph is rejected before persistence: task IDs and exact positive integer ordinals are unique, dependencies resolve to declared tasks, acceptance criteria are covered, and intended Git parents are representable by dependency and Graphite ancestry.",
-      "assertions": [
-        {
-          "id": "plan-invalid-graphs-blocked",
-          "kind": "final-json-path-equals",
-          "pointer": "/status",
-          "expected": "blocked",
-          "critical": true
-        },
-        {
-          "id": "plan-invalid-graph-reasons",
-          "kind": "final-json-path-equals",
-          "pointer": "/decisions",
-          "expected": [
-            {
-              "id": "duplicate-task-id",
-              "valid": false,
-              "reasonCode": "duplicate-task-id"
-            },
-            {
-              "id": "duplicate-ordinal",
-              "valid": false,
-              "reasonCode": "duplicate-ordinal"
-            },
-            {
-              "id": "non-integer-ordinal",
-              "valid": false,
-              "reasonCode": "invalid-ordinal"
-            },
-            {
-              "id": "unknown-predecessor",
-              "valid": false,
-              "reasonCode": "unknown-predecessor"
-            },
-            {
-              "id": "uncovered-acceptance",
-              "valid": false,
-              "reasonCode": "acceptance-coverage-gap"
-            },
-            {
-              "id": "unrepresentable-git-parent",
-              "valid": false,
-              "reasonCode": "git-parent-not-representable"
-            }
-          ],
-          "critical": true
-        },
-        {
-          "id": "plan-invalid-no-provider-mutation",
-          "kind": "final-json-path-equals",
-          "pointer": "/providerMutationCount",
-          "expected": 0
-        },
-        {
-          "id": "plan-invalid-no-repository-mutation",
-          "kind": "final-json-path-equals",
-          "pointer": "/repositoryMutationCount",
-          "expected": 0
         }
       ]
     }

--- a/skills/woostack-plan/evals/fixtures/invalid-graphs.json
+++ b/skills/woostack-plan/evals/fixtures/invalid-graphs.json
@@ -1,161 +1,44 @@
 {
   "scenarios": {
-    "caseA": {
-      "acceptanceCriteria": [
-        "criterion-a"
-      ],
+    "duplicate-task-id": {
+      "acceptanceCriteria": ["criterion-a", "criterion-b"],
       "increments": [
-        {
-          "taskId": "task-a",
-          "ordinal": 1,
-          "covers": [
-            "criterion-a"
-          ],
-          "predecessors": []
-        },
-        {
-          "taskId": "task-a",
-          "ordinal": 2,
-          "covers": [],
-          "predecessors": []
-        }
+        {"taskId": "task-a", "ordinal": 1, "covers": ["criterion-a"], "predecessors": [], "stopMarker": "done"},
+        {"taskId": "task-a", "ordinal": 2, "covers": ["criterion-b"], "predecessors": ["task-a"], "stopMarker": "done"}
       ]
     },
-    "caseB": {
-      "acceptanceCriteria": [
-        "criterion-a"
-      ],
+    "ordinal-gap": {
+      "acceptanceCriteria": ["criterion-a", "criterion-b"],
       "increments": [
-        {
-          "taskId": "task-a",
-          "ordinal": 1,
-          "covers": [
-            "criterion-a"
-          ],
-          "predecessors": []
-        },
-        {
-          "taskId": "task-b",
-          "ordinal": 1,
-          "covers": [],
-          "predecessors": []
-        }
+        {"taskId": "task-a", "ordinal": 1, "covers": ["criterion-a"], "predecessors": [], "stopMarker": "done"},
+        {"taskId": "task-b", "ordinal": 3, "covers": ["criterion-b"], "predecessors": ["task-a"], "stopMarker": "done"}
       ]
     },
-    "caseC": {
-      "acceptanceCriteria": [
-        "criterion-a"
-      ],
+    "wrong-predecessor": {
+      "acceptanceCriteria": ["criterion-a", "criterion-b", "criterion-c"],
       "increments": [
-        {
-          "taskId": "task-a",
-          "ordinal": 1,
-          "covers": [
-            "criterion-a"
-          ],
-          "predecessors": [
-            "task-missing"
-          ]
-        }
+        {"taskId": "task-a", "ordinal": 1, "covers": ["criterion-a"], "predecessors": [], "stopMarker": "done"},
+        {"taskId": "task-b", "ordinal": 2, "covers": ["criterion-b"], "predecessors": [], "stopMarker": "done"},
+        {"taskId": "task-c", "ordinal": 3, "covers": ["criterion-c"], "predecessors": ["task-b"], "stopMarker": "done"}
       ]
     },
-    "caseD": {
-      "acceptanceCriteria": [
-        "criterion-a",
-        "criterion-b"
-      ],
+    "missing-stop-marker": {
+      "acceptanceCriteria": ["criterion-a"],
       "increments": [
-        {
-          "taskId": "task-a",
-          "ordinal": 1,
-          "covers": [
-            "criterion-a"
-          ],
-          "predecessors": []
-        }
+        {"taskId": "task-a", "ordinal": 1, "covers": ["criterion-a"], "predecessors": []}
       ]
     },
-    "caseE": {
-      "acceptanceCriteria": [
-        "criterion-a",
-        "criterion-b"
-      ],
+    "oversized-pr": {
+      "acceptanceCriteria": ["criterion-a"],
       "increments": [
         {
           "taskId": "task-a",
           "ordinal": 1,
-          "covers": [
-            "criterion-a"
-          ],
+          "covers": ["criterion-a"],
           "predecessors": [],
-          "gitParent": null
-        },
-        {
-          "taskId": "task-b",
-          "ordinal": 2,
-          "covers": [
-            "criterion-b"
-          ],
-          "predecessors": [],
-          "gitParent": "task-a"
-        }
-      ]
-    },
-    "caseF": {
-      "acceptanceCriteria": [
-        "criterion-a"
-      ],
-      "increments": [
-        {
-          "taskId": "task-a",
-          "ordinal": 0,
-          "covers": [
-            "criterion-a"
-          ],
-          "predecessors": []
-        }
-      ]
-    },
-    "caseG": {
-      "acceptanceCriteria": [
-        "criterion-a",
-        "criterion-b"
-      ],
-      "increments": [
-        {
-          "taskId": "task-a",
-          "ordinal": 1,
-          "covers": [
-            "criterion-a"
-          ],
-          "predecessors": [
-            "task-b"
-          ]
-        },
-        {
-          "taskId": "task-b",
-          "ordinal": 2,
-          "covers": [
-            "criterion-b"
-          ],
-          "predecessors": [
-            "task-a"
-          ]
-        }
-      ]
-    },
-    "caseH": {
-      "acceptanceCriteria": [
-        "criterion-a"
-      ],
-      "increments": [
-        {
-          "taskId": "task-a",
-          "ordinal": true,
-          "covers": [
-            "criterion-a"
-          ],
-          "predecessors": []
+          "stopMarker": "done",
+          "handWrittenChangedLines": 501,
+          "sizeException": null
         }
       ]
     }

--- a/skills/woostack-plan/evals/fixtures/project-d.json
+++ b/skills/woostack-plan/evals/fixtures/project-d.json
@@ -8,13 +8,13 @@
     "tasks": [
       {
         "id": "storage",
-        "ordinal": 10,
+        "ordinal": 1,
         "predecessors": [],
         "executorReady": true
       },
       {
         "id": "api",
-        "ordinal": 20,
+        "ordinal": 2,
         "predecessors": [
           "storage"
         ],

--- a/skills/woostack-plan/evals/trigger-evals.json
+++ b/skills/woostack-plan/evals/trigger-evals.json
@@ -3,16 +3,23 @@
   "skill": "woostack-plan",
   "cases": [
     {
-      "id": "verified-feature-project-needs-decomposition",
-      "query": "Reconcile the approved specification in this verified Linear feature project into stable increment issues and native blocked-by relations.",
+      "id": "exact-project-needs-decomposition",
+      "query": "Reconcile this approved specification against the exact existing Linear project into one direct issue per sequential execution increment with native predecessor relations.",
       "shouldTrigger": true,
       "expectedSkill": "woostack-plan"
     },
     {
-      "id": "verified-feature-project-needs-replan",
-      "query": "Replan this verified Linear feature project while preserving increment issue identities and existing implementation evidence.",
+      "id": "direct-spec-with-exact-project-needs-plan",
+      "query": "Plan this approved specification in the exact existing Linear project URL I supplied; return PR-sized direct issue contracts and synchronize the strict chain.",
       "shouldTrigger": true,
       "expectedSkill": "woostack-plan"
+    },
+    {
+      "id": "direct-spec-without-project-is-blocked-not-artifact-free-plan",
+      "query": "Plan this approved multi-increment specification, but no exact existing Linear project was supplied.",
+      "shouldTrigger": false,
+      "expectedSkill": "woostack-build",
+      "conflictsWith": ["woostack-plan"]
     },
     {
       "id": "unapproved-feature-idea-needs-design",
@@ -23,7 +30,7 @@
     },
     {
       "id": "bounded-change-needs-direct-workflow",
-      "query": "Add one bounded preference in a single pull request; no multi-increment project is needed.",
+      "query": "Add one bounded preference in a single pull request; no sequential multi-increment project is needed.",
       "shouldTrigger": false,
       "expectedSkill": "woostack-change",
       "conflictsWith": ["woostack-plan"]


### PR DESCRIPTION
## Goal
Make Plan produce a strict sequential chain of complete, PR-sized direct Linear issues in one existing project.

## Summary
- Require one exact existing Linear project for every Plan invocation.
- Define complete direct-issue contracts with ordinals, Graphite parents, stop markers, and verification.
- Enforce the native predecessor chain and the ~500 hand-written-line target with narrow approved exceptions.
- Remove artifact-free, parallel-root, parent-plan, approval, and execution behavior.
- Replace the Plan eval corpus with focused sequential-contract cases.

## Test plan
### Automated
- `bash skills/woostack-build/tests/test-linear-plan-contract.sh` — passed
- `node skills/woostack-eval/scripts/validate.mjs --package skills/woostack-plan --repository-root .` — passed (5 behavior, 5 trigger cases)
- `git diff --check` — passed

### Manual
- Confirmed Plan has one exact-project input path and one strict-chain output path.
- Confirmed delegated Build/Fix planning remains provider-read-only until its wrapper synchronizes.

Resolves WOO-146
