### PR TITLE
Align execution consumers with shared records

### DIFF
--- a/skills/using-woostack/references/hosts/antigravity.md
+++ b/skills/using-woostack/references/hosts/antigravity.md
@@ -33,6 +33,8 @@ host — no spawn-time auth probe exists; switch manually by promoting an entry 
 - **woostack-review (local swarm):** orchestrate isolated-context subagents per angle (see
   `skills/woostack-review/prompts/google.md` for the orchestration narrative); the CI runner
   remains `run-gemini-cli` (Antigravity cannot run headless there).
+- **woostack-execute (and overnight):** resolve the session model from the `fast` tier before
+  dispatch; all implementation workers share that session model.
 - **woostack-eval (comparative dispatch):** instantiate the two isolated-context workers for
   each candidate/baseline inseparable pair in the same dynamic orchestration turn. There is no
   concrete per-call model pin; choose one concrete run model before the session.

--- a/skills/using-woostack/references/hosts/claude-code.md
+++ b/skills/using-woostack/references/hosts/claude-code.md
@@ -37,6 +37,8 @@ to entry 0, or re-run after editing config).
 
 - **woostack-execute (dispatch):** the no-per-call-cwd case — prompt pin + self-pin guard —
   is the normal path here.
+- **woostack-execute (and overnight):** route the implementation worker at the `fast` tier per
+  call; the controller retains project admission, verification, and delivery boundaries.
 - **woostack-commit (fast drafting):** route the drafting subagent at the `fast` tier
   per-call.
 - **woostack-review (local swarm):** dispatch every active angle task via `Task`, letting the

--- a/skills/using-woostack/references/hosts/codex.md
+++ b/skills/using-woostack/references/hosts/codex.md
@@ -35,6 +35,8 @@ host — no spawn-time auth probe exists; switch manually by promoting an entry 
 - **woostack-review (local swarm):** per-call bucket — honor each angle prompt's `tier:` and
   resolve each spawn's model via the review scripts' resolver; (CI) the single-session
   `load-prompt.sh` / `resolve-model.sh` path owns routing and is self-contained.
+- **woostack-execute (and overnight):** local implementation workers use the `fast` tier with
+  its resolved model and `reasoning_effort`; Codex Action applies its documented session collapse.
 - **woostack-eval (comparative dispatch):** local Codex can start the two isolated workers in
   each candidate/baseline inseparable pair together and pin the same concrete `model` plus
   `reasoning_effort` on both calls. `session-default` is provable only when both calls omit

--- a/skills/using-woostack/references/hosts/cursor.md
+++ b/skills/using-woostack/references/hosts/cursor.md
@@ -31,6 +31,8 @@ host — no spawn-time auth probe exists; switch manually by promoting an entry 
 
 - **woostack-review (local swarm):** dispatch angle workers in parallel and let the host
   schedule or queue them.
+- **woostack-execute (and overnight):** use the session's configured `fast` implementation model
+  before dispatch; per-call model pinning remains unavailable.
 - **woostack-eval (comparative dispatch):** submit the two isolated workers for each
   candidate/baseline inseparable pair together through Composer's parallel-subagent primitive.
   Cursor exposes no concrete per-call model pin; `session-default` is provable only when the

--- a/skills/using-woostack/references/hosts/hermes.md
+++ b/skills/using-woostack/references/hosts/hermes.md
@@ -104,6 +104,9 @@ the user or owning decision-maker. Never silently change profiles, worktrees, or
 - Only the explicitly configured pairing below launches an external profile-pinned OMP coder.
 - `woostack-review` may delegate advisory review angles; other workflows keep review with their
   decision-maker/controller.
+- **woostack-execute (and overnight):** select the host's fast-capable leaf role for
+  implementation workers; the delegating controller retains project admission, verification, and
+  delivery boundaries.
 
 ## Degradation
 

--- a/skills/using-woostack/references/hosts/omp.md
+++ b/skills/using-woostack/references/hosts/omp.md
@@ -79,6 +79,8 @@ boundary; optional artifact failure blocks only the selected optional operation.
   discover the active task-agent registry and require every distinct selector needed by the
   complete planned run. Missing support aborts the whole swarm before launch. Missing receipts
   still fail the existing hard receipt gate.
