### PR TITLE
fix: remove dormant engineer-unit review mode

### DIFF
--- a/site/scripts/linear-only-docs.test.mjs
+++ b/site/scripts/linear-only-docs.test.mjs
@@ -13,37 +13,20 @@ const WOO_167_RESERVED_FILES = Object.freeze([
   'site/content/docs/concepts/engineer-agents.mdx',
   'site/content/docs/harnesses/hermes.mdx',
 ]);
-const WOO_166_DORMANT_REVIEW_LOCATIONS = Object.freeze(new Map([
-  ['skills/woostack-review/prompts/_worker-header.md', ['engineer-unit']],
-  ['skills/woostack-review/prompts/validator-prosecutor.md', ['engineer-unit']],
-  ['skills/woostack-review/prompts/validator.md', ['engineer-unit']],
-  ['skills/woostack-review/references/ci.md', ['Hermes']],
-  ['skills/woostack-review/scripts/resolve-outdir.sh', ['WOO_REVIEW_ENGINEER_UNIT']],
-  ['skills/woostack-review/scripts/run-bounded-swarm.sh', [
-    'WOO_REVIEW_ENGINEER_UNIT',
-    'WOO_REVIEW_IDENTITY_MANIFEST',
-    'reviewer-identities.json',
-  ]],
-  ['skills/woostack-review/scripts/verify-receipts.sh', [
-    'WOO_REVIEW_ENGINEER_UNIT',
-    'WOO_REVIEW_IDENTITY_MANIFEST',
-    'reviewer-identities.json',
-    'implementingCoder',
-    'decisionMaker',
-  ]],
-  ['skills/woostack-review/scripts/tests/test-bounded-swarm.sh', [
-    'WOO_REVIEW_ENGINEER_UNIT',
-    'reviewer-identities.json',
-    'implementingCoder',
-    'decisionMaker',
-  ]],
-  ['skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh', [
-    'WOO_REVIEW_ENGINEER_UNIT',
-    'reviewer-identities.json',
-    'implementingCoder',
-    'decisionMaker',
-  ]],
-]));
+const WOO_166_REVIEW_PATHS = Object.freeze([
+  'skills/woostack-review/prompts/_orchestrator-header.md',
+  'skills/woostack-review/prompts/_worker-header.md',
+  'skills/woostack-review/prompts/validator-prosecutor.md',
+  'skills/woostack-review/prompts/validator.md',
+  'skills/woostack-review/references/ci.md',
+  'skills/woostack-review/scripts/resolve-outdir.sh',
+  'skills/woostack-review/scripts/run-bounded-swarm.sh',
+  'skills/woostack-review/scripts/verify-receipts.sh',
+  'skills/woostack-review/scripts/tests/test-bounded-swarm.sh',
+  'skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh',
+  'skills/woostack-review/scripts/tests/test-review-payload-ranges.sh',
+  'skills/woostack-review/evals/evals.json',
+]);
 const REVIEW_MODE_MARKERS = Object.freeze([
   'WOO_REVIEW_ENGINEER_UNIT',
   'WOO_REVIEW_IDENTITY_MANIFEST',
@@ -84,7 +67,7 @@ const PATHS = [
   'site/content/docs/harnesses/omp.mdx',
   'skills/using-woostack/references/hosts/omp.md',
   'site/content/docs/harnesses/index.mdx',
-  ...WOO_166_DORMANT_REVIEW_LOCATIONS.keys(),
+  ...WOO_166_REVIEW_PATHS,
 ];
 
 let files;
@@ -464,31 +447,23 @@ test('approval relay remains responsible-user and receipt bound', () => {
   assert.match(contract, /Linear receipt\/event/i);
 });
 
-test('reserved WOO-167 assets and the WOO-166 mode remain present but unreachable', () => {
+test('reserved WOO-167 assets remain unreachable and the WOO-166 Review mode is absent', () => {
   assert.equal(WOO_167_RESERVED_FILES.length, 6, 'WOO-167 whole-file inventory must stay exact');
   for (const relativePath of WOO_167_RESERVED_FILES) {
     assert.ok(files.has(relativePath), `${relativePath}: retained WOO-167 asset was removed too early`);
   }
 
-  assert.equal(WOO_166_DORMANT_REVIEW_LOCATIONS.size, 9,
-    'WOO-166 mixed-file inventory must stay exact');
-  for (const [relativePath, markers] of WOO_166_DORMANT_REVIEW_LOCATIONS) {
+  assert.equal(WOO_166_REVIEW_PATHS.length, 12, 'WOO-166 focused path inventory must stay exact');
+  for (const relativePath of WOO_166_REVIEW_PATHS) {
     const content = read(relativePath);
-    for (const marker of markers) {
-      assert.ok(content.includes(marker), `${relativePath}: missing retained marker ${marker}`);
+    for (const marker of REVIEW_MODE_MARKERS) {
+      assert.ok(!content.includes(marker), `${relativePath}: removed Review marker remains: ${marker}`);
     }
-  }
-  const dormantReviewText = [...WOO_166_DORMANT_REVIEW_LOCATIONS.keys()]
-    .map((relativePath) => read(relativePath))
-    .join('\n');
-  for (const marker of REVIEW_MODE_MARKERS) {
-    assert.ok(dormantReviewText.includes(marker), `WOO-166 inventory omits exact marker ${marker}`);
+    assert.doesNotMatch(content, /engineer-unit|local\/Hermes|Hermes-direct|\bHermes\b/i,
+      `${relativePath}: removed Hermes-direct Review wording remains`);
   }
 
-  const reservedPaths = new Set([
-    ...WOO_167_RESERVED_FILES,
-    ...WOO_166_DORMANT_REVIEW_LOCATIONS.keys(),
-  ]);
+  const reservedPaths = new Set(WOO_167_RESERVED_FILES);
   const supportedPaths = [...new Set([...PATHS, ...authoredSitePaths])]
     .filter((relativePath) => !reservedPaths.has(relativePath));
   const retiredReference =
@@ -501,7 +476,7 @@ test('reserved WOO-167 assets and the WOO-166 mode remain present but unreachabl
     }
     for (const marker of REVIEW_MODE_MARKERS) {
       assert.ok(!content.includes(marker),
-        `${relativePath}: supported surface activates dormant Review marker ${marker}`);
+        `${relativePath}: supported surface activates removed Review marker ${marker}`);
     }
     if (relativePath !== 'site/content/docs/hermes.mdx') {
       assert.doesNotMatch(content, /\b(?:launch-omp|bind-engineer-unit)\b/,

--- a/skills/using-woostack/tests/test-harness-agent-boundary.sh
+++ b/skills/using-woostack/tests/test-harness-agent-boundary.sh
@@ -154,45 +154,22 @@ woo167_reserved_files = (
 for relative in woo167_reserved_files:
     read_raw(relative)
 
-# WOO-166 owns only these mixed-file dormant Review branches/tests/prompt contracts.
-# The marker map records their current boundaries without snapshotting their prose.
-woo166_dormant_locations = {
-    "skills/woostack-review/prompts/_worker-header.md": ("engineer-unit",),
-    "skills/woostack-review/prompts/validator-prosecutor.md": ("engineer-unit",),
-    "skills/woostack-review/prompts/validator.md": ("engineer-unit",),
-    "skills/woostack-review/references/ci.md": ("Hermes",),
-    "skills/woostack-review/scripts/resolve-outdir.sh": ("WOO_REVIEW_ENGINEER_UNIT",),
-    "skills/woostack-review/scripts/run-bounded-swarm.sh": (
-        "WOO_REVIEW_ENGINEER_UNIT",
-        "WOO_REVIEW_IDENTITY_MANIFEST",
-        "reviewer-identities.json",
-    ),
-    "skills/woostack-review/scripts/verify-receipts.sh": (
-        "WOO_REVIEW_ENGINEER_UNIT",
-        "WOO_REVIEW_IDENTITY_MANIFEST",
-        "reviewer-identities.json",
-        "implementingCoder",
-        "decisionMaker",
-    ),
-    "skills/woostack-review/scripts/tests/test-bounded-swarm.sh": (
-        "WOO_REVIEW_ENGINEER_UNIT",
-        "reviewer-identities.json",
-        "implementingCoder",
-        "decisionMaker",
-    ),
-    "skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh": (
-        "WOO_REVIEW_ENGINEER_UNIT",
-        "reviewer-identities.json",
-        "implementingCoder",
-        "decisionMaker",
-    ),
-}
-for relative, markers in woo166_dormant_locations.items():
-    body = read_raw(relative)
-    for marker in markers:
-        if marker not in body:
-            failures.append(f"{relative}: retained WOO-166 marker missing: {marker}")
-
+# WOO-166 removes the dormant mixed-file Review mode while retaining one generic
+# local advisory path and the CI path.
+woo166_review_paths = (
+    "skills/woostack-review/prompts/_orchestrator-header.md",
+    "skills/woostack-review/prompts/_worker-header.md",
+    "skills/woostack-review/prompts/validator-prosecutor.md",
+    "skills/woostack-review/prompts/validator.md",
+    "skills/woostack-review/references/ci.md",
+    "skills/woostack-review/scripts/resolve-outdir.sh",
+    "skills/woostack-review/scripts/run-bounded-swarm.sh",
+    "skills/woostack-review/scripts/verify-receipts.sh",
+    "skills/woostack-review/scripts/tests/test-bounded-swarm.sh",
+    "skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh",
+    "skills/woostack-review/scripts/tests/test-review-payload-ranges.sh",
+    "skills/woostack-review/evals/evals.json",
+)
 exact_review_mode_markers = (
     "WOO_REVIEW_ENGINEER_UNIT",
     "WOO_REVIEW_IDENTITY_MANIFEST",
@@ -200,11 +177,28 @@ exact_review_mode_markers = (
     "implementingCoder",
     "decisionMaker",
 )
-retained_review_text = "\n".join(read_raw(path) for path in woo166_dormant_locations)
-for marker in exact_review_mode_markers:
-    if marker not in retained_review_text:
-        failures.append(f"WOO-166 inventory does not retain exact marker: {marker}")
+for relative in woo166_review_paths:
+    body = read_raw(relative)
+    for marker in exact_review_mode_markers:
+        if marker in body:
+            failures.append(f"{relative}: removed Review marker remains: {marker}")
+    if re.search(r"engineer-unit|local/Hermes|Hermes-direct|\bHermes\b", body, re.I):
+        failures.append(f"{relative}: removed Hermes-direct Review wording remains")
 
+review_runtime = " ".join(read(path) for path in woo166_review_paths)
+require(review_runtime, r"generic local", "Review no longer documents one generic local path")
+require(review_runtime, r"authority[\"`: ]+advisory-only|advisory-only authority",
+        "Review no longer requires advisory worker authority")
+require(review_runtime, r"missing.*receipt.*hard-fail|hard-fails.*missing.*receipt",
+        "Review no longer hard-fails a missing local worker receipt")
+require(review_runtime, r"github-actions-single-session",
+        "Review no longer retains the CI single-session sentinel")
+require(review_runtime, r"fresh read-only advisory reviewer session",
+        "Review no longer keeps local workers read-only")
+require(review_runtime, r"prosecutor.*defender.*intersect|intersection.*prosecutor.*defender",
+        "Review no longer retains both validator passes and intersection")
+require(review_runtime, r"native GitHub.*IDs.*differ|native actor-ID gate",
+        "Review no longer retains the native GitHub actor safeguard")
 # Scan every supported source and authored text surface. Reserved bodies, their tests, and
 # assertion-only boundary tests are records rather than callsites; generated, gitignored skill
 # pages mirror their source and are not a second surface. The top-level guide is scanned for mode
@@ -215,7 +209,7 @@ assertion_only_paths = {
     "skills/woostack-doctor/scripts/tests/test-omp-agents.sh",
     "site/scripts/linear-only-docs.test.mjs",
 }
-reserved_paths = set(woo167_reserved_files) | set(woo166_dormant_locations)
+reserved_paths = set(woo167_reserved_files)
 text_suffixes = {".md", ".mdx", ".sh", ".mjs", ".js", ".json", ".yml", ".yaml"}
 skip_parts = {".git", ".next", ".woostack", "node_modules"}
 supported_texts = {}
@@ -267,7 +261,7 @@ for relative, body in supported_texts.items():
         failures.append(f"{relative}: supported surface reaches a reserved launcher")
     for marker in exact_review_mode_markers:
         if marker in body:
-            failures.append(f"{relative}: supported surface activates dormant Review marker {marker}")
+            failures.append(f"{relative}: supported surface activates removed Review marker {marker}")
 if failures:
     print("FAIL: external-engineer and harness boundary", file=sys.stderr)
     for failure in failures:

--- a/skills/woostack-review/SKILL.md
+++ b/skills/woostack-review/SKILL.md
@@ -87,15 +87,25 @@ block posting rather than silently reducing coverage.
 
 ### 3. Run both adversarial validators
 
-Run two fresh read-only validator sessions against the same complete `raw_findings.json` and exact
-reviewed head, using [`prompts/validator.md`](prompts/validator.md):
+Run the required fresh read-only validator sessions against the same complete
+`raw_findings.json` and exact reviewed head. Normal adversarial mode runs the Prosecutor with
+[`prompts/validator-prosecutor.md`](prompts/validator-prosecutor.md) and the Defender with
+[`prompts/validator.md`](prompts/validator.md); a valid config with `disable_adversarial: true`
+intentionally runs only the Defender.
 
-- Prosecutor writes `$OUTDIR/findings.prosecutor.json`.
-- Defender writes `$OUTDIR/findings.defender.json`.
+- Prosecutor writes `$OUTDIR/findings.prosecutor.json` and `$OUTDIR/receipt.prosecutor.json`.
+- Defender writes `$OUTDIR/findings.defender.json` and `$OUTDIR/receipt.defender.json`.
 
-Verify both validator receipts, then run `scripts/intersect-findings.sh`. The resulting
-**prosecutor/defender intersection** in `$OUTDIR/findings.json` is the only accepted finding set.
-One validator, a self-review, or a union of unvalidated worker output is not a completed pass.
+Immediately before intersection, run the exact validator receipt gate and then the intersection:
+
+```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/verify-receipts.sh" --validators
+bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
+```
+
+The resulting **prosecutor/defender intersection** in `$OUTDIR/findings.json` is the only accepted
+finding set in normal mode. A missing/invalid required receipt, self-review, or union of
+unvalidated worker output is not a completed pass and blocks posting.
 
 ### 4. Post every accepted finding and one verdict
 
@@ -124,7 +134,7 @@ that was not independently observed.
 ## Hard constraints
 
 - One exact existing PR and one standard public command.
-- One detected multi-angle pass, then both Prosecutor and Defender, then deterministic intersection.
+- One detected multi-angle pass, then both validators normally (Defender only under the explicit config opt-out), then deterministic intersection.
 - Every accepted blocker and nit is posted to that exact PR.
 - Blockers request changes; no-blocker and nit-only results do not block.
 - Review workers are read-only; Review never edits code or merges.

--- a/skills/woostack-review/prompts/_worker-header.md
+++ b/skills/woostack-review/prompts/_worker-header.md
@@ -15,12 +15,11 @@ Every artifact you write under `$OUTDIR/findings.*.json` (default `/tmp/pr-revie
 - **Write your execution receipt as your LAST action.** After writing your real findings array, and
   just before EXIT, write `$OUTDIR/receipt.<angle>.json` (chunked:
   `$OUTDIR/receipt.<angle>.<chunk>.json`) as a JSON object:
-  `{"angle":"<angle>","chunk":<chunk-id-or-null>,"runner":"<host or provider>","model":"<resolved model>","tier":"<fast|standard|deep>","ts":"<ISO-8601 timestamp>","reviewerProfile":"<host-bound reviewer profile>","reviewerSessionId":"<fresh reviewer session ID>","reviewerPrincipalId":"<native reviewer principal ID>","reviewerCredentialContextId":"<non-secret reviewer credential-context ID>","authority":"advisory-only"}`.
-  `runner`, `model`, and every supplied reviewer-identity field MUST be non-empty. In an
-  engineer-unit run, copy the exact non-secret reviewer binding supplied by the controller; never
-  infer it, substitute the implementing coder or decision-maker, or use a profile/token-store name
-  as a native principal. `verify-receipts.sh` compares it with the controller-owned identity
-  manifest and rejects a missing, foreign, shared-session, or shared-credential binding.
+  `{"angle":"<angle>","chunk":<chunk-id-or-null>,"runner":"<host or provider>","model":"<resolved model>","tier":"<fast|standard|deep>","ts":"<ISO-8601 timestamp>","authority":"advisory-only"}`.
+  `runner`, `model`, and `tier` MUST be non-empty. A generic local worker SHOULD additionally
+  report its real non-secret host binding as the complete set `reviewerProfile`,
+  `reviewerSessionId`, `reviewerPrincipalId`, and `reviewerCredentialContextId` when those values
+  are available; never infer them or use a profile/token-store name as a native principal.
 - In the GitHub Actions single-session path, bind the receipt to the producing job attempt:
   `reviewerProfile:"github-actions-single-session"`,
   `reviewerRunAttempt:<GITHUB_RUN_ATTEMPT>`,
@@ -32,21 +31,19 @@ Every artifact you write under `$OUTDIR/findings.*.json` (default `/tmp/pr-revie
   therefore accepts downloaded receipts from an earlier successful producer attempt without
   detaching them from that attempt. This CI sentinel is diff-only execution identity, not a
   development principal or issue authority.
-  A generic non-paired local run without a controller manifest SHOULD report its real host binding
-  when available. Any `reviewerPrincipalId` here binds worker execution only: it is not the native
-  GitHub posting actor ID and can never substitute for the independent GitHub actor read-backs at
-  verdict time.
+  A generic local run SHOULD report its real host binding when available. Any
+  `reviewerPrincipalId` here binds worker execution only: it is not the native GitHub posting
+  actor ID and can never substitute for the independent GitHub actor read-backs at verdict time.
 
-In an engineer-unit run, `$OUTDIR` is a private per-worker namespace outside the implementation
-repository. `$WOO_REVIEW_BINDING_PATH` names the only controller-supplied identity record this
-worker may read. Copy its exact profile, session, principal, and credential-context values into
-the receipt; never scan for or infer peer bindings. Write only this work item's designated
-`findings.*.json` and `receipt.*.json` outputs. The controller harvests those two files after
-execution and independently verifies repository immutability and receipt identity.
+Every local angle worker and validator runs as a fresh read-only advisory reviewer session,
+separate from the coding session. The parent harness owns that isolation: workers may read the
+prefetched review artifacts and write only their designated `findings.*.json` and
+`receipt.*.json` outputs under `$OUTDIR`. They cannot edit the implementation repository, post or
+accept a review, merge, or silently reduce the detected angle or validator set.
 - The receipt distinguishes honest `[]` from a worker that never ran, but it proves execution only
   and is never authoritative contract context, Linear read-back, `reviewResult`, or work acceptance.
-  Missing/invalid identity or any authority other than `"advisory-only"` HARD-FAILS before merge,
-  validation, or post.
+  A missing receipt, invalid required field, incomplete supplied reviewer identity, or any authority
+  other than `"advisory-only"` HARD-FAILS before merge, validation, or post.
 - If your runtime offers a "write file" tool, use it directly — do NOT echo the JSON through a chat channel that prepends prose.
 - **Escape discipline inside string fields.** Every `"description"`, `"fix"`, and `"suggestion"` is a JSON string — inside it, the only valid backslash escapes are `\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`, and `\uXXXX`. Bare backslashes in code samples (Windows paths, regex like `\d`, LaTeX) MUST be doubled to `\\`. Tabs and newlines in code samples MUST be `\t` / `\n`, never raw control bytes. The merge step has a fallback sanitizer, but a finding that loses content during sanitization is one that fails to land cleanly on the PR.
 - Before writing each finding's `line` and optional `end_line`, validate the anchor via:
@@ -63,7 +60,7 @@ execution and independently verifies repository immutability and receipt identit
 - **PR metadata** (title, body, headRefOid, headRefName, baseRefName, files, author): `/tmp/pr-review/meta.json`
 - **Enabled angles** (one per line): `/tmp/pr-review/angles.txt`
 - **Project rules** (optional, present only if discovered): `/tmp/pr-review/rules.md`
-- **Current contract** (optional; local/Hermes only): `$OUTDIR/intent.md` — created by the parent
+- **Current contract** (optional; local coding harness only): `$OUTDIR/intent.md` — created by the parent
   controller from the active caller-approved contract under `workflow://active-contract`
   provenance. Exact Linear artifact fields may be appended under `linear://project/<uuid>` or
   `linear://issue/<uuid>` only after official-MCP verification. Its presence enables the

--- a/skills/woostack-review/prompts/anthropic.md
+++ b/skills/woostack-review/prompts/anthropic.md
@@ -134,7 +134,7 @@ Launch one `claude-opus-4-8` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/vali
 
 ### Step 3b — Defender pass
 
-Launch one `claude-opus-4-8` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` as its prompt. It applies the strict "defense attorney" filter — drops pedantic / lint-catchable / maybe-issues / placeholder-suggestion findings — and writes `$OUTDIR/findings.defender.json`. It writes `$OUTDIR/findings.defender.json` and EXITs — it does NOT run the intersect script or post (the orchestrator does that next). Apply only `validator.md`'s validation/filter rules (its Steps 1–2) to produce `findings.defender.json`; IGNORE validator.md's Step 3/3b/4 and its STOP-GATE — the orchestrator runs the intersect itself in the next step.
+Launch one `claude-opus-4-8` subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` as its prompt. It applies the strict "defense attorney" filter — drops pedantic / lint-catchable / maybe-issues / placeholder-suggestion findings — and writes `$OUTDIR/findings.defender.json`. It writes `$OUTDIR/findings.defender.json` and EXITs — it does NOT run the receipt gate, intersect script, or post (the orchestrator does those next). Apply `validator.md` through its validator receipt, then stop at its local-worker exit gate; the orchestrator runs the receipt gate and intersection itself in the next step.
 
 The two passes MUST be sequential — the prosecutor's file must already exist before the defender runs when adversarial mode is on.
 
@@ -143,6 +143,7 @@ The two passes MUST be sequential — the prosecutor's file must already exist b
 After both validator subagents finish, the orchestrator (this session) runs:
 
 ```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/verify-receipts.sh" --validators
 bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
 ```
 

--- a/skills/woostack-review/prompts/google.md
+++ b/skills/woostack-review/prompts/google.md
@@ -118,7 +118,7 @@ Spawn one subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator-prosecutor.md
 
 ### Phase 3b — Defender pass
 
-Spawn one subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` as its brief. It applies the strict "defense attorney" filter — drops pedantic / lint-catchable / maybe-issues / placeholder-suggestion findings — and writes `$OUTDIR/findings.defender.json`. It writes `$OUTDIR/findings.defender.json` and EXITs — it does NOT run the intersect script or post (the orchestrator does that next). Apply only `validator.md`'s validation/filter rules (its Steps 1–2) to produce `findings.defender.json`; IGNORE validator.md's Step 3/3b/4 and its STOP-GATE — the orchestrator runs the intersect itself in the next phase.
+Spawn one subagent with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` as its brief. It applies the strict "defense attorney" filter — drops pedantic / lint-catchable / maybe-issues / placeholder-suggestion findings — and writes `$OUTDIR/findings.defender.json`. It writes `$OUTDIR/findings.defender.json` and EXITs — it does NOT run the receipt gate, intersect script, or post (the orchestrator does those next). Apply `validator.md` through its validator receipt, then stop at its local-worker exit gate; the orchestrator runs the receipt gate and intersection itself in the next phase.
 
 The two passes MUST be sequential — the prosecutor's file must already exist before the defender runs when adversarial mode is on.
 
@@ -127,6 +127,7 @@ The two passes MUST be sequential — the prosecutor's file must already exist b
 After both validator subagents finish, the orchestrator (this session) runs:
 
 ```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/verify-receipts.sh" --validators
 bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
 ```
 

--- a/skills/woostack-review/prompts/openai.md
+++ b/skills/woostack-review/prompts/openai.md
@@ -105,11 +105,12 @@ Apply `$WOO_REVIEW_ACTION_PATH/prompts/validator-prosecutor.md` against `raw_fin
 
 ### Phase 3b — Defender pass
 
-Apply `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` against `raw_findings.json`. Bias: try to prove each finding wrong; drop pedantic / lint-catchable / "maybe" findings; enforce the comment-shape + `fix_type` rules. Write surviving findings to `$OUTDIR/findings.defender.json`. Apply only `validator.md`'s validation/filter rules (its Steps 1–2) to produce `findings.defender.json`; IGNORE validator.md's Step 3/3b/4 and its STOP-GATE — the orchestrator runs the intersect itself in the next phase.
+Apply `$WOO_REVIEW_ACTION_PATH/prompts/validator.md` against `raw_findings.json`. Bias: try to prove each finding wrong; drop pedantic / lint-catchable / "maybe" findings; enforce the comment-shape + `fix_type` rules. Write surviving findings to `$OUTDIR/findings.defender.json`, then write its validator receipt as the pass's final action. Stop at the local-worker exit gate; the orchestrator runs the receipt gate and intersection itself in the next phase.
 
 ### Phase 3c — Intersect
 
 ```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/verify-receipts.sh" --validators
 bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
 ```
 

--- a/skills/woostack-review/prompts/opencode.md
+++ b/skills/woostack-review/prompts/opencode.md
@@ -97,11 +97,12 @@ If the OpenCode runtime supports per-call routing, spawn a `deep`-tier subagent 
 
 ### Phase 3b — Defender pass
 
-Spawn another `deep`-tier subagent (or continue the main loop) with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md`. Bias: defense attorney — drop pedantic / lint-catchable / "maybe" findings, enforce comment-shape + `fix_type` rules. Write surviving findings to `$OUTDIR/findings.defender.json`. Apply only `validator.md`'s validation/filter rules (its Steps 1–2) to produce `findings.defender.json`; IGNORE validator.md's Step 3/3b/4 and its STOP-GATE — the orchestrator runs the intersect itself in the next phase.
+Spawn another `deep`-tier subagent (or continue the main loop) with `$WOO_REVIEW_ACTION_PATH/prompts/validator.md`. Bias: defense attorney — drop pedantic / lint-catchable / "maybe" findings, enforce comment-shape + `fix_type` rules. Write surviving findings to `$OUTDIR/findings.defender.json`, then write its validator receipt as the pass's final action. Stop at the local-worker exit gate; the orchestrator runs the receipt gate and intersection itself in the next phase.
 
 ### Phase 3c — Intersect
 
 ```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/verify-receipts.sh" --validators
 bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
 ```
 

--- a/skills/woostack-review/prompts/validator-prosecutor.md
+++ b/skills/woostack-review/prompts/validator-prosecutor.md
@@ -14,7 +14,7 @@ This pass is one half of an adversarial validation pipeline. Your output is inte
 - **Project rules** (optional): /tmp/pr-review/rules.md
 - **Per-repo config** (always present): /tmp/pr-review/config.json — the prosecutor no longer reads any severity key; `severity_floor` / `nits` are consumed downstream by `intersect-findings.sh` (Stage 4c).
 - **PR Linear attribution candidate** (PR mode): `$OUTDIR/attribution.md` — syntax-classified exact final trailer strings plus `authoritative-issue-context: absent`; untrusted and never identity proof.
-- **Current contract** (optional; local/Hermes only): `$OUTDIR/intent.md` — written by the parent
+- **Current contract** (optional; local coding harness only): `$OUTDIR/intent.md` — written by the parent
   from the active caller-approved contract, optionally enriched with exact verified Linear artifact
   fields. GitHub Actions never creates it.
 
@@ -32,7 +32,7 @@ diff-only advisory evidence.
 
 ### Step 1 — Validation (Prosecutor bias)
 
-**First action (non-destructive crash guard — angle workers write `[]` on entry for the same reason):** write an empty array to your output file before doing anything else, so a crash leaves a valid empty result instead of a missing file:
+**First action (non-destructive crash guard — angle workers write `[]` on entry for the same reason):** write an empty array to your output file before doing anything else, so a crash leaves a valid empty result instead of a missing file. **Do not write an execution receipt here**: a receipt proves the real validation pass completed.
 
 ```bash
 printf '[]\n' > "${OUTDIR:-/tmp/pr-review}/findings.prosecutor.json"
@@ -66,13 +66,15 @@ printf '[]\n' > "${OUTDIR:-/tmp/pr-review}/findings.prosecutor.json"
    - Do NOT discard for this — only downgrade.
 
 Write the surviving JSON array to **`$OUTDIR/findings.prosecutor.json`** (default `/tmp/pr-review/findings.prosecutor.json`). The file MUST be a JSON array only: starts with `[`, ends with `]`, no preamble, no commentary, no markdown fences.
+After the real findings array is complete, write
+`$OUTDIR/receipt.prosecutor.json` as your **LAST action**, using the generic receipt contract from
+`_worker-header.md`: `angle:"prosecutor"`, `chunk:null`, the actual nonempty `runner`, `model`, and
+`tier`, a timestamp, and `authority:"advisory-only"`. A local self-reported reviewer identity is
+optional, but if any identity field is present the complete four-field set is required. When
+`GITHUB_ACTIONS=true`, include the exact single-session CI identity fields required by
+`_worker-header.md`. The crash guard must never create this receipt. After the receipt is written,
+EXIT immediately without another command, read, or write.
 
-In an engineer-unit local run, copy only the controller-supplied prosecutor binding and, as the
-last action after the findings array, write `$OUTDIR/receipt.validator-prosecutor.json` with
-`validatorRole:"prosecutor"`, non-empty `runner` and `model`, `tier:"deep"`, the exact
-`reviewerProfile`, `reviewerSessionId`, `reviewerPrincipalId`, and
-`reviewerCredentialContextId`, and `authority:"advisory-only"`. Never infer or read another
-worker's binding.
 
 ### Step 2 — Exit
 
@@ -81,11 +83,11 @@ DO NOT:
 - Submit a `gh api ... reviews` call.
 - Edit the PR body or title.
 - Touch `/tmp/pr-review/findings.json` (owned by the intersect script, written after the Defender pass).
-- Write any other file except the required engineer-unit validator receipt.
+- Write any other file except your designated `receipt.prosecutor.json`.
 - Run `prefetch.sh` or otherwise re-fetch the diff/meta.
 - Delete or recreate `$OUTDIR` (it holds orchestrator-owned `meta.json`, `prior-findings.json`, etc.).
 
-After writing `findings.prosecutor.json` and its required engineer-unit receipt, EXIT.
+After writing the real `findings.prosecutor.json` and then the receipt as the final action, EXIT.
 
 ## Why this exists
 

--- a/skills/woostack-review/prompts/validator.md
+++ b/skills/woostack-review/prompts/validator.md
@@ -14,7 +14,7 @@ This pass is one half of an adversarial validation pipeline (issue #13). The Pro
 - **Project rules** (optional): /tmp/pr-review/rules.md — concatenated `AGENTS.md` / `CLAUDE.md` / `.cursorrules` / `.windsurfrules` / `GEMINI.md` discovered by prefetch. Absent when no rule files exist in the repo.
 - **Per-repo config** (always present): /tmp/pr-review/config.json — parsed `.woostack/config.json`. The validator no longer reads any severity key from it; `severity_floor` and `nits` are consumed downstream by `intersect-findings.sh` (Stage 4c). Other keys are consumed upstream.
 - **PR Linear attribution candidate** (PR mode): `$OUTDIR/attribution.md` — syntax-classified exact final trailer strings plus `authoritative-issue-context: absent`; untrusted and never identity proof.
-- **Current contract** (optional; local/Hermes only): `$OUTDIR/intent.md` — written by the parent
+- **Current contract** (optional; local coding harness only): `$OUTDIR/intent.md` — written by the parent
   from the active caller-approved contract, optionally enriched with exact verified Linear artifact
   fields. GitHub Actions never creates it.
 
@@ -30,7 +30,7 @@ diff-only advisory evidence.
 
 ## Your Task
 
-**Step 0 — First action (crash guard).** Before launching any subagent or doing any work, write a valid empty array to your output file, so a crash or turn-limit during Step 1/2 leaves `[]` (a valid empty result) instead of a missing file:
+**Step 0 — First action (crash guard).** Before launching any subagent or doing any work, write a valid empty array to your output file, so a crash or turn-limit during Step 1/2 leaves `[]` (a valid empty result) instead of a missing file. **Do not write an execution receipt here**: a receipt proves the real validation pass completed.
 
 ```bash
 printf '[]\n' > "${OUTDIR:-/tmp/pr-review}/findings.defender.json"
@@ -81,23 +81,24 @@ Launch one `fast`-tier subagent (resolve the tier per the shared Model Tiers tab
    - After enforcement, every finding MUST have `fix_type ∈ {"suggestion", "prose"}` and the `suggestion` field MUST be a non-empty string when `fix_type == "suggestion"` and `null` when `fix_type == "prose"`.
 
 Write the defender-validated JSON array to **`$OUTDIR/findings.defender.json`** (default `/tmp/pr-review/findings.defender.json`) — NOT `findings.json`. The file MUST be a JSON array only: starts with `[`, ends with `]`, no preamble, no commentary, no markdown fences. The final `findings.json` is produced by the intersect script in Step 3.
+After the real findings array is complete, write `$OUTDIR/receipt.defender.json` as the
+**LAST action of the validator pass**, using the generic receipt contract from
+`_worker-header.md`: `angle:"defender"`, `chunk:null`, the actual nonempty `runner`, `model`, and
+`tier`, a timestamp, and `authority:"advisory-only"`. A local self-reported reviewer identity is
+optional, but if any identity field is present the complete four-field set is required. When
+`GITHUB_ACTIONS=true`, include the exact single-session CI identity fields required by
+`_worker-header.md`. The crash guard must never create this receipt. A local swarm worker exits
+immediately after this final action; the sequential CI session may continue only into the
+controller-owned gate/intersection/posting tail below.
 
-In an engineer-unit local run, copy only the controller-supplied defender binding and, as the last
-action after the findings array, write `$OUTDIR/receipt.validator-defender.json` with
-`validatorRole:"defender"`, non-empty `runner` and `model`, `tier:"deep"`, the exact
-`reviewerProfile`, `reviewerSessionId`, `reviewerPrincipalId`, and
-`reviewerCredentialContextId`, and `authority:"advisory-only"`. Never infer or read another
-worker's binding.
 
 ---
 
 > ## STOP GATE — are you a swarm worker or the sequential validator?
 >
-> Steps 3 and 4 below (intersect + **posting the GitHub review**) run **ONLY** when the environment variable `WOO_REVIEW_SEQUENTIAL_VALIDATE=1` is set. That variable is set **exclusively** by the GitHub Action's `validate` mode, where a single agent owns the whole tail of the pipeline.
+> Steps 3 and 4 below (receipt gate + intersect + **posting the GitHub review**) run **ONLY** when the environment variable `WOO_REVIEW_SEQUENTIAL_VALIDATE=1` is set. That variable is set **exclusively** by the GitHub Action's `validate` mode, where a single agent owns the whole tail of the pipeline.
 >
-> **If `WOO_REVIEW_SEQUENTIAL_VALIDATE` is unset or not `1`, you are a swarm worker (SKILL.md Stage 4b).** Your job ended at Step 2: you have written `$OUTDIR/findings.defender.json` and, for an engineer-unit run, its validator receipt. **EXIT NOW.** The host orchestrator owns intersect (Stage 4c) and posting (Stage 5). Do NOT run `intersect-findings.sh`, do NOT `mv` over `findings.json`, do NOT post a review, do NOT re-run `prefetch.sh`, and do NOT delete or recreate `$OUTDIR`.
->
-> Enforce it after writing the findings and any required engineer-unit receipt: `[ "${WOO_REVIEW_SEQUENTIAL_VALIDATE:-}" = "1" ] || { echo "swarm worker — defender artifacts written; EXITing before Step 3"; exit 0; }`
+> Determine this mode before the final receipt write. **If `WOO_REVIEW_SEQUENTIAL_VALIDATE` is unset or not `1`, you are a swarm worker (SKILL.md Stage 4b).** Write the real `$OUTDIR/findings.defender.json`, then `$OUTDIR/receipt.defender.json` as your final action, and **EXIT NOW without another command**. The host orchestrator owns receipt verification, intersect (Stage 4c), and posting (Stage 5). Do NOT run `verify-receipts.sh`, do NOT run `intersect-findings.sh`, do NOT `mv` over `findings.json`, do NOT post a review, do NOT re-run `prefetch.sh`, and do NOT delete or recreate `$OUTDIR`.
 
 ---
 
@@ -105,14 +106,20 @@ worker's binding.
 
 ### Step 3 — Intersect with Prosecutor pass *(SEQUENTIAL / CI ONLY — requires `WOO_REVIEW_SEQUENTIAL_VALIDATE=1`; swarm workers already EXITed above)*
 
-Run the deterministic intersection script. It reads `findings.prosecutor.json` + `findings.defender.json`, applies the merge rules (severity = min, blocking = AND, defender's prose wins), writes `/tmp/pr-review/findings.json`, and emits per-pass counts to `/tmp/pr-review/validator-metrics.json`.
+Verify the required validator role receipts immediately before running the deterministic
+intersection script. The verifier requires both exact roles in normal adversarial mode and only
+the Defender when a valid `config.json` intentionally sets `disable_adversarial:true`. The
+intersection reads `findings.prosecutor.json` + `findings.defender.json`, applies the merge rules
+(severity = min, blocking = AND, defender's prose wins), writes `/tmp/pr-review/findings.json`, and
+emits per-pass counts to `/tmp/pr-review/validator-metrics.json`.
 
 ```bash
+bash "$WOO_REVIEW_ACTION_PATH/scripts/verify-receipts.sh" --validators
 bash "$WOO_REVIEW_ACTION_PATH/scripts/intersect-findings.sh"
 ```
 
 Notes:
-- If `disable_adversarial: true` is set in `/tmp/pr-review/config.json`, OR if `findings.prosecutor.json` is missing/empty (e.g. the Prosecutor pass was not scheduled), the script copies your defender output verbatim to `findings.json` and tags the metrics as `mode: defender-only`. No special handling required from you.
+- If `disable_adversarial: true` is set in a valid `/tmp/pr-review/config.json`, the verified Defender-only path copies your output verbatim to `findings.json`. Otherwise, a missing or invalid Prosecutor or Defender receipt blocks before intersection.
 - After this step, `findings.json` is the intersected set that Step 4 posts. Do not re-read `findings.defender.json` for posting.
 
 ### Step 4 — Post Native PR Review *(SEQUENTIAL / CI ONLY — swarm workers already EXITed above)*

--- a/skills/woostack-review/references/ci.md
+++ b/skills/woostack-review/references/ci.md
@@ -8,8 +8,8 @@ detect ─► fan-out (parallel angle workers) ─► merge ─► skeptical val
 
 The first-party composite action in `action.yml` and reusable workflow in
 `.github/workflows/reusable-review.yml` ship a **diff-only advisory** review. GitHub Actions has no
-host-exposed Linear MCP channel, so this path deliberately differs from a local/Hermes review:
-it never reads the managed issue contract and never runs the contract-aware `acceptance` angle.
+host-exposed Linear MCP channel, so this path deliberately differs from a local coding-harness
+review: it never reads the managed issue contract and never runs the contract-aware `acceptance` angle.
 
 ## Companion GitHub Action
 
@@ -70,7 +70,7 @@ secret store under the canonical
 - Worker execution receipts and the posted GitHub Review are advisory-only evidence. Even an
   `APPROVE` event means only the native GitHub code-review verdict; it claims neither Linear
   read-back nor issue acceptance.
-- A separately authenticated Hermes controller or responsible human may later resolve the exact
+- A separately authenticated controller or responsible human may later resolve the exact
   attribution through official MCP and reconcile the GitHub receipt under the canonical
   [status conventions](../../woostack-status/references/conventions.md). That is a separate read,
   authority check, and typed-event workflow; CI never performs or predicts it.

--- a/skills/woostack-review/scripts/resolve-outdir.sh
+++ b/skills/woostack-review/scripts/resolve-outdir.sh
@@ -24,18 +24,11 @@ if [ -z "${OUTDIR:-}" ]; then
   # shellcheck source=skills/woostack-review/scripts/resolve-root.sh
   source "$(dirname "${BASH_SOURCE[0]:-$0}")/resolve-root.sh"
   _wr_hash="$(printf '%s' "$WOOSTACK_ROOT" | { sha1sum 2>/dev/null || shasum; } | cut -c1-12)"
-  # Engineer-unit workers must never receive a writable path inside the implementation
-  # repository. Keep that default external even when the workspace has .woostack.
-  case "${WOO_REVIEW_ENGINEER_UNIT:-}" in
-    1|true|yes) _wr_base="/tmp" ;;
-    *)
-      if [ -d "${WOOSTACK_ROOT}/.woostack" ]; then
-        _wr_base="${WOOSTACK_ROOT}/.woostack/tmp"
-      else
-        _wr_base="/tmp"
-      fi
-      ;;
-  esac
+  if [ -d "${WOOSTACK_ROOT}/.woostack" ]; then
+    _wr_base="${WOOSTACK_ROOT}/.woostack/tmp"
+  else
+    _wr_base="/tmp"
+  fi
   if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
     OUTDIR="${_wr_base}/pr-review-${_wr_hash}"
   else

--- a/skills/woostack-review/scripts/run-bounded-swarm.sh
+++ b/skills/woostack-review/scripts/run-bounded-swarm.sh
@@ -8,12 +8,8 @@ Usage: run-bounded-swarm.sh [--max-concurrency N] -- <worker command...>
 Runs detected woostack-review work items from $OUTDIR/angles.txt and, when
 present, $OUTDIR/chunks.txt. By default it starts every work item and lets the
 host manage scheduling pressure; pass a cap for explicit bounded concurrency.
-For each worker, exports WOO_REVIEW_ANGLE and WOO_REVIEW_CHUNK. Generic runs
-retain the caller environment. With WOO_REVIEW_ENGINEER_UNIT=true, each worker
-starts in OUTDIR with a fresh HOME/XDG/TMPDIR and an allowlisted environment:
-PATH/locale, OUTDIR/action path, tier/model routing, and known provider API
-variables plus any comma-separated names explicitly listed in
-WOO_REVIEW_PROVIDER_ENV. Linear/GitHub-write/SSH/Git/profile contexts are absent.
+For each worker, exports WOO_REVIEW_ANGLE and WOO_REVIEW_CHUNK while retaining
+the caller environment so the selected harness/provider can execute normally.
 The worker must write $OUTDIR/findings.$WOO_REVIEW_ANGLE.json when unchunked, or
 $OUTDIR/findings.$WOO_REVIEW_ANGLE.$WOO_REVIEW_CHUNK.json when chunked.
 
@@ -24,98 +20,6 @@ USAGE
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=skills/woostack-review/scripts/resolve-outdir.sh
 source "$SCRIPT_DIR/resolve-outdir.sh"
-
-engineer_unit=false
-case "${WOO_REVIEW_ENGINEER_UNIT:-}" in
-  1|true|yes) engineer_unit=true ;;
-  0|false|no|"") ;;
-  *)
-    echo "::error::WOO_REVIEW_ENGINEER_UNIT must be true/false (or 1/0)" >&2
-    exit 2
-    ;;
-esac
-
-engineer_repo_root=""
-engineer_repo_fingerprint_before=""
-engineer_identity_manifest=""
-engineer_identity_manifest_hash_before=""
-engineer_worker_root=""
-if [ "$engineer_unit" = true ]; then
-  engineer_repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
-    echo "::error::engineer-unit swarm requires a Git worktree for mutation fingerprinting" >&2
-    exit 2
-  }
-  engineer_repo_root="$(cd "$engineer_repo_root" && pwd -P)"
-  if [ -d "$OUTDIR" ]; then
-    engineer_outdir="$(cd "$OUTDIR" && pwd -P)"
-  else
-    engineer_outdir_parent="$(dirname "$OUTDIR")"
-    [ -d "$engineer_outdir_parent" ] || {
-      echo "::error::engineer-unit OUTDIR parent must already exist outside the implementation repository/worktree" >&2
-      exit 2
-    }
-    engineer_outdir="$(cd "$engineer_outdir_parent" && pwd -P)/$(basename "$OUTDIR")"
-  fi
-  case "$engineer_outdir/" in
-    "$engineer_repo_root/"*)
-      echo "::error::engineer-unit OUTDIR must be outside the implementation repository/worktree" >&2
-      exit 2
-      ;;
-  esac
-fi
-
-review_provider_env=(
-  ANTHROPIC_API_KEY
-  OPENAI_API_KEY
-  OPENAI_BASE_URL
-  AZURE_OPENAI_API_KEY
-  AZURE_OPENAI_ENDPOINT
-  GOOGLE_API_KEY
-  GEMINI_API_KEY
-  OPENROUTER_API_KEY
-  AI_GATEWAY_API_KEY
-)
-
-if [ "$engineer_unit" = true ] && [ -n "${WOO_REVIEW_PROVIDER_ENV:-}" ]; then
-  IFS=',' read -r -a extra_provider_env <<< "$WOO_REVIEW_PROVIDER_ENV"
-  for name in "${extra_provider_env[@]}"; do
-    case "$name" in
-      ""|[0-9]*|*[!A-Za-z0-9_]*)
-        echo "::error::invalid variable name in WOO_REVIEW_PROVIDER_ENV: $name" >&2
-        exit 2
-        ;;
-      LINEAR_*|GH_*|GITHUB_*|GIT_*|GRAPHITE_*|SSH_*|HERMES_*|OMP_*|CLAUDE_*|CODEX_*|OPENCODE_*|BROWSER_*|XDG_*|WOO_REVIEW_*|HOME|TMPDIR|PWD|OLDPWD|SHELL|USER|LOGNAME|PATH|TERM|CI|FORCE_TIER|INPUT_MODEL|*PROFILE*|*SESSION*|*PRINCIPAL*|*CREDENTIAL*|*TOKEN_CACHE*|*TOKEN_STORE*|*AUTH_CONTEXT*|*MCP*|*OAUTH*)
-        echo "::error::WOO_REVIEW_PROVIDER_ENV may name provider-only variables, not host/reviewer/Git credentials or contexts: $name" >&2
-        exit 2
-        ;;
-      *) review_provider_env+=("$name") ;;
-    esac
-  done
-fi
-repository_fingerprint() { # repository root
-  local root="$1" branch head staged unstaged untracked
-  branch="$(git -C "$root" symbolic-ref --quiet --short HEAD 2>/dev/null || printf 'DETACHED')"
-  head="$(git -C "$root" rev-parse --verify 'HEAD^{commit}')" || return 1
-  staged="$(git -C "$root" diff --binary --full-index --no-ext-diff --cached | git hash-object --stdin)" || return 1
-  unstaged="$(git -C "$root" diff --binary --full-index --no-ext-diff | git hash-object --stdin)" || return 1
-  untracked="$({
-    while IFS= read -r -d '' path; do
-      path_base64="$(printf '%s' "$path" | base64 | tr -d '\n')"
-      object="$(git -C "$root" hash-object --no-filters -- "$path")" || exit 1
-      printf '%s\t%s\n' "$path_base64" "$object"
-    done < <(LC_ALL=C git -C "$root" ls-files --others --exclude-standard -z)
-  } | jq -Rn '[inputs | split("\t") | {pathBase64: .[0], object: .[1]}]')" || return 1
-
-  jq -cn \
-    --arg branch "$branch" \
-    --arg head "$head" \
-    --arg staged "$staged" \
-    --arg unstaged "$unstaged" \
-    --argjson untracked "$untracked" \
-    '{branch:$branch,head:$head,staged:$staged,unstaged:$unstaged,untracked:$untracked}' |
-    git hash-object --stdin
-}
-
 
 max_concurrency="${WOO_REVIEW_MAX_CONCURRENCY:-}"
 while [ "$#" -gt 0 ]; do
@@ -272,103 +176,9 @@ run_worker() {
   (
     export WOO_REVIEW_ANGLE="$angle"
     export WOO_REVIEW_CHUNK="$chunk"
-    if [ "$engineer_unit" = true ]; then
-      controller_outdir="$OUTDIR"
-      worker_outdir="$(mktemp -d "$engineer_worker_root/work.XXXXXX")"
-      worker_outdir="$(cd "$worker_outdir" && pwd -P)"
-      cp -R "$controller_outdir/." "$worker_outdir/"
-      rm -f \
-        "$worker_outdir"/findings.*.json \
-        "$worker_outdir"/receipt.*.json \
-        "$worker_outdir"/reviewer-identities.json
-      jq -e --arg angle "$angle" --arg chunk "$chunk" '
-        [
-          .reviewers[]
-          | select(
-              .angle == $angle
-              and (
-                (($chunk == "") and ((.chunk == null) or (.chunk == "")))
-                or (.chunk == $chunk)
-              )
-            )
-        ]
-        | if length == 1 then .[0] else error("missing exact worker binding") end
-      ' "$engineer_identity_manifest" > "$worker_outdir/reviewer-binding.json"
-      chmod 400 "$worker_outdir/reviewer-binding.json"
-
-      reviewer_home="$worker_outdir/home"
-      mkdir -p \
-        "$reviewer_home/tmp" \
-        "$reviewer_home/.config" \
-        "$reviewer_home/.cache" \
-        "$reviewer_home/.local/share" \
-        "$reviewer_home/.local/state" \
-        "$reviewer_home/runtime"
-      chmod 700 "$reviewer_home/runtime"
-      worker_env=(
-        "PATH=${PATH:-/usr/bin:/bin}"
-        "LANG=${LANG:-C}"
-        "HOME=$reviewer_home"
-        "TMPDIR=$reviewer_home/tmp"
-        "XDG_CONFIG_HOME=$reviewer_home/.config"
-        "XDG_CACHE_HOME=$reviewer_home/.cache"
-        "XDG_DATA_HOME=$reviewer_home/.local/share"
-        "XDG_STATE_HOME=$reviewer_home/.local/state"
-        "XDG_RUNTIME_DIR=$reviewer_home/runtime"
-        "OUTDIR=$worker_outdir"
-        "WOO_REVIEW_BINDING_PATH=$worker_outdir/reviewer-binding.json"
-        "WOO_REVIEW_ACTION_PATH=${WOO_REVIEW_ACTION_PATH:-$SCRIPT_DIR/..}"
-        "WOO_REVIEW_ANGLE=$angle"
-        "WOO_REVIEW_CHUNK=$chunk"
-      )
-      for name in \
-        TERM USER LOGNAME SHELL NO_COLOR CI \
-        FORCE_TIER INPUT_MODEL WOO_REVIEW_PROVIDER WOO_REVIEW_HOST \
-        "${review_provider_env[@]}"; do
-        value="${!name-}"
-        [ -n "$value" ] && worker_env+=("$name=$value")
-      done
-      worker_rc=0
-      (
-        cd "$worker_outdir"
-        env -i "${worker_env[@]}" "${worker_cmd[@]}"
-      ) || worker_rc=$?
-
-      output_suffix="$angle${chunk:+.$chunk}"
-      for output_kind in findings receipt; do
-        worker_output="$worker_outdir/$output_kind.$output_suffix.json"
-        if [ -f "$worker_output" ] && [ ! -L "$worker_output" ]; then
-          cp "$worker_output" "$controller_outdir/$output_kind.$output_suffix.json"
-        fi
-      done
-      exit "$worker_rc"
-    else
-      "${worker_cmd[@]}"
-    fi
+    "${worker_cmd[@]}"
   )
 }
-if [ "$engineer_unit" = true ]; then
-  engineer_identity_manifest="${WOO_REVIEW_IDENTITY_MANIFEST:-$OUTDIR/reviewer-identities.json}"
-  OUTDIR="$OUTDIR" \
-    WOO_REVIEW_ENGINEER_UNIT=true \
-    WOO_REVIEW_IDENTITY_MANIFEST="$engineer_identity_manifest" \
-    bash "$SCRIPT_DIR/verify-receipts.sh" --list-missing >/dev/null
-  engineer_identity_manifest_hash_before="$(
-    git hash-object --no-filters -- "$engineer_identity_manifest"
-  )" || {
-    echo "::error::could not fingerprint the controller-owned reviewer identity manifest" >&2
-    exit 2
-  }
-  engineer_worker_root="$(mktemp -d "/tmp/woostack-review-workers.XXXXXX")"
-  chmod 700 "$engineer_worker_root"
-  trap 'rm -rf "$engineer_worker_root"' EXIT HUP INT TERM
-  engineer_repo_fingerprint_before="$(repository_fingerprint "$engineer_repo_root")" || {
-    echo "::error::could not capture the engineer worktree fingerprint before review dispatch" >&2
-    exit 2
-  }
-fi
-
-
 
 run_queue() {
   local queue=("$@")
@@ -532,27 +342,6 @@ jq -n \
 
 if [ "$degraded" = true ]; then
   echo "::warning::bounded swarm degraded; invalid angle artifacts after retry: $(label_list "${still_invalid[@]}")" >&2
-fi
-
-if [ "$engineer_unit" = true ]; then
-  engineer_identity_manifest_hash_after="$(
-    git hash-object --no-filters -- "$engineer_identity_manifest"
-  )" || {
-    echo "::error::controller-owned reviewer identity manifest disappeared during dispatch" >&2
-    exit 1
-  }
-  if [ "$engineer_identity_manifest_hash_after" != "$engineer_identity_manifest_hash_before" ]; then
-    echo "::error::review worker changed the controller-owned reviewer identity manifest" >&2
-    exit 1
-  fi
-  engineer_repo_fingerprint_after="$(repository_fingerprint "$engineer_repo_root")" || {
-    echo "::error::could not capture the engineer worktree fingerprint after review dispatch" >&2
-    exit 1
-  }
-  if [ "$engineer_repo_fingerprint_after" != "$engineer_repo_fingerprint_before" ]; then
-    echo "::error::engineer-unit review worker changed repository/worktree state; receipts and findings are invalid" >&2
-    exit 1
-  fi
 fi
 
 # Single-authority receipt gate. Findings degradation (above) is a soft warning;

