### PR TITLE
fix: stop sweep re-review after zero-blocker fixes

### DIFF
--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -340,7 +340,7 @@ review → address-comments per PR.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `review_sweep.max_rounds` | integer > 0 | `3` | Maximum review→address rounds per PR before the sweep declares it blocked. Any Address-produced head change, including a nit fix, requires another round; resolved nits on an unchanged head advance without re-review. A non-positive or non-integer value warns and falls back to `3`. |
+| `review_sweep.max_rounds` | integer > 0 | `3` | Maximum review→address rounds per PR before the sweep declares it blocked. Freeze the Review's zero-blocker/blocker classification before Address; thread resolution cannot erase a blocker. A changed head reruns Review when that frozen result contains a blocker (including a mixed set). Correction-only delta proof means the entire pre/post-head delta is limited solely to corrections for the exact recorded non-blocking Review findings; unrelated, partial, or unverified deltas block. A zero-blocker Address-produced head may advance without re-review only with that proof, focused verification, full reply/resolution evidence, descendant restack, and complete head/base/ancestry/thread read-back. A non-positive or non-integer value warns and falls back to `3`. |
 
 ## Commit hook
 

--- a/skills/woostack-sweep/SKILL.md
+++ b/skills/woostack-sweep/SKILL.md
@@ -33,7 +33,9 @@ empty range reports `nothing to sweep` and is not a clean result.
 4. Reject an unsubmitted branch, duplicate PR, moved head, cycle, gap, ambiguous membership, or any
    disagreement among Git, Graphite, and GitHub. Never submit a missing PR.
 5. For each PR, bind the canonical PR number, head and base SHAs/branches, changed paths, complete
-   thread snapshot, and task contract. A head or thread-set change invalidates that round.
+   thread snapshot, and task contract. An external, unexplained, or unverified head or thread-set
+   change invalidates that round; verified Address/restack transitions are governed by the explicit
+   round-outcome branch.
 6. Load `review_sweep.max_rounds` from `.woostack/config.json`; require a positive integer and
    default to `3` when absent. A malformed value warns and falls back to `3`. Bind that cap before
    any PR enters the loop.
@@ -57,23 +59,39 @@ Process each in-range PR from oldest dependency to tip. For each PR and each cur
    [`woostack-review <PR#>`](../woostack-review/SKILL.md) pass for this current head that posts all
    blockers and nits. Do not reuse a result from another head or substitute self-review. Record all
    posted blocking findings and nits.
-3. **Address new findings.** Refresh the current thread snapshot and address every new finding with
-   the exact Address Comments contract. Require evidence replies and resolution reads for all
-4. **Choose the round outcome.** First compare the bound head after Address. Any explained head
-   change produced by Address invalidates the prior Review for every finding severity: restack
-   affected descendants using the boundary below, read back every affected head/base/ancestry, then
-   repeat this PR's one Review → Address sequence on the new current head. An unexplained head
-   change is blocked. On an unchanged head, repeat after a blocking Review only when Address
-   produced new evidence; if a blocker remains unresolved without new evidence, halt with that
-   exact blocker and do not restack or re-review. If Review found only nits and every nit was
-   resolved on the unchanged head, advance without re-review. A missing/partial review, unknown
-   check, or unsafe decision is blocked, not clean.
+3. **Address new findings.** Before Address, freeze the zero-blocker/blocker classification from the
+   complete just-completed Review result. Address thread resolution cannot erase a blocker
+   classification for this round. Refresh the current thread snapshot and address every new finding
+   with the exact Address Comments contract. Require full reply/resolution evidence for all findings,
+   including actor-gated native COMMENT outcomes.
+4. **Choose the round outcome.** The computed zero-blocker outcome is frozen from the complete
+   just-completed Review result; it governs over Address resolution and any actor-gated native COMMENT.
+   First compare the bound head after Address:
+   - An explained head change is a change produced by Address with complete evidence. If the change is
+     unexplained, partial, or otherwise unsafe, fail closed and block.
+   - When the finding set contains a blocker, including a mixed blocker/non-blocking set, an explained
+     head change invalidates the prior Review: perform descendant restack using the boundary below,
+     complete head/base/ancestry/thread read-back, then rerun this PR's one Review → Address sequence
+     on the new current head within the bound. A blocker change therefore reruns Review; a mixed set
+     retains the same invalidation and rerun.
+   - Correction-only delta proof means the entire pre/post-head delta is limited solely to corrections
+     for the exact recorded non-blocking Review findings. Unrelated, partial, or unverified deltas
+     fail closed and block.
+   - With a zero-blocker changed-head outcome, correction-only delta proof, focused verification, full
+     reply/resolution evidence, descendant restack, and complete head/base/ancestry/thread read-back
+     all pass, advance without re-review. The changed head then becomes the current clean candidate;
+     any failed or missing proof blocks.
+   - On an unchanged head, repeat after a blocking Review only when Address produced new evidence; if
+     a blocker remains unresolved without new evidence, halt with that exact blocker and do not restack
+     or re-review. A missing/partial Review, unknown check, or unsafe decision is blocked, not clean.
 5. **Halt repeated blockers.** If the same blocker recurs on an unchanged head with no new code or
    evidence, halt and return that exact blocker and safe resume boundary. Do not spend another round
    or claim progress.
 
 A PR is clean only after its current head has completed the applicable Review/Address sequence, has
