### PR TITLE
Prefix build and fix project titles

### DIFF
--- a/skills/woostack-build/SKILL.md
+++ b/skills/woostack-build/SKILL.md
@@ -18,9 +18,10 @@ Build never merges.
 /woostack-build --project <exact Linear URL-or-UUID>
 ```
 
-Build always resolves the exact supplied project or creates exactly one project from validated
-repository/workspace/team defaults before starting the conversation. It has no artifact-free
-fallback. Before acting, load and apply the shared
+Build always resolves the exact supplied project or creates exactly one project whose name starts
+with `[Build] ` and otherwise derives from the accepted goal. Supplied projects retain their
+existing names. Build uses validated repository/workspace/team defaults before starting the
+conversation and has no artifact-free fallback. Before acting, load and apply the shared
 [Linear artifact contract](../woostack-init/references/artifact-backends.md), the
 [repository/project context procedure](references/linear-context.md), and the
 [Linear synchronization procedure](references/linear-procedure.md). Those references own

--- a/skills/woostack-build/evals/evals.json
+++ b/skills/woostack-build/evals/evals.json
@@ -42,14 +42,14 @@
     },
     {
       "id": "creates-canonical-project-before-ideation",
-      "prompt": "Evaluate fixtures/project-admission.json as a new woostack-build invocation with no exact project. Do not contact a provider or mutate the repository. Validate the configured repository, workspace, team, official MCP preflight, stable operation identity, absence proof, create response, and independent read-back. Return exactly one JSON object with keys status, officialMcpVerified, projectCreated, projectId, operationIdentityPreserved, independentReadBackVerified, nextStep, repositoryMutationCount.",
+      "prompt": "Evaluate fixtures/project-admission.json as a new woostack-build invocation with no exact project. Do not contact a provider or mutate the repository. Validate the configured repository, workspace, team, official MCP preflight, stable operation identity, prefixed project name, absence proof, create response, and independent read-back. Return exactly one JSON object with keys status, officialMcpVerified, projectCreated, projectId, projectName, operationIdentityPreserved, independentReadBackVerified, nextStep, repositoryMutationCount.",
       "fixtures": [
         "project-admission.json"
       ],
       "capabilities": [
         "read-workspace"
       ],
-      "expected": "Build uses validated defaults to create exactly one canonical project with one stable operation identity, independently verifies it, performs no repository mutation, and proceeds to ideation only after project admission succeeds.",
+      "expected": "Build uses validated defaults to create exactly one canonical project named `[Build] Bound cache freshness` with one stable operation identity, independently verifies it, performs no repository mutation, and proceeds to ideation only after project admission succeeds.",
       "assertions": [
         {
           "id": "build-project-admission-ready",
@@ -77,6 +77,13 @@
           "kind": "final-json-path-equals",
           "pointer": "/projectId",
           "expected": "project-build-43"
+        },
+        {
+          "id": "build-created-project-name",
+          "kind": "final-json-path-equals",
+          "pointer": "/projectName",
+          "expected": "[Build] Bound cache freshness",
+          "critical": true
         },
         {
           "id": "build-operation-identity-preserved",

--- a/skills/woostack-build/evals/fixtures/project-admission.json
+++ b/skills/woostack-build/evals/fixtures/project-admission.json
@@ -17,10 +17,12 @@
     "complete": true
   },
   "createResponse": {
-    "nativeProjectRef": "project-build-43"
+    "nativeProjectRef": "project-build-43",
+    "name": "[Build] Bound cache freshness"
   },
   "independentRead": {
     "nativeProjectRef": "project-build-43",
+    "name": "[Build] Bound cache freshness",
     "operationIdentity": "11111111-1111-4111-8111-111111111111",
     "repository": "https://github.com/acme/widgets",
     "workspace": "acme",

--- a/skills/woostack-build/references/linear-context.md
+++ b/skills/woostack-build/references/linear-context.md
@@ -18,8 +18,9 @@ rules. Use the [Linear synchronization procedure](linear-procedure.md) for mutat
 3. If `--project` supplied an exact URL/stable UUID, read only that project and verify its identity,
    workspace/team, and canonical repository association.
 4. Otherwise allocate one stable client mutation UUID, prove that no project exists for that
-   operation identity, create exactly one project in the resolved workspace/team, independently
-   read it back, and retain the exact native identity.
+   operation identity, and create exactly one project in the resolved workspace/team. Its name
+   starts with `[Build] ` and otherwise derives from the accepted goal. Independently read the
+   project back, verify the exact name, and retain its native identity.
 5. Preflight official Linear MCP capabilities for complete project reads, paginated direct-issue
    reads, native dependency-relation reads, project/issue writes, relation writes, comments/updates
    used as approval evidence, and independent read-back.

--- a/skills/woostack-build/tests/test-linear-build-contract.sh
+++ b/skills/woostack-build/tests/test-linear-build-contract.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 python3 - "$ROOT" <<'PY'
+import json
 import re
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ from pathlib import Path
 root = Path(sys.argv[1])
 paths = {
     "build": root / "skills/woostack-build/SKILL.md",
+    "context": root / "skills/woostack-build/references/linear-context.md",
     "ideate": root / "skills/woostack-ideate/SKILL.md",
     "harden": root / "skills/woostack-harden/SKILL.md",
     "plan": root / "skills/woostack-plan/SKILL.md",
@@ -54,6 +56,18 @@ for needle in (
     "canonical fingerprints",
 ):
     require("build", needle)
+
+require("build", "name starts with `[Build] `")
+require("build", "Supplied projects retain their existing names")
+require("context", "name starts with `[Build] `")
+fixture = json.loads(
+    (root / "skills/woostack-build/evals/fixtures/project-admission.json").read_text()
+)
+expected_project_name = "[Build] Bound cache freshness"
+if fixture["createResponse"]["name"] != expected_project_name:
+    failures.append("build: create request does not use the [Build] project prefix")
+if fixture["independentRead"]["name"] != expected_project_name:
+    failures.append("build: independent read does not verify the prefixed project name")
 
 chain_pattern = re.compile(
     r"resolve/create canonical project\s*→\s*"

--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -26,9 +26,11 @@ creates a competing issue plan, performs implementation, or owns delivery review
              [--issue <exact Linear URL-or-UUID>] [--inline|--subagent]
 ```
 