--- a/skills/woostack-review/scripts/tests/test-bounded-swarm.sh
+++ b/skills/woostack-review/scripts/tests/test-bounded-swarm.sh
@@ -186,167 +186,23 @@ assert_eq "$(jq -r '.mode' "$work4/out/swarm-metrics.json")" "host-managed" "def
 assert_eq "$(jq -r '.max_concurrency == null' "$work4/out/swarm-metrics.json")" "true" "default metrics record no concurrency cap"
 rm -rf "$work4"
 
-engineer="$work/engineer"
-repo="$engineer/repo"
-out="$engineer/out"
-mkdir -p "$repo" "$out" "$engineer/caller-home"
-git -C "$repo" init -q
-git -C "$repo" config user.email test@example.com
-git -C "$repo" config user.name "Receipt Test"
-git -C "$repo" config commit.gpgsign false
-printf 'reviewed\n' > "$repo/tracked.txt"
-git -C "$repo" add tracked.txt
-git -C "$repo" commit -qm initial
-printf '%s\n' bugs > "$out/angles.txt"
-jq -n '{
-  schemaVersion: 1,
-  implementingCoder: {
-    profile: "omp-engineer",
-    sessionId: "omp-session",
-    principalId: "linear-engineer",
-    credentialContextId: "omp-credential"
-  },
-  decisionMaker: {
-    profile: "hermes-engineer",
-    sessionId: "hermes-session",
-    principalId: "linear-decision-maker",
-    credentialContextId: "hermes-credential"
-  },
-  reviewers: [{
-    angle: "bugs",
-    chunk: null,
-    reviewerProfile: "reviewer-bugs",
-    reviewerSessionId: "reviewer-session-bugs",
-    reviewerPrincipalId: "reviewer-principal-bugs",
-    reviewerCredentialContextId: "reviewer-credential-bugs"
-  }]
-}' > "$out/reviewer-identities.json"
-cat > "$engineer/isolated-worker.sh" <<'WORKER'
+work5="$(mktemp -d)"
+mkdir -p "$work5/out"
+printf '%s\n' bugs > "$work5/out/angles.txt"
+cat > "$work5/worker.sh" <<'WORKER'
 #!/usr/bin/env bash
 set -euo pipefail
