### PR TITLE
fix: require bounded Linear description patches

### DIFF
--- a/site/content/docs/concepts/workflows.mdx
+++ b/site/content/docs/concepts/workflows.mdx
@@ -67,6 +67,8 @@ supported project link; it is not repurposed as a plan issue. The complete diagn
 specification live on the canonical project, with executor-ready contracts on direct issues and
 native dependencies between them.
 
+Build and Fix patch existing descriptions under the shared [narrow-description invariant](https://github.com/howarewoo/woostack/blob/main/skills/woostack-init/references/artifact-backends.md#existing-description-mutation-invariant); complete descriptions are create-only.
+
 Both approval gates use the shared
 [Linear artifact contract's link-only Ask presentation](https://github.com/howarewoo/woostack/blob/main/skills/woostack-init/references/artifact-backends.md#approval-ask-presentation).
 The responsible user's active-conversation approvals still require matching Linear receipts and

--- a/skills/woostack-build/references/linear-procedure.md
+++ b/skills/woostack-build/references/linear-procedure.md
@@ -38,10 +38,12 @@ them through recovery. For each issue:
 
 1. read the exact current target when it exists;
 2. preserve unrelated human-authored content;
-3. write the smallest complete corrected title/description/project-membership payload;
-4. independently read native identity, content, project membership, parent absence, revision, and
-   mutation identity back; and
-5. compute `canonicalIncrementFingerprint` only from the independently read canonical fields.
+3. apply the [existing-description mutation invariant](../../woostack-init/references/artifact-backends.md#existing-description-mutation-invariant) to any existing description and write its supported description patch as a standalone mutation;
+4. write the smallest corrected title and project-membership payload as separately selected
+   metadata mutations under their applicable contracts;
+5. independently read native identity, content, title, project membership, parent absence, revision,
+   and every mutation identity back; and
+6. compute `canonicalIncrementFingerprint` only from the independently read canonical fields.
 
 Then write missing native dependency relations. Independently read the complete relation set back
 and compare normalized predecessor→successor tuples with the hardened DAG. Never simulate

--- a/skills/woostack-build/tests/test-linear-build-contract.sh
+++ b/skills/woostack-build/tests/test-linear-build-contract.sh
@@ -76,6 +76,26 @@ for needle in (
 ):
     require("artifact", needle)
 
+for needle in (
+    "## Existing-description mutation invariant",
+    "Creation and mutation are separate contracts",
+    "complete intended description in the create payload",
+    "**Existing record:** never replace a full description",
+    "Build one smallest safe atomic patch",
+    "smallest exact text span that is unique in the current description",
+    "one readable Markdown section with a unique heading and unambiguous bounds (including EOF)",
+    "expected prior text/section",
+    "Never send a reconstructed whole description",
+    "Missing, duplicate, stale, unsupported, partial, or unknown",
+    "never retry the full",
+    "allocate a new identity",
+    "Afterward, completely independently re-read and verify",
+    "preservation of unrelated description content",
+):
+    require("artifact", needle)
+for name in ("procedure", "ideate", "harden", "plan"):
+    require(name, "existing-description mutation invariant")
+
 for name in ("build", "context", "procedure"):
     require(name, "Approval Ask presentation")
     require(name, "exact canonical Linear project link")
@@ -154,7 +174,8 @@ require(
     "ideate",
     "After each user reply that contains one or more verified decisions, perform exactly one synchronization cycle",
 )
-require("ideate", "one read, one write, and one independent read-back cycle")
+require("ideate", "minimum serial read-patch-read sequence")
+require("ideate", "For each required region in order")
 forbid("ideate", r"Ask \*\*one question per message\*\*")
 require("harden", "writes only what the user validates")
 require("plan", "Delegated planning performs no provider read or mutation")

--- a/skills/woostack-harden/SKILL.md
+++ b/skills/woostack-harden/SKILL.md
@@ -49,9 +49,7 @@ For the first material inconsistency:
    the evidence. Offer a recommendation only as an explicitly unverified recommendation.
 3. Wait for explicit user validation. **Never silently change a specification or plan from
    repository evidence, even when the repository convention appears unambiguous or safer.**
-4. After a correction is validated, re-read the exact target, preserve unrelated human-authored
-   content, write the smallest complete corrected content to that same record, and independently
-   read it back before asking the next question.
+4. After a correction is validated, re-read the exact target, apply the shared [existing-description mutation invariant](../woostack-init/references/artifact-backends.md#existing-description-mutation-invariant), preserve unrelated human-authored content, write the smallest corrected content to that same record, and independently read it back before asking the next question.
 5. For plan changes, independently verify the affected direct issue(s) and complete native
    dependency set; preserve historical parent/container issues and never simulate dependencies in
    prose.

--- a/skills/woostack-harden/references/angle-preflight.md
+++ b/skills/woostack-harden/references/angle-preflight.md
@@ -3,7 +3,7 @@
 Use this short pre-flight while hardening an admitted exact Linear project or direct-issue plan. It
 is a prompt selector, not an approval gate or a second review rubric. The canonical angle names and
 configuration live in [`woostack-review`'s `VALID_ANGLES`](../../woostack-review/scripts/load-config.sh)
-and the authoritative rubrics live in [`woostack-review/prompts/angles/`](../../woostack-review/prompts/angles/).
+and the authoritative rubrics live under `skills/woostack-review/prompts/angles/`.
 Link to those lenses; do not copy their checklists here.
 
 ## Prompts

--- a/skills/woostack-ideate/SKILL.md
+++ b/skills/woostack-ideate/SKILL.md
@@ -56,19 +56,17 @@ into a decision without asking.
 After each user reply that contains one or more verified decisions, perform exactly one synchronization
 cycle before asking the next batch:
 
-1. Re-read the exact project and current revision.
-2. Write one smallest complete high-level specification update containing only the explicit,
-   unambiguous decisions in that reply. Preserve unrelated human-authored content and do not write
-   placeholders, inferred defaults, or a competing local artifact.
-3. Independently read the exact project back, verify its identity/content/revision, and compute the
-   canonical project-specification fingerprint.
+1. Determine the minimum ordered set of non-overlapping description spans or sections needed to
+   persist only the explicit, unambiguous decisions in that reply.
+2. For each required region in order, re-read the exact project and current revision, apply one
+   atomic patch under the shared [existing-description mutation invariant](../woostack-init/references/artifact-backends.md#existing-description-mutation-invariant), then independently read the exact project back and verify its identity, content, and revision before continuing. Preserve unrelated human-authored content and do not write placeholders, inferred defaults, or a competing local artifact.
+3. From the final independent read-back, compute the canonical project-specification fingerprint.
 
 Partial or ambiguous answers remain unresolved: persist only explicit, unambiguous decisions from the
 reply and carry every unresolved item into a later eligible batch. A reply with no explicit,
 unambiguous verified decision causes no synchronization write; keep its questions unresolved. Do not
-start the next batch until the one read, one write, and one independent read-back cycle for a reply
-containing verified decisions is complete. Continue the dialogue only from that independently read
-content.
+start the next batch until the minimum serial read-patch-read sequence for every required region is
+complete. Continue the dialogue only from the final independently read content.
 
 If the read, mutation, pagination, identity, revision, or read-back is missing, foreign, ambiguous,
 conflicting, or unknown, stop at the last verified boundary. Do not substitute conversation content

--- a/skills/woostack-init/references/artifact-backends.md
+++ b/skills/woostack-init/references/artifact-backends.md
@@ -302,6 +302,32 @@ Build and selected standalone-plan synchronization may set current increment pro
 native dependency relations. It never creates or changes parent-child containment. Other metadata
 changes require the caller's explicit request.
 
+## Existing-description mutation invariant
+
+Creation and mutation are separate contracts:
+
+- **Creation:** a new project or issue may receive its complete intended description in the create
+  payload, followed by the required complete independent read-back.
+- **Existing record:** never replace a full description. Immediately before mutation, completely
+  re-read the exact target (description, revision/content identity, and all relevant paginated
+  updates/comments/relations) and retain it as the patch base. Build one smallest safe atomic patch:
+  either the smallest exact text span that is unique in the current description, or one readable
+  Markdown section with a unique heading and unambiguous bounds (including EOF). Require the
+  expected prior text/section, and replace or insert only that bounded region through the supported
+  narrow payload.
+  Never send a reconstructed whole description.
+- Missing, duplicate, stale, unsupported, partial, or unknown target/span/section/boundary state
+  blocks at that boundary. A failed, partial, or unknown outcome also blocks; never retry the full
+  description or allocate a new identity.
+- Afterward, completely independently re-read and verify native identity, the intended patch,
+  preservation of unrelated description content, revision/content identity, canonical fingerprints,
+  approval records, and drift state. Missing or failed read-back blocks.
+
+A description patch changes no unrelated fields, including title, assignee, delegate, status, labels,
+archival state, unrelated relations, or project membership. Separately selected metadata mutations
+defer to their applicable existing contracts; this invariant does not add fingerprint or approval
+requirements to those contracts.
+
 ## Active Execute project-start synchronization
 
 Normal Execute has one narrow workflow-owned status exception: in both `--project` and `--issue`

--- a/skills/woostack-plan/SKILL.md
+++ b/skills/woostack-plan/SKILL.md
@@ -105,8 +105,7 @@ only as a structure around concrete steps, never as a substitute for those steps
 ## Linear synchronization
 
 After the chain is complete and valid, verify the canonical repository association and selected
-workspace/team, then synchronize one exact project graph using the [Linear synchronization
-procedure](../woostack-build/references/linear-procedure.md):
+workspace/team, then apply the [existing-description mutation invariant](../woostack-init/references/artifact-backends.md#existing-description-mutation-invariant) while synchronizing one exact project graph using the [Linear synchronization procedure](../woostack-build/references/linear-procedure.md):
 
 1. Reconcile the complete current project context without creating a project.
 2. Create or reconcile exactly one direct project issue per increment with its full contract.


### PR DESCRIPTION
## Summary

<!-- What does this PR change in the spec, and why? -->

## Affected spec sections

- [ ] `spec/architecture.md`
- [ ] `spec/frameworks.md`
- [ ] `spec/infrastructure.md`
- [ ] `spec/patterns.md`
- [ ] `spec/development.md`
- [ ] `spec/bootstrap.md`
- [ ] `README.md` / other top-level docs

## Notes for downstream projects

<!-- Does this change require existing projects bootstrapped from the spec to update? Anything breaking? -->

## Checklist

- [ ] Cross-links to related sections still resolve
- [ ] No version numbers hard-coded in `frameworks.md` where "latest" suffices

## Goal
Require bounded atomic patches for existing Linear project and issue descriptions without weakening canonical read-back or approval safeguards.

## Summary
- Defines creation-only full-description writes and fail-closed atomic patch rules for existing descriptions.
- Links Ideate, Harden, Plan, and Build/Fix synchronization to the shared invariant.
- Adds structural contract coverage and updates the authored workflow documentation.
- Replaces an invalid directory Markdown link so the touched Harden skill package passes immutable review prefetch validation.

## Test plan
### Automated
- `node skills/woostack-eval/scripts/validate.mjs --package skills/woostack-harden --repository-root . --tracked-only --json` — passed with `"valid":true`.
- `PR_NUMBER=628 bash "$WOO_REVIEW_ACTION_PATH/scripts/prefetch.sh"` — passed at commit `0a3288bc`.
- `bash skills/woostack-build/tests/test-linear-build-contract.sh` — passed.
- `bash skills/woostack-build/scripts/tests/test-build-spec-commit-ordering.sh` — passed: 30 passed, 0 failed.
- `pnpm -C site build` — passed after installing worktree-local dependencies with `pnpm -C site install --offline --frozen-lockfile`; initial attempts failed because the isolated worktree lacked `node_modules` and Turbopack rejected an out-of-root dependency symlink.
- `git diff --check` — passed.

### Manual
- Official Linear MCP bounded line-ending-normalization patch plus complete independent project read-back — passed; description, resources, status, and approved fingerprint were preserved while `updatedAt` advanced.

Resolves WOO-174
