### PR TITLE
fix: synchronize Linear project status during execution

### DIFF
--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -121,10 +121,19 @@ Missing required capability blocks at the retained safe boundary; selected stand
 failure blocks only that optional operation. Before root-cause proof, Fix makes no provider call.
 `woostack-change` ignores the `linear` object.
 
+`linear.projectStatuses.started` names the native status used when Execute observes any direct issue
+in `In Progress` or `In Review`. It resolves to exactly one status in the selected workspace/team
+and must have native category `started`. Execute updates only the exact project's status, with a
+stable mutation identity and independent read-back; an exact match is an idempotent no-op. If all
+direct issues are `Backlog`/`Todo`, synchronization waits until the selected issue transitions
+to `In Progress` and reads back before repository mutation.
+
 `linear.projectStatuses.canceled` names the native status used to close an existing project-backed
-Build, Fix, or standalone Plan workflow after explicit abandonment. The workflow reads the status
-transition back and never creates a project solely to cancel it. Source issues, handoff, replanning,
-and blockers are not abandonment and leave projects open.
+Build, Fix, or standalone Plan workflow after explicit abandonment. It must resolve to exactly one
+native status with category `canceled`; the workflow pre-reads the exact project, updates only its
+status with a stable mutation identity, and independently reads the transition back. The workflow
+never creates a project solely to cancel it. Source issues, handoff, replanning, and blockers are not
+abandonment and leave projects open.
 
 The canonical
 [Linear artifact contract](https://github.com/howarewoo/woostack/blob/main/skills/woostack-init/references/artifact-backends.md)

--- a/skills/woostack-execute/SKILL.md
+++ b/skills/woostack-execute/SKILL.md
@@ -49,6 +49,24 @@ execution.
 `--project` is **project mode**. `--issue` is **issue mode** and selects only that exact issue; it
 never advances a sibling. Both modes use the same two approval records and repository admission.
 
+### Active project status gate
+
+Before any worktree or source mutation in both `--project` and `--issue` modes, apply the shared
+[active Execute project-start synchronization](../woostack-init/references/artifact-backends.md#active-execute-project-start-synchronization)
+contract to the exact canonical nonterminal project. Independently read the complete, paginated
+direct-issue set and project status. If any direct issue is `In Progress` or `In Review`, resolve
+`linear.projectStatuses.started`, require native category `started`, and make the exact project
+started (or record an exact started no-op) before continuing. If all direct issues are
+`Backlog`/`Todo`, defer the gate until the selected issue transitions to `In Progress` and reads
+back; then synchronize the project before repository work. Terminal project conflict, mapping
+failure, drift, timeout, partial/foreign output, or failed/unknown read-back blocks without
+reopening or continuing. The project-status receipt is independent of the issue lifecycle receipt
+and resume-checkpoint evidence.
+
+The gate mutates only the project's native status with one stable mutation identity and independently
+reads back project identity, status ID/name/category, revision, and operation identity. An exact
+started match is idempotent.
+
 ## Project controller
 
 1. Read the complete approved project graph and classify every direct issue by its immutable ordinal.
@@ -57,8 +75,10 @@ never advances a sibling. Both modes use the same two approval records and repos
 3. For a non-root issue, prove its immediate predecessor's exact branch/head and Graphite parent.
    For the first issue, prove the frozen integration base. Reject a missing, moved, or conflicting
    predecessor. No other issue is admitted in the same cycle.
-4. Persist and independently read back `In Progress`, the issue's branch/worktree/run intent, and
-   the project's resume checkpoint.
+4. Apply the active project status gate. When all direct issues are `Backlog`/`Todo`, persist and
+   independently read back the selected issue's `In Progress` transition first, then synchronize and independently read
+   back the project's configured started status. Keep the project-status receipt distinct from the
+   issue lifecycle receipt and project resume checkpoint.
 5. Create or resume exactly one deterministic isolated worktree owned by this run. Dispatch the
    configured fast-model subagent with the exact issue scope and exclusive worktree ownership.
 6. After the worker returns, run one focused verification and changed-path smoke scenario, then one
@@ -83,11 +103,13 @@ same run and state; rediscover existing commits or PRs before retrying and never
 ## Issue controller
 
 Issue mode performs exactly the selected issue's cycle once: admit its matching project records,
-prove its predecessor/base and Graphite parent, persist/read back `In Progress`, dispatch one
-fast-model subagent in its isolated worktree, verify and validate the one issue, submit and read
-back one PR, persist delivery evidence, move/read back `In Review`, and remove the clean worktree.
-Issue mode never advances siblings, even when the selected issue succeeds. Failures retain exact
-recovery evidence.
+prove its predecessor/base and Graphite parent, apply the active project status gate (including
+the selected issue's `In Progress` transition when all direct issues are `Backlog`/`Todo`), then
+dispatch one fast-model subagent in its isolated worktree. The gate's project-status receipt stays
+separate from issue lifecycle and resume-checkpoint evidence. Verify and validate the one issue,
+submit and read back one PR, persist delivery evidence, move/read back `In Review`, and remove the
+clean worktree. Issue mode never advances siblings, even when the selected issue succeeds. Failures
+retain exact recovery evidence.
 
 ## Worker and verification boundary
 

--- a/skills/woostack-execute/evals/evals.json
+++ b/skills/woostack-execute/evals/evals.json
@@ -90,6 +90,86 @@
         {"id": "failure-boundary", "kind": "final-json-path-equals", "pointer": "/firstBoundary", "expected": "spec-validator", "critical": true},
         {"id": "failure-next", "kind": "final-json-path-equals", "pointer": "/nextAction", "expected": "repair-confirmed-omission-or-resume", "critical": true}
       ]
+    },
+    {
+      "id": "planned-project-with-in-progress-issue-starts-project",
+      "prompt": "In project mode, first independently read the exact canonical project by stable native ID (including current status and native category), the selected direct issue issue-001 by stable ID (including lifecycle status), and the configured projectStatuses.started mapping. The reads prove this nonterminal project is Planned, issue-001 is In Progress, and exactly one mapping exists with a stable native status ID/name and native category started. Mutate only that exact project to that mapping, then independently re-read it and require an exact ID/name/category/status match confirming started; do not begin repository mutation yet. Return exactly one JSON object with keys status, mode, projectStatusAction, issueTransition, repositoryMutationStarted, and projectStatusReceipt, normalized as status=proceed, mode=project, projectStatusAction=sync-started, issueTransition=already-in-progress, projectStatusReceipt=independent-readback, and repositoryMutationStarted=false.",
+      "capabilities": ["read-workspace"],
+      "expected": "An active direct issue starts the exact project before repository mutation while preserving the issue lifecycle.",
+      "assertions": [
+        {"id": "planned-in-progress-status", "kind": "final-json-path-equals", "pointer": "/status", "expected": "proceed", "critical": true},
+        {"id": "planned-in-progress-mode", "kind": "final-json-path-equals", "pointer": "/mode", "expected": "project", "critical": true},
+        {"id": "planned-in-progress-action", "kind": "final-json-path-equals", "pointer": "/projectStatusAction", "expected": "sync-started", "critical": true},
+        {"id": "planned-in-progress-issue", "kind": "final-json-path-equals", "pointer": "/issueTransition", "expected": "already-in-progress", "critical": true},
+        {"id": "planned-in-progress-no-repo-first", "kind": "final-json-path-equals", "pointer": "/repositoryMutationStarted", "expected": false, "critical": true},
+        {"id": "planned-in-progress-receipt", "kind": "final-json-path-equals", "pointer": "/projectStatusReceipt", "expected": "independent-readback", "critical": true}
+      ]
+    },
+    {
+      "id": "planned-project-with-in-review-issue-starts-project",
+      "prompt": "In issue mode, independently read the exact canonical project by stable native ID (including current status and native category), the current direct issue issue-002 by stable ID (including lifecycle status), and the configured projectStatuses.started mapping. The reads prove this nonterminal project is Backlog, issue-002 is In Review, and exactly one mapping exists with a stable native status ID/name and native category started. Mutate only that exact project to that mapping, then independently re-read it and require an exact ID/name/category/status match confirming started; do not advance any sibling. Return exactly one JSON object with keys status, mode, projectStatusAction, issueTransition, siblingsAdvanced, and projectStatusReceipt, normalized as status=proceed, mode=issue, projectStatusAction=sync-started, issueTransition=already-in-review, siblingsAdvanced=false, and projectStatusReceipt=independent-readback.",
+      "capabilities": ["read-workspace"],
+      "expected": "An In Review direct issue also starts the exact project in issue mode without advancing siblings.",
+      "assertions": [
+        {"id": "planned-in-review-status", "kind": "final-json-path-equals", "pointer": "/status", "expected": "proceed", "critical": true},
+        {"id": "planned-in-review-mode", "kind": "final-json-path-equals", "pointer": "/mode", "expected": "issue", "critical": true},
+        {"id": "planned-in-review-action", "kind": "final-json-path-equals", "pointer": "/projectStatusAction", "expected": "sync-started", "critical": true},
+        {"id": "planned-in-review-issue", "kind": "final-json-path-equals", "pointer": "/issueTransition", "expected": "already-in-review", "critical": true},
+        {"id": "planned-in-review-no-sibling", "kind": "final-json-path-equals", "pointer": "/siblingsAdvanced", "expected": false, "critical": true},
+        {"id": "planned-in-review-receipt", "kind": "final-json-path-equals", "pointer": "/projectStatusReceipt", "expected": "independent-readback", "critical": true}
+      ]
+    },
+    {
+      "id": "started-project-is-idempotent",
+      "prompt": "First complete independent reads of the exact canonical project by stable native ID (including current status, native ID, name, and category), the configured projectStatuses.started mapping, and the direct issue by stable ID (including lifecycle status). The reads prove the project status exactly matches the configured mapping by stable native ID, name, and native started category, and the issue is In Progress. Because this is an exact stable match, do not issue a project mutation and do not begin repository mutation. Return exactly one JSON object with keys status, projectStatusAction, projectStatusMutation, and repositoryMutationStarted, normalized as status=proceed, projectStatusAction=no-op, projectStatusMutation=false, and repositoryMutationStarted=false.",
+      "capabilities": ["read-workspace"],
+      "expected": "An exact started match is an idempotent no-op and does not issue a project mutation.",
+      "assertions": [
+        {"id": "started-no-op-status", "kind": "final-json-path-equals", "pointer": "/status", "expected": "proceed", "critical": true},
+        {"id": "started-no-op-action", "kind": "final-json-path-equals", "pointer": "/projectStatusAction", "expected": "no-op", "critical": true},
+        {"id": "started-no-op-mutation", "kind": "final-json-path-equals", "pointer": "/projectStatusMutation", "expected": false, "critical": true},
+        {"id": "started-no-op-order", "kind": "final-json-path-equals", "pointer": "/repositoryMutationStarted", "expected": false, "critical": true}
+      ]
+    },
+    {
+      "id": "all-planned-transitions-then-starts-project",
+      "prompt": "First independently read the exact Planned project by stable native ID, all direct issue records, and the configured projectStatuses.started mapping. Complete reads prove every direct issue is Backlog or Todo, issue-001 is the selected issue, and exactly one started-category mapping is available. The issue-001 transition mutation has succeeded, and an independent reread of that exact issue proves In Progress. The exact project mutation to the unique configured started mapping has succeeded, and an independent reread of that exact project proves a matching ID/name/category/status. Repository mutation begins only after those issue and project receipts. Return exactly one JSON object with keys status, operationOrder, projectStatusReceipt, and repositoryMutationStarted, normalized as status=proceed, operationOrder=[\"issue-in-progress-readback\",\"project-started-readback\",\"repository-mutation\"], projectStatusReceipt=independent-readback, and repositoryMutationStarted=true.",
+      "capabilities": ["read-workspace"],
+      "expected": "Execution with all direct issues Backlog/Todo defers project synchronization until the selected issue transition, then reads back the project before repository mutation.",
+      "assertions": [
+        {"id": "all-planned-status", "kind": "final-json-path-equals", "pointer": "/status", "expected": "proceed", "critical": true},
+        {"id": "all-planned-order", "kind": "final-json-path-equals", "pointer": "/operationOrder", "expected": ["issue-in-progress-readback", "project-started-readback", "repository-mutation"], "critical": true},
+        {"id": "all-planned-receipt", "kind": "final-json-path-equals", "pointer": "/projectStatusReceipt", "expected": "independent-readback", "critical": true},
+        {"id": "all-planned-repo", "kind": "final-json-path-equals", "pointer": "/repositoryMutationStarted", "expected": true, "critical": true}
+      ]
+    },
+    {
+      "id": "terminal-project-conflict-blocks",
+      "prompt": "Independently read the exact canonical project by stable native ID and the direct issue by stable ID before any mutation. The reads prove the issue is In Progress and the canonical project is terminal (its exact status is Completed or Canceled), so this is a terminal project conflict rather than a recoverable status mismatch. Do not reopen or mutate the project, transition the issue, or mutate the repository. Return exactly one JSON object with keys status, reason, mutationAllowed, issueTransitionAttempted, projectReopened, and repositoryMutationStarted, normalized as status=blocked, reason=terminal-project-conflict, mutationAllowed=false, issueTransitionAttempted=false, projectReopened=false, and repositoryMutationStarted=false.",
+      "capabilities": ["read-workspace"],
+      "expected": "A terminal project conflict blocks without reopening the project, changing the issue, or mutating the repository.",
+      "assertions": [
+        {"id": "terminal-status", "kind": "final-json-path-equals", "pointer": "/status", "expected": "blocked", "critical": true},
+        {"id": "terminal-reason", "kind": "final-json-path-equals", "pointer": "/reason", "expected": "terminal-project-conflict", "critical": true},
+        {"id": "terminal-no-mutation", "kind": "final-json-path-equals", "pointer": "/mutationAllowed", "expected": false, "critical": true},
+        {"id": "terminal-no-issue-transition", "kind": "final-json-path-equals", "pointer": "/issueTransitionAttempted", "expected": false, "critical": true},
+        {"id": "terminal-no-reopen", "kind": "final-json-path-equals", "pointer": "/projectReopened", "expected": false, "critical": true},
+        {"id": "terminal-no-repo", "kind": "final-json-path-equals", "pointer": "/repositoryMutationStarted", "expected": false, "critical": true}
+      ]
+    },
+    {
+      "id": "project-status-unknown-boundary-blocks",
+      "prompt": "Independently read the exact nonterminal project by stable native ID and the direct issue by stable ID before starting the project-status operation. The issue read-back independently proves In Progress, so set issueLifecycleReadBack=true. Resolve the unique configured started mapping, attempt the mutation against that exact project and mapping, and treat a timeout or any independent read-back that is failed, partial, foreign, or unknown as the failed boundary: the exact project status read-back is not proven. Do not reopen the project, start repository mutation, or retry with a different identity; retain the same operation identity. Return exactly one JSON object with keys status, firstBoundary, issueLifecycleReadBack, repositoryMutationStarted, projectReopened, and retryIdentity, normalized as status=blocked, firstBoundary=project-status-readback, issueLifecycleReadBack=true, repositoryMutationStarted=false, projectReopened=false, and retryIdentity=same-project-status-operation.",
+      "capabilities": ["read-workspace"],
+      "expected": "A failed or unknown project status mutation/read-back blocks before repository mutation, retains the stable identity, and never reopens the project.",
+      "assertions": [
+        {"id": "unknown-status", "kind": "final-json-path-equals", "pointer": "/status", "expected": "blocked", "critical": true},
+        {"id": "unknown-boundary", "kind": "final-json-path-equals", "pointer": "/firstBoundary", "expected": "project-status-readback", "critical": true},
+        {"id": "unknown-issue-readback", "kind": "final-json-path-equals", "pointer": "/issueLifecycleReadBack", "expected": true, "critical": true},
+        {"id": "unknown-no-repo", "kind": "final-json-path-equals", "pointer": "/repositoryMutationStarted", "expected": false, "critical": true},
+        {"id": "unknown-no-reopen", "kind": "final-json-path-equals", "pointer": "/projectReopened", "expected": false, "critical": true},
+        {"id": "unknown-stable-identity", "kind": "final-json-path-equals", "pointer": "/retryIdentity", "expected": "same-project-status-operation", "critical": true}
+      ]
     }
   ]
 }