-[ "$PWD" = "$(cd "$OUTDIR" && pwd -P)" ]
-[ -z "${GH_TOKEN:-}" ]
-[ -z "${GITHUB_TOKEN:-}" ]
-[ -z "${SSH_AUTH_SOCK:-}" ]
-[ -z "${GIT_ASKPASS:-}" ]
-[ -z "${HERMES_PROFILE:-}" ]
-[ "${REVIEW_PROVIDER_TOKEN:-}" = "provider-token" ]
-[ -r "$WOO_REVIEW_BINDING_PATH" ]
-[ ! -e "$OUTDIR/reviewer-identities.json" ]
-jq -e '.angle == "bugs" and .reviewerProfile == "reviewer-bugs"' \
-  "$WOO_REVIEW_BINDING_PATH" >/dev/null
-jq -n --arg pwd "$PWD" --arg home "$HOME" '[{pwd:$pwd,home:$home}]' \
-  > "$OUTDIR/findings.$WOO_REVIEW_ANGLE.json"
-printf '{"angle":"%s","chunk":null,"runner":"test","model":"test-model","tier":"standard","ts":"t","reviewerProfile":"reviewer-bugs","reviewerSessionId":"reviewer-session-bugs","reviewerPrincipalId":"reviewer-principal-bugs","reviewerCredentialContextId":"reviewer-credential-bugs","authority":"advisory-only"}\n' \
-  "$WOO_REVIEW_ANGLE" > "$OUTDIR/receipt.$WOO_REVIEW_ANGLE.json"
-WORKER
-chmod +x "$engineer/isolated-worker.sh"
-rc=0
-(
-  cd "$repo"
-  OUTDIR="$out" \
-    WOO_REVIEW_ENGINEER_UNIT=true \
-    WOO_REVIEW_PROVIDER_ENV=REVIEW_PROVIDER_TOKEN \
-    REVIEW_PROVIDER_TOKEN=provider-token \
-    GH_TOKEN=github-secret \
-    GITHUB_TOKEN=github-actions-secret \
-    SSH_AUTH_SOCK=/tmp/ssh-agent.sock \
-    GIT_ASKPASS=/tmp/git-askpass \
-    HERMES_PROFILE=hermes-engineer \
-    HOME="$engineer/caller-home" \
-    bash "$SCRIPT" -- "$engineer/isolated-worker.sh"
-) >/dev/null 2>&1 || rc=$?
-assert_exit 0 "$rc" "engineer swarm runs in isolated reviewer environment"
-assert_contains "$(jq -r '.[0].pwd' "$out/findings.bugs.json")" \
-  "woostack-review-workers." "engineer worker cwd is a private output namespace"
-assert_contains "$(jq -r '.[0].home' "$out/findings.bugs.json")" \
-  "woostack-review-workers." "engineer worker receives fresh private HOME"
-
-mkdir -p "$repo/.woostack"
-default_engineer_out="$(
-  cd "$repo"
-  env -u OUTDIR WOO_REVIEW_ENGINEER_UNIT=true \
-    bash -c '. "$1"; printf "%s" "$OUTDIR"' _ "$DIR/resolve-outdir.sh"
-)"
-assert_contains "$default_engineer_out" "/tmp/pr-review-" \
-  "engineer-unit default OUTDIR stays outside repositories with .woostack"
-
-inside_out="$repo/.woostack/tmp/review"
-mkdir -p "$inside_out"
-printf '%s\n' bugs > "$inside_out/angles.txt"
-cp "$out/reviewer-identities.json" "$inside_out/reviewer-identities.json"
-rc=0
-err="$(
-  cd "$repo"
-  OUTDIR="$inside_out" WOO_REVIEW_ENGINEER_UNIT=true \
-    bash "$SCRIPT" -- "$engineer/isolated-worker.sh" 2>&1
-)" || rc=$?
-assert_exit 2 "$rc" "engineer swarm rejects an in-repository OUTDIR before dispatch"
-assert_contains "$err" "OUTDIR must be outside" "OUTDIR failure names the repository boundary"
-assert_eq "$([ ! -e "$inside_out/findings.bugs.json" ] && echo yes)" "yes" \
-  "in-repository OUTDIR rejection occurs before worker output"
-rc=0
-err="$(
-  OUTDIR="$out" \
-    WOO_REVIEW_ENGINEER_UNIT=true \
-    WOO_REVIEW_PROVIDER_ENV=GH_TOKEN \
-    GH_TOKEN=github-secret \
-    bash "$SCRIPT" -- "$engineer/isolated-worker.sh" 2>&1
-)" || rc=$?
-assert_exit 2 "$rc" "engineer provider allowlist rejects GitHub credentials"
-assert_contains "$err" "provider-only variables" "provider allowlist rejection names the isolation rule"
-
-manifest_out="$engineer/manifest-mutation-out"
-mkdir -p "$manifest_out"
-printf '%s\n' bugs > "$manifest_out/angles.txt"
-cp "$out/reviewer-identities.json" "$manifest_out/reviewer-identities.json"
-manifest_hash_before="$(git hash-object --no-filters -- "$manifest_out/reviewer-identities.json")"
-cat > "$engineer/manifest-mutating-worker.sh" <<'WORKER'
-#!/usr/bin/env bash
-set -euo pipefail
-printf '{}\n' > "$OUTDIR/reviewer-identities.json"
 printf '[]\n' > "$OUTDIR/findings.$WOO_REVIEW_ANGLE.json"
