### PR TITLE
docs(site): document getting started dependencies

### DIFF
--- a/site/content/docs/getting-started.mdx
+++ b/site/content/docs/getting-started.mdx
@@ -9,6 +9,18 @@ description: Install woostack, initialize safe Linear defaults, and optionally c
   exact native Linear approval event clears only the matching fix/build revision gate.
 </Callout>
 
+## Dependencies
+
+Prepare these tools before installing woostack:
+
+- An [agent harness](/docs/harnesses) that supports Agent Skills.
+- Node.js and pnpm. The installation command below uses `pnpx`.
+- Bash, Git, the GitHub CLI (`gh`), the Graphite CLI (`gt`), and `jq`. Authenticate both CLIs
+  and initialize Graphite for the target repository before running a workflow that delivers a PR.
+- An authenticated official Linear MCP connection for `/woostack-build` and post-diagnosis
+  `/woostack-fix`. Local initialization and Linear-free workflows such as `/woostack-change` do
+  not require it.
+
 ## 1. Install the skills
 
 Install the collection with the package manager supported by your skill host:


### PR DESCRIPTION
## Goal

Document woostack's prerequisites before readers run the installation command.

## Summary

- Add a Dependencies section to the Getting Started page.
- List the supported agent harness, local CLI/tooling requirements, and conditional Linear MCP access.
- Clarify that local initialization and Linear-free workflows do not require Linear.

## Test plan

- `pnpm install --frozen-lockfile` — completed successfully in `site/`.
- `pnpm build` — compiled successfully and generated `/docs/getting-started`.
- Browser smoke at `/docs/getting-started` — confirmed the Dependencies heading, four rendered list items, harness link, and layout at the observed 800×600 viewport.