--- a/skills/woostack-execute/references/controller.md
+++ b/skills/woostack-execute/references/controller.md
@@ -38,14 +38,36 @@ scope, allocation, records, or boundaries.
 Project mode repeatedly runs one cycle; issue mode runs one cycle for the selected issue only.
 
 ```text
-admit → select lowest unfinished ordinal → prove predecessor/base
-  → persist/read back In Progress + resume checkpoint
+admit → read exact project + complete direct-issue set
+  → select lowest unfinished ordinal → prove predecessor/base
+  → active issue? resolve/read back projectStatuses.started
+  → all direct issues are `Backlog`/`Todo`? persist/read back selected issue In Progress
+  → all direct issues are `Backlog`/`Todo`? resolve/read back projectStatuses.started
+  → persist issue intent + resume checkpoint
   → create or resume one worktree → dispatch fast-model worker
   → focused verification/smoke → bounded spec validator
   → commit/Graphite submit → read back branch/commit/PR/receipt
   → persist delivery evidence + read back In Review
   → clean-worktree teardown → (project: stop marker? pause : next ordinal)
 ```
+
+### Project status gate
+
+Both modes apply the shared [active Execute project-start synchronization](../../woostack-init/references/artifact-backends.md#active-execute-project-start-synchronization)
+contract to the exact canonical nonterminal project before any worktree or source mutation.
+Independently read the exact project and complete, paginated direct-issue set. If any direct issue is
+`In Progress` or `In Review`, resolve `projectStatuses.started` to exactly one native status,
+require native category `started`, and synchronize the project before issue lifecycle work. If all
+direct issues are `Backlog`/`Todo`, first transition only the selected issue to `In Progress`
+and independently read that issue transition back, then synchronize the project before repository
+mutation. An exact started project status is an idempotent no-op.
+
+The gate pre-reads the exact project immediately before mutation, retains one stable mutation
+identity, and mutates only the project's native status field. Independently read back project
+identity, status ID/name/category, revision, and mutation identity. Completed or canceled projects,
+missing or invalid mappings, drift, incomplete pagination, timeout, partial/foreign output, or
+failed/unknown mutation or read-back block at the boundary without reopening or continuing. Keep
+the project-status receipt separate from issue lifecycle and resume-checkpoint evidence.
 
 An issue is unfinished until canonical Linear state and delivery evidence show `In Review` for this
 workflow. Project mode selects the lowest unfinished ordinal in the approved direct-issue order.
@@ -101,7 +123,9 @@ Git/Graphite/GitHub evidence. Never post a screenshot to a GitHub PR or external
 
 Read back each Linear write. Move the issue only through `Backlog`/`Todo` → `In Progress` → `In
 Review`; persist issue branch/worktree/run evidence and project resume checkpoint after the relevant
-boundary. Do not alter approved content, dependency edges, assignment, ownership, or acceptance.
+boundary. Apply the shared project status gate before repository mutation and independently read back
+its separate project-status receipt. Do not alter approved content, dependency edges, assignment,
+ownership, or acceptance.
 
 Before commit, re-read records, selected issue, predecessor, worktree, branch, diff, and Graphite
 parent. Invoke [`woostack-commit`](../../woostack-commit/SKILL.md) with the exact selected issue. The

--- a/skills/woostack-execute/scripts/tests/test-exact-issue-admission.sh
+++ b/skills/woostack-execute/scripts/tests/test-exact-issue-admission.sh
@@ -12,6 +12,7 @@ from pathlib import Path
 root = Path(sys.argv[1])
 skill = re.sub(r"\s+", " ", (root / "skills/woostack-execute/SKILL.md").read_text())
 controller = re.sub(r"\s+", " ", (root / "skills/woostack-execute/references/controller.md").read_text())
+artifact = re.sub(r"\s+", " ", (root / "skills/woostack-init/references/artifact-backends.md").read_text())
 driver = re.sub(r"\s+", " ", (root / "skills/woostack-execute/references/subagent-driver.md").read_text())
 checks = [
     (skill, r"Exactly one of `--project` or `--issue` is required", "exact resource admission missing"),
@@ -49,6 +50,21 @@ checks = [
     (controller, r"Controller-owned screenshot evidence", "controller screenshot ownership missing"),
     (controller, r"Never post a screenshot to a GitHub PR or external hosting", "controller GitHub/external screenshot prohibition missing"),
     (controller, r"non-authoritative.*mandatory Linear lifecycle.*Git/Graphite/GitHub evidence", "controller screenshot evidence authority boundary missing"),
+    (skill, r"active Execute project-start synchronization", "execute project-status contract cross-link missing"),
+    (skill, r"both `--project` and `--issue` modes", "both execute modes missing project-status gate"),
+    (skill, r"`Backlog`/`Todo`.*`In Progress`.*project", "unstarted plus in-progress lifecycle outcome missing"),
+    (skill, r"`Backlog`/`Todo`.*`In Review`.*project", "unstarted plus in-review lifecycle outcome missing"),
+    (skill, r"exact started match is idempotent", "exact started no-op outcome missing"),
+    (skill, r"all direct issues.*`Backlog`/`Todo`.*`In Progress` transition.*synchroniz", "all-unstarted transition/sync outcome missing"),
+    (controller, r"Completed or canceled projects", "terminal project conflict outcome missing"),
+    (controller, r"failed/unknown mutation or read-back", "failed or unknown project mutation outcome missing"),
+    (artifact, r"complete, paginated direct-issue set", "artifact direct-issue pagination contract missing"),
+    (artifact, r"exactly one native project status.*native category.*`started`", "native started status resolution missing"),
+    (artifact, r"Immediately before a needed project mutation, re-read the exact project.*stable mutation identity", "project mutation pre-read/identity missing"),
+    (artifact, r"exact existing started status.*idempotent no-op", "artifact idempotency contract missing"),
+    (artifact, r"completed or canceled project.*terminal conflict.*blocks", "artifact terminal blocking contract missing"),
+    (artifact, r"update only the project's native status field", "one-field project mutation contract missing"),
+    (artifact, r"Independently read back the exact project.*stable mutation identity", "project mutation read-back missing"),
     (driver, r"configured fast-model subagent", "driver fast model missing"),
 ]
 for text, pattern, message in checks:

--- a/skills/woostack-init/references/artifact-backends.md
+++ b/skills/woostack-init/references/artifact-backends.md
@@ -267,12 +267,35 @@ it never silently changes repository scope.
 Before every artifact mutation, verify the canonical repository association and resolved
 caller-selected workspace/team, then re-read the exact target and fields being changed. Write the
 smallest selected payload. Preserve unrelated human-authored content. Do not change assignee,
-delegate, status, labels, archival state, or unrelated relations/project membership. Build and
-selected standalone-plan synchronization may set current increment project membership and native
-dependency relations. It never creates or changes parent-child containment. The
-[project-backed workflow closure invariant](#project-backed-workflow-closure)
-is the sole workflow-owned status exception; other metadata changes require the caller's explicit
-request.
+delegate, status, labels, archival state, or unrelated relations/project membership, except for the
+[active Execute project-start synchronization](#active-execute-project-start-synchronization)
+exception and the [project-backed workflow closure invariant](#project-backed-workflow-closure).
+Build and selected standalone-plan synchronization may set current increment project membership and
+native dependency relations. It never creates or changes parent-child containment. Other metadata
+changes require the caller's explicit request.
+
+## Active Execute project-start synchronization
+
+Normal Execute has one narrow workflow-owned status exception: in both `--project` and `--issue`
+modes, an exact canonical nonterminal project is synchronized to the configured
+`projectStatuses.started` status when any current direct issue is canonically `In Progress` or `In
+Review`. Read the complete, paginated direct-issue set and the exact project's native identity,
+workspace/team, current status, and revision before resolving or mutating anything. Resolve
+`projectStatuses.started` to exactly one native project status and require its native category to be
+`started`; missing, invalid, ambiguous, foreign, drifted, or incompletely paginated resolution
+blocks.
+
+If every direct issue is still `Backlog`/`Todo`, defer this synchronization until the selected
+issue has transitioned to `In Progress` and that issue transition has independently read back.
+Then synchronize the same exact project before any worktree or source mutation. A completed or
+canceled project is a terminal conflict and blocks without reopening or continuing. Immediately
+before a needed project mutation, re-read the exact project and retain one stable mutation identity.
+An exact existing started status (stable native ID/name and `started` category) is an idempotent
+no-op; otherwise update only the project's native status field. Independently read back the exact
+project and verify its identity, started status ID/name/category, revision, and stable mutation
+identity. Timeout, partial or foreign output, mutation failure, or failed/unknown read-back blocks at
+that boundary without reopening or continuing. The project-status receipt is distinct from issue
+lifecycle and resume-checkpoint evidence.
 
 Use a stable client-generated operation ID when the host API exposes one. After mutation, perform a
 new independent complete read and compare:


### PR DESCRIPTION
## Goal

Keep the canonical Linear project at its configured started status whenever any admitted direct issue is In Progress or In Review.

## Summary

- Add the shared active-execution project-start contract with exact native-status resolution, idempotent no-op handling, terminal and unknown-state blocking, stable mutation identity, and independent read-back.
- Apply the gate to both `--project` and `--issue` execution, with deterministic controller ordering, six lifecycle eval cases, structural assertions, and authored configuration docs.

## Test plan

### Automated

- `bash skills/woostack-execute/tests/run-tests.sh` — passed.
- `node skills/woostack-eval/scripts/validate.mjs --package skills/woostack-execute --repository-root .` — passed; 12 behavior cases and 5 trigger cases validated.
- `pnpm -C site build` — passed; 144 static pages generated.

### Manual

- Exercised the six added lifecycle scenarios against the Execute contract; every asserted normalized outcome was observed. One initial model response for the In Review case was retried and then matched the contract.
- Opened `/docs/configuration` in Chromium and confirmed the rendered started/canceled status mapping copy includes In Progress, In Review, Backlog/Todo, and independent read-back behavior.

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [x] `README.md` / other top-level docs

## Notes for downstream projects

No data, application, dependency, or version migration. Installed woostack consumers receive the updated Execute and Linear artifact contracts.

## Checklist

- [x] Cross-links to related sections still resolve
- [x] No version numbers hard-coded in `frameworks.md` where "latest" suffices

Resolves WOO-160