-printf '{"angle":"%s","chunk":null,"runner":"test","model":"test-model","tier":"standard","ts":"t","reviewerProfile":"reviewer-bugs","reviewerSessionId":"reviewer-session-bugs","reviewerPrincipalId":"reviewer-principal-bugs","reviewerCredentialContextId":"reviewer-credential-bugs","authority":"advisory-only"}\n' \
-  "$WOO_REVIEW_ANGLE" > "$OUTDIR/receipt.$WOO_REVIEW_ANGLE.json"
 WORKER
-chmod +x "$engineer/manifest-mutating-worker.sh"
-rc=0
-(
-  cd "$repo"
-  OUTDIR="$manifest_out" \
-    WOO_REVIEW_ENGINEER_UNIT=true \
-    bash "$SCRIPT" -- "$engineer/manifest-mutating-worker.sh"
-) >/dev/null 2>&1 || rc=$?
-manifest_hash_after="$(git hash-object --no-filters -- "$manifest_out/reviewer-identities.json")"
-assert_exit 0 "$rc" "worker-local manifest writes cannot alter controller state"
-assert_eq "$manifest_hash_after" "$manifest_hash_before" \
-  "controller identity manifest is outside every worker namespace"
-
-mutation_out="$engineer/mutation-out"
-mkdir -p "$mutation_out"
-printf '%s\n' bugs > "$mutation_out/angles.txt"
-cp "$out/reviewer-identities.json" "$mutation_out/reviewer-identities.json"
-printf '%s\n' "$repo" > "$mutation_out/repo-path"
-cat > "$engineer/mutating-worker.sh" <<'WORKER'
-#!/usr/bin/env bash
-set -euo pipefail
-repo="$(cat "$OUTDIR/repo-path")"
-printf 'mutated\n' > "$repo/tracked.txt"
-printf '[]\n' > "$OUTDIR/findings.$WOO_REVIEW_ANGLE.json"
-printf '{"angle":"%s","chunk":null,"runner":"test","model":"test-model","tier":"standard","ts":"t","reviewerProfile":"reviewer-bugs","reviewerSessionId":"reviewer-session-bugs","reviewerPrincipalId":"reviewer-principal-bugs","reviewerCredentialContextId":"reviewer-credential-bugs","authority":"advisory-only"}\n' \
-  "$WOO_REVIEW_ANGLE" > "$OUTDIR/receipt.$WOO_REVIEW_ANGLE.json"
-WORKER
-chmod +x "$engineer/mutating-worker.sh"
+chmod +x "$work5/worker.sh"
 rc=0
 err="$(