-no unresolved blocker or nit, and all replies/resolution reads are verified. A stack is ready only
+no unresolved blocker or nit, and all replies/resolution reads are verified. For a changed head with
+zero blockers, the correction-only delta proof, focused verification, descendant restack, and complete
+head/base/ancestry/thread read-back are also required before the clean gate. A stack is ready only
 when every in-range submitted PR is clean and Graphite ancestry and heads are current.
 
 ## Restack affected descendants

--- a/skills/woostack-sweep/evals/evals.json
+++ b/skills/woostack-sweep/evals/evals.json
@@ -54,23 +54,59 @@
       ]
     },
     {
-      "id": "nit-fix-head-change-reviews-again",
-      "prompt": "Sweep exact PR 501. Its first current-head review reports one nit. Address fixes that nit with code, producing a new verified head and resolving the thread. Re-review the new head before declaring the PR clean. Return one JSON object with reviewCalls, heads, ordered events, thread resolution, and status.",
+      "id": "nit-fix-head-change-advances",
+      "prompt": "Sweep exact PR 501. Its first current-head review reports one nit and no blockers. Address fixes that nit with a correction-only code delta, producing a new verified head and resolving the thread. Do not re-review the new head when the correction-only proof, focused verification, full reply/resolution evidence, descendant restack, and complete head/base/ancestry/thread read-back all pass. Return one JSON object with reviewCalls, heads, ordered events, thread resolution, verification, restack, readBack, and status.",
       "capabilities": ["read-workspace"],
-      "expected": "The Address-produced head change invalidates the first review even though the finding was a nit, so the new head receives a second review before clean status.",
+      "expected": "A zero-blocker nit-only Address-produced correction-only head change advances without a second review; the new head is verified and the PR is clean.",
       "assertions": [
-        {"id": "new-head-reviewed", "kind": "final-json-path-equals", "pointer": "/reviewCalls", "expected": 2, "critical": true},
+        {"id": "one-review", "kind": "final-json-path-equals", "pointer": "/reviewCalls", "expected": 1, "critical": true},
         {"id": "head-changed", "kind": "final-json-path-equals", "pointer": "/heads", "expected": ["sha-501-a", "sha-501-b"], "critical": true},
-        {"id": "address-before-new-head-review", "kind": "final-json-path-equals", "pointer": "/events", "expected": ["review:sha-501-a", "address:sha-501-a->sha-501-b", "review:sha-501-b"], "critical": true},
+        {"id": "address-without-rereview", "kind": "final-json-path-equals", "pointer": "/events", "expected": ["review:sha-501-a", "address:sha-501-a->sha-501-b", "verify:focused", "restack:descendants", "readBack:complete", "advance:sha-501-b"], "critical": true},
         {"id": "nit-resolved", "kind": "final-json-path-equals", "pointer": "/threadResolution", "expected": true, "critical": true},
+        {"id": "full-reply-resolution-evidence", "kind": "final-json-path-equals", "pointer": "/findings/repliesAndResolutions", "expected": true, "critical": true},
+        {"id": "correction-only-proof", "kind": "final-json-path-equals", "pointer": "/verification/correctionOnly", "expected": true, "critical": true},
+        {"id": "focused-verification", "kind": "final-json-path-equals", "pointer": "/verification/focused", "expected": true, "critical": true},
+        {"id": "descendant-restack", "kind": "final-json-path-equals", "pointer": "/restack/descendants", "expected": true, "critical": true},
+        {"id": "complete-evidence", "kind": "final-json-path-equals", "pointer": "/readBack/complete", "expected": true, "critical": true},
+        {"id": "clean", "kind": "final-json-path-equals", "pointer": "/status", "expected": "clean", "critical": true}
+      ]
+    },
+    {
+      "id": "non-blocking-correction-only-head-advances",
+      "prompt": "Sweep exact PR 511. Its current-head review reports two non-blocking findings and no blockers. Address applies a correction-only code delta, producing verified head sha-511-b, with every finding replied to and resolved. Prove the delta is correction-only, run focused verification, restack affected descendants, and read back every affected head/base/ancestry/thread before advancing without re-review. Return one JSON object with reviewCalls, heads, events, findings, verification, restack, readBack, and status.",
+      "capabilities": ["read-workspace"],
+      "expected": "A zero-blocker ordinary non-blocking correction-only head change uses one Review, advances without re-review, and is clean only after all evidence and read-backs pass.",
+      "assertions": [
+        {"id": "one-review", "kind": "final-json-path-equals", "pointer": "/reviewCalls", "expected": 1, "critical": true},
+        {"id": "correction-head", "kind": "final-json-path-equals", "pointer": "/heads", "expected": ["sha-511-a", "sha-511-b"], "critical": true},
+        {"id": "advance-no-rereview", "kind": "final-json-path-equals", "pointer": "/events", "expected": ["review:sha-511-a", "address:sha-511-a->sha-511-b", "verify:focused", "restack:descendants", "readBack:complete", "advance:sha-511-b"], "critical": true},
+        {"id": "zero-blockers", "kind": "final-json-path-equals", "pointer": "/findings/blockers", "expected": [], "critical": true},
+        {"id": "full-reply-resolution-evidence", "kind": "final-json-path-equals", "pointer": "/findings/repliesAndResolutions", "expected": true, "critical": true},
+        {"id": "correction-only-proof", "kind": "final-json-path-equals", "pointer": "/verification/correctionOnly", "expected": true, "critical": true},
+        {"id": "focused-verification", "kind": "final-json-path-equals", "pointer": "/verification/focused", "expected": true, "critical": true},
+        {"id": "descendant-restack", "kind": "final-json-path-equals", "pointer": "/restack/descendants", "expected": true, "critical": true},
+        {"id": "complete-readback", "kind": "final-json-path-equals", "pointer": "/readBack/complete", "expected": true, "critical": true},
+        {"id": "clean", "kind": "final-json-path-equals", "pointer": "/status", "expected": "clean", "critical": true}
+      ]
+    },
+    {
+      "id": "mixed-findings-head-change-reruns",
+      "prompt": "Sweep exact PR 521. Its current-head review reports blocker B1 and one non-blocking finding. Address resolves both with a new verified head sha-521-b, restacks affected descendants, and reads back all affected heads/bases/ancestry and thread evidence. Because the finding set is mixed and includes a blocker, rerun Review on sha-521-b before declaring the PR clean. Return one JSON object with reviewCalls, heads, events, restack, readBack, and status.",
+      "capabilities": ["read-workspace"],
+      "expected": "A mixed blocker/non-blocking finding set retains explained-head invalidation and reruns on the new head; the second review is required before clean status.",
+      "assertions": [
+        {"id": "rerun", "kind": "final-json-path-equals", "pointer": "/reviewCalls", "expected": 2, "critical": true},
+        {"id": "head-changed", "kind": "final-json-path-equals", "pointer": "/heads", "expected": ["sha-521-a", "sha-521-b"], "critical": true},
+        {"id": "rerun-order", "kind": "final-json-path-equals", "pointer": "/events", "expected": ["review:sha-521-a", "address:sha-521-a->sha-521-b", "restack:descendants", "readBack:complete", "review:sha-521-b"], "critical": true},
+        {"id": "restack-readback", "kind": "final-json-path-equals", "pointer": "/readBack/complete", "expected": true, "critical": true},
         {"id": "clean", "kind": "final-json-path-equals", "pointer": "/status", "expected": "clean", "critical": true}
       ]
     },
     {
       "id": "max-rounds-blocks-next-head-review",
-      "prompt": "Sweep exact PR 601 with review_sweep.max_rounds set to 2. Review sha-601-a finds a nit and Address fixes it with code at sha-601-b. Review sha-601-b finds another nit and Address fixes it with code at sha-601-c. Before reviewing sha-601-c, enforce the configured round cap. Return one JSON object with reviewCalls, reviewedHeads, currentHead, events, status, and safeResumeBoundary.",
+      "prompt": "Sweep exact PR 601 with review_sweep.max_rounds set to 2. Review sha-601-a finds blocker B601 and Address fixes it with code at sha-601-b. Review sha-601-b finds another blocker B602 and Address fixes it with code at sha-601-c. Before reviewing sha-601-c, enforce the configured round cap. Return one JSON object with reviewCalls, reviewedHeads, currentHead, events, status, and safeResumeBoundary.",
       "capabilities": ["read-workspace"],
-      "expected": "The two configured rounds run, but the second Address-produced head cannot start a third review; the sweep blocks on sha-601-c with an exact resume boundary.",
+      "expected": "The two configured blocking rounds run, but the second Address-produced head cannot start a third review; the sweep blocks on sha-601-c with an exact resume boundary.",
       "assertions": [
         {"id": "review-cap", "kind": "final-json-path-equals", "pointer": "/reviewCalls", "expected": 2, "critical": true},
         {"id": "reviewed-heads", "kind": "final-json-path-equals", "pointer": "/reviewedHeads", "expected": ["sha-601-a", "sha-601-b"], "critical": true},

--- a/skills/woostack-sweep/scripts/tests/test-round-verdict-contract.sh
+++ b/skills/woostack-sweep/scripts/tests/test-round-verdict-contract.sh
@@ -3,11 +3,25 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 python3 - "$ROOT" <<'PY'
+import json
 import re
 import sys
 from pathlib import Path
 
-text = re.sub(r"\s+", " ", (Path(sys.argv[1]) / "skills/woostack-sweep/SKILL.md").read_text())
+root = Path(sys.argv[1])
+text = re.sub(r"\s+", " ", (root / "skills/woostack-sweep/SKILL.md").read_text())
+evals = json.loads((root / "skills/woostack-sweep/evals/evals.json").read_text())
+max_round_case = next((case for case in evals["cases"] if case.get("id") == "max-rounds-blocks-next-head-review"), None)
+fixture_failures = []
+if not max_round_case:
+    fixture_failures.append("max-rounds fixture missing")
+else:
+    prompt = max_round_case.get("prompt", "").lower()
+    expected = max_round_case.get("expected", "").lower()
+    if "blocker" not in prompt or "nit" in prompt:
+        fixture_failures.append("max-rounds prompt must encode blockers, not nits")
+    if "block" not in expected or "nit" in expected:
+        fixture_failures.append("max-rounds expected outcome must encode blocking, not nits")
 checks = {
     "branch command target": r"/woostack-sweep \[PR#\|branch\]",
     "exact branch binding": r"With `branch`, require one exact branch-name match.*bind that submitted branch to its canonical GitHub PR",
@@ -17,18 +31,28 @@ checks = {
     "pre-existing address": r"Address pre-existing threads.*before review",
     "review exactly once": r"Invoke exactly one canonical multi-angle.*woostack-review <PR#>",
     "new findings": r"Address new findings.*every new finding",
-    "all head changes invalidate review": r"Any explained head change produced by Address invalidates the prior Review for every finding severity",
-    "restack changed head": r"restack affected descendants.*read back every affected head/base/ancestry.*repeat this PR's one Review → Address sequence",
-    "unchanged progress": r"On an unchanged head, repeat after a blocking Review only when Address produced new evidence",
+    "blocker-only head invalidation": r"explained head change.*only when.*blocker|blocker.*explained head change.*invalidates.*prior Review",
+    "zero-blocker changed head advances": r"zero-blocker.*(correction-only|changed-head).*advance.*without re-review",
+    "native comment cannot override": r"computed zero-blocker outcome.*actor-gated native COMMENT|computed.*zero-blocker.*over.*native COMMENT",
+    "qualified head/thread drift": r"external, unexplained, or unverified head or thread-set change invalidates.*verified Address/restack transitions.*round-outcome branch",
+    "frozen review classification": r"freeze the zero-blocker/blocker classification.*complete just-completed Review result.*resolution cannot erase a blocker",
+    "unsafe correction delta blocks": r"unrelated, partial, or unverified deltas.*block",
+    "correction-only proof": r"correction-only delta proof",
+    "complete address evidence": r"full reply/resolution evidence",
+    "focused verification": r"focused (checks|verification)",
+    "restack descendants before advance": r"descendant restack",
+    "complete changed-head read-back": r"complete head/base/ancestry/thread read-back",
+    "blocker changed head reruns": r"blocker.*(mixed|explained head).*rerun|blocker.*repeat.*Review",
+    "unchanged blocker progress": r"On an unchanged head, repeat after a blocking Review only when Address produced new evidence",
     "no-progress stop": r"blocker remains unresolved without new evidence, halt.*do not restack or re-review",
-    "advance unchanged nits": r"only nits and every nit was resolved on the unchanged head, advance without re-review",
     "unchanged halt": r"same blocker recurs on an unchanged head with no new code or evidence",
     "clean gate": r"no unresolved blocker or nit.*replies/resolution reads are verified",
     "stack ready": r"every in-range submitted PR is clean and Graphite ancestry and heads are current",
     "fail closed": r"missing/partial review, unknown check, or unsafe decision is blocked",
 }
 failures = [name for name, pattern in checks.items() if not re.search(pattern, text, re.I | re.S)]
-for forbidden in ("Linear", "artifact", "--interactive", "--full"):
+failures.extend(fixture_failures)
+for forbidden in ("Linear", "artifact", "--interactive", "--full", "every finding severity", "only nits and every nit", "a head or thread-set change invalidates that round"):
     if forbidden.lower() in text.lower():
         failures.append(f"obsolete {forbidden} path")
 if failures:


### PR DESCRIPTION
## Goal

Stop Sweep from re-reviewing a verified correction-only head after a zero-blocker Review, while preserving bounded reruns for blocker and mixed-finding rounds.

## Summary

- Freeze the just-completed Review's zero-blocker/blocker classification before Address mutates threads or the head.
- Advance a verified zero-blocker correction-only head after focused verification, descendant restack, and complete head/base/ancestry/thread read-back; fail closed on unrelated or unverified drift.
- Keep blocker and mixed-finding head changes on the bounded Review → Address rerun path, including max-round coverage.
- Align the structural contract, deterministic Sweep fixtures, and authored `review_sweep.max_rounds` documentation.

## Test plan

- [x] `bash skills/woostack-sweep/scripts/tests/run-tests.sh`
- [x] `node skills/woostack-eval/scripts/validate.mjs --package skills/woostack-sweep --repository-root . --tracked-only --json` (`valid: true`)
- [x] `python3 -m json.tool skills/woostack-sweep/evals/evals.json`
- [x] Deterministic fixture smoke: zero-blocker correction-only cases stop after one Review; blocker/mixed cases rerun; max-round case blocks at the configured cap.
- [x] `pnpm -C site build`
- [x] `git diff --check`

Full `/woostack-eval` is intentionally deferred until the changed self-hosted corpus bytes are committed and byte-identical to `HEAD`, per repository policy.

## Linear

Resolves [WOO-175](https://linear.app/woostack/issue/WOO-175/stop-rerunning-zero-blocker-sweep-reviews)
