### PR TITLE
fix(change): require Graphite-compatible worktrees

### DIFF
--- a/skills/woostack-change/SKILL.md
+++ b/skills/woostack-change/SKILL.md
@@ -62,7 +62,7 @@ detached HEAD, duplicate worktrees or branches, unexplained dirty state, conflic
 scope drift, and collisions. Never reset, clean, stash, overwrite, or create around unexpected
 user work.
 
-Create one isolated worktree under the canonical worktree contract, with one Graphite branch
+Create and assert one isolated worktree under the [canonical worktree contract](../woostack-init/references/worktrees.md#5-create-and-assert), with one Graphite-tracked branch
 whose parent is the verified integration base. When exact task, worktree, branch, parent, and head
 facts already exist, attach to that workspace and resume it; never create a duplicate.
 

--- a/skills/woostack-change/evals/evals.json
+++ b/skills/woostack-change/evals/evals.json
@@ -4,19 +4,19 @@
   "cases": [
     {
       "id": "bounded-admission-creates-one-isolated-worktree",
-      "prompt": "Evaluate fixtures/change-contract-a.json at admission. Do not mutate Git or files. Explain whether the request is admitted, what must be verified before mutation, and whether one isolated worktree and Graphite branch may be created.",
+      "prompt": "Evaluate fixtures/change-contract-a.json at admission. Do not mutate Git or files. Explain whether the request is admitted, what must be verified before mutation, and whether valid behavior creates and checks out the task branch atomically in the new worktree at the exact start SHA before `gt track --parent <verified-integration-base>`, rejects `git worktree add --detach` plus task-worktree `gt create`, avoids switching or repurposing the primary checkout, and permits one isolated worktree and Graphite branch.",
       "fixtures": [
         "change-contract-a.json"
       ],
       "capabilities": [
         "read-workspace"
       ],
-      "expected": "A bounded non-bug request is admitted only after repository, base, dirty-state, and collision facts are checked; one deterministic isolated worktree and branch may then be created, with no duplicate workspace or merge.",
+      "expected": "A bounded non-bug request is admitted only after repository, base, dirty-state, and collision facts are checked; valid creation uses `git worktree add -b <task-branch> <task-worktree> <exact-start-sha>` to create and check out the task branch atomically at the exact start SHA before `gt track --parent <verified-integration-base>`, rejects `git worktree add --detach` plus task-worktree `gt create`, leaves the primary checkout untouched, and preserves one isolated worktree, one PR, and no merge.",
       "assertions": [
         {
           "id": "admission-boundary",
           "kind": "qualitative",
-          "rubric": "Does the response keep classification and repository preflight read-only, identify the bounded scope, and require a single isolated worktree/branch rather than editing the primary checkout?",
+          "rubric": "Does the response keep classification and repository preflight read-only, identify the bounded scope, require `git worktree add -b` to create/check out the task branch atomically in the new worktree at the exact start SHA before `gt track --parent <verified-integration-base>`, reject `git worktree add --detach` plus task-worktree `gt create`, and avoid switching or repurposing the primary checkout?",
           "critical": true
         },
         {

--- a/skills/woostack-change/scripts/tests/test-command-surface.sh
+++ b/skills/woostack-change/scripts/tests/test-command-surface.sh
@@ -19,7 +19,7 @@ required = {
     "bug reroute": r"bug, regression.*woostack-fix",
     "multi-pr reroute": r"multiple PRs.*woostack-build",
     "preflight": r"git worktree list --porcelain.*local and remote branches.*Graphite ancestry.*canonical GitHub PR state",
-    "direct isolation": r"Create one isolated worktree.*one Graphite branch",
+    "direct isolation": r"Create and assert one isolated worktree under the \[canonical worktree contract\]\(\.\./woostack-init/references/worktrees\.md#5-create-and-assert\).*one Graphite-tracked branch",
     "direct implementation": r"implement every change needed for the accepted bounded scope",
     "focused smoke": r"focused verification and the changed-path smoke scenario",
     "one PR": r"submit at most one PR",


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices

## Goal

Make fresh woostack-change worktrees follow the canonical Graphite-compatible branch-first setup.

## Summary

- Restore the anchored link to the canonical worktree create/assert procedure.
- Protect the link and branch-first/track-second behavior in structural and behavior-corpus coverage.

## Test plan

### Automated

- `bash skills/woostack-change/scripts/tests/test-command-surface.sh` — passed
- `node skills/woostack-eval/scripts/validate.mjs --package skills/woostack-change --repository-root . --json` — passed

### Manual

- Removing the canonical anchor in a disposable copy made the structural test fail on `direct isolation`.
- A disposable Graphite 1.7.14 repository accepted `git worktree add -b` followed by `gt track --parent main` and read back the task branch, exact start SHA, and parent.
- A disposable detached worktree rejected task-worktree `gt create` with `Cannot perform this operation without a branch checked out.`

Resolves WOO-168