-  (
-    cd "$repo"
-    OUTDIR="$mutation_out" \
-      WOO_REVIEW_ENGINEER_UNIT=true \
-      bash "$SCRIPT" -- "$engineer/mutating-worker.sh"
-  ) 2>&1
+  OUTDIR="$work5/out" bash "$SCRIPT" -- "$work5/worker.sh" 2>&1
 )" || rc=$?
-assert_exit 1 "$rc" "engineer worker repository mutation hard-fails"
-assert_contains "$err" "changed repository/worktree state" "mutation failure names repository fingerprint gate"
+assert_exit 1 "$rc" "generic local swarm hard-fails when a worker omits its receipt"
+assert_contains "$err" "no angle analysis executed" "missing-receipt failure cannot report a false-clean review"
+assert_eq "$(jq -c '.missing_receipts' "$work5/out/swarm-metrics.json")" '["bugs"]' \
+  "metrics preserve the missing generic local receipt"
+rm -rf "$work5"
 
 finish

--- a/skills/woostack-review/scripts/tests/test-review-payload-ranges.sh
+++ b/skills/woostack-review/scripts/tests/test-review-payload-ranges.sh
@@ -89,8 +89,8 @@ HEAD_SHA=deadbeef \
   IMPLEMENTATION_AUTHOR_GITHUB_USER_ID= \
   AUTH_LOGIN=apparently-distinct-reviewer \
   PR_AUTHOR=apparently-distinct-author \
