### PR TITLE
feat: post UI validation screenshots to Linear

### DIFF
--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -62,10 +62,11 @@ never advances a sibling. Both modes use the same two approval records and repos
 5. Create or resume exactly one deterministic isolated worktree owned by this run. Dispatch the
    configured fast-model subagent with the exact issue scope and exclusive worktree ownership.
 6. After the worker returns, run one focused verification and changed-path smoke scenario, then one
-   bounded spec-compliance validator against the approved issue contract. On success, invoke
-   [`woostack-commit`](../woostack-commit/SKILL.md) with the exact selected issue to commit and submit
-   exactly one Graphite PR. Independently read back branch, commit, PR URL/head/base, the exact
-   `Resolves <issue identifier>` body line, verification receipt, and Graphite parent.
+   bounded spec-compliance validator against the approved issue contract. When validation produces
+   screenshots, apply [Controller-owned screenshot evidence](references/controller.md#controller-owned-screenshot-evidence) before commit. On success, invoke [`woostack-commit`](../woostack-commit/SKILL.md)
+   with the exact selected issue to commit and submit exactly one Graphite PR. Independently read
+   back branch, commit, PR URL/head/base, the exact `Resolves <issue identifier>` body line,
+   verification receipt, and Graphite parent.
 7. Persist the delivery evidence, move the issue to `In Review`, and independently read back the
    Linear issue/project checkpoint. Remove the worktree only after all required evidence is present
    and the exact worktree is clean.
@@ -98,9 +99,12 @@ Linear writes, and work in another worktree.
 
 The worker edits only its isolated worktree and returns changed paths, diff identity, focused check
 and smoke observations, and one status. It does not commit, push, submit a PR, change Linear, review,
-validate its own acceptance, or advance the controller. The controller runs only one focused
-verification/smoke and one small bounded spec-compliance validator. Repair confirmed omissions in
-scope; broad quality findings, redesigns, and unrelated cleanup return to the owning workflow.
+validate its own acceptance, or advance the controller. The controller owns screenshot inspection,
+safe selection, attachment upload, inline comment, and fresh comment/image read-back; the worker never
+receives Linear, attachment, browser, GitHub-write, commit, PR, review, acceptance, or sibling
+authority. The controller runs only one focused verification/smoke and one small bounded
+spec-compliance validator. Repair confirmed omissions in scope; broad quality findings, redesigns,
+and unrelated cleanup return to the owning workflow.
 
 ## Linear and repository lifecycle
 

--- a/skills/woostack-execute/references/controller.md
+++ b/skills/woostack-execute/references/controller.md
@@ -83,6 +83,20 @@ omission through the same worker; do not broaden the check into unrelated analys
 A timeout or missing response is `UNKNOWN`, not failure; inspect process and worktree before any
 redispatch.
 
+### Controller-owned screenshot evidence
+
+Immediately after successful focused UI validation and image inspection, when validation produced
+screenshots and before commit, the controller selects exactly one final representative safe
+screenshot. It refuses any screenshot visibly containing secrets, credentials, or personal data:
+warn, continue repository delivery, and never claim it was posted. For a safe screenshot, use
+Linear's supported attachment flow to attach it to the exact admitted Linear issue and post one
+inline comment that renders the image beneath a short scenario/state caption.
+Claim screenshot success only after a fresh independent comment/image read-back proves the exact
+comment contains both caption and image. Any upload, comment, or read-back failure is best-effort
+Linear evidence failure: warn, continue repository delivery, and never claim success. Screenshot
+evidence is non-authoritative and does not replace mandatory Linear lifecycle or
+Git/Graphite/GitHub evidence. Never post a screenshot to a GitHub PR or external hosting.
+
 ## Linear and PR boundaries
 
 Read back each Linear write. Move the issue only through `Backlog`/`Todo` → `In Progress` → `In

--- a/skills/woostack-execute/scripts/tests/test-exact-issue-admission.sh
+++ b/skills/woostack-execute/scripts/tests/test-exact-issue-admission.sh
@@ -40,6 +40,15 @@ checks = [
     (controller, r"woostack-commit.*exact selected issue", "controller does not pass the exact issue to commit"),
     (controller, r"exactly one closing reference for the selected issue", "controller closing-reference read-back missing"),
     (controller, r"fresh independent Linear, Git, Graphite, and GitHub evidence", "resume evidence missing"),
+    (skill, r"\[Controller-owned screenshot evidence\]\(references/controller\.md#controller-owned-screenshot-evidence\)", "skill screenshot controller cross-link missing"),
+    (controller, r"Immediately after successful focused UI validation and image inspection.*when validation produced screenshots and before commit.*exactly one final representative safe screenshot", "controller screenshot trigger/selection missing"),
+    (controller, r"refuses any screenshot visibly containing secrets, credentials, or personal data.*warn.*continue repository delivery.*never claim it was posted", "controller sensitive-data refusal missing"),
+    (controller, r"supported attachment flow.*exact admitted Linear issue.*post one inline comment that renders the image beneath a short scenario/state caption", "controller issue attachment/comment missing"),
+    (controller, r"fresh independent comment/image read-back.*exact comment contains.*both caption and image", "controller caption/image read-back missing"),
+    (controller, r"upload, comment, or read-back failure.*best-effort Linear evidence failure.*warn.*continue repository delivery.*never claim success", "controller best-effort continuation missing"),
+    (controller, r"Controller-owned screenshot evidence", "controller screenshot ownership missing"),
+    (controller, r"Never post a screenshot to a GitHub PR or external hosting", "controller GitHub/external screenshot prohibition missing"),
+    (controller, r"non-authoritative.*mandatory Linear lifecycle.*Git/Graphite/GitHub evidence", "controller screenshot evidence authority boundary missing"),
     (driver, r"configured fast-model subagent", "driver fast model missing"),
 ]
 for text, pattern, message in checks:


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices

## Goal

Record the final representative screenshot from successful Execute UI validation as inline evidence on the exact Linear increment issue.

## Summary

- Define the controller-owned Linear attachment and inline comment sequence after UI validation.
- Preserve sensitive-data refusal, best-effort failures, independent read-back, and worker authority boundaries.
- Add structural regression guards for the screenshot-evidence contract.

## Test plan

### Automated

- `bash skills/woostack-execute/scripts/tests/test-exact-issue-admission.sh` — passed
- `bash skills/woostack-execute/tests/run-tests.sh` — passed
- `git diff --check` — passed

### Manual

- Reviewed the exact three-file diff against approved WOO-159; no application UI scenario exists for this skill-contract change.

Resolves WOO-159