### PR TITLE
fix: defer self-hosted eval in Fix and Build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ directory, not in this repo.
   [`skills/woostack-bootstrap/references/`](skills/woostack-bootstrap/references/) without
   updating every cross-link and the bootstrap skill table.
 - Do not commit `.env*`, secrets, generated app files, or personal compressed prose.
+- **Mode A Fix/Build self-hosted Eval corpus/fixture changes.** This is deterministic repository policy, not a Harden question: if a Mode A Fix/Build execution plan changes self-hosted Eval corpus or referenced fixture bytes, use deterministic validation only and defer full `/woostack-eval` to a separate explicit invocation after those bytes are committed and byte-identical to `HEAD`; otherwise, direct explicit `/woostack-eval` retains its existing approval path, including normal Eval for tracked bytes byte-identical to `HEAD`.
 
 ## Quick file map
 

--- a/skills/woostack-eval/scripts/tests/test-command-surface.sh
+++ b/skills/woostack-eval/scripts/tests/test-command-surface.sh
@@ -90,8 +90,12 @@ require(agents.count("[`woostack-eval`](skills/woostack-eval/SKILL.md)") == 1, "
 require(agents.count("[`woostack-reflect`](skills/woostack-reflect/SKILL.md)") == 1, "AGENTS.md public list must register woostack-reflect once")
 require("[`skills/woostack-eval/SKILL.md`](skills/woostack-eval/SKILL.md)" in agents, "AGENTS.md quick map must register woostack-eval once")
 require("[`skills/woostack-reflect/SKILL.md`](skills/woostack-reflect/SKILL.md)" in agents, "AGENTS.md quick map must register woostack-reflect once")
-require(agents.count("`/woostack-eval`") == 1, "AGENTS.md must route Mode B to woostack-eval exactly once")
+mode_b = re.search(r"^\*\*Mode B:.*?(?=^## Hard constraints)", agents, re.M | re.S)
+require(mode_b is not None and len(re.findall(r"`/woostack-eval`", mode_b.group(0))) == 1, "AGENTS.md must route Mode B to woostack-eval exactly once")
 require(agents.count("`/woostack-reflect`") == 1, "AGENTS.md must route Mode B to woostack-reflect exactly once")
+require("if a Mode A Fix/Build execution plan changes self-hosted Eval corpus or referenced fixture bytes, use deterministic validation only and defer full `/woostack-eval` to a separate explicit invocation after those bytes are committed and byte-identical to `HEAD`" in agents, "AGENTS.md must defer Mode A Fix/Build-changed self-hosted Eval bytes through the deterministic branch")
+require("otherwise, direct explicit `/woostack-eval` retains its existing approval path, including normal Eval for tracked bytes byte-identical to `HEAD`" in agents, "AGENTS.md must preserve direct explicit Eval approval and the byte-identical branch")
+require("This is deterministic repository policy, not a Harden question" in agents, "AGENTS.md must keep self-hosted Eval policy outside Harden")
 
 actual_fixed = sorted(path.parent.name for path in (root / "skills").glob("*/SKILL.md"))
 require(actual_fixed == sorted(fixed), f"fixed SKILL.md surface mismatch: {actual_fixed!r}")


### PR DESCRIPTION
## Goal
Stop self-hosted Mode A Fix/Build plans from turning changed evaluation corpus bytes into a recurring extra approval question.

## Summary
- Add a repository-local deterministic rule: validate changed corpus/fixture bytes and defer full `/woostack-eval` until a separate post-commit invocation.
- Preserve direct explicit Eval approval and tracked byte-identical corpus behavior.
- Extend the existing command-surface contract with scoped routing and policy assertions.

## Test plan
### Automated
- `bash skills/woostack-eval/scripts/tests/test-command-surface.sh` — passed
- `git diff --check` — passed
- `bash skills/woostack-eval/scripts/tests/test-critical-corpora.sh` — failed on both frozen base and task branch with the pre-existing `skills/woostack-build case count changed`; not an increment gate

### Manual
- Confirmed the committed diff contains exactly `AGENTS.md` and `skills/woostack-eval/scripts/tests/test-command-surface.sh`.

## Checklist
- [x] Cross-links to related sections still resolve
- [x] No version numbers hard-coded in `frameworks.md` where "latest" suffices

Resolves WOO-171