-  HERMES_PROFILE=hermes-engineer \
-  TOKEN_STORE_NAME=hermes-token-cache \
+  REVIEWER_PROFILE=local-reviewer \
+  TOKEN_STORE_NAME=local-review-token-cache \
   python3 "$work/builder.py" > "$work/missing-actor.json"
 assert_eq "$(jq -r '.event' "$work/missing-actor.json")" "COMMENT" "missing native author proof cannot approve"
 assert_contains "$(jq -r '.body' "$work/missing-actor.json")" '**Status: APPROVED** — No validated findings.' "missing-proof COMMENT preserves computed status line"

--- a/skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-receipts-identity.sh
@@ -10,57 +10,6 @@ work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
 printf '%s\n' bugs > "$OUTDIR/angles.txt"
 
-write_manifest() {
-  local reviewer_profile="$1"
-  local reviewer_session="$2"
-  local reviewer_principal="$3"
-  local reviewer_credential="$4"
-  jq -n \
-    --arg reviewer_profile "$reviewer_profile" \
-    --arg reviewer_session "$reviewer_session" \
-    --arg reviewer_principal "$reviewer_principal" \
-    --arg reviewer_credential "$reviewer_credential" \
-    '{
-      schemaVersion: 1,
-      implementingCoder: {
-        profile: "omp-engineer-search",
-        sessionId: "omp-coding-session-search",
-        principalId: "linear-app-engineer-search",
-        credentialContextId: "omp-auth-search"
-      },
-      decisionMaker: {
-        profile: "hermes-engineer-search",
-        sessionId: "hermes-controller-session-search",
-        principalId: "linear-app-decision-maker-search",
-        credentialContextId: "hermes-auth-search"
-      },
-      reviewers: [{
-        angle: "bugs",
-        chunk: null,
-        reviewerProfile: $reviewer_profile,
-        reviewerSessionId: $reviewer_session,
-        reviewerPrincipalId: $reviewer_principal,
-        reviewerCredentialContextId: $reviewer_credential
-      }],
-      validators: [
-        {
-          role: "prosecutor",
-          reviewerProfile: "reviewer-prosecutor",
-          reviewerSessionId: "reviewer-session-prosecutor",
-          reviewerPrincipalId: "reviewer-native-prosecutor",
-          reviewerCredentialContextId: "reviewer-auth-prosecutor"
-        },
-        {
-          role: "defender",
-          reviewerProfile: "reviewer-defender",
-          reviewerSessionId: "reviewer-session-defender",
-          reviewerPrincipalId: "reviewer-native-defender",
-          reviewerCredentialContextId: "reviewer-auth-defender"
-        }
-      ]
-    }' > "$OUTDIR/reviewer-identities.json"
-}
-
 write_receipt() {
   local reviewer_profile="$1"
   local reviewer_session="$2"
@@ -86,23 +35,7 @@ write_receipt() {
     }' > "$OUTDIR/receipt.bugs.json"
 }
 
-write_validator_receipt() {
-  local role="$1"
-  jq -n --arg role "$role" '{
-    validatorRole: $role,
-    runner: "claude-code",
-    model: "claude-opus-4-8",
-    tier: "deep",
-    reviewerProfile: ("reviewer-" + $role),
-    reviewerSessionId: ("reviewer-session-" + $role),
-    reviewerPrincipalId: ("reviewer-native-" + $role),
-    reviewerCredentialContextId: ("reviewer-auth-" + $role),
-    authority: "advisory-only"
-  }' > "$OUTDIR/receipt.validator-$role.json"
-}
-
-# Base execution identity and advisory authority remain mandatory without a
-# paired-engineer manifest.
+# Generic local execution fields and advisory authority remain mandatory.
 printf '{"angle":"bugs","chunk":null,"runner":"claude-code","model":"","tier":"standard","ts":"t","authority":"advisory-only"}\n' > "$OUTDIR/receipt.bugs.json"
 rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
 assert_exit 1 "$rc" "empty model → invalid receipt → exit 1"
@@ -112,6 +45,10 @@ printf '{"angle":"bugs","chunk":null,"runner":"","model":"m","tier":"standard","
 rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
 assert_exit 1 "$rc" "empty runner → invalid receipt → exit 1"
 assert_contains "$err" "bugs" "names the angle whose identity is incomplete"
+
+printf '{"angle":"bugs","chunk":null,"runner":"r","model":"m","tier":"","ts":"t","authority":"advisory-only"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 1 "$rc" "empty tier → invalid receipt"
 
 printf '{"angle":"bugs","chunk":null,"runner":"r","model":"m","tier":"standard","ts":"t"}\n' > "$OUTDIR/receipt.bugs.json"
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
@@ -125,84 +62,22 @@ printf '{"angle":"bugs","chunk":null,"runner":"r","model":"m","tier":"standard",
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
 assert_exit 1 "$rc" "partial reviewer identity → invalid receipt"
 
-# An engineer-unit run fails closed without its controller-owned manifest.
-export WOO_REVIEW_ENGINEER_UNIT=true
-rm -f "$OUTDIR/reviewer-identities.json"
+# The one generic local path accepts either a minimal receipt or a complete
+# self-reported host binding, but never treats either as acceptance authority.
+printf '{"angle":"bugs","chunk":null,"runner":"claude-code","model":"claude-sonnet-4-6","tier":"standard","ts":"t","authority":"advisory-only"}\n' > "$OUTDIR/receipt.bugs.json"
+rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "minimal generic local advisory receipt passes"
+
 write_receipt "reviewer-quality-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
 rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "engineer-unit receipt without identity manifest → configuration failure"
