### PR TITLE
Harden plan checks and approval receipts

### DIFF
--- a/skills/woostack-init/references/artifact-backends.md
+++ b/skills/woostack-init/references/artifact-backends.md
@@ -190,6 +190,14 @@ grants a gate. A provider-native comment is not required and is not, by itself, 
 
 `approvedBy` is the responsible user's stable principal identity, `approvedAt` is the recorded
 approval event timestamp, and `approvalEventRef` is the stable Linear receipt/event reference.
+
+When the official MCP exposes a server-generated receipt identity only after event creation, create
+exactly one provisional event containing every approval-record field except `approvalEventRef`.
+That provisional event is allocation evidence, not an approval record, and it never clears any
+gate. Derive `approvalEventRef` from the returned stable native identity, update that same event
+exactly once, then independently read and verify the complete final record before continuing. An
+unknown create or update outcome blocks at that same identity; never allocate a second event,
+fabricate a reference, or treat a partial response as approval.
 The controller must independently verify those fields, the exact fingerprints and sets, and their
 causal order. Before execution, after every worker handback, before every redispatch, immediately
 before each commit, and before selecting another increment, independently re-read the exact

--- a/skills/woostack-init/scripts/tests/test-linear-only-contract.sh
+++ b/skills/woostack-init/scripts/tests/test-linear-only-contract.sh
@@ -55,6 +55,8 @@ for pattern, message in (
     (r"executionPlanApprovalRecord", "execution-plan approval record missing"),
     (r"project-specification change invalidates both.*issue or dependency change invalidates only", "approval invalidation rules missing"),
     (r"projectStatuses\.canceled", "canceled-status mapping missing"),
+    (r"server-generated.*approvalEventRef.*same.*event.*independently.*read", "server-generated approval receipt finalization missing"),
+    (r"provisional.*never clears.*gate", "provisional approval event can appear authoritative"),
 ):
     require("artifact-backends.md", contract, pattern, message)
 
@@ -79,6 +81,12 @@ if re.search(r"fixApprovalRecord|approve-to-execute|bind exactly one issue", fix
 plan = flat(root / "skills/woostack-plan/SKILL.md")
 require("woostack-plan", plan, r"`--project` is mandatory", "exact-project selection boundary missing")
 require("woostack-plan", plan, r"exactly one direct project issue for each execution increment", "direct-issue persistence missing")
+require(
+    "woostack-plan",
+    plan,
+    r"verification command.*repository-local script or path.*already exist.*predecessor increment.*same increment.*create",
+    "planned verification existence check missing",
+)
 
 change = flat(root / "skills/woostack-change/SKILL.md")
 require("woostack-change", change, r"(never reads or writes Linear|makes no Linear call)", "change is not Linear-free")

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -67,6 +67,13 @@ Every direct issue must retain these fields in its complete description:
 - a declared Graphite parent; and
 - a hand-written changed-line estimate and size rationale.
 
+Before admitting any verification command or smoke scenario, independently verify each named
+repository-local script or path already exists at the frozen base, is created by a predecessor
+increment whose native dependency orders it before use, or will be created by the same increment
+before use. Verify a manifest-defined command against its exact manifest entry and state any
+external runtime prerequisite. A missing or invented command blocks plan persistence; never defer
+existence checking to Execute.
+
 The size target is approximately 500 or fewer hand-written changed lines per intended PR. Generated
 files and lockfiles may exceed that target only when inseparable from the increment. One large
 exception is allowed only for an explicitly approved deletion-only PR that removes an already


### PR DESCRIPTION
## Goal
Prevent nonexistent verification commands from entering approved plans and define safe finalization for server-generated Linear approval receipt identities.

## Summary
- Require Plan to prove repository-local verification scripts and paths exist at the frozen base or are created by the same increment before persistence.
- Keep server-generated approval events provisional and non-authoritative until the same event contains its final `approvalEventRef` and is independently read back.
- Add focused structural coverage for both invariants.

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [x] `README.md` / other top-level docs

## Notes for downstream projects

No migration. This is a follow-up to #613 and preserves existing approval record schemas.

## Test plan
### Automated
- `bash skills/woostack-init/scripts/tests/test-linear-only-contract.sh` — passed
- `bash skills/woostack-build/tests/test-linear-build-contract.sh` — passed

### Manual
- A candidate plan naming a proven-missing repository script was blocked.
- A provisional server-generated receipt kept the gate closed and required updating the same event followed by independent read-back.

## Checklist

- [x] Cross-links to related sections still resolve
- [x] No version numbers hard-coded in `frameworks.md` where "latest" suffices