### PR TITLE
docs: name OMP sessions from current goal

### DIFF
--- a/skills/using-woostack/references/hosts/omp.md
+++ b/skills/using-woostack/references/hosts/omp.md
@@ -6,6 +6,9 @@ Use this adapter inside an active Oh My Pi session. Discover the actual `task`, 
 capabilities available in the session. Repository rules and the selected workflow skill remain
 authoritative. Linear remains optional for non-Fix workflows and for Fix diagnosis before root-cause proof; a proved new Fix requires the configured official MCP project/issue path before implementation.
 
+When a woostack skill is invoked, rename the active session with a concise title derived from the
+user's current goal. Do not use the slash-command name as the title.
+
 ## Subagent spawn
 
 OMP's `task` primitive accepts a worker selector but no per-call model/tier/effort argument.

--- a/skills/using-woostack/tests/test-harness-agent-boundary.sh
+++ b/skills/using-woostack/tests/test-harness-agent-boundary.sh
@@ -75,6 +75,11 @@ agents = read("AGENTS.md")
 readme = read("README.md")
 hermes = read("site/content/docs/hermes.mdx")
 
+require(omp, r"rename the active session.*current goal.*slash-command",
+        "OMP guidance does not rename sessions from the current goal")
+forbid(using, r"rename the active session|slash-command name",
+       "using-woostack contains OMP-specific session naming guidance")
+
 for text, label in ((using, "using-woostack"), (omp, "OMP guidance"),
                     (doctor, "doctor"), (review, "Review"),
                     (orchestrator, "Review orchestrator")):


### PR DESCRIPTION
## Summary

- Teach the OMP host adapter to rename the active session from the user's current goal whenever a woostack skill is invoked.
- Explicitly reject the slash-command name as the session title.
- Keep the host-agnostic `using-woostack` skill free of OMP-specific guidance and enforce that boundary structurally.

## Test plan

- `bash skills/using-woostack/tests/test-harness-agent-boundary.sh`
- Direct content assertion that naming guidance exists only in `references/hosts/omp.md`