+assert_exit 0 "$rc" "complete generic local reviewer binding passes"
 
-# Exact manifest binding passes.
-write_manifest "reviewer-quality-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 0 "$rc" "host-bound independent reviewer receipt passes"
+rm -f "$OUTDIR/receipt.bugs.json"
+rc=0; err="$(bash "$SCRIPT" 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "missing generic local receipt hard-fails"
+assert_contains "$err" "no angle analysis executed" "missing receipt reports that review did not run"
 
-jq '.reviewers[0].angle = "security"' \
-  "$OUTDIR/reviewer-identities.json" > "$OUTDIR/reviewer-identities.tmp"
-mv "$OUTDIR/reviewer-identities.tmp" "$OUTDIR/reviewer-identities.json"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "reviewer manifest must exactly cover the expected angle/chunk work set"
-write_manifest "reviewer-quality-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
-
-# A receipt cannot merely self-report a foreign reviewer.
-write_receipt "reviewer-forged-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 1 "$rc" "receipt identity must match controller manifest"
-
-# The manifest itself rejects the paired coder, the decision-maker session, the
-# shared engineer principal, and either role's credential context.
-write_manifest "omp-engineer-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "paired coding profile cannot be reviewer"
-
-write_manifest "reviewer-quality-search" "hermes-controller-session-search" "reviewer-native-search" "reviewer-auth-search"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "decision-maker session cannot be delegated reviewer session"
-
-write_manifest "reviewer-quality-search" "reviewer-session-search" "linear-app-engineer-search" "reviewer-auth-search"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "engineer principal cannot back delegated reviewer"
-
-write_manifest "reviewer-quality-search" "reviewer-session-search" "reviewer-native-search" "omp-auth-search"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "implementation credential context cannot be shared with reviewer"
-
-write_manifest "reviewer-quality-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
-jq '.decisionMaker.principalId = .implementingCoder.principalId' \
-  "$OUTDIR/reviewer-identities.json" > "$OUTDIR/reviewer-identities.tmp"
-mv "$OUTDIR/reviewer-identities.tmp" "$OUTDIR/reviewer-identities.json"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "implementing coder and decision-maker native host principals must differ"
-
-write_manifest "reviewer-quality-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
-jq '.reviewers += [(.reviewers[0] | .angle = "security")]' \
-  "$OUTDIR/reviewer-identities.json" > "$OUTDIR/reviewer-identities.tmp"
-mv "$OUTDIR/reviewer-identities.tmp" "$OUTDIR/reviewer-identities.json"
-rc=0; bash "$SCRIPT" >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "delegated reviewers cannot share profile/session/principal/credential identity"
-
-# The decisive validator outputs require their own independent manifest bindings and receipts.
-write_manifest "reviewer-quality-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
-write_validator_receipt prosecutor
-write_validator_receipt defender
-rc=0; bash "$SCRIPT" --validators >/dev/null 2>&1 || rc=$?
-assert_exit 0 "$rc" "independently bound prosecutor and defender receipts pass"
-
-jq '.validators[1].reviewerPrincipalId = .validators[0].reviewerPrincipalId' \
-  "$OUTDIR/reviewer-identities.json" > "$OUTDIR/reviewer-identities.tmp"
-mv "$OUTDIR/reviewer-identities.tmp" "$OUTDIR/reviewer-identities.json"
-rc=0; bash "$SCRIPT" --validators >/dev/null 2>&1 || rc=$?
-assert_exit 2 "$rc" "validator bindings must be independent from each other"
-
-write_manifest "reviewer-quality-search" "reviewer-session-search" "reviewer-native-search" "reviewer-auth-search"
-rm -f "$OUTDIR/receipt.validator-defender.json"
-rc=0; bash "$SCRIPT" --validators >/dev/null 2>&1 || rc=$?
-assert_exit 1 "$rc" "missing defender receipt blocks validator acceptance"
-
-# CI has no engineer-unit manifest, but its single-session advisory identity is
-# explicit and deterministic.
-unset WOO_REVIEW_ENGINEER_UNIT
-rm -f "$OUTDIR/reviewer-identities.json"
+# CI uses an explicit deterministic single-session advisory identity.
 export GITHUB_ACTIONS=true
 export GITHUB_RUN_ID=9001
 export GITHUB_RUN_ATTEMPT=2

--- a/skills/woostack-review/scripts/tests/test-verify-validator-receipts.sh
+++ b/skills/woostack-review/scripts/tests/test-verify-validator-receipts.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+source "$ROOT/skills/woostack-init/scripts/tests/assert.sh"
+SCRIPT="$DIR/verify-receipts.sh"
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+export OUTDIR="$work/out"; mkdir -p "$OUTDIR"
+unset GITHUB_ACTIONS GITHUB_RUN_ID GITHUB_RUN_ATTEMPT GITHUB_REPOSITORY
+printf '{}\n' > "$OUTDIR/config.json"
+
+# These are only the prompts' crash guards; they do not prove either validator completed.
+printf '[]\n' > "$OUTDIR/findings.prosecutor.json"
+printf '[]\n' > "$OUTDIR/findings.defender.json"
+
+write_validator_receipt() {
+  local role="$1"
+  jq -n --arg role "$role" '{
+    angle: $role,
+    chunk: null,
+    runner: "local-test",
+    model: "test-model",
+    tier: "deep",
+    ts: "2026-08-07T00:00:00Z",
+    authority: "advisory-only"
+  }' > "$OUTDIR/receipt.$role.json"
+}
+
+write_validator_receipt prosecutor
+write_validator_receipt defender
+rc=0; bash "$SCRIPT" --validators >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "valid prosecutor and defender role receipts pass"
+
+rm -f "$OUTDIR/receipt.prosecutor.json"
+rc=0; err="$(bash "$SCRIPT" --validators 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "missing prosecutor receipt hard-fails despite both crash-guard arrays"
+assert_contains "$err" "prosecutor" "missing validator role is identified"
+assert_contains "$err" "refusing intersection" "missing validator receipt blocks intersection"
+
+printf '{"disable_adversarial":true}\n' > "$OUTDIR/config.json"
+rc=0; bash "$SCRIPT" --validators >/dev/null 2>&1 || rc=$?
+assert_exit 0 "$rc" "valid defender-only config requires only the defender receipt"
+
+rm -f "$OUTDIR/receipt.defender.json"
+rc=0; err="$(bash "$SCRIPT" --validators 2>&1 1>/dev/null)" || rc=$?
+assert_exit 1 "$rc" "defender-only config still requires the defender receipt"
+assert_contains "$err" "defender" "missing defender role is identified"
+assert_contains "$err" "refusing intersection" "missing defender receipt blocks intersection"
+
+for provider_prompt in anthropic.md google.md openai.md opencode.md; do
+  assert_contains \
+    "$(cat "$ROOT/skills/woostack-review/prompts/$provider_prompt")" \
+    'verify-receipts.sh" --validators' \
+    "$provider_prompt gates validator receipts before intersection"
+done
+
+finish

--- a/skills/woostack-review/scripts/tests/test-worker-brief-skill-scope.sh
+++ b/skills/woostack-review/scripts/tests/test-worker-brief-skill-scope.sh
@@ -37,8 +37,8 @@ OPENAI="$ROOT/skills/woostack-review/prompts/openai.md"
 
 # The simplified Review surface retains the isolation and authority boundary without duplicating
 # host-specific dispatch prose.
-assert_file_contains "$REVIEW_SKILL" \
-  "fresh read-only profiles/sessions distinct from the implementing coder" \
+assert_file_matches "$REVIEW_SKILL" \
+  "fresh read-only profiles/sessions distinct from the implementing[[:space:]]+coder" \
   "Review requires fresh worker isolation from the implementing coder"
 assert_file_matches "$REVIEW_SKILL" \
   "Workers cannot edit source/tests, post to GitHub, access Linear.*accept work, or merge" \

--- a/skills/woostack-review/scripts/verify-receipts.sh
+++ b/skills/woostack-review/scripts/verify-receipts.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
 # Postflight gate: assert every expected angle (from angles.txt × chunks.txt) wrote
 # a VALID execution receipt. A valid receipt binds the expected work item to its
-# runner/model/tier, advisory-only authority, and (for an engineer-unit run) the
-# controller-owned reviewer identity manifest. For repository-routed Codex/OpenAI
+# runner/model/tier and advisory-only authority. For repository-routed Codex/OpenAI
 # workers, the model must also match the tier mapping. This is the single authority
-# on "did the independently bound angle worker actually execute": empty findings
-# are an honest clean review ONLY when the receipt proves the worker ran.
+# on "did the angle worker actually execute": empty findings are an honest clean
+# review ONLY when the receipt proves the worker ran.
 #
 # Modes:
 #   (default)       gate: emit ::error and exit 1 if any expected angle receipt is invalid.
 #   --list-missing  print invalid "<angle>" or "<angle>.<chunk>" labels, exit 0.
-#   --validators    gate the engineer-unit prosecutor and defender identity receipts.
+#   --validators    gate the required prosecutor/defender role receipts before intersection.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
@@ -25,96 +24,6 @@ case "${1:-}" in
   -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
   *) echo "::error::unknown argument: $1" >&2; exit 2 ;;
 esac