-`--project` is optional: when supplied it is one exact canonical project URL or stable UUID; when
-omitted, Fix creates exactly one project after root-cause proof using validated repository,
-workspace, and team defaults. `--issue` is optional source context, not the fix contract. It may
+`--project` is optional: when supplied it is one exact canonical project URL or stable UUID and
+retains its existing name. When omitted, Fix creates exactly one project after root-cause proof
+whose name starts with `[Fix] ` and otherwise derives from the proved correction, using validated
+repository, workspace, and team defaults. `--issue` is optional source context, not the fix
+contract. It may
 identify one exact Linear issue or a source issue associated with the supplied input; it is never
 repurposed as the canonical project, rewritten as a plan, closed, or treated as approval. A source
 issue is left unchanged except for the supported link to the canonical project. A supplied PR is

--- a/skills/woostack-fix/evals/evals.json
+++ b/skills/woostack-fix/evals/evals.json
@@ -37,11 +37,12 @@
     },
     {
       "id": "canonical-project-preserves-source-record",
-      "prompt": "After root-cause proof, Fix admits canonical project project-fix-241 and independently reads it back. It adds only a supported projectLink to the source issue, preserves unrelated fields, and Plan returns direct issues issue-pr-241a and issue-pr-241b. Return JSON with projectId, projectReadBackVerified, sourceChangedFields, sourceUnrelatedFieldsPreserved, and directIssueIds.",
+      "prompt": "After root-cause proof, Fix creates canonical project project-fix-241 named `[Fix] Prevent cache refresh stampedes` and independently reads it back. It adds only a supported projectLink to the source issue, preserves unrelated fields, and Plan returns direct issues issue-pr-241a and issue-pr-241b. Return JSON with projectId, projectName, projectReadBackVerified, sourceChangedFields, sourceUnrelatedFieldsPreserved, and directIssueIds.",
       "capabilities": ["read-workspace"],
-      "expected": "Fix keeps one canonical project, changes only the source issue's supported project link, and admits both direct plan issues.",
+      "expected": "Fix keeps one canonical project with the required `[Fix] ` name prefix, changes only the source issue's supported project link, and admits both direct plan issues.",
       "assertions": [
         {"id":"one-project","kind":"final-json-path-equals","pointer":"/projectId","expected":"project-fix-241","critical":true},
+        {"id":"prefixed-project-name","kind":"final-json-path-equals","pointer":"/projectName","expected":"[Fix] Prevent cache refresh stampedes","critical":true},
         {"id":"project-readback","kind":"final-json-path-equals","pointer":"/projectReadBackVerified","expected":true,"critical":true},
         {"id":"source-only-link","kind":"final-json-path-equals","pointer":"/sourceChangedFields","expected":["projectLink"],"critical":true},
         {"id":"source-preserved","kind":"final-json-path-equals","pointer":"/sourceUnrelatedFieldsPreserved","expected":true,"critical":true},

--- a/skills/woostack-fix/evals/fixtures/approved-fix.json
+++ b/skills/woostack-fix/evals/fixtures/approved-fix.json
@@ -30,6 +30,7 @@
   },
   "projectAdmission": {
     "projectId": "project-fix-241",
+    "name": "[Fix] Prevent cache refresh stampedes",
     "created": true,
     "repository": "https://github.com/acme/cache-service",
     "workspaceId": "workspace-acme",
@@ -39,7 +40,7 @@
   },
   "projectSpec": {
     "canonicalProjectSpecFingerprint": "sha256:project-spec-241",
-    "title": "Prevent cache refresh stampedes",
+    "title": "[Fix] Prevent cache refresh stampedes",
     "rootCauseChain": "Refresh duration exceeds lock expiry, allowing a second owner before completion.",
     "acceptance": ["One refresh owns the lock for the full protected operation.", "Concurrent callers do not duplicate origin work."],
     "inScope": ["src/cache.js", "test/cache.test.js"],

--- a/skills/woostack-fix/scripts/tests/test-closeout-invariant.sh
+++ b/skills/woostack-fix/scripts/tests/test-closeout-invariant.sh
@@ -22,6 +22,8 @@ require(r"Debug\s*→\s*Ideate\s*→\s*Harden.*project-spec approval.*Linear.*Pl
 require(r"accepts a goal or untrusted Linear, GitHub, Sentry, or monitoring input", "untrusted input coverage")
 require(r"root-cause proof.*create or update a project.*branch.*worktree.*mutate the repository", "proof write barrier")
 require(r"owns one canonical project", "one canonical project")
+require(r"name starts with `\[Fix\] `", "prefixed fix project name")
+require(r"supplied.*project.*retains its existing name", "supplied project name preservation")
 require(r"source issue.*never repurposed|never repurpos(?:e|ed) a supplied source\s+issue", "source issue preservation")
 require(r"multiple direct PR-linked issues", "multiple direct PR issues")
 require(r"projectSpecApprovalRecord", "project approval record")
@@ -52,6 +54,10 @@ if blocked["repository"]["mutationCount"] != 0 or blocked["debug"]["providerCall
 
 if fixture["projectAdmission"]["projectId"] != "project-fix-241" or not fixture["projectAdmission"]["independentReadBack"]:
     failures.append("canonical project admission")
+if fixture["projectAdmission"]["name"] != "[Fix] Prevent cache refresh stampedes":
+    failures.append("fix project name prefix")
+if not fixture["projectSpec"]["title"].startswith("[Fix] "):
+    failures.append("fix project specification title prefix")
 source = fixture["sourceIssue"]
 if source["changedFields"] != ["projectLink"] or not source["unrelatedFieldsPreserved"]:
     failures.append("source issue changed beyond project link")


### PR DESCRIPTION
## Summary

- Require newly created Build projects to start with `[Build] `.
- Require newly created Fix projects to start with `[Fix] `.
- Preserve names on exact caller-supplied projects and cover both conventions in fixtures, evals, and contract tests.

## Verification

- `bash skills/woostack-build/tests/test-linear-build-contract.sh`
- `bash skills/woostack-fix/scripts/tests/test-closeout-invariant.sh`
- `jq empty skills/woostack-build/evals/evals.json skills/woostack-build/evals/fixtures/project-admission.json skills/woostack-fix/evals/evals.json skills/woostack-fix/evals/fixtures/approved-fix.json`
- `pnpm -C site build`

## Scope

Only `skills/woostack-build/**` and `skills/woostack-fix/**` change. Existing projects are not renamed.