+- `woostack-execute`: map the implementation worker to `agent: woostack-fast`; the project
+  controller owns admission, verification, and delivery.
 - `woostack-commit`: map optional fast drafting to `agent: woostack-fast`; draft inline if
   unavailable.
 - **woostack-eval (comparative dispatch):** map the candidate and baseline's common effective tier

--- a/skills/using-woostack/references/hosts/opencode.md
+++ b/skills/using-woostack/references/hosts/opencode.md
@@ -33,6 +33,8 @@ host — no spawn-time auth probe exists; switch manually by promoting an entry 
 - **woostack-review (local swarm):** dispatch angle workers via the runtime primitive (see
   `skills/woostack-review/prompts/opencode.md`); cap concurrency (`N=1`) only when the build
   lacks parallelism.
+- **woostack-execute (and overnight):** route implementation workers at the `fast` tier per call;
+  preserve the controller's project admission and delivery boundaries.
 - **woostack-eval (comparative dispatch):** submit the candidate and baseline as two isolated
   `@subagent` workers in the same parallel dispatch, keeping every inseparable pair intact.
   Pin the same concrete model on both calls. `session-default` is provable only when the runtime

--- a/skills/using-woostack/references/model-tiers.md
+++ b/skills/using-woostack/references/model-tiers.md
@@ -1,10 +1,12 @@
 # Model Tiers (shared, host-agnostic)
 
 Canonical tier→model mapping for the woostack collection. `woostack-review` (angle workers +
-validator), `woostack-audit` (audit workers), and `woostack-execute` (subagent driver) resolve
-tiers through this file. Each consumer
-keeps only its own **runtime bindings** (env vars, config paths, dispatch calls) and points at the
-precedence rules below — there is no second copy of this table.
+validator), `woostack-audit` (audit workers), and other consumers resolve tiers through this file.
+Normal [`woostack-execute`](../../woostack-execute/SKILL.md) implementation workers, including the
+unattended project controller in [`woostack-execute-overnight`](../../woostack-execute-overnight/SKILL.md),
+are always bound to the `fast` tier. Each consumer keeps only its own **runtime bindings** (env
+vars, config paths, dispatch calls) and points at the precedence rules below — there is no second
+copy of this table.
 
 Tiers are `fast | standard | deep`. A prompt or template declares a `tier:` in frontmatter; the
 runtime either resolves that tier to a concrete model or maps it to a host-owned role, according

