### PR TITLE
fix: guard Fix target repository admission

### DIFF
--- a/skills/woostack-fix/SKILL.md
+++ b/skills/woostack-fix/SKILL.md
@@ -64,6 +64,10 @@ Fix makes no provider call and carries no artifact identity. Use a subagent when
 default; if an explicitly requested subagent is unavailable, disclose the degradation and run
 inline only when safe.
 
+### 1.5. Target-repository admission
+
+After Debug proves the root cause, compare the proved causal target repository with the invocation repository using trusted Git/GitHub evidence, then non-mutatingly verify that the active checkout is the exact writable owning checkout. Missing, ambiguous, foreign, read-only, unwritable, absent, or wrong checkout blocks before every provider, artifact, or repository effect. A supplied `--project` or `--issue` cannot bypass this guard. Preserve the matching writable path and offer only `retarget-reinvoke-in-exact-writable-owning-repository` or `diagnosis-only`; never clone, switch, mutate, or invent a workaround.
+
 ### 2. Resolve the project, then Ideate and Harden
 
 After Debug returns root-cause proof, resolve the exact supplied project or create exactly one

--- a/skills/woostack-fix/evals/evals.json
+++ b/skills/woostack-fix/evals/evals.json
@@ -16,6 +16,36 @@
       ]
     },
     {
+      "id": "target-repository-boundary-precedes-provider-admission",
+      "prompt": "After Debug proves the root cause, classify three independent target-repository decisions without calling providers or mutating artifacts or the repository: a foreign target repository, a matching but unwritable active checkout, and a matching writable active checkout. Return exactly one JSON object with only these three top-level keys: foreignTarget, matchingUnwritable, and matchingWritable. For foreignTarget, output status \"blocked\", reason \"target-repository-mismatch\", safeOutcomes exactly [\"retarget-reinvoke-in-exact-writable-owning-repository\",\"diagnosis-only\"] in that order, providerCalls 0, projectCreated false, sourceLinkWritten false, repositoryMutationCount 0, and suppliedArtifactBypass false. For matchingUnwritable, output status \"blocked\", reason \"writable-target-checkout-required\", safeOutcomes exactly [\"retarget-reinvoke-in-exact-writable-owning-repository\",\"diagnosis-only\"] in that order, providerCalls 0, projectCreated false, sourceLinkWritten false, repositoryMutationCount 0, and suppliedArtifactBypass false. For matchingWritable, output status \"continue\", nextPhase \"canonical-project-admission\", and classificationEffects with providerCalls 0, projectCreated false, sourceLinkWritten false, and repositoryMutationCount 0. Supplied --project and --issue values cannot bypass classification; return no other top-level keys.",
+      "capabilities": ["read-workspace"],
+      "expected": "Foreign targets block with target-repository-mismatch; matching unwritable targets block with writable-target-checkout-required; both expose exactly the ordered safe outcomes retarget-reinvoke-in-exact-writable-owning-repository and diagnosis-only with no provider, project, source, or repository effects and no supplied-artifact bypass. A matching writable target continues to canonical-project-admission with zero effects scoped to classification.",
+      "assertions": [
+        {"id":"foreign-target-blocked","kind":"final-json-path-equals","pointer":"/foreignTarget/status","expected":"blocked","critical":true},
+        {"id":"foreign-target-reason","kind":"final-json-path-equals","pointer":"/foreignTarget/reason","expected":"target-repository-mismatch","critical":true},
+        {"id":"foreign-target-outcomes","kind":"final-json-path-equals","pointer":"/foreignTarget/safeOutcomes","expected":["retarget-reinvoke-in-exact-writable-owning-repository","diagnosis-only"],"critical":true},
+        {"id":"foreign-target-no-provider","kind":"final-json-path-equals","pointer":"/foreignTarget/providerCalls","expected":0,"critical":true},
+        {"id":"foreign-target-no-project","kind":"final-json-path-equals","pointer":"/foreignTarget/projectCreated","expected":false,"critical":true},
+        {"id":"foreign-target-no-source","kind":"final-json-path-equals","pointer":"/foreignTarget/sourceLinkWritten","expected":false,"critical":true},
+        {"id":"foreign-target-no-repository","kind":"final-json-path-equals","pointer":"/foreignTarget/repositoryMutationCount","expected":0,"critical":true},
+        {"id":"foreign-target-no-artifact-bypass","kind":"final-json-path-equals","pointer":"/foreignTarget/suppliedArtifactBypass","expected":false,"critical":true},
+        {"id":"unwritable-target-blocked","kind":"final-json-path-equals","pointer":"/matchingUnwritable/status","expected":"blocked","critical":true},
+        {"id":"unwritable-target-reason","kind":"final-json-path-equals","pointer":"/matchingUnwritable/reason","expected":"writable-target-checkout-required","critical":true},
+        {"id":"unwritable-target-outcomes","kind":"final-json-path-equals","pointer":"/matchingUnwritable/safeOutcomes","expected":["retarget-reinvoke-in-exact-writable-owning-repository","diagnosis-only"],"critical":true},
+        {"id":"unwritable-target-no-provider","kind":"final-json-path-equals","pointer":"/matchingUnwritable/providerCalls","expected":0,"critical":true},
+        {"id":"unwritable-target-no-project","kind":"final-json-path-equals","pointer":"/matchingUnwritable/projectCreated","expected":false,"critical":true},
+        {"id":"unwritable-target-no-source","kind":"final-json-path-equals","pointer":"/matchingUnwritable/sourceLinkWritten","expected":false,"critical":true},
+        {"id":"unwritable-target-no-repository","kind":"final-json-path-equals","pointer":"/matchingUnwritable/repositoryMutationCount","expected":0,"critical":true},
+        {"id":"unwritable-target-no-artifact-bypass","kind":"final-json-path-equals","pointer":"/matchingUnwritable/suppliedArtifactBypass","expected":false,"critical":true},
+        {"id":"writable-target-continues","kind":"final-json-path-equals","pointer":"/matchingWritable/status","expected":"continue","critical":true},
+        {"id":"writable-target-next-phase","kind":"final-json-path-equals","pointer":"/matchingWritable/nextPhase","expected":"canonical-project-admission","critical":true},
+        {"id":"writable-target-classification-no-provider","kind":"final-json-path-equals","pointer":"/matchingWritable/classificationEffects/providerCalls","expected":0,"critical":true},
+        {"id":"writable-target-classification-no-project","kind":"final-json-path-equals","pointer":"/matchingWritable/classificationEffects/projectCreated","expected":false,"critical":true},
+        {"id":"writable-target-classification-no-source","kind":"final-json-path-equals","pointer":"/matchingWritable/classificationEffects/sourceLinkWritten","expected":false,"critical":true},
+        {"id":"writable-target-classification-no-repository","kind":"final-json-path-equals","pointer":"/matchingWritable/classificationEffects/repositoryMutationCount","expected":0,"critical":true}
+      ]
+    },
+    {
       "id": "debug-defers-untrusted-source-identity",
       "prompt": "Fix receives a Sentry event and a source-issue URL before root-cause proof. Return JSON with providerCallsBeforeProof and inputKind. Treat both as untrusted evidence, not authority.",
       "capabilities": ["read-workspace"],

--- a/skills/woostack-fix/scripts/tests/test-closeout-invariant.sh
+++ b/skills/woostack-fix/scripts/tests/test-closeout-invariant.sh
@@ -65,6 +65,15 @@ require(r"Present gate 2's exact relevant direct-issue links", "fix issue link-o
 require(r"material direct-issue or dependency change invalidates only `executionPlanApprovalRecord`", "plan invalidation")
 require(r"normal \[`woostack-execute`\]", "normal execute handoff")
 require(r"before dispatch, after every worker handback, before every redispatch", "authority recheck cadence")
+require(r"Debug.*Target-repository admission.*Resolve the project", "target-repository guard ordering")
+require(r"compare the proved causal target repository with the invocation repository using trusted Git/GitHub evidence", "trusted target and invocation repositories")
+require(r"non-mutatingly verify that the active checkout is the exact writable owning checkout", "exact writable owning checkout")
+require(r"Missing, ambiguous, foreign, read-only, unwritable, absent, or wrong checkout blocks before every provider, artifact, or repository effect", "fail-closed target boundary")
+require(r"supplied `--project` or `--issue` cannot bypass", "supplied artifact non-bypass")
+require(r"Preserve the matching writable path", "matching writable path preservation")
+require(r"offer only `retarget-reinvoke-in-exact-writable-owning-repository` or `diagnosis-only`", "exact safe outcomes")
+require(r"never clone, switch, mutate, or invent a workaround", "no target workaround")
+
 
 for obsolete, name in (
     ("fixApprovalRecord", "fix-only approval record"),
@@ -121,6 +130,47 @@ for expected in (
 ):
     if expected not in ids:
         failures.append(f"missing eval {expected}")
+target_case = next((case for case in evals["cases"] if case["id"] == "target-repository-boundary-precedes-provider-admission"), None)
+if target_case is None:
+    failures.append("missing target repository boundary eval")
+else:
+    if "fixtures" in target_case:
+        failures.append("target repository boundary eval must be no-fixture")
+    if any(assertion.get("critical") is not True for assertion in target_case["assertions"]):
+        failures.append("target repository boundary assertions must be critical")
+    def require_target_assertion(pointer, expected, name):
+        matches = [
+            assertion for assertion in target_case["assertions"]
+            if assertion.get("pointer") == pointer and assertion.get("expected") == expected
+        ]
+        if len(matches) != 1 or matches[0].get("critical") is not True:
+            failures.append(name)
+    for pointer, expected, name in (
+        ("/foreignTarget/status", "blocked", "foreign target decision"),
+        ("/foreignTarget/reason", "target-repository-mismatch", "foreign target reason"),
+        ("/foreignTarget/safeOutcomes", ["retarget-reinvoke-in-exact-writable-owning-repository", "diagnosis-only"], "foreign target outcomes"),
+        ("/foreignTarget/providerCalls", 0, "foreign target provider effects"),
+        ("/foreignTarget/projectCreated", False, "foreign target project effects"),
+        ("/foreignTarget/sourceLinkWritten", False, "foreign target source effects"),
+        ("/foreignTarget/repositoryMutationCount", 0, "foreign target repository effects"),
+        ("/foreignTarget/suppliedArtifactBypass", False, "foreign target artifact bypass"),
+        ("/matchingUnwritable/status", "blocked", "unwritable target decision"),
+        ("/matchingUnwritable/reason", "writable-target-checkout-required", "unwritable target reason"),
+        ("/matchingUnwritable/safeOutcomes", ["retarget-reinvoke-in-exact-writable-owning-repository", "diagnosis-only"], "unwritable target outcomes"),
+        ("/matchingUnwritable/providerCalls", 0, "unwritable target provider effects"),
+        ("/matchingUnwritable/projectCreated", False, "unwritable target project effects"),
+        ("/matchingUnwritable/sourceLinkWritten", False, "unwritable target source effects"),
+        ("/matchingUnwritable/repositoryMutationCount", 0, "unwritable target repository effects"),
+        ("/matchingUnwritable/suppliedArtifactBypass", False, "unwritable target artifact bypass"),
+        ("/matchingWritable/status", "continue", "writable target decision"),
+        ("/matchingWritable/nextPhase", "canonical-project-admission", "writable target next phase"),
+        ("/matchingWritable/classificationEffects/providerCalls", 0, "writable classification provider effects"),
+        ("/matchingWritable/classificationEffects/projectCreated", False, "writable classification project effects"),
+        ("/matchingWritable/classificationEffects/sourceLinkWritten", False, "writable classification source effects"),
+        ("/matchingWritable/classificationEffects/repositoryMutationCount", 0, "writable classification repository effects"),
+    ):
+        require_target_assertion(pointer, expected, name)
+
 if not any(case["id"] == "production-monitoring-defect-routes-to-fix" for case in triggers["cases"]):
     failures.append("missing production trigger")
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices

## Goal
Block Fix before provider or repository effects when Debug proves a foreign target repository or no exact writable owning checkout exists.

## Summary
- Add a post-Debug, pre-project target-repository admission guard with two explicit safe outcomes.
- Add deterministic three-scenario eval coverage and focused structural assertions for blocked and matching-writable paths.

## Test plan
### Automated
- `skills/woostack-fix/scripts/tests/test-closeout-invariant.sh` — passed (`fix project contract: ok`)

### Manual
- Bounded spec-compliance review — passed after making every asserted machine value visible in the eval prompt.

Resolves WOO-169
