### PR TITLE
docs: document isolated site dependency installs

### DIFF
--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -26,4 +26,8 @@ gitignored, so humanize the source `SKILL.md`, never the generated MDX.
 
 - Keep authored pages in sync with the skills they describe (see the root `AGENTS.md` hard
   constraints).
+- In an isolated worktree without `site/node_modules`, run
+  `pnpm -C site install --frozen-lockfile` from the repository root before building. Never
+  symlink `node_modules` from another checkout because Turbopack rejects dependency links that
+  point outside the current project root.
 - Run `pnpm build` to confirm the site still builds.


### PR DESCRIPTION
## Goal

Make isolated docs-site builds use dependencies installed inside the current worktree.

## Summary

- Require a frozen `site` dependency install when an isolated worktree has no `site/node_modules`.
- Prohibit cross-worktree `node_modules` symlinks because Turbopack rejects dependency links outside the current project root.

## Test plan

### Automated

- `git diff --check` — passed.

### Manual

- Confirmed `site/AGENTS.md` is the only changed path and contains both the frozen-install command and symlink prohibition.

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [x] `README.md` / other top-level docs

## Notes for downstream projects

No generated project or runtime behavior changes.

## Checklist

- [x] Cross-links to related sections still resolve
- [x] No version numbers hard-coded in `frameworks.md` where "latest" suffices