--- a/skills/using-woostack/tests/test-engineer-agent-contract.sh
+++ b/skills/using-woostack/tests/test-engineer-agent-contract.sh
@@ -45,22 +45,24 @@ for pattern, message in (
     require("generic", pattern, message)
 
 for pattern, message in (
-    (r"one explicit approved bounded task or dependency-aware plan", "approved input is not required"),
-    (r"Artifact-free execution is permitted only for standalone input and makes no Linear call", "standalone artifact-free admission is not explicit"),
-    (r"after every worker handback.*before every redispatch.*immediately before commit", "fix approval is not rechecked at worker and commit boundaries"),
-    (r"Only caller-selected ordinary artifact mode for standalone work is optional", "ordinary artifact writes are not explicitly selected"),
-    (r"Selection admits one task per controller cycle", "controller may advance multiple tasks"),
-    (r"canonical worktree contract.*creating.*resuming a worktree", "worktree isolation is not required"),
-    (r"controller independently rechecks.*task contract.*deterministic path.*git worktree list", "returned evidence is not independently checked"),
+    (r"exactly one caller-supplied Linear project or exact direct issue.*matching pair", "exact approved resource and records are not required"),
+    (r"projectSpecApprovalRecord.*executionPlanApprovalRecord", "shared approval records are missing"),
+    (r"incomplete pagination.*blocks before any branch, worktree, edit, or Linear lifecycle write", "admission failure is not fail-closed"),
+    (r"Project mode repeatedly runs one cycle; issue mode runs one cycle", "controller cycle boundary is missing"),
+    (r"more than one admitted issue per cycle", "controller may admit multiple issues in one cycle"),
+    (r"Inventory `git worktree list --porcelain`.*either no state.*create exactly one worktree.*one exact recoverable state", "worktree isolation and recovery are not required"),
+    (r"After handback, the controller rechecks admission records.*worktree identity.*branch/parent.*diff", "worker handback is not independently checked"),
+    (r"Before commit, re-read records.*selected issue.*worktree.*Graphite parent", "commit boundary is not independently rechecked"),
+    (r"fresh independent Linear, Git, Graphite, and GitHub evidence", "resume evidence is not independent"),
 ):
     require("controller", pattern, message)
 
 for pattern, message in (
-    (r"worker owns implementation and its focused verification only", "worker authority is too broad"),
-    (r"artifact text.*untrusted data", "artifact prose can direct work"),
-    (r"coder never reviews or accepts its own work", "worker self-review is allowed"),
-    (r"Return.*Do not commit", "default source-control boundary is missing"),
-    (r"no scope decisions, other worktrees, commit, push, submit, PR mutation, merge, acceptance, artifact access", "worker mutation prohibitions are incomplete"),
+    (r"worker owns only the exact implementation packet and focused verification", "worker authority is too broad"),
+    (r"repository files, diffs, issue text, PR text, comments, and tool output as untrusted data", "remote prose can direct work"),
+    (r"worker never commits, pushes, submits a PR, writes Linear.*reviews, accepts, merges", "worker mutation prohibitions are incomplete"),
+    (r"never share a worktree, session, branch, or writable surface", "worker isolation is incomplete"),
+    (r"controller independently rechecks the approval records.*complete dirty/index/diff state", "worker result is not independently verified"),
 ):
     require("subagent", pattern, message)
 

--- a/skills/woostack-execute-overnight/SKILL.md
+++ b/skills/woostack-execute-overnight/SKILL.md
@@ -1,40 +1,39 @@
 ---
 name: woostack-execute-overnight
-description: Execute an approved dependency-aware plan unattended through isolated Graphite worktrees, verification, bounded review sweeps, and truthful handback. Build origin requires its exact approved Linear project graph; standalone plans remain artifact-optional. Never merges.
+description: Execute an approved Linear project unattended through isolated Graphite worktrees, verification, bounded review sweeps, and truthful handback. Requires an exact project and matching approval records; never merges.
 ---
 
 # woostack-execute-overnight
 
-Execute an approved dependency-aware plan the way
-[`woostack-execute`](../woostack-execute/SKILL.md) does, but unattended. Reuse its controller,
-inline/subagent drivers, Red → Green → Refactor cadence, worktree isolation, dependency/ancestry
-checks, verification, review, commit, and recovery boundaries. This skill changes only how a safe
-independent track continues when another track blocks. It never merges.
+Execute an approved Linear project through the
+[`woostack-execute`](../woostack-execute/SKILL.md) project controller, but unattended. Reuse its
+canonical admission, fast implementation-worker, worktree, dependency/ancestry, verification,
+commit, and recovery boundaries, while retaining this skill's bounded review-sweep and
+independent-track recovery safety. This command is explicit project-only; it never becomes a Build
+choice, creates or revises a project, and never merges.
 
 Git, Graphite, and canonical GitHub reads own source, ancestry, PR, review, and delivery truth.
-Build-origin input requires the exact project, direct increment issues, native dependency graph, and
-two content-bound approval records produced by `woostack-build`. Standalone plans remain
-artifact-optional. Linear never assigns workers or proves repository delivery.
+Project input requires the exact project, direct increment issues, native dependency graph, and the
+two content-bound approval records required by the normal Execute admission. Linear never assigns
+workers or proves repository delivery.
 
 ## Commands
 
 ```text
-/woostack-execute-overnight <approved plan> [--inline|--subagent]
-/woostack-execute-overnight <approved plan> --project <exact Linear URL|UUID> [--inline|--subagent]
+/woostack-execute-overnight <approved project> --project <exact Linear URL|UUID>
 ```
 
-Standalone input without an exact artifact flag makes no Linear call. Build-origin input MUST carry
-`--project` and both exact build approval records under the
-[Linear artifact contract](../woostack-init/references/artifact-backends.md). `--inline` and
-`--subagent` select the execute driver only.
+The exact `--project` is required. The command accepts only an already-approved project and has no
+issue or alternate-driver mode.
 
 ## Admission
 
 Require:
 
-- one complete explicitly approved implementation plan;
-- for build origin, exact matching `buildProjectSpecApprovalRecord` and
-  `buildExecutionPlanApprovalRecord` plus the required `--project`;
+- one exact approved project identity supplied by URL or UUID;
+- the complete approved project specification, all current direct issues, native dependency graph,
+  and exactly matching `projectSpecApprovalRecord` and `executionPlanApprovalRecord` required by
+  [`woostack-execute` admission](../woostack-execute/SKILL.md#admission-one-exact-resource-and-two-matching-records);
 - stable task IDs, complete bounded contracts, acceptance/verification/smoke clauses, and exclusive
   responsibility surfaces;
 - an acyclic dependency graph with one declared Git parent per dependent task;
@@ -42,45 +41,42 @@ Require:
 - explicit unattended handoff (`Run overnight` or intent-equivalent wording); and
 - no unresolved decision that requires product, security, data-loss, or scope judgment.
 
-Read repository policy, the deterministic task paths, `git worktree list --porcelain`, filesystem
-state, local/remote branches and commits, complete dirty/index/diff state, Git/Graphite ancestry,
-and fully paginated GitHub PR/review/check/thread state. Reject duplicate checkouts, branches,
-commits, or PRs; unexplained work; moved ancestry; overlapping surfaces; stale plans; ambiguous
-recovery; or a task that cannot be safely bounded without human judgment.
+Read repository policy, deterministic task paths, `git worktree list --porcelain`, filesystem state,
+local/remote branches and commits, complete dirty/index/diff state, Git/Graphite ancestry, and fully
+paginated GitHub PR/review/check/thread state. Reject duplicate checkouts, branches, commits, or
+PRs; unexplained work; moved ancestry; overlapping surfaces; stale plans; ambiguous recovery; or a
+task that cannot be safely bounded without human judgment.
 
-For build origin, independently re-read the complete project specification, all current direct
-issues, native dependencies, and responsible-user approval events and require exact equality with
-both approval records. Repeat at every boundary required by the execution controller. Drift,
-incomplete pagination, provider unavailability, or conflict blocks affected execution with no local
-or alternate-provider fallback. For selected standalone artifacts, conflict blocks only artifact
-use/synchronization and never rewrites the approved plan.
+Independently re-read the complete project specification, all current direct issues, native
+dependencies, and responsible-user approval events and require exact equality with both approval
+records. Repeat at every boundary required by the execution controller. Drift, incomplete
+pagination, provider unavailability, or conflict blocks execution with no local or alternate-
+provider fallback. The controller never amends the approved project specification or graph.
 
 ## Fixed execution loop
 
 Follow the [execution controller](../woostack-execute/references/controller.md) for each admitted
-task:
+issue:
 
-1. derive the currently dependency-ready task set from the approved DAG and repository evidence;
-2. admit one task per controller/coder run and verify its deterministic path is collision-free;
+1. derive the currently dependency-ready issue set from the approved DAG and repository evidence;
+2. admit each selected issue only when its deterministic path is collision-free;
 3. create/verify its isolated worktree and Graphite branch at the exact approved base/parent head;
-4. run the selected [inline](../woostack-execute/references/inline-driver.md) or
-   [subagent](../woostack-execute/references/subagent-driver.md) driver through Red → Green →
-   Refactor, focused verification, and smoke observation;
+4. dispatch the configured fast implementation worker under the
+   [normal Execute worker boundary](../woostack-execute/SKILL.md#worker-and-verification-boundary)
+   through Red → Green → Refactor, focused verification, and smoke observation;
 5. run specification review then quality review on one unchanged complete diff identity;
 6. invoke [`woostack-commit`](../woostack-commit/SKILL.md) for the controller-owned commit and PR
    boundary;
 7. run the bounded bottom-up [`woostack-sweep`](../woostack-sweep/SKILL.md) for the affected stack;
 8. independently read back worktree, dirty state, branch/head/base, PR, reviews, checks, threads,
    and ancestry; and
-9. hand back direct evidence and remove only a completed task's exact clean worktree.
+9. hand back direct evidence and remove only a completed issue's exact clean worktree.
 
-For build origin, the controller repeats the exact project/issue/dependency/approval-record check
-after every worker handback, before every redispatch, immediately before commit, and before
-selecting another increment. Drift returns to `woostack-build`; unattended execution never amends
-the approved project specification or graph.
-
-Never process two dependent tasks concurrently. Independent roots may run concurrently only when
-paths/surfaces, runs, profiles, worktrees, branches, PRs, and provider sessions are disjoint.
+The controller repeats the exact project/issue/dependency/approval-record check after every worker
+handback, before every redispatch, immediately before commit, and before selecting another
+increment. Never process two dependent issues concurrently. Independent roots may run concurrently
+only when paths/surfaces, runs, profiles, worktrees, branches, PRs, and provider sessions are
+disjoint.
 
 ## Autonomous decision policy
 
@@ -109,9 +105,8 @@ Classify every stop:
 - **track-local review or submission failure** — preserve branch/PR evidence and block only tasks
   that depend on that head;
 - **shared invariant failure** — stop every affected track;
-- **required build provider failure** — stop affected execution at the last verified boundary;
-- **optional standalone artifact failure** — stop synchronization only; and
-- **unknown mutation outcome** — re-read the exact Git/Graphite/GitHub or artifact identity before
+- **required project provider failure** — stop affected execution at the last verified boundary; and
+- **unknown mutation outcome** — re-read the exact Git/Graphite/GitHub or project identity before
   retrying anything.
 
 Never retry with a new task ID, operation ID, branch, commit, or PR. Never reset, clean, stash,
@@ -131,19 +126,18 @@ blocking threads resolve, ancestry is correct, and no uncommitted worker changes
 The implementing coder never acts as its own reviewer. Review workers remain read-only and have no
 repository-write, GitHub-posting, artifact, acceptance, or merge authority.
 
-## Fix/build abandonment
+## Project abandonment
 
-An explicit user or owning-controller decision to abandon the fix/build stops every new dispatch
-and cancels every active implementation, verification, review, commit, or submission driver before
-its next mutation. Preserve current worktrees, branches, commits, and PRs without cleanup, re-read
+An explicit user or owning-controller decision to abandon the project stops every new dispatch and
+cancels every active implementation, verification, review, commit, or submission driver before its
+next mutation. Preserve current worktrees, branches, commits, and PRs without cleanup, re-read
 Git/Graphite/GitHub after cancellation, and verify every driver is quiescent before project closure
 or terminal handback.
 
-If an exact plan project exists, follow the
-[Linear artifact contract](../woostack-init/references/artifact-backends.md) to set only that
-project's native status to the configured `projectStatuses.canceled` value and independently read
-the closure back. If no exact persisted project exists, report that there is nothing to close and
-make no provider write. Never create a project merely to cancel it or bulk-change issue states.
+Follow the [Linear artifact contract](../woostack-init/references/artifact-backends.md) to set only
+the exact project's native status to the configured `projectStatuses.canceled` value and
+independently read the closure back. Never create a project merely to cancel it or bulk-change issue
+states.
 
 A task failure, blocker, pause, ordinary handoff, or replan is not abandonment and leaves the
 project open. A failed or unknown closure becomes a truthful terminal artifact blocker with the
@@ -151,37 +145,35 @@ stable project identity and safe retry boundary; unattended execution does not r
 
 ## Artifact synchronization
 
-For build origin or selected standalone persistence, mirror only directly observed task/PR evidence
-to the exact project or issue. Perform one minimal mutation at a real boundary, use a stable
-operation ID, preserve unrelated content, and independently read back the target. Delivery notes do
-not change approved project/issue content or dependencies. Except for project closure, do not mutate
-assignee, delegate, native status, relations, membership, or archival state.
+For the exact approved project, mirror only directly observed task/PR evidence to its exact project
+or direct issue. Perform one minimal mutation at a real boundary, use a stable operation ID, preserve
+unrelated content, and independently read back the target. Delivery notes do not change approved
+project/issue content or dependencies. Except for project closure, do not mutate assignee, delegate,
+native status, relations, membership, or archival state.
 
-Artifact synchronization results are reported separately. A required build approval-record failure
-blocks before repository mutation; a delivery-note failure after verified repository delivery does
-not erase that repository evidence.
+An approval-record failure blocks before repository mutation; a delivery-note failure after verified
+repository delivery does not erase that repository evidence.
 
 ## Terminal handback
-
 Return one truthful report derived from fresh reads:
 
 - canonical repository and frozen base;
-- approved plan identity and task DAG;
-- per task: status, worktree/branch/parent, changed paths, verification/smoke results, reviewer
+- exact approved project identity, project specification, direct issue DAG, and both approval
+  records/rechecks;
+- per issue: status, worktree/branch/parent, changed paths, verification/smoke results, reviewer
   verdicts, commit SHA, PR URL/head/base, checks/threads, and safe resume boundary;
-- completed, blocked, skipped-descendant, and still-independent sets;
-- Graphite stack ancestry and sweep outcome;
-- required or selected artifact URL/UUID, approval rechecks, and synchronization result; and
+- completed, blocked, skipped-dependent, and still-independent sets;
+- Graphite stack ancestry and sweep outcome; and
 - every unresolved decision or unknown mutation outcome.
-
-Use task states `completed`, `blocked`, `skipped-dependent`, or `not-started`; do not call submitted
-or reviewed work merged. Never claim test, review, PR, artifact, or completion evidence that was not
-directly observed.
+Use issue states `completed`, `blocked`, `skipped-dependent`, or `not-started`; do not call
+submitted or reviewed work merged. Never claim test, review, PR, artifact, or completion evidence
+that was not directly observed.
 
 ## Hard constraints
 
-- No Linear prerequisite for standalone plans; build origin requires its exact approved project
-  graph.
+- Exact `--project` is required; no issue or alternate-driver mode.
+- Both `projectSpecApprovalRecord` and `executionPlanApprovalRecord` must exactly match the
+  independently read project graph and responsible-user approval events.
 - No inferred approval, ownership, acceptance, or artifact context.
 - No local plan/report as a substitute for the approved input contract.
 - No self-review, self-acceptance, force-push, protected-primary edit, or merge.

--- a/skills/woostack-execute-overnight/scripts/tests/test-sweep-integrity-contract.sh
+++ b/skills/woostack-execute-overnight/scripts/tests/test-sweep-integrity-contract.sh
@@ -5,27 +5,30 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 python3 - "$ROOT" <<'PY'
 import re, sys
 from pathlib import Path
-text=re.sub(r"\s+"," ",(Path(sys.argv[1])/"skills/woostack-execute-overnight/SKILL.md").read_text())
+
+raw=(Path(sys.argv[1])/"skills/woostack-execute-overnight/SKILL.md").read_text()
+text=re.sub(r"\s+"," ",raw)
 checks={
- "commands":r"/woostack-execute-overnight <approved plan>.*--project",
- "no implicit Linear":r"Standalone input without an exact artifact flag makes no Linear call",
+ "project-only command":r"/woostack-execute-overnight <approved project> --project <exact Linear URL\|UUID>",
+ "explicit project-only":r"explicit project-only",
  "repository authority":r"Git, Graphite, and canonical GitHub reads own source, ancestry, PR, review, and delivery truth",
- "approved plan":r"one complete explicitly approved implementation plan",
+ "exact project admission":r"one exact approved project identity supplied by URL or UUID",
+ "shared approval records":r"projectSpecApprovalRecord.*executionPlanApprovalRecord",
+ "canonical Execute admission":r"woostack-execute.*admission",
  "complete DAG":r"stable task IDs.*acyclic dependency graph",
  "repo preflight":r"deterministic task paths.*git worktree list.*dirty/index/diff state.*Git/Graphite ancestry.*GitHub PR/review/check/thread state",
- "artifact conflict":r"For selected standalone artifacts, conflict blocks only artifact use/synchronization and never rewrites the approved plan",
- "fixed loop":r"derive the currently dependency-ready task set.*Red → Green → Refactor.*specification review then quality review.*woostack-commit.*woostack-sweep",
- "no dependent concurrency":r"Never process two dependent tasks concurrently",
+ "approval rechecks":r"re-read the complete project specification.*require exact equality with both approval records.*Repeat at every boundary",
+ "fixed loop":r"derive the currently dependency-ready issue set.*fast implementation worker.*specification review then quality review.*woostack-commit.*woostack-sweep",
+ "no dependent concurrency":r"Never process two dependent issues concurrently",
  "bounded autonomy":r"must not invent or change.*product behavior.*architecture.*security/privacy posture.*dependency edges",
  "independent continuation":r"continue another dependency-independent track only when",
- "failure isolation":r"task-local failure.*track-local review or submission failure.*shared invariant failure.*required build provider failure.*optional standalone artifact failure.*unknown mutation outcome",
+ "failure isolation":r"task-local failure.*track-local review or submission failure.*shared invariant failure.*required project provider failure.*unknown mutation outcome",
  "no destructive recovery":r"Never reset, clean, stash, delete, overwrite, reassign, force-push",
  "bounded sweep":r"full review.*restack only through Graphite.*re-review",
  "no self review":r"implementing coder never acts as its own reviewer",
  "artifact narrow":r"Except for project closure, do not mutate assignee, delegate, native status, relations, membership, or archival state",
- "abandonment quiescence":r"decision to abandon the fix/build.*cancels every active.*verify every driver is quiescent",
+ "abandonment quiescence":r"decision to abandon the project.*cancels every active.*verify every driver is quiescent",
  "abandonment closure":r"projectStatuses\.canceled.*independently read",
- "no-project handback":r"no exact persisted project exists.*nothing to close.*make no provider write",
  "no synthetic cancellation":r"Never create a project merely to cancel it",
  "non-abandonment stays open":r"task failure, blocker, pause, ordinary handoff, or replan is not abandonment and leaves the project open",
  "fresh handback":r"Return one truthful report derived from fresh reads",
@@ -33,11 +36,14 @@ checks={
  "never merge":r"No self-review, self-acceptance, force-push, protected-primary edit, or merge",
 }
 failures=[name for name,pat in checks.items() if not re.search(pat,text,re.I|re.S)]
-if re.search(r"(?:requires?|must have).*Linear (?:project|issue).*before (?:execution|admission)|Linear (?:project|issue) is required",text,re.I|re.S):
- failures.append("mandatory Linear authority")
+for retired in ("fixApprovalRecord", "buildProjectSpecApprovalRecord",
+                "buildExecutionPlanApprovalRecord", "inline-driver.md",
+                "--inline", "--subagent", "artifact-free", "standalone"):
+    if retired.lower() in raw.lower():
+        failures.append(f"retired mode or approval record: {retired}")
 if failures:
  print("overnight contract violations:",file=sys.stderr)
  print("\n".join(f"- {f}" for f in failures),file=sys.stderr)
  raise SystemExit(1)
-print("repository-first overnight contract: ok")
+print("project-only overnight contract: ok")
 PY


### PR DESCRIPTION
## Goal
Align Execute Overnight and host execution guidance with the shared project approval records and sequential Execute boundary.

## Summary
- Make Execute Overnight explicit project-only: exact `--project`, `projectSpecApprovalRecord`, and `executionPlanApprovalRecord`.
- Remove its standalone, inline, alternate-driver, and legacy build-origin approval paths.
- Reuse normal Execute admission, fast implementation-worker, worktree, verification, commit, and recovery boundaries while retaining Overnight's independent review/sweep safety.
- Bind normal and overnight Execute implementation workers to the fast tier across supported host guidance.
- Update the engineer-agent contract assertions for the sequential controller and isolated fast worker.
- Preserve woostack-commit's legitimate optional artifact-free attribution behavior.

## Test plan
### Automated
- `bash skills/woostack-execute-overnight/tests/run-tests.sh`
- `bash skills/woostack-execute-overnight/scripts/tests/run-tests.sh`
- `bash skills/woostack-commit/tests/test-progressive-disclosure.sh`
- `bash skills/using-woostack/tests/test-engineer-agent-contract.sh`
- `node skills/woostack-eval/scripts/validate.mjs --package skills/woostack-execute-overnight --repository-root .`
- `git diff --check`

### Manual
- Confirmed Build remains normal-Execute-only.
- Confirmed explicit Overnight still retains approval rechecks, failure isolation, review/sweep, and no-merge boundaries.

Resolves WOO-150