-
-identity_manifest="${WOO_REVIEW_IDENTITY_MANIFEST:-$OUTDIR/reviewer-identities.json}"
-identity_manifest_required=false
-case "${WOO_REVIEW_ENGINEER_UNIT:-}" in
-  1|true|yes) identity_manifest_required=true ;;
-  0|false|no|"") ;;
-  *)
-    echo "::error::WOO_REVIEW_ENGINEER_UNIT must be true/false (or 1/0)" >&2
-    exit 2
-    ;;
-esac
-
-if [ "$identity_manifest_required" = true ] && [ ! -s "$identity_manifest" ]; then
-  echo "::error::engineer-unit review requires a non-empty controller-owned reviewer identity manifest: $identity_manifest" >&2
-  exit 2
-fi
-
-if [ -e "$identity_manifest" ]; then
-  if [ ! -s "$identity_manifest" ] || ! jq -e '
-    def nonempty: type == "string" and length > 0;
-    . as $m
-    | (type == "object")
-    and (.schemaVersion == 1)
-    and ($m.implementingCoder | type == "object"
-      and (.profile | nonempty)
-      and (.sessionId | nonempty)
-      and (.principalId | nonempty)
-      and (.credentialContextId | nonempty))
-    and ($m.decisionMaker | type == "object"
-      and (.profile | nonempty)
-      and (.sessionId | nonempty)
-      and (.principalId | nonempty)
-      and (.credentialContextId | nonempty))
-    and ($m.implementingCoder.profile != $m.decisionMaker.profile)
-    and ($m.implementingCoder.sessionId != $m.decisionMaker.sessionId)
-    and ($m.implementingCoder.principalId != $m.decisionMaker.principalId)
-    and ($m.implementingCoder.credentialContextId != $m.decisionMaker.credentialContextId)
-    and ($m.reviewers | type == "array" and length > 0)
-    and (all($m.reviewers[];
-      (type == "object")
-      and (.angle | nonempty)
-      and ((.chunk == null) or (.chunk | type == "string"))
-      and (.reviewerProfile | nonempty)
-      and (.reviewerSessionId | nonempty)
-      and (.reviewerPrincipalId | nonempty)
-      and (.reviewerCredentialContextId | nonempty)
-      and (.reviewerProfile != $m.implementingCoder.profile)
-      and (.reviewerProfile != $m.decisionMaker.profile)
-      and (.reviewerSessionId != $m.implementingCoder.sessionId)
-      and (.reviewerSessionId != $m.decisionMaker.sessionId)
-      and (.reviewerPrincipalId != $m.implementingCoder.principalId)
-      and (.reviewerPrincipalId != $m.decisionMaker.principalId)
-      and (.reviewerCredentialContextId != $m.implementingCoder.credentialContextId)
-      and (.reviewerCredentialContextId != $m.decisionMaker.credentialContextId)
-    ))
-    and (($m.reviewers | map([.angle, (.chunk // "")] | join("\u0000")) | unique | length)
-      == ($m.reviewers | length))
-    and (($m.reviewers | map(.reviewerProfile) | unique | length) == ($m.reviewers | length))
-    and (($m.reviewers | map(.reviewerSessionId) | unique | length) == ($m.reviewers | length))
-    and (($m.reviewers | map(.reviewerPrincipalId) | unique | length) == ($m.reviewers | length))
-    and (($m.reviewers | map(.reviewerCredentialContextId) | unique | length)
-      == ($m.reviewers | length))
-  ' "$identity_manifest" >/dev/null 2>&1; then
-    echo "::error::invalid reviewer identity manifest: $identity_manifest" >&2
-    exit 2
-  fi
-fi
-
-receipt_matches_identity_manifest() { # angle chunk receipt
-  local angle="$1" chunk="$2" receipt="$3"
-  jq -e --arg a "$angle" --arg c "$chunk" --slurpfile receipt "$receipt" '
-    . as $m
-    | [
-        $m.reviewers[]
-        | select(
-            .angle == $a
-            and (
-              (($c == "") and ((.chunk == null) or (.chunk == "")))
-              or (.chunk == $c)
-            )
-          )
-      ] as $bindings
-    | ($bindings | length) == 1
-      and ($receipt | length) == 1
-      and ($receipt[0].reviewerProfile == $bindings[0].reviewerProfile)
-      and ($receipt[0].reviewerSessionId == $bindings[0].reviewerSessionId)
-      and ($receipt[0].reviewerPrincipalId == $bindings[0].reviewerPrincipalId)
-      and ($receipt[0].reviewerCredentialContextId == $bindings[0].reviewerCredentialContextId)
-  ' "$identity_manifest" >/dev/null 2>&1
-}
 
 receipt_matches_ci_identity() { # receipt
   local receipt="$1" attempt session principal credential
@@ -151,126 +60,34 @@ receipt_matches_ci_identity() { # receipt
     ' "$receipt" >/dev/null 2>&1
 }
 
+angles=()
+chunks=("")
 if [ "$mode" = "validators" ]; then
-  [ "$identity_manifest_required" = true ] || {
-    echo "::error::validator identity receipts are required only for an engineer-unit review" >&2
-    exit 2
-  }
-  if ! jq -e '
-    def nonempty: type == "string" and length > 0;
-    . as $m
-    | ($m.validators | type == "array" and length == 2)
-    and (($m.validators | map(.role) | sort) == ["defender", "prosecutor"])
-    and (all($m.validators[];
-      (type == "object")
-      and (.reviewerProfile | nonempty)
-      and (.reviewerSessionId | nonempty)
-      and (.reviewerPrincipalId | nonempty)
-      and (.reviewerCredentialContextId | nonempty)
-    ))
-    and (
-      (
-        [
-          $m.implementingCoder | {
-            reviewerProfile: .profile,
-            reviewerSessionId: .sessionId,
-            reviewerPrincipalId: .principalId,
-            reviewerCredentialContextId: .credentialContextId
-          },
-          $m.decisionMaker | {
-            reviewerProfile: .profile,
-            reviewerSessionId: .sessionId,
-            reviewerPrincipalId: .principalId,
-            reviewerCredentialContextId: .credentialContextId
-          }
-        ] + $m.reviewers + $m.validators
-      ) as $all
-      | (($all | map(.reviewerProfile) | unique | length) == ($all | length))
-      and (($all | map(.reviewerSessionId) | unique | length) == ($all | length))
-      and (($all | map(.reviewerPrincipalId) | unique | length) == ($all | length))
-      and (($all | map(.reviewerCredentialContextId) | unique | length) == ($all | length))
-    )
-  ' "$identity_manifest" >/dev/null 2>&1; then
-    echo "::error::invalid or non-independent validator identity bindings" >&2
+  if [ -s "$OUTDIR/config.json" ] &&
+    jq -e 'type == "object" and .disable_adversarial == true' "$OUTDIR/config.json" >/dev/null 2>&1; then
+    angles=("defender")
+  else
+    angles=("prosecutor" "defender")
+  fi
+else
+  angles_file="$OUTDIR/angles.txt"
+  if [ ! -s "$angles_file" ]; then
+    echo "::error::missing or empty angles file: $angles_file" >&2
     exit 2
   fi
 
-  validator_failed=false
-  for validator_role in prosecutor defender; do
-    validator_receipt="$OUTDIR/receipt.validator-${validator_role}.json"
-    if [ ! -s "$validator_receipt" ] || ! jq -e \
-      --arg role "$validator_role" \
-      --slurpfile receipt "$validator_receipt" '
-        . as $m
-        | [.validators[] | select(.role == $role)] as $bindings
-        | ($bindings | length) == 1
-        and ($receipt | length) == 1
-        and ($receipt[0] | type == "object")
-        and ($receipt[0].validatorRole == $role)
-        and (($receipt[0].runner // "") | type == "string" and length > 0)
-        and (($receipt[0].model // "") | type == "string" and length > 0)
-        and ($receipt[0].tier == "deep")
-        and ($receipt[0].authority == "advisory-only")
-        and ($receipt[0].reviewerProfile == $bindings[0].reviewerProfile)
-        and ($receipt[0].reviewerSessionId == $bindings[0].reviewerSessionId)
-        and ($receipt[0].reviewerPrincipalId == $bindings[0].reviewerPrincipalId)
-        and ($receipt[0].reviewerCredentialContextId == $bindings[0].reviewerCredentialContextId)
-      ' "$identity_manifest" >/dev/null 2>&1; then
-      echo "::error::invalid or missing validator identity receipt: validator-${validator_role}" >&2
-      validator_failed=true
-    fi
-  done
-  [ "$validator_failed" = false ] || exit 1
-  exit 0
-fi
-
-angles_file="$OUTDIR/angles.txt"
-if [ ! -s "$angles_file" ]; then
-  echo "::error::missing or empty angles file: $angles_file" >&2
-  exit 2
-fi
-
-angles=()
-while IFS= read -r a; do [ -n "$a" ] && angles+=("$a"); done < "$angles_file"
-if [ "${#angles[@]}" -eq 0 ]; then
-  echo "::error::no angles found in $angles_file" >&2
-  exit 2
-fi
-
-chunks=("")
-chunks_file="$OUTDIR/chunks.txt"
-if [ -s "$chunks_file" ]; then
-  chunks=()
-  while IFS= read -r c; do [ -n "$c" ] && chunks+=("$c"); done < "$chunks_file"
-  [ "${#chunks[@]}" -eq 0 ] && chunks=("")
-fi
-
-if [ -s "$identity_manifest" ]; then
-  manifest_expected_total=$(( ${#angles[@]} * ${#chunks[@]} ))
-  manifest_binding_total="$(jq -r '.reviewers | length' "$identity_manifest")"
-  [ "$manifest_binding_total" -eq "$manifest_expected_total" ] || {
-    echo "::error::reviewer identity manifest does not exactly cover the expected angle/chunk work set" >&2
+  while IFS= read -r a; do [ -n "$a" ] && angles+=("$a"); done < "$angles_file"
+  if [ "${#angles[@]}" -eq 0 ]; then
+    echo "::error::no angles found in $angles_file" >&2
     exit 2
-  }
-  for manifest_angle in "${angles[@]}"; do
-    for manifest_chunk in "${chunks[@]}"; do
-      manifest_binding_count="$(
-        jq -r --arg a "$manifest_angle" --arg c "$manifest_chunk" '
-          [.reviewers[] | select(
-            .angle == $a
-            and (
-              (($c == "") and ((.chunk == null) or (.chunk == "")))
-              or (.chunk == $c)
-            )
-          )] | length
-        ' "$identity_manifest"
-      )"
-      [ "$manifest_binding_count" -eq 1 ] || {
-        echo "::error::reviewer identity manifest lacks one exact binding for ${manifest_angle}${manifest_chunk:+.$manifest_chunk}" >&2
-        exit 2
-      }
-    done
-  done
+  fi
+
+  chunks_file="$OUTDIR/chunks.txt"
+  if [ -s "$chunks_file" ]; then
+    chunks=()
+    while IFS= read -r c; do [ -n "$c" ] && chunks+=("$c"); done < "$chunks_file"
+    [ "${#chunks[@]}" -eq 0 ] && chunks=("")
+  fi
 fi
 
 receipt_path() { # angle chunk
@@ -327,10 +144,8 @@ receipt_needs_openai_model_check() { # file
 
 # Valid iff: JSON object; .angle == angle; (.chunk matches, or both empty/null);
 # .runner, .model, and .tier are non-empty; .authority is advisory-only; any
-# supplied reviewer identity is complete. An engineer-unit manifest additionally
-# binds that identity to the host-selected reviewer and excludes the implementing
-# coder and decision-maker identities/credential contexts. GitHub Actions uses
-# its explicit single-session CI identity shape when no manifest is present.
+# supplied reviewer identity is complete. GitHub Actions additionally requires
+# its explicit single-session CI identity shape.
 is_valid_receipt() { # angle chunk file
   local angle="$1" chunk="$2" f="$3" tier model expected
   [ -s "$f" ] || return 1
@@ -360,9 +175,7 @@ is_valid_receipt() { # angle chunk file
     )
   ' "$f" >/dev/null 2>&1 || return 1
 
-  if [ -s "$identity_manifest" ]; then
-    receipt_matches_identity_manifest "$angle" "$chunk" "$f" || return 1
-  elif [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
     receipt_matches_ci_identity "$f" || return 1
   fi
 
@@ -386,6 +199,15 @@ for angle in "${angles[@]}"; do
     fi
   done
 done
+if [ "$mode" = "validators" ]; then
+  if [ "${#missing[@]}" -gt 0 ]; then
+    miss_csv="$(IFS=', '; echo "${missing[*]}")"
+    echo "::error::woostack-review: validator role receipt(s) missing or invalid: ${miss_csv}. The adversarial validation pass is NOT complete; refusing intersection." >&2
+    exit 1
+  fi
+  echo "verify-receipts: all ${#angles[@]} required validator role receipt(s) valid."
+  exit 0
+fi
 
 if [ "$mode" = "list" ]; then
   for m in ${missing[@]+"${missing[@]}"}; do printf '%s\n' "$m"; done


### PR DESCRIPTION
## Goal

Remove the unreachable engineer-unit Review mode after the supported Hermes runtime was detached, while preserving one generic harness-local advisory path and the GitHub Actions path.

Linear: [WOO-166](https://linear.app/woostack/issue/WOO-166/remove-dormant-engineer-unit-review-mode)

## Summary

- removes the dormant engineer-unit environment, identity-manifest, controller-binding, and private-home execution branches
- retains generic advisory angle receipts, read-only worker isolation, OpenAI tier/model validation, and CI single-session actor safeguards
- requires prosecutor/defender execution receipts before every provider intersection so crash-guard arrays cannot produce a false-clean review
- preserves the explicit `disable_adversarial: true` defender-only path and leaves all WOO-167 reserved assets untouched
- updates focused Review and harness-boundary regressions

## Test plan

- [x] 47 non-prefetch `skills/woostack-review/scripts/tests/test-*.sh` scripts
- [x] `bash skills/using-woostack/tests/test-harness-agent-boundary.sh`
- [x] `node --test site/scripts/linear-only-docs.test.mjs`
- [x] changed shell syntax checks and `git diff --check`
- [x] `pnpm -C site build`
- [x] generic local advisory smoke: one angle receipt, prosecutor + defender receipts, deterministic empty intersection, non-degraded metrics, repository diff unchanged
- [x] independent